### PR TITLE
USER_IS_TEAM is wrongly used in FeedbackSessionResultsBundle #4018

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -902,7 +902,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
 
     public String getNameForEmail(String email) {
         String name = emailNameTable.get(email);
-        if (name == null) {
+        if (name == null || name.equals(Const.USER_IS_MISSING)) {
             return Const.USER_UNKNOWN_TEXT;
         } else if (name.equals(Const.USER_IS_NOBODY)) {
             return Const.USER_NOBODY_TEXT;
@@ -915,7 +915,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
 
     public String getLastNameForEmail(String email) {
         String name = emailLastNameTable.get(email);
-        if (name == null) {
+        if (name == null || name.equals(Const.USER_IS_MISSING)) {
             return Const.USER_UNKNOWN_TEXT;
         } else if (name.equals(Const.USER_IS_NOBODY)) {
             return Const.USER_NOBODY_TEXT;
@@ -1010,8 +1010,8 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
     
     public String getRecipientNameForResponse(FeedbackResponseAttributes response) {
         String name = emailNameTable.get(response.recipientEmail);
-        if (name == null || name.equals(Const.USER_IS_TEAM)) {
-            return Const.USER_UNKNOWN_TEXT; // TODO: this doesn't look right
+        if (name == null || name.equals(Const.USER_IS_MISSING)) {
+            return Const.USER_UNKNOWN_TEXT;
         } else if (name.equals(Const.USER_IS_NOBODY)) {
             return Const.USER_NOBODY_TEXT;
         } else {
@@ -1021,7 +1021,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
 
     public String getGiverNameForResponse(FeedbackResponseAttributes response) {
         String name = emailNameTable.get(response.giverEmail);
-        if (name == null || name.equals(Const.USER_IS_TEAM)) {
+        if (name == null || name.equals(Const.USER_IS_MISSING)) {
             return Const.USER_UNKNOWN_TEXT;
         } else if (name.equals(Const.USER_IS_NOBODY)) {
             return Const.USER_NOBODY_TEXT;

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1188,6 +1188,7 @@ public class Const {
     public static final String GENERAL_QUESTION = "%GENERAL%";
     public static final String USER_IS_TEAM = "%TEAM%";
     public static final String USER_IS_NOBODY = "%NOBODY%";
+    public static final String USER_IS_MISSING = "%MISSING%";
     
     public static final Date TIME_REPRESENTS_FOLLOW_OPENING;
     public static final Date TIME_REPRESENTS_FOLLOW_VISIBLE;

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -2385,9 +2385,10 @@ public class FeedbackSessionsLogic {
                     lastName = Const.USER_IS_NOBODY;
                     team = email;
                 } else {
-                    // Assume that the email is actually a team name.
-                    name = Const.USER_IS_TEAM;
-                    lastName = Const.USER_IS_TEAM;
+                    // The email represents a missing *Attribute.
+                    // It might be a team name or the *Attribute has been deleted.
+                    name = Const.USER_IS_MISSING;
+                    lastName = Const.USER_IS_MISSING;
                     team = email;
                 }
             } else {
@@ -2402,7 +2403,7 @@ public class FeedbackSessionsLogic {
             giverRecipientName = team;
             giverRecipientLastName = team;
             teamName = "";
-        } else if (name != Const.USER_IS_NOBODY && name != Const.USER_IS_TEAM) {
+        } else if (!name.equals(Const.USER_IS_NOBODY) && !name.equals(Const.USER_IS_MISSING)) {
             giverRecipientName = name;
             giverRecipientLastName = lastName;
             teamName = team;


### PR DESCRIPTION
Fixes #4018 
Not entirely sure that this is the best way, but this works and is more representative of what's happening, rather than `USER_IS_TEAM`.