### PR TITLE
Eliminate use of WebDriverBackedSelenium in Browser.java #1800

### DIFF
--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -245,25 +245,13 @@ public abstract class AppPage {
      * Switches to the new browser window just opened.
      */
     protected void switchToNewWindow() {
-        String curWin = browser.driver.getWindowHandle();
-        for (String handle : browser.driver.getWindowHandles()) {
-            if (handle.equals(curWin))
-                continue;
-            browser.selenium.selectWindow(handle);
-            browser.selenium.windowFocus();
-        }
+        browser.switchToNewWindow();
     }
     
     public void closeCurrentWindowAndSwitchToParentWindow() {
-        browser.selenium.close();
-        switchToParentWindow();
+        browser.closeCurrentWindowAndSwitchToParentWindow();
     }
     
-    public void switchToParentWindow() {
-        browser.selenium.selectWindow("null");
-        browser.selenium.windowFocus();
-    }
-
     public void reloadPage() {
         browser.driver.get(browser.driver.getCurrentUrl());
         waitForPageToLoad();
@@ -518,7 +506,7 @@ public abstract class AppPage {
      * from the first table (which is of type {@code class=table}) in the page.
      */
     public String getCellValueFromDataTable(int row, int column) {
-        return browser.selenium.getTable("css=table[class~='table']." + row + "." + column);
+        return getCellValueFromDataTable(0, row, column);
     }
     
     /** 

--- a/src/test/java/teammates/test/pageobjects/Browser.java
+++ b/src/test/java/teammates/test/pageobjects/Browser.java
@@ -2,9 +2,12 @@ package teammates.test.pageobjects;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Stack;
 
 import org.openqa.selenium.WebDriver;
+
 import com.thoughtworks.selenium.webdriven.WebDriverBackedSelenium;
+
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -45,12 +48,40 @@ public class Browser {
     
     public boolean isAdminLoggedIn;
     
+    /**
+     * Keeps track of multiple windows opened by the {@link WebDriver}.
+     */
+    private final Stack<String> windowHandles = new Stack<String>();
+    
     public Browser() {
         this.driver = createWebDriver();
         this.driver.manage().window().maximize();
         this.selenium = new WebDriverBackedSelenium(this.driver, TestProperties.inst().TEAMMATES_URL);
         isInUse = false; 
         isAdminLoggedIn = false;
+    }
+    
+    /**
+     * Switches to new browser window for browsing.
+     */
+    public void switchToNewWindow() {
+        String curWin = driver.getWindowHandle();
+        for (String handle : driver.getWindowHandles()) {
+            if (!handle.equals(curWin) && !windowHandles.contains(curWin)) {
+                windowHandles.push(curWin);
+                driver.switchTo().window(handle);
+                break;
+            }
+        }
+    }
+    
+    /**
+     * Closes the current browser window and switches back to the last window
+     * used previously.
+     */
+    public void closeCurrentWindowAndSwitchToParentWindow() {
+        driver.close();
+        driver.switchTo().window(windowHandles.pop());
     }
     
     private WebDriver createWebDriver() {

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -33,10 +33,10 @@ public class FeedbackSubmitPage extends AppPage {
         return isCorrectCourseId && isCorrectFeedbackSessionName && containsExpectedPageContents();
     }
     
-    @SuppressWarnings("deprecation")
     public void selectRecipient(int qnNumber, int responseNumber, String recipientName) {
-        browser.selenium.select("name=" + Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT + 
-                "-" + qnNumber + "-" + responseNumber, "label=" + recipientName);
+        Select selectElement = new Select(browser.driver.findElement(
+                By.name(Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT + "-" + qnNumber + "-" + responseNumber)));
+        selectElement.selectByVisibleText(recipientName);
     }
     
     public void fillResponseTextBox(int qnNumber, int responseNumber, String text) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
@@ -543,14 +543,18 @@ public class InstructorFeedbacksPage extends AppPage {
         return browser.driver.findElements(By.className("sessionsRow")).size();
     }
     
-    @SuppressWarnings("deprecation")
     private String getFeedbackSessionCourseId(int rowId) {
-        return browser.selenium.getTable("css=table[id=table-sessions]." + (rowId + 1) + ".0");
+        return browser.driver.findElement(By.id("table-sessions"))
+                             .findElements(By.xpath("tbody/tr")).get(rowId)
+                             .findElements(By.xpath("td")).get(0)
+                             .getText();
     }
 
-    @SuppressWarnings("deprecation")
     private String getFeedbackSessionName(int rowId) {
-        return browser.selenium.getTable("css=table[id=table-sessions]." + (rowId + 1) + ".1");
+        return browser.driver.findElement(By.id("table-sessions"))
+                             .findElements(By.xpath("tbody/tr")).get(rowId)
+                             .findElements(By.xpath("td")).get(1)
+                             .getText();
     }
 
     private <T extends AppPage>T goToLinkInRow(By locator, Class<T> destinationPageType) {

--- a/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
@@ -318,9 +318,7 @@ public class InstructorHomePage extends AppPage {
         if (courseRowID == -1)
             return -2;
         String template = "//div[@id='course-%d']//tr[@id='session%d']";
-        @SuppressWarnings("deprecation")
-        int max = (Integer) (browser.selenium)
-                .getXpathCount("//div[starts-with(@id, 'course-')]//tr");
+        int max = browser.driver.findElements(By.xpath("//div[starts-with(@id, 'course-')]//tr")).size();
         for (int id = 0; id < max; id++) {
             if (getElementText(
                     By.xpath(String.format(template + "//td[1]", courseRowID,


### PR DESCRIPTION
Fixes #1800

`waitForPageToLoad` is not removed yet because while the `WebDriver` has an equivalent for that, it [functions differently](http://www.seleniumhq.org/docs/appendix_migrating_from_rc_to_webdriver.jsp#waitforpagetoload-returns-too-soon) (i.e considers "a page is loaded" differently) and using it causes a considerable amount of test failures due to timing issues, so resolving it warrants its own issue.

Hopefully the `TimeoutException` thrown by `selectWindow` is now suppressed.