### PR TITLE
Instructor feedback copy modal: form data can be sent multiple times #4801

### DIFF
--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -141,7 +141,8 @@ function setupFsCopyModal() {
                 $('#courseList').html(data);
                 // If the user alt-clicks, the form does not send any parameters and results in an error.
                 // Prevent default form submission and submit using jquery.
-                $('#fscopy_submit').one('click', 
+                $('#fscopy_submit').off('click')
+                                   .on('click', 
                                         function(event) {
                                             $('#fscopy_submit').prop('disabled', true);
                                             event.preventDefault();

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -141,7 +141,7 @@ function setupFsCopyModal() {
                 $('#courseList').html(data);
                 // If the user alt-clicks, the form does not send any parameters and results in an error.
                 // Prevent default form submission and submit using jquery.
-                $('#fscopy_submit').click(
+                $('#fscopy_submit').one('click', 
                                         function(event) {
                                             $('#fscopy_submit').prop('disabled', true);
                                             event.preventDefault();


### PR DESCRIPTION
Fixes #4801.

This doesn't cause a change in behaviour currently, so there are no modifications to testing. But it causes tests to fail in #4749