### PR TITLE
InstructorCommentsPageUiTest fails in dev due to dates #4877

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorCommentsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorCommentsPageUiTest.java
@@ -201,20 +201,20 @@ public class InstructorCommentsPageUiTest extends BaseUiTestCase {
         commentsPage.verifyHtmlMainContent("/instructorCommentsPageAddFrc.html");
         
         ______TS("action: edit feedback response comment");
-        commentsPage.clickResponseCommentEdit(1, 1, 1, 1);
-        commentsPage.clickResponseCommentVisibilityEdit("1-1-1-1");
-        commentsPage.clickAllCheckboxes("1-1-1-1");
-        commentsPage.fillTextareaToEditResponseComment(1, 1, 1, 1, "");
-        commentsPage.saveResponseComment(1, 1, 1, 1);
-        commentsPage.verifyCommentFormErrorMessage("1-1-1-1", "Comment cannot be empty");
-        commentsPage.fillTextareaToEditResponseComment(1, 1, 1, 1, "edited response comment\na new line");
-        commentsPage.saveResponseComment(1, 1, 1, 1);
+        commentsPage.clickResponseCommentEdit(1, 1, 1, 2);
+        commentsPage.clickResponseCommentVisibilityEdit("1-1-1-2");
+        commentsPage.clickAllCheckboxes("1-1-1-2");
+        commentsPage.fillTextareaToEditResponseComment(1, 1, 1, 2, "");
+        commentsPage.saveResponseComment(1, 1, 1, 2);
+        commentsPage.verifyCommentFormErrorMessage("1-1-1-2", "Comment cannot be empty");
+        commentsPage.fillTextareaToEditResponseComment(1, 1, 1, 2, "edited response comment\na new line");
+        commentsPage.saveResponseComment(1, 1, 1, 2);
         commentsPage.reloadPage();
         commentsPage.loadResponseComments();
         commentsPage.verifyHtmlMainContent("/instructorCommentsPageEditFrc.html");
         
         ______TS("action: delete feedback response comment");
-        commentsPage.clickResponseCommentDelete(1, 1, 1, 1);
+        commentsPage.clickResponseCommentDelete(1, 1, 1, 2);
         commentsPage.reloadPage();
         commentsPage.loadResponseComments();
         commentsPage.verifyHtmlMainContent("/instructorCommentsPageDeleteFrc.html");

--- a/src/test/resources/pages/instructorCommentsPageAddFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddFrc.html
@@ -1774,14 +1774,10 @@
                   <tr>
                     <td>
                       <ul class="list-group comments" id="responseCommentTable-1-1-1">
-                        <li class="list-group-item list-group-item-warning giver_display-by-you status_display-public" id="responseCommentRow-1-1-1-1">
+                        <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-1">
                           <div id="commentBar-1-1-1-1">
                             <span class="text-muted">
-                              From: comments.instructor1@course1.tmt [${datetime.now}]
-                            </span>
-                            <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver, and instructors" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
-                            </span>
-                            <span class="glyphicon glyphicon-bell" data-original-title="This comment is pending to notify recipients" data-placement="top" data-toggle="tooltip" title="">
+                              From: comments.instructor1@course1.tmt [Tue, 01 Mar 2016, 11:59 PM UTC] (last edited by comments.instructor1@course1.tmt at Wed, 02 Mar 2016, 11:59 PM UTC)
                             </span>
                             <form class="responseCommentDeleteForm pull-right">
                               <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-1-1" style="display: none;" title="" type="button">
@@ -1800,7 +1796,7 @@
                             </a>
                           </div>
                           <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">
-                            added response comment
+                            Instructor 1 comment to student 1 self feedback
                           </div>
                           <form class="responseCommentEditForm" id="responseCommentEditForm-1-1-1-1" style="display: none;">
                             <div class="form-group form-inline">
@@ -1842,10 +1838,10 @@
                                       </div>
                                     </td>
                                     <td>
-                                      <input checked="checked" class="visibilityCheckbox answerCheckbox centered" name="receiverLeaderCheckbox" type="checkbox" value="GIVER">
+                                      <input class="visibilityCheckbox answerCheckbox centered" name="receiverLeaderCheckbox" type="checkbox" value="GIVER">
                                     </td>
                                     <td>
-                                      <input checked="checked" class="visibilityCheckbox giverCheckbox" type="checkbox" value="GIVER">
+                                      <input class="visibilityCheckbox giverCheckbox" type="checkbox" value="GIVER">
                                     </td>
                                   </tr>
                                   <tr id="response-instructors-1-1-1-1">
@@ -1855,10 +1851,10 @@
                                       </div>
                                     </td>
                                     <td>
-                                      <input checked="checked" class="visibilityCheckbox answerCheckbox" type="checkbox" value="INSTRUCTORS">
+                                      <input class="visibilityCheckbox answerCheckbox" type="checkbox" value="INSTRUCTORS">
                                     </td>
                                     <td>
-                                      <input checked="checked" class="visibilityCheckbox giverCheckbox" type="checkbox" value="INSTRUCTORS">
+                                      <input class="visibilityCheckbox giverCheckbox" type="checkbox" value="INSTRUCTORS">
                                     </td>
                                   </tr>
                                 </tbody>
@@ -1866,7 +1862,7 @@
                             </div>
                             <div class="form-group">
                               <textarea class="form-control" id="responsecommenttext-1-1-1-1" name="responsecommenttext" placeholder="Your comment about this response" rows="3">
-                                added response comment
+                                Instructor 1 comment to student 1 self feedback
                               </textarea>
                             </div>
                             <div class="col-sm-offset-5">
@@ -1880,14 +1876,18 @@
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
-                            <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
-                            <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="showresponsecommentsto" type="hidden" value="">
+                            <input name="showresponsegiverto" type="hidden" value="">
                           </form>
                         </li>
-                        <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-2">
+                        <li class="list-group-item list-group-item-warning giver_display-by-you status_display-public" id="responseCommentRow-1-1-1-2">
                           <div id="commentBar-1-1-1-2">
                             <span class="text-muted">
-                              From: comments.instructor1@course1.tmt [Tue, 01 Mar 2016, 11:59 PM UTC] (last edited by comments.instructor1@course1.tmt at Wed, 02 Mar 2016, 11:59 PM UTC)
+                              From: comments.instructor1@course1.tmt [${datetime.now}]
+                            </span>
+                            <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver, and instructors" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
+                            </span>
+                            <span class="glyphicon glyphicon-bell" data-original-title="This comment is pending to notify recipients" data-placement="top" data-toggle="tooltip" title="">
                             </span>
                             <form class="responseCommentDeleteForm pull-right">
                               <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-1-2" style="display: none;" title="" type="button">
@@ -1906,7 +1906,7 @@
                             </a>
                           </div>
                           <div id="plainCommentText-1-1-1-2" style="margin-left: 15px;">
-                            Instructor 1 comment to student 1 self feedback
+                            added response comment
                           </div>
                           <form class="responseCommentEditForm" id="responseCommentEditForm-1-1-1-2" style="display: none;">
                             <div class="form-group form-inline">
@@ -1948,10 +1948,10 @@
                                       </div>
                                     </td>
                                     <td>
-                                      <input class="visibilityCheckbox answerCheckbox centered" name="receiverLeaderCheckbox" type="checkbox" value="GIVER">
+                                      <input checked="checked" class="visibilityCheckbox answerCheckbox centered" name="receiverLeaderCheckbox" type="checkbox" value="GIVER">
                                     </td>
                                     <td>
-                                      <input class="visibilityCheckbox giverCheckbox" type="checkbox" value="GIVER">
+                                      <input checked="checked" class="visibilityCheckbox giverCheckbox" type="checkbox" value="GIVER">
                                     </td>
                                   </tr>
                                   <tr id="response-instructors-1-1-1-2">
@@ -1961,10 +1961,10 @@
                                       </div>
                                     </td>
                                     <td>
-                                      <input class="visibilityCheckbox answerCheckbox" type="checkbox" value="INSTRUCTORS">
+                                      <input checked="checked" class="visibilityCheckbox answerCheckbox" type="checkbox" value="INSTRUCTORS">
                                     </td>
                                     <td>
-                                      <input class="visibilityCheckbox giverCheckbox" type="checkbox" value="INSTRUCTORS">
+                                      <input checked="checked" class="visibilityCheckbox giverCheckbox" type="checkbox" value="INSTRUCTORS">
                                     </td>
                                   </tr>
                                 </tbody>
@@ -1972,7 +1972,7 @@
                             </div>
                             <div class="form-group">
                               <textarea class="form-control" id="responsecommenttext-1-1-1-2" name="responsecommenttext" placeholder="Your comment about this response" rows="3">
-                                Instructor 1 comment to student 1 self feedback
+                                added response comment
                               </textarea>
                             </div>
                             <div class="col-sm-offset-5">
@@ -1986,8 +1986,8 @@
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
-                            <input name="showresponsecommentsto" type="hidden" value="">
-                            <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">

--- a/src/test/resources/pages/instructorCommentsPageEditFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageEditFrc.html
@@ -1777,7 +1777,7 @@
                         <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-1">
                           <div id="commentBar-1-1-1-1">
                             <span class="text-muted">
-                              From: comments.instructor1@course1.tmt [${datetime.now}] (last edited by comments.instructor1@course1.tmt at ${datetime.now})
+                              From: comments.instructor1@course1.tmt [Tue, 01 Mar 2016, 11:59 PM UTC] (last edited by comments.instructor1@course1.tmt at Wed, 02 Mar 2016, 11:59 PM UTC)
                             </span>
                             <form class="responseCommentDeleteForm pull-right">
                               <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-1-1" style="display: none;" title="" type="button">
@@ -1796,9 +1796,7 @@
                             </a>
                           </div>
                           <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">
-                            edited response comment
-                            <br>
-                            a new line
+                            Instructor 1 comment to student 1 self feedback
                           </div>
                           <form class="responseCommentEditForm" id="responseCommentEditForm-1-1-1-1" style="display: none;">
                             <div class="form-group form-inline">
@@ -1864,7 +1862,7 @@
                             </div>
                             <div class="form-group">
                               <textarea class="form-control" id="responsecommenttext-1-1-1-1" name="responsecommenttext" placeholder="Your comment about this response" rows="3">
-                                edited response comment <br>a new line
+                                Instructor 1 comment to student 1 self feedback
                               </textarea>
                             </div>
                             <div class="col-sm-offset-5">
@@ -1885,7 +1883,7 @@
                         <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-2">
                           <div id="commentBar-1-1-1-2">
                             <span class="text-muted">
-                              From: comments.instructor1@course1.tmt [Tue, 01 Mar 2016, 11:59 PM UTC] (last edited by comments.instructor1@course1.tmt at Wed, 02 Mar 2016, 11:59 PM UTC)
+                              From: comments.instructor1@course1.tmt [${datetime.now}] (last edited by comments.instructor1@course1.tmt at ${datetime.now})
                             </span>
                             <form class="responseCommentDeleteForm pull-right">
                               <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-1-2" style="display: none;" title="" type="button">
@@ -1904,7 +1902,9 @@
                             </a>
                           </div>
                           <div id="plainCommentText-1-1-1-2" style="margin-left: 15px;">
-                            Instructor 1 comment to student 1 self feedback
+                            edited response comment
+                            <br>
+                            a new line
                           </div>
                           <form class="responseCommentEditForm" id="responseCommentEditForm-1-1-1-2" style="display: none;">
                             <div class="form-group form-inline">
@@ -1970,7 +1970,7 @@
                             </div>
                             <div class="form-group">
                               <textarea class="form-control" id="responsecommenttext-1-1-1-2" name="responsecommenttext" placeholder="Your comment about this response" rows="3">
-                                Instructor 1 comment to student 1 self feedback
+                                edited response comment <br>a new line
                               </textarea>
                             </div>
                             <div class="col-sm-offset-5">


### PR DESCRIPTION
Fixes #4877 
Essentially this is just switching the order of the comments displayed, but it's needed to fix the test. The problem is removed for good because we won't ever go back to "before 1 Mar '16".