### PR TITLE
Fixing instructor student search: "(" causes server error #4596

### DIFF
--- a/src/main/java/teammates/storage/search/SearchQuery.java
+++ b/src/main/java/teammates/storage/search/SearchQuery.java
@@ -81,10 +81,10 @@ public abstract class SearchQuery {
 
         if(keywords.size() < 1) return "";
         
-        StringBuilder preparedQueryString = new StringBuilder("("+ keywords.get(0));
+        StringBuilder preparedQueryString = new StringBuilder("("+ "\"" + keywords.get(0) + "\"");
         
         for(int i = 1; i < keywords.size(); i++){
-            preparedQueryString.append(OR).append(keywords.get(i));
+            preparedQueryString.append(OR).append("\""+ keywords.get(i) + "\"");
         }
         return preparedQueryString.toString() + ")";
     }


### PR DESCRIPTION
This Issue will occur not only for brackets but also for other special characters. Since we cannot make sure that when these special characters be included in the search query, we need to enclose each key word with quotes. 
Reference - https://cloud.google.com/appengine/docs/java/search/query_strings 