### PR TITLE
InstructorFeedbackEditPageUiTest failing on dev server #4755

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -262,6 +262,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         
         
         feedbackEditPage.clickNewQuestionButton();
+        feedbackEditPage.waitForElementVisibility(browser.driver.findElement(By.id("questionTableNew")));
         feedbackEditPage.clickVisibilityOptionsForNewQuestion();
         feedbackEditPage.clickResponseVisiblityCheckBoxForNewQuestion("RECEIVER_TEAM_MEMBERS");
         feedbackEditPage.clickVisibilityPreviewForNewQuestion();


### PR DESCRIPTION
Fixes #4755 
Failure is caused by the "edit visibility" button being clicked before the div finished rendering. Sort of a race condition.