### PR TITLE
FeedbackRubricQuestionUiTest failing on dev server #4817

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRankQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRankQuestionUiTest.java
@@ -256,28 +256,28 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("instructor1", "instructor", false, "question");
         instructorResultsPage.waitForPanelsToExpand();
         
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRankQuestionView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRankQuestionView.html");
         
         
         ______TS("Rank instructor results : Giver > Recipient > Question");
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("instructor1", "instructor", false, "giver-recipient-question");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRankGRQView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRankGRQView.html");
         
         ______TS("Rank instructor results : Giver > Question > Recipient");
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("instructor1", "instructor", false, "giver-question-recipient");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRankGQRView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRankGQRView.html");
         
         ______TS("Rank instructor results : Recipient > Giver > Question ");
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("instructor1", "instructor", false, "recipient-question-giver");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRankRQGView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRankRQGView.html");
         
         ______TS("Rank instructor results : Recipient > Question > Giver");
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("instructor1", "instructor", false, "recipient-giver-question");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRankRGQView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRankRGQView.html");
     }
     
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRubricQuestionUiTest.java
@@ -75,28 +75,28 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("teammates.test.instructor", "openSession2", false, "question");
         instructorResultsPage.waitForPanelsToExpand();
         
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRubricQuestionView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRubricQuestionView.html");
         
         
         // Giver Recipient Question View
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("teammates.test.instructor", "openSession2", false, "giver-recipient-question");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRubricGRQView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRubricGRQView.html");
         
         // Giver Question Recipient View
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("teammates.test.instructor", "openSession2", false, "giver-question-recipient");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRubricGQRView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRubricGQRView.html");
         
         // Recipient Giver Question View
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("teammates.test.instructor", "openSession2", false, "recipient-question-giver");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRubricRQGView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRubricRQGView.html");
         
         // Recipient Question Giver View
         instructorResultsPage = loginToInstructorFeedbackResultsPageWithViewType("teammates.test.instructor", "openSession2", false, "recipient-giver-question");
         instructorResultsPage.waitForPanelsToExpand();
-        instructorResultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageRubricRGQView.html");
+        instructorResultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageRubricRGQView.html");
         
     }
     

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorCoursesPageUiTest.java
@@ -154,13 +154,13 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
         ______TS("Course Stats");
         coursesPage = getCoursesPage();
         coursesPage.triggerAjaxLoadCourseStats(1);
-        coursesPage.verifyHtmlAjaxMainContent("/instructorCoursesStatsAjaxSuccessful.html");
+        coursesPage.verifyHtmlMainContentWithRetry("/instructorCoursesStatsAjaxSuccessful.html");
 
         ______TS("Course Stats Failed");
         coursesPage = getCoursesPage();
         coursesPage.changeHrefInAjaxLoadCourseStatsLink("invalidLink");
         coursesPage.triggerAjaxLoadCourseStats(1);
-        coursesPage.verifyHtmlAjaxMainContent("/instructorCoursesStatsAjaxFailure.html");
+        coursesPage.verifyHtmlMainContentWithRetry("/instructorCoursesStatsAjaxFailure.html");
         coursesPage = getCoursesPage();
     }
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
@@ -147,14 +147,14 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         String helperId = testData.accounts.get("helperWithSessions").googleId;
         
         feedbackPage = getFeedbackPageForInstructor(helperId);
-        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackAllSessionTypesWithHelperView.html");
+        feedbackPage.verifyHtmlMainContentWithRetry("/instructorFeedbackAllSessionTypesWithHelperView.html");
         
         
         ______TS("typical case, sort by name");
         
         feedbackPage = getFeedbackPageForInstructor(idOfInstructorWithSessions);
         
-        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackAllSessionTypes.html");
+        feedbackPage.verifyHtmlMainContentWithRetry("/instructorFeedbackAllSessionTypes.html");
 
         feedbackPage.sortByName().verifyTablePattern(
                 0, 1,"Awaiting Session{*}First Session{*}Manual Session{*}Open Session{*}Private Session");
@@ -554,7 +554,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
                       BackDoor.getFeedbackSession(courseId, sessionName));
     
         feedbackPage.clickAndConfirm(feedbackPage.getDeleteLink(courseId, sessionName));
-        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackDeleteSuccessful.html");
+        feedbackPage.verifyHtmlMainContentWithRetry("/instructorFeedbackDeleteSuccessful.html");
         
     }
 
@@ -589,7 +589,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickAndConfirm(feedbackPage.getPublishLink(courseId, sessionName));
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_PUBLISHED);
         assertEquals(true, BackDoor.getFeedbackSession(courseId, sessionName).isPublished());
-        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackPublishSuccessful.html");
+        feedbackPage.verifyHtmlMainContentWithRetry("/instructorFeedbackPublishSuccessful.html");
         
         
         ______TS("PUBLISHED: publish link hidden");
@@ -627,7 +627,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickAndConfirm(feedbackPage.getUnpublishLink(courseId, sessionName));
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_UNPUBLISHED);
         assertEquals(false, BackDoor.getFeedbackSession(courseId, sessionName).isPublished());
-        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackUnpublishSuccessful.html");
+        feedbackPage.verifyHtmlMainContentWithRetry("/instructorFeedbackUnpublishSuccessful.html");
         
         
         ______TS("PUBLISHED: unpublish link hidden");

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -81,23 +81,23 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Open Session");
         resultsPage.waitForPanelsToExpand();
         // This is the full HTML verification for Instructor Feedback Results Page, the rest can all be verifyMainHtml
-        resultsPage.verifyHtml("/instructorFeedbackResultsPageOpen.html");
+        resultsPage.verifyHtmlWithRetry("/instructorFeedbackResultsPageOpen.html");
 
         ______TS("Typical case: standard session results: helper view");
 
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.helper1", "Open Session");
         resultsPage.waitForPanelsToExpand();
-        resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageOpenViewForHelperOne.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageOpenViewForHelperOne.html");
 
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.helper2", "Open Session");
         resultsPage.waitForPanelsToExpand();
-        resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageOpenViewForHelperTwo.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageOpenViewForHelperTwo.html");
 
         ______TS("Typical case: empty session");
 
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Empty Session");
         resultsPage.waitForPanelsToExpand();
-        resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageEmpty.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageEmpty.html");
         
     }
     
@@ -149,7 +149,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.SanitizedTeam.instr", "Session with sanitized data");
         resultsPage.waitForPanelsToExpand();
         
-        resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsPageWithSanitizedData.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsPageWithSanitizedData.html");
     }
 
     public void testModerateResponsesButton() {

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -350,7 +350,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "Open Session", true, "question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestion.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByQuestion.html");
         
         ______TS("Failure case: Ajax error");
         
@@ -376,14 +376,14 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
 
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html");
         
         ______TS("Typical case: ajax for view by question for helper2");
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.helper2",
                                         "Open Session", true, "question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html");
 
         ______TS("Typical case: ajax for view by giver > recipient > question");
 
@@ -392,7 +392,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
 
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByGRQ.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByGRQ.html");
 
         ______TS("Typical case: test view photo for view by giver > recipient > question");
 
@@ -415,7 +415,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true, "giver-question-recipient");
         
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByGQR.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByGQR.html");
                 
         ______TS("Typical case: test view photo for view by giver > question > recipient");
         
@@ -429,7 +429,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "recipient-question-giver");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByRQG.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByRQG.html");
 
         ______TS("Typical case: test view photo for view by recipient > question > giver");
 
@@ -443,7 +443,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "recipient-giver-question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByRGQ.html");
+        resultsPage.verifyHtmlMainContentWithRetry("/instructorFeedbackResultsAjaxByRGQ.html");
 
         ______TS("Typical case: test view photo for view by recipient > giver > question");
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
@@ -91,7 +91,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         loginAsInstructor("CHomeUiT.instructor.tmms.unloaded");
         
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLWithUnloadedCourse.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLWithUnloadedCourse.html");
         
         loginAsCommonInstructor();
         removeTestDataOnServer(unloadedCourseTestData);
@@ -123,18 +123,18 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         ______TS("test case: fail, fetch response rate of invalid url");
         homePage.setViewResponseLinkValue(viewResponseLink, "/invalid/url");
         viewResponseLink.click();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLResponseRateFail.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLResponseRateFail.html");
         
         ______TS("test case: fail to fetch response rate again, check consistency of fail message");
         viewResponseLink = homePage.getViewResponseLink("CHomeUiT.CS2104", "Fourth Feedback Session");
         viewResponseLink.click();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLResponseRateFail.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLResponseRateFail.html");
         
         ______TS("test case: pass with valid url after multiple fails");
         viewResponseLink = homePage.getViewResponseLink("CHomeUiT.CS2104", "Fourth Feedback Session");
         homePage.setViewResponseLinkValue(viewResponseLink, currentValidUrl);
         viewResponseLink.click();
-        homePage.verifyHtmlAjaxMainContent("/instructorHomeHTMLResponseRatePass.html");
+        homePage.verifyHtmlMainContentWithRetry("/instructorHomeHTMLResponseRatePass.html");
     }
     
     public void testContent() throws Exception{
@@ -153,17 +153,17 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         testData = loadDataBundle("/InstructorHomePageUiTest2.json");
         removeAndRestoreTestDataOnServer(testData);
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeNewInstructorWithSampleCourse.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeNewInstructorWithSampleCourse.html");
         
         ______TS("content: multiple courses");
         
         loadFinalHomePageTestData();
         homePage.clickHomeTab();
         // Should not see private session
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLWithHelperView.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLWithHelperView.html");
         updateInstructorToCoownerPrivileges();
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTML.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTML.html");
     }
 
     private void updateInstructorToCoownerPrivileges() {
@@ -328,7 +328,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         // the course's isArchived status should not be modified
         assertFalse(BackDoor.getCourse(courseIdForCS1101).isArchived);
         
-        homePage.verifyHtmlAjaxMainContent("/instructorHomeCourseArchiveSuccessful.html");
+        homePage.verifyHtmlMainContentWithRetry("/instructorHomeCourseArchiveSuccessful.html");
         
         ______TS("archive action failed");
         
@@ -423,7 +423,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         
         homePage.clickAndConfirm(homePage.getDeleteCourseLink(courseId));
         assertTrue(BackDoor.isCourseNonExistent(courseId));
-        homePage.verifyHtmlAjaxMainContent("/instructorHomeCourseDeleteSuccessful.html");
+        homePage.verifyHtmlMainContentWithRetry("/instructorHomeCourseDeleteSuccessful.html");
         
         //delete the other course as well
         courseId = testData.courses.get("CHomeUiT.CS1101").id;
@@ -441,27 +441,27 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
     public void testSortAction() throws Exception{
         ______TS("sort courses by id");
         homePage.clickSortByIdButton();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortById.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortById.html");
 
         ______TS("sort courses by name");
         homePage.clickSortByNameButton();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortByName.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortByName.html");
 
         ______TS("sort courses by date");
         homePage.clickSortByDateButton();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortByDate.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortByDate.html");
 
         ______TS("sort sessions by session name");
         homePage.sortTablesByName();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortSessionsByName.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortSessionsByName.html");
 
         ______TS("sort sessions by session start date");
         homePage.sortTablesByStartDate();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortSessionsByStartDate.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortSessionsByStartDate.html");
 
         ______TS("sort sessions by session end date");
         homePage.sortTablesByEndDate();
-        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortSessionsByEndDate.html");
+        homePage.verifyHtmlMainContentWithRetry("/InstructorHomeHTMLSortSessionsByEndDate.html");
     }
     
     private void loginAsCommonInstructor(){

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
@@ -109,7 +109,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
         // This is the full HTML verification for Instructor Student List Page, the rest can all be verifyMainHtml
-        viewPage.verifyHtmlAjax("/instructorStudentListWithHelperView.html");
+        viewPage.verifyHtmlWithRetry("/instructorStudentListWithHelperView.html");
 
         // update current instructor privileges
         BackDoor.deleteInstructor(instructorWith2Courses.courseId, instructorWith2Courses.email);
@@ -122,7 +122,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage = loginAdminToPage(browser, viewPageUrl, InstructorStudentListPage.class);
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentList.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentList.html");
 
         ______TS("content: 1 course with no students");
 
@@ -132,7 +132,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
 
         viewPage = loginAdminToPage(browser, viewPageUrl, InstructorStudentListPage.class);
         viewPage.checkCourse(0);
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageNoStudent.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentListPageNoStudent.html");
 
         ______TS("content: no course");
 
@@ -264,14 +264,14 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
         viewPage.checkCourse(2);
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageDisplayArchivedCourses.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentListPageDisplayArchivedCourses.html");
 
         ______TS("action: hide archive");
 
         viewPage.clickDisplayArchiveOptions();
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageHideArchivedCourses.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentListPageHideArchivedCourses.html");
 
         ______TS("action: re-display archive");
 
@@ -279,7 +279,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
         viewPage.checkCourse(2);
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageDisplayArchivedCourses.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentListPageDisplayArchivedCourses.html");
     }
 
     @AfterClass

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentRecordsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentRecordsPageUiTest.java
@@ -59,7 +59,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
 
         viewPage = getStudentRecordsPage();
         // This is the full HTML verification for Instructor Student Records Page, the rest can all be verifyMainHtml
-        viewPage.verifyHtmlAjax("/instructorStudentRecords.html");
+        viewPage.verifyHtmlWithRetry("/instructorStudentRecords.html");
 
         ______TS("content: typical case, normal student records with comments, helper view");
 
@@ -70,7 +70,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsWithHelperView.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentRecordsWithHelperView.html");
 
         ______TS("content: normal student records with private feedback session");
 
@@ -82,7 +82,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageWithPrivateFeedback.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentRecordsPageWithPrivateFeedback.html");
 
         ______TS("content: no student records, no profiles");
 
@@ -94,7 +94,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageNoRecords.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentRecordsPageNoRecords.html");
 
         ______TS("content: multiple feedback session type student record");
 
@@ -108,7 +108,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageMixedQuestionType.html");
+        viewPage.verifyHtmlMainContentWithRetry("/instructorStudentRecordsPageMixedQuestionType.html");
 
     }
 

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -738,7 +738,7 @@ public abstract class AppPage {
         return verifyHtml(null, filePath, false);
     }
 
-    private AppPage verifyHtml(By by, String filePath, boolean isAfterAjaxLoad) throws IOException {
+    private AppPage verifyHtml(By by, String filePath, boolean isWithRetry) throws IOException {
         // TODO: improve this method by insert header and footer
         //       to the file specified by filePath
         if (filePath.startsWith("/")) {
@@ -749,7 +749,7 @@ public abstract class AppPage {
         try {
             String expected = FileHelper.readFile(filePath);
             expected = HtmlHelper.injectTestProperties(expected);
-            if (isAfterAjaxLoad) {
+            if (isWithRetry) {
                 int maxRetryCount = 5;
                 int waitDuration = 1000;
                 for (int i = 0; i < maxRetryCount; i++) {
@@ -830,13 +830,13 @@ public abstract class AppPage {
      * loaded page has the same HTML content as 
      * the content given in the file at {@code filePath}. <br>
      * The HTML is checked for logical equivalence, not text equivalence. <br>
-     * Since the verification is done after making AJAX request(s), the HTML is checked
-     * after "waitDuration", for "maxRetryCount" number of times.
+     * The check is done multiple times with waiting times in between to account for
+     * certain elements to finish loading (e.g ajax load, panel collapsing/expanding).
      * @param filePath If this starts with "/" (e.g., "/expected.html"), the 
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAjaxMainContent(String filePath) throws IOException {
+    public AppPage verifyHtmlMainContentWithRetry(String filePath) throws IOException {
         return verifyHtml(MAIN_CONTENT, filePath, true);
     }
 
@@ -844,13 +844,13 @@ public abstract class AppPage {
      * Verifies that the currently loaded page has the same HTML content as 
      * the content given in the file at {@code filePath}. <br>
      * The HTML is checked for logical equivalence, not text equivalence. <br>
-     * Since the verification is done after making AJAX request(s), the HTML is checked
-     * after "waitDuration", for "maxRetryCount" number of times.
+     * The check is done multiple times with waiting times in between to account for
+     * certain elements to finish loading (e.g ajax load, panel collapsing/expanding).
      * @param filePath If this starts with "/" (e.g., "/expected.html"), the 
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAjax(String filePath) throws IOException {
+    public AppPage verifyHtmlWithRetry(String filePath) throws IOException {
         return verifyHtml(null, filePath, true);
     }
 


### PR DESCRIPTION
Fixes #4817

The existing `verifyHtmlAjax(MainContent)` is not hijacked; the method has always been `verifyHtml(MainContent)WithRetry` all along, but previously its usage was only for ajax load. Now it's extended to panel collapsing/expanding.