### PR TITLE
Update client API to OAuth #4753

### DIFF
--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -258,7 +258,7 @@ Troubleshooting instructions are given [in this document](https://docs.google.co
   Comes with App Engine SDK.
 * **Xerces XML Parser** [version 2.9.1]: This library is required to parse the XML config files. This library may not be needed on some platforms as it may already come packaged on some JREs (particulary windows)
 * **SendGrid** Alternative framework to JavaMail for sending emails.
-* **Google Cloud SDK**: API to run script on GAE remotely.
+* **Google Cloud SDK**: This is a set of tools that helps us manage resources and applications hosted on Google Cloud Platform. We use it to run client scripts on GAE remotely.
 
 ####Tools used in testing
 

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -212,8 +212,11 @@ TBD
 
 ##Run client scripts
 Client scripts are scripts that help us remotely manipulate data on GAE via its Remote API. Most of developers may not need to write and/or run client scripts but if you are to do so, additional steps are required:
+
 1. Download and install Google Cloud SDK at https://cloud.google.com/sdk/downloads.
+
 2. Run `gcloud auth login` in the terminal of your PC and choose your google account for authentication.
+
 3. Now you can run your script without getting exceptions.
 
 

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -210,14 +210,14 @@ TBD
     Note that GAE daily quota will be exhausted after 2-3 runs of the full test suite.
 
 
-##Run client scripts
-Client scripts are scripts that help us remotely manipulate data on GAE via its Remote API. Most of developers may not need to write and/or run client scripts but if you are to do so, additional steps are required:
+##Running client scripts
+Client scripts are scripts that remotely manipulate data on GAE via its Remote API. Most of developers may not need to write and/or run client scripts but if you are to do so, additional steps are required:
 
 1. Download and install Google Cloud SDK at https://cloud.google.com/sdk/downloads.
 
 2. Run `gcloud auth login` in the terminal of your PC and choose your google account for authentication.
 
-3. Now you can run your script without getting exceptions.
+3. Now you can run your scripts.
 
 
 ##Troubleshooting

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -21,7 +21,7 @@ Important: When a version is specified, please install that version instead of t
    and point it to where you extracted the SDK zip file. <br>
    Further instructions for installing can be found at https://developers.google.com/eclipse/docs/using_sdks.
 8. Install the latest [TestNG Eclipse plugin](http://testng.org/doc/download.html).
-9. (Optional) Install Google Cloud SDK.
+9. (Optional) Install Google Cloud SDK at https://cloud.google.com/sdk/downloads.
 
 ##Setting up the dev server
 `Dev server` means running the server in your own computer.

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -21,7 +21,6 @@ Important: When a version is specified, please install that version instead of t
    and point it to where you extracted the SDK zip file. <br>
    Further instructions for installing can be found at https://developers.google.com/eclipse/docs/using_sdks.
 8. Install the latest [TestNG Eclipse plugin](http://testng.org/doc/download.html).
-9. (Optional) Install Google Cloud SDK at https://cloud.google.com/sdk/downloads.
 
 ##Setting up the dev server
 `Dev server` means running the server in your own computer.
@@ -210,7 +209,13 @@ TBD
     deployed app and not the dev server).
     Note that GAE daily quota will be exhausted after 2-3 runs of the full test suite.
 
-4. (Optional) After installing Google Cloud SDK and deploying to your staging server, run `gcloud auth login` in the terminal of your PC and choose your google account for authentication.
+
+##Run client scripts
+Client scripts are scripts that help us remotely manipulate data on GAE via its Remote API. Most of developers may not need to write and/or run client scripts but if you are to do so, additional steps are required:
+1. Download and install Google Cloud SDK at https://cloud.google.com/sdk/downloads.
+2. Run `gcloud auth login` in the terminal of your PC and choose your google account for authentication.
+3. Now you can run your script without getting exceptions.
+
 
 ##Troubleshooting
 Troubleshooting instructions are given [in this document](https://docs.google.com/document/d/1_p7WOGryOStPfTGA_ZifE1kVlskb1zfd3HZwc4lE4QQ/pub?embedded=true)

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -21,6 +21,7 @@ Important: When a version is specified, please install that version instead of t
    and point it to where you extracted the SDK zip file. <br>
    Further instructions for installing can be found at https://developers.google.com/eclipse/docs/using_sdks.
 8. Install the latest [TestNG Eclipse plugin](http://testng.org/doc/download.html).
+9. (Optional) Install Google Cloud SDK.
 
 ##Setting up the dev server
 `Dev server` means running the server in your own computer.
@@ -209,6 +210,8 @@ TBD
     deployed app and not the dev server).
     Note that GAE daily quota will be exhausted after 2-3 runs of the full test suite.
 
+4. (Optional) After installing Google Cloud SDK and deploying to your staging server, run `gcloud auth login` in the terminal of your PC and choose your google account for authentication.
+
 ##Troubleshooting
 Troubleshooting instructions are given [in this document](https://docs.google.com/document/d/1_p7WOGryOStPfTGA_ZifE1kVlskb1zfd3HZwc4lE4QQ/pub?embedded=true)
 
@@ -247,6 +250,7 @@ Troubleshooting instructions are given [in this document](https://docs.google.co
   Comes with App Engine SDK.
 * **Xerces XML Parser** [version 2.9.1]: This library is required to parse the XML config files. This library may not be needed on some platforms as it may already come packaged on some JREs (particulary windows)
 * **SendGrid** Alternative framework to JavaMail for sending emails.
+* **Google Cloud SDK**: API to run script on GAE remotely.
 
 ####Tools used in testing
 

--- a/src/main/java/teammates/client/remoteapi/RemoteApiClient.java
+++ b/src/main/java/teammates/client/remoteapi/RemoteApiClient.java
@@ -23,8 +23,13 @@ public abstract class RemoteApiClient {
 
         boolean isDevServer = appDomain.equals(LOCALHOST);
         if (isDevServer) {
+            // Dev Server doesn't require credential.
             options.useDevelopmentServerCredential();
         } else {
+            // If you are trying to run script on Staging Server:
+            // Step 1: Install Google Cloud SDK in your local PC first, https://cloud.google.com/sdk/downloads
+            // Step 2: Run `gcloud auth login` in the terminal and choose your google account
+            // Step 3: Run the script again.
             options.useApplicationDefaultCredential();
         }
         

--- a/src/main/java/teammates/client/remoteapi/RemoteApiClient.java
+++ b/src/main/java/teammates/client/remoteapi/RemoteApiClient.java
@@ -8,21 +8,26 @@ import com.google.appengine.tools.remoteapi.RemoteApiOptions;
 import teammates.test.driver.TestProperties;
 
 public abstract class RemoteApiClient {
-
+    private final String LOCALHOST = "localhost";
+    
     protected void doOperationRemotely() throws IOException {
         TestProperties testProperties = TestProperties.inst();
 
+        String appDomain = testProperties.TEAMMATES_REMOTEAPI_APP_DOMAIN;
+        int appPort = testProperties.TEAMMATES_REMOTEAPI_APP_PORT;
+        
         System.out.println("--- Starting remote operation ---");
-        System.out.println("Going to connect to:"
-                + testProperties.TEAMMATES_REMOTEAPI_APP_DOMAIN + ":"
-                + testProperties.TEAMMATES_REMOTEAPI_APP_PORT);
+        System.out.println("Going to connect to:" + appDomain + ":" + appPort);
 
-        RemoteApiOptions options = new RemoteApiOptions().server(
-                testProperties.TEAMMATES_REMOTEAPI_APP_DOMAIN,
-                testProperties.TEAMMATES_REMOTEAPI_APP_PORT).credentials(
-                testProperties.TEST_ADMIN_ACCOUNT,
-                testProperties.TEST_ADMIN_PASSWORD);
+        RemoteApiOptions options = new RemoteApiOptions().server(appDomain, appPort);
 
+        boolean isDevServer = appDomain.equals(LOCALHOST);
+        if (isDevServer) {
+            options.useDevelopmentServerCredential();
+        } else {
+            options.useApplicationDefaultCredential();
+        }
+        
         RemoteApiInstaller installer = new RemoteApiInstaller();
         installer.install(options);
         try {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,16 +64,6 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <url-pattern>/appstats/*</url-pattern>
     </servlet-mapping>
 
-    <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>appstats</web-resource-name>
-            <url-pattern>/appstats/*</url-pattern>
-        </web-resource-collection>
-        <auth-constraint>
-            <role-name>admin</role-name>
-        </auth-constraint>
-    </security-constraint>
-    
     <servlet>
         <display-name>Remote API Servlet</display-name>
         <servlet-name>RemoteApiServlet</servlet-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -64,6 +64,16 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <url-pattern>/appstats/*</url-pattern>
     </servlet-mapping>
 
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>appstats</web-resource-name>
+            <url-pattern>/appstats/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>admin</role-name>
+        </auth-constraint>
+    </security-constraint>
+
     <servlet>
         <display-name>Remote API Servlet</display-name>
         <servlet-name>RemoteApiServlet</servlet-name>


### PR DESCRIPTION
Fixes #4753
As in https://cloud.google.com/appengine/docs/java/tools/remoteapi#configuring_remote_api_on_an_app_engine_client , we have to replace `credentials(testProperties.TEST_ADMIN_ACCOUNT, testProperties.TEST_ADMIN_PASSWORD)`, which uses deprecated ClientLogin, by `useApplicationDefaultCredential()`, which uses OAuth protocol to get access to staging server.

In order to get access to staging server, we have to run `gcloud auth login` in local PC terminal (but make sure you have installed Google Cloud SDK first, https://cloud.google.com/sdk/downloads).

For dev server, we don't have to do this but I need someone to test it without installing Google Cloud SDK (we could try running my sanitization script `DataMigrationForSanitizedDataInStudentAttributes`).