### PR TITLE
NPE in createFeedbackResponse #2675

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -49,14 +49,7 @@ public class FeedbackResponsesLogic {
             frDb.createEntity(fra);
         } catch (Exception EntityAlreadyExistsException) {
             try {
-                FeedbackResponseAttributes existingFeedback = new FeedbackResponseAttributes();
-
-                existingFeedback = frDb.getFeedbackResponse(
-                        fra.feedbackQuestionId, fra.giverEmail,
-                        fra.recipientEmail);
-                fra.setId(existingFeedback.getId());
-
-                frDb.updateFeedbackResponse(fra);
+                updateFeedbackResponse(fra);
             } catch (Exception EntityDoesNotExistException) {
                 Assumption.fail();
             }


### PR DESCRIPTION
For Issue #2675 

When creating the feedback response, if entity already exists, the code will update the feedback response instead. However, the current code does not do quite a number of null checking, so replacing it with the actual updateFeedbackResponse method should solve the problem.
