### PR TITLE
Multiple problems in MashupPageUiTest #4538

### DIFF
--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -269,34 +269,50 @@
                 <div id="index">
                     <iframe class="full-width" src="../index.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Features Page</div>
                 <div id="features">
                     <iframe class="full-width" src="../features.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">About Us Page</div>
                 <div id="about">
                     <iframe class="full-width" src="../about.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Contact Page</div>
                 <div id="contact">
                     <iframe class="full-width" src="../contact.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Terms Of Use Page</div>
                 <div id="terms">
                     <iframe class="full-width" src="../terms.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Request Account Page</div>
                 <div id="request">
                     <iframe class="full-width" src="../request.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Student Help Page</div>
                 <div id="studentHelp">
                     <iframe class="full-width" src="../studentHelp.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Instructor Help Page</div>
                 <div id="instructorHelp">
                     <iframe class="full-width" src="../instructorHelp.html"></iframe>
                 </div>
+                <br><hr class="hr-bold"><br>
+                
                 <div class="pageinfo">Deadline Exceeded Error Page</div>
                 <div id="deadlineExceededErrorPage"></div>
                 <br><hr class="hr-bold"><br>

--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -328,13 +328,13 @@
                 $('#instructorEnrollPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_ENROLL_PAGE%>?user=teammates.test&courseid=CS1101 #mainContent');
                 $('#instructorCourseDetailsPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_DETAILS_PAGE%>?user=teammates.test&courseid=CS1101 #mainContent');
                 $('#instructorStudentListPage').load('<%=Const.ActionURIs.INSTRUCTOR_STUDENT_LIST_PAGE%>?user=teammates.test #mainContent');
-                $('#instructorCourseStudentDetailsPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE%>?user=teammates.test&courseid=CS2104&studentemail=teammates.test%40gmail.com #mainContent');
-                $('#instructorCourseStudentEditPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT%>?user=teammates.test&courseid=CS2104&studentemail=benny.c.tmms%40gmail.com #mainContent');
-                $('#instructorStudentRecordsPage').load('<%=Const.ActionURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE%>?user=teammates.test&courseid=CS2104&studentemail=benny.c.tmms%40gmail.com #mainContent');
+                $('#instructorCourseStudentDetailsPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE%>?user=teammates.test&courseid=CS2104&studentemail=teammates.test%40gmail.tmt #mainContent');
+                $('#instructorCourseStudentEditPage').load('<%=Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT%>?user=teammates.test&courseid=CS2104&studentemail=benny.c.tmms%40gmail.tmt #mainContent');
+                $('#instructorStudentRecordsPage').load('<%=Const.ActionURIs.INSTRUCTOR_STUDENT_RECORDS_PAGE%>?user=teammates.test&courseid=CS2104&studentemail=benny.c.tmms%40gmail.tmt #mainContent');
                 $('#instructorFeedbackPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACKS_PAGE%>?user=teammates.test #mainContent');
                 $('#instructorFeedbackEditPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_EDIT_PAGE%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session #mainContent');
-                $('#instructorFeedbackPreviewAsStudentPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_PREVIEW_ASSTUDENT%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session&previewas=teammates.test@gmail.com #mainContent');
-                $('#instructorFeedbackPreviewAsInstructorPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_PREVIEW_ASINSTRUCTOR%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session&previewas=teammates.test@gmail.com #mainContent');
+                $('#instructorFeedbackPreviewAsStudentPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_PREVIEW_ASSTUDENT%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session&previewas=teammates.test@gmail.tmt #mainContent');
+                $('#instructorFeedbackPreviewAsInstructorPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_PREVIEW_ASINSTRUCTOR%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session&previewas=teammates.test@gmail.tmt #mainContent');
                 $('#instructorFeedbackSubmitPage').load('<%=Const.ActionURIs.INSTRUCTOR_FEEDBACK_SUBMISSION_EDIT_PAGE%>?user=teammates.test&courseid=CS2104&fsname=First+feedback+session #mainContent');
                 <%
                     String instrQuestionId = null;
@@ -355,7 +355,7 @@
                 $('#studentHomePage').load('<%=Const.ActionURIs.STUDENT_HOME_PAGE%>?user=teammates.test #mainContent');
                 $('#studentProfilePage').load('<%=Const.ActionURIs.STUDENT_PROFILE_PAGE%>?user=alice.b.tmms #mainContent');
                 <%
-                    StudentAttributes student = new Logic().getStudentForEmail("CS4215", "teammates.test@gmail.com");
+                    StudentAttributes student = new Logic().getStudentForEmail("CS4215", "teammates.test@gmail.tmt");
                     if (student != null) {
                         String url = StringHelper.encrypt(student.key);
                 %>

--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -397,9 +397,15 @@
                 $('#adminHomePage').load('<%=Const.ActionURIs.ADMIN_HOME_PAGE%> #mainContent');
                 $('#adminSearchPage').load('<%=Const.ActionURIs.ADMIN_SEARCH_PAGE%>?limit=20&query=teammates&search=Search #mainContent');
                 $('#adminActivityLogPage').load('<%=Const.ActionURIs.ADMIN_ACTIVITY_LOG_PAGE%> #mainContent');
-                $('#deadlineExceededErrorPage').load('<%=Const.ViewURIs.DEADLINE_EXCEEDED_ERROR_PAGE%> #mainContent');
-                $('#errorPage').load('<%=Const.ViewURIs.ERROR_PAGE%> #mainContent');
-                $('#entityNotFoundPage').load('<%=Const.ViewURIs.ENTITY_NOT_FOUND_PAGE%> #mainContent');
+                $.get('<%=Const.ViewURIs.DEADLINE_EXCEEDED_ERROR_PAGE%>').fail(function(data) {
+                    $('#deadlineExceededErrorPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
+                });
+                $.get('<%=Const.ViewURIs.ERROR_PAGE%>').fail(function(data) {
+                    $('#errorPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
+                });
+                $.get('<%=Const.ViewURIs.ENTITY_NOT_FOUND_PAGE%>').fail(function(data) {
+                    $('#entityNotFoundPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
+                });
                 $('#index').find('iframe').on('load', function() {
                     calcHeight($('#index').find('iframe'));
                 });

--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -406,7 +406,7 @@
                     calcHeight($('#studentHelp').find('iframe'));
                 });
                 $('#instructorHelp').find('iframe').on('load', function() {
-                    calcHeight($('#instructorHelpt').find('iframe'));
+                    calcHeight($('#instructorHelp').find('iframe'));
                 });
             });
             

--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -17,7 +17,7 @@
         <link type="text/css" href="/bootstrap/css/bootstrap-theme.min.css" rel="stylesheet">
         <link type="text/css" href="/stylesheets/teammatesCommon.css" rel="stylesheet">
         <link type="text/css" href="/stylesheets/mashup.css" rel="stylesheet">
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+        <script type="text/javascript" src="/js/lib/jquery.min.js"></script>
         <script type="text/javascript" src="/bootstrap/js/bootstrap.min.js"></script>
         <script type="text/javascript" src="/js/common.js"></script>
     </head>

--- a/src/main/webapp/mashup.jsp
+++ b/src/main/webapp/mashup.jsp
@@ -397,15 +397,9 @@
                 $('#adminHomePage').load('<%=Const.ActionURIs.ADMIN_HOME_PAGE%> #mainContent');
                 $('#adminSearchPage').load('<%=Const.ActionURIs.ADMIN_SEARCH_PAGE%>?limit=20&query=teammates&search=Search #mainContent');
                 $('#adminActivityLogPage').load('<%=Const.ActionURIs.ADMIN_ACTIVITY_LOG_PAGE%> #mainContent');
-                $.get('<%=Const.ViewURIs.DEADLINE_EXCEEDED_ERROR_PAGE%>').fail(function(data) {
-                    $('#deadlineExceededErrorPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
-                });
-                $.get('<%=Const.ViewURIs.ERROR_PAGE%>').fail(function(data) {
-                    $('#errorPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
-                });
-                $.get('<%=Const.ViewURIs.ENTITY_NOT_FOUND_PAGE%>').fail(function(data) {
-                    $('#entityNotFoundPage').html($('<div/>').html(data.responseText).find('#mainContent').html());
-                });
+                loadErrorPage('<%=Const.ViewURIs.DEADLINE_EXCEEDED_ERROR_PAGE%>', '#deadlineExceededErrorPage');
+                loadErrorPage('<%=Const.ViewURIs.ERROR_PAGE%>', '#errorPage');
+                loadErrorPage('<%=Const.ViewURIs.ENTITY_NOT_FOUND_PAGE%>', '#entityNotFoundPage');
                 $('#index').find('iframe').on('load', function() {
                     calcHeight($('#index').find('iframe'));
                 });
@@ -434,6 +428,12 @@
             
             function calcHeight(iframe) {
                 $(iframe).height($(iframe).contents().find('html').height());
+            }
+            
+            function loadErrorPage(uri, id) {
+                $.get(uri).fail(function(data) {
+                    $(id).html($('<div/>').html(data.responseText).find('#mainContent').html());
+                });
             }
         })();
     </script>


### PR DESCRIPTION
Fixes #4538 

#### Issues fixed so far:
1. Fix student's email address (.com to .tmt) so `instructorCourseStudentDetailsPage`, `instructorCourseStudentEditPage`, `instructorStudentRecordsPage`, `instructorFeedbackPreviewAsStudentPage`, `instructorFeedbackPreviewAsInstructorPage` and `studentCourseJoinConfirmationPage` could be correctly loaded.
2. Use local jqeury library instead of taking from CDN
3. Fix a typo so `instructorHelp` iframe's height could be shown properly.
4. Add red line boundaries between static page
5. Load error pages regardless of 500 status.