### PR TITLE
Severe logs without error data #4550

### DIFF
--- a/src/main/java/teammates/common/util/ActivityLogEntry.java
+++ b/src/main/java/teammates/common/util/ActivityLogEntry.java
@@ -540,19 +540,19 @@ public class ActivityLogEntry {
         }
         String url = HttpRequestHelper.getRequestedURL(req);
         
-        String message = "";
-        if(errorEmail != null){
-            try {
-                  message += "<span class=\"text-danger\">" + errorEmail.getSubject() + "</span><br>";
-                  message += "<a href=\"#\" onclick=\"showHideErrorMessage('error" + errorEmail.hashCode() +"');\">Show/Hide Details >></a>";
-                  message += "<br>";
-                  message += "<span id=\"error" + errorEmail.hashCode() + "\" style=\"display: none;\">";
-                  message += errorEmail.getContent().toString();
-                  message += "</span>";
-              } catch (Exception e) {
-                  message = "System Error. Unable to retrieve Email Report";
-              }
-          }
+        String message;
+        
+        try {
+            message = "<span class=\"text-danger\">" + errorEmail.getSubject() + "</span><br>"
+                    + "<a href=\"#\" onclick=\"showHideErrorMessage('error" + errorEmail.hashCode() + "');\">Show/Hide Details >></a>"
+                    + "<br>"
+                    + "<span id=\"error" + errorEmail.hashCode() + "\" style=\"display: none;\">"
+                    + errorEmail.getContent().toString()
+                    + "</span>";
+        } catch (Exception e) {
+            message = "System Error: Unable to retrieve Email Report: "
+                    + TeammatesException.toStringWithStackTrace(e);
+        }
         
         String courseId = HttpRequestHelper.getValueFromRequestParameterMap(req, Const.ParamsNames.COURSE_ID);
         String studentEmail = HttpRequestHelper.getValueFromRequestParameterMap(req, Const.ParamsNames.STUDENT_EMAIL);

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -805,6 +805,8 @@ public class Emails {
             forceSendEmailThroughGaeWithoutLogging(email);
             log.severe("Sent crash report: " + Emails.getEmailInfo(email));
         } catch (Exception e) {
+            log.severe("Crash report failed to send. Detailed error stack trace: "
+                     + TeammatesException.toStringWithStackTrace(error));
             logSevereForErrorInSendingItem("crash report", email, e);
         }
     

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -116,8 +116,9 @@ public class ControllerServlet extends HttpServlet {
             }
         } catch (Throwable e) {
             MimeMessage email = new Logic().emailErrorReport(req, e);
-
-            log.severe(ActivityLogEntry.generateSystemErrorReportLogMessage(req, email)); 
+            if (email != null) {
+                log.severe(ActivityLogEntry.generateSystemErrorReportLogMessage(req, email));
+            }
             cleanUpStatusMessageInSession(req);
             resp.sendRedirect(Const.ViewURIs.ERROR_PAGE);
         }  


### PR DESCRIPTION
Fixes #4550
Here's what happened: take a look at these lines in `ControllerServlet`:
```java
MimeMessage email = new Logic().emailErrorReport(req, e); // can be null
log.severe(ActivityLogEntry.generateSystemErrorReportLogMessage(req, email));
```
Here, if the variable `email` is null, the log will have no data, which is what is seen in the issue thread.
How can the variable `email` be null? Further probing will bring us to this function in `Emails.java`:
```java
public MimeMessage sendErrorReport(HttpServletRequest req, Throwable error) {
    MimeMessage email = null;
    try {
        ...
        email = generateSystemErrorEmail(...) // this function can throw Exception
        ...
    } catch (Exception e) {
        logSevereForErrorInSendingItem("crash report", email, e);
    }
    return email;
}
```
That is, the `email` will be null if there is an error in generating the system error email.

To alleviate, when such failure occurs, an alternative severe log will be done from `Emails.java` which will show the error's stack trace, on top of also sending the reason for why the crash report failed to send (i.e if the crash report failed to send the admin will receive _two_ severe logs: one logging the error that's supposedly reported in the crash report, and another one logging why the crash report failed to send).

(P.S the newly added stack traces will also have no line breaks)