### PR TITLE
Panel headings for responses should be coloured differently #2631

### DIFF
--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -1,4 +1,5 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
 
 <%@ page import="java.util.Map"%>
 <%@ page import="java.util.List"%>
@@ -171,8 +172,13 @@
                     					recipientName = data.bundle
                     							.getNameForEmail(singleResponse.recipientEmail);
                     				}
+                                    
+                                    String panelHeaderClass = giverName.equals("You")
+                                                              ? "panel-info"
+                                                              : "panel-primary";
+               
                     %>
-                    <div class="panel panel-primary">
+                    <div class="panel <%= panelHeaderClass %>">
                         <div class="panel-heading"><b>To:</b> <%=recipientName%></div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageCONSTSUM.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONSTSUM.html
@@ -340,7 +340,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -371,7 +371,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -389,7 +389,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Charlie Davis</div>
                         <table class="table">
                             <tbody>    
@@ -407,7 +407,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
@@ -423,7 +423,7 @@ The actual calculation is a bit complex and the finer details can be found
     </table>
 </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -441,7 +441,7 @@ The actual calculation is a bit complex and the finer details can be found
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageMCQ.html
@@ -340,7 +340,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -372,7 +372,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -390,7 +390,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    
@@ -490,7 +490,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageMSQ.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageMSQ.html
@@ -340,7 +340,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -372,7 +372,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -390,7 +390,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    
@@ -454,7 +454,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageNUMSCALE.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageNUMSCALE.html
@@ -339,7 +339,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -370,7 +370,7 @@ ul #nav {
 </span></span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -388,7 +388,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    
@@ -496,7 +496,7 @@ ul #nav {
                     </div>
                 </div>
                 <br />
-                              <div class="panel panel-default">
+                <div class="panel panel-default">
                   <div class="panel-heading">
                      <h4>
                         Question 4:
@@ -558,7 +558,7 @@ ul #nav {
                            </form>
                         </div>
                      </div>
-                     <div class="panel panel-primary">
+                     <div class="panel panel-info">
                         <div class="panel-heading">
                            <b>
                               To:

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -335,7 +335,7 @@ ul #nav {
                         <h4>Question 1: <span class="text-preserve-space">What is the best selling point of your product?</span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> You</div>
                         <table class="table">
                             <tbody>    
@@ -380,7 +380,7 @@ ul #nav {
                         <h4>Question 2: <span class="text-preserve-space">Rate 3 other students' products</span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -398,7 +398,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    
@@ -416,7 +416,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Drop out</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -497,7 +497,7 @@ ul #nav {
                         <h4>Question 3: <span class="text-preserve-space">Feedback to class</span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> -</div>
                         <table class="table">
                             <tbody>    
@@ -588,7 +588,7 @@ ul #nav {
                         <h4>Question 5: <span class="text-preserve-space">Give feedback to your team mates</span></h4>
                         
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Alice Betsy</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
@@ -400,7 +400,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Charlie Davis</div>
                         <table class="table">
                             <tbody>    
@@ -418,7 +418,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Danny Engrid</div>
                         <table class="table">
                             <tbody>    

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -426,7 +426,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Alice Betsy</div>
                         <table class="table">
                             <tbody>    
@@ -444,7 +444,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Benny Charles</div>
                         <table class="table">
                             <tbody>    
@@ -462,7 +462,7 @@ ul #nav {
                             </table>
                         </div>
                     
-                    <div class="panel panel-primary">
+                    <div class="panel panel-info">
                         <div class="panel-heading"><b>To:</b> Unknown user</div>
                         <table class="table">
                             <tbody>    


### PR DESCRIPTION
HTML pages for tests were changed also.
Fixes #2631
![panels1](https://cloud.githubusercontent.com/assets/592986/5322455/c185404e-7cbd-11e4-896b-c47099710b01.PNG)
