### PR TITLE
 ActivityLogEntry: Remove redundant code in getMessageInfo #4850

### DIFF
--- a/src/main/java/teammates/common/util/ActivityLogEntry.java
+++ b/src/main/java/teammates/common/util/ActivityLogEntry.java
@@ -387,9 +387,7 @@ public class ActivityLogEntry {
     }
     
     public String getMessageInfo(){
-        
-        Sanitizer.sanitizeForHtml(message);
-        
+                
         if (message.toLowerCase().contains(Const.ACTION_RESULT_FAILURE.toLowerCase())){
             message = message.replace(Const.ACTION_RESULT_FAILURE, "<span class=\"text-danger\"><strong>" + Const.ACTION_RESULT_FAILURE + "</strong><br>");
             message = message + "</span><br>";

--- a/src/main/java/teammates/storage/search/SearchQuery.java
+++ b/src/main/java/teammates/storage/search/SearchQuery.java
@@ -81,10 +81,10 @@ public abstract class SearchQuery {
 
         if(keywords.size() < 1) return "";
         
-        StringBuilder preparedQueryString = new StringBuilder("("+ keywords.get(0));
+        StringBuilder preparedQueryString = new StringBuilder("("+ "\""+keywords.get(0)+"\"");
         
         for(int i = 1; i < keywords.size(); i++){
-            preparedQueryString.append(OR).append(keywords.get(i));
+            preparedQueryString.append(OR).append("\""+keywords.get(i)+"\"");
         }
         return preparedQueryString.toString() + ")";
     }


### PR DESCRIPTION
Removed the line of code which is not being used to change the status of the 'message' variable. 