### PR TITLE
InstructorCourseJoin: parameter becomes null although it was checked for null before #1817

### DIFF
--- a/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
@@ -437,8 +437,41 @@ public class AccountsLogicTest extends BaseComponentTestCase {
         assertEquals(nonInstrAccount.googleId, joinedInstructor.googleId);
         instructorsLogic.verifyInstructorExists(nonInstrAccount.googleId);
         
+        
+        ______TS("success: instructor join and assigned institute when some instructors have not joined course");
+        
+        instructor = dataBundle.instructors.get("instructor4");
+        
+        instructorsLogic.addInstructor(instructor.courseId, "anInstructorWithoutGoogleId", "anInstructorWithoutGoogleId@gmail.com");  
+        
+        nonInstrAccount = dataBundle.accounts.get("student2InCourse1");
+        nonInstrAccount.email = "newInstructor@gmail.com";
+        nonInstrAccount.name = " newInstructor";
+        nonInstrAccount.googleId = "newInstructorGoogleId";
+       
+        instructorsLogic.addInstructor(instructor.courseId, nonInstrAccount.name, nonInstrAccount.email);
+        key = instructorsLogic.getKeyForInstructor(instructor.courseId, nonInstrAccount.email);
+        encryptedKey = StringHelper.encrypt(key);
+        
+        accountsLogic.joinCourseForInstructor(encryptedKey, nonInstrAccount.googleId);
+        
+        joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, nonInstrAccount.email);
+        assertEquals(nonInstrAccount.googleId, joinedInstructor.googleId);
+        instructorsLogic.verifyInstructorExists(nonInstrAccount.googleId);
+        
+        AccountAttributes instructorAccount = accountsLogic.getAccount(nonInstrAccount.googleId);
+        assertEquals("National University of Singapore", instructorAccount.institute);
+        
+        
         ______TS("failure: instructor already joined");
-
+        
+        nonInstrAccount = dataBundle.accounts.get("student1InCourse1");
+        instructor = dataBundle.instructors.get("instructorNotYetJoinCourse");
+        
+        key = instructorsLogic.getKeyForInstructor(instructor.courseId, nonInstrAccount.email);
+        encryptedKey = StringHelper.encrypt(key);
+        joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, nonInstrAccount.email);
+        
         try {
             accountsLogic.joinCourseForInstructor(encryptedKey, joinedInstructor.googleId);
             signalFailureToDetectException();


### PR DESCRIPTION
For Issue #1817 
Added a test where an instructor account without Google ID was added to the course, and a subsequent instructor was added to see if the institute was able to be copied from an existing instructor and at the same time skipping over instructors without Google IDs instead of throwing an exception.
