### PR TITLE
admin accounts management page is not scalable #4837

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
@@ -18,24 +18,24 @@ public class AdminAccountManagementPageAction extends Action {
         new GateKeeper().verifyAdminPrivileges(account);
         
         String instructorGoogleId = this.getRequestParamValue("googleId");
+        if (instructorGoogleId == null) {
+            instructorGoogleId = "";
+        }
         
         Map<String, ArrayList<InstructorAttributes>> instructorCoursesTable = new HashMap<String, ArrayList<InstructorAttributes>>();
         Map<String, AccountAttributes> instructorAccountsTable = new HashMap<String, AccountAttributes>();
         
-        if (instructorGoogleId == null) {
-            instructorGoogleId = "";
-        }
         List<InstructorAttributes> instructorsList = logic.getInstructorsForGoogleId(instructorGoogleId);
         AccountAttributes instructorAccount = logic.getAccount(instructorGoogleId);
         
         boolean isToShowAll = this.getRequestParamAsBoolean("all");
-        boolean isAccountExisting = instructorAccount != null && !instructorsList.isEmpty();
+        boolean isAccountExisting = instructorAccount != null;
         if (isAccountExisting) {
             instructorAccountsTable.put(instructorAccount.googleId, instructorAccount);
             
-            for(InstructorAttributes instructor : instructorsList){
+            for (InstructorAttributes instructor : instructorsList) {
                 ArrayList<InstructorAttributes> courseList = instructorCoursesTable.get(instructor.googleId);
-                if (courseList == null){
+                if (courseList == null) {
                     courseList = new ArrayList<InstructorAttributes>();
                     instructorCoursesTable.put(instructor.googleId, courseList);
                 }

--- a/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
@@ -22,14 +22,15 @@ public class AdminAccountManagementPageAction extends Action {
         Map<String, ArrayList<InstructorAttributes>> instructorCoursesTable = new HashMap<String, ArrayList<InstructorAttributes>>();
         Map<String, AccountAttributes> instructorAccountsTable = new HashMap<String, AccountAttributes>();
         
-        if (instructorGoogleId == null) instructorGoogleId = "";
+        if (instructorGoogleId == null) {
+            instructorGoogleId = "";
+        }
         List<InstructorAttributes> instructorsList = logic.getInstructorsForGoogleId(instructorGoogleId);
         AccountAttributes instructorAccount = logic.getAccount(instructorGoogleId);
         
         boolean isToShowAll = this.getRequestParamAsBoolean("all");
         boolean isAccountExisting = instructorAccount != null && !instructorsList.isEmpty();
         if (isAccountExisting) {
-            
             instructorAccountsTable.put(instructorAccount.googleId, instructorAccount);
             
             for(InstructorAttributes instructor : instructorsList){

--- a/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
@@ -15,39 +15,39 @@ public class AdminAccountManagementPageAction extends Action {
 
     @Override
     protected ActionResult execute() throws EntityDoesNotExistException {
-        
         new GateKeeper().verifyAdminPrivileges(account);
         
-        @SuppressWarnings("deprecation") //This method is deprecated to prevent unintended usage. This is an intended usage.
-        List<InstructorAttributes> allInstructorsList = logic.getAllInstructors();
-        @SuppressWarnings("deprecation") //This method is deprecated to prevent unintended usage. This is an intended usage.
-        List<AccountAttributes> allInstructorAccountsList = logic.getInstructorAccounts();
-        
-        boolean isToShowAll = this.getRequestParamAsBoolean("all");
+        String instructorGoogleId = this.getRequestParamValue("googleId");
         
         Map<String, ArrayList<InstructorAttributes>> instructorCoursesTable = new HashMap<String, ArrayList<InstructorAttributes>>();
         Map<String, AccountAttributes> instructorAccountsTable = new HashMap<String, AccountAttributes>();
         
-        for(AccountAttributes acc : allInstructorAccountsList){
-            instructorAccountsTable.put(acc.googleId, acc);
-        }
+        if (instructorGoogleId == null) instructorGoogleId = "";
+        List<InstructorAttributes> instructorsList = logic.getInstructorsForGoogleId(instructorGoogleId);
+        AccountAttributes instructorAccount = logic.getAccount(instructorGoogleId);
         
-        for(InstructorAttributes instructor : allInstructorsList){
-            ArrayList<InstructorAttributes> courseList = instructorCoursesTable.get(instructor.googleId);
-            if (courseList == null){
-                courseList = new ArrayList<InstructorAttributes>();
-                instructorCoursesTable.put(instructor.googleId, courseList);
-            }
+        boolean isToShowAll = this.getRequestParamAsBoolean("all");
+        boolean isAccountExisting = instructorAccount != null && !instructorsList.isEmpty();
+        if (isAccountExisting) {
             
-            courseList.add(instructor);
+            instructorAccountsTable.put(instructorAccount.googleId, instructorAccount);
+            
+            for(InstructorAttributes instructor : instructorsList){
+                ArrayList<InstructorAttributes> courseList = instructorCoursesTable.get(instructor.googleId);
+                if (courseList == null){
+                    courseList = new ArrayList<InstructorAttributes>();
+                    instructorCoursesTable.put(instructor.googleId, courseList);
+                }
+                
+                courseList.add(instructor);
+            }
         }
             
         AdminAccountManagementPageData data = new AdminAccountManagementPageData(account, instructorAccountsTable,
                                                                                  instructorCoursesTable, isToShowAll);
         
-        statusToAdmin = "Admin Account Management Page Load<br>" + 
-                "<span class=\"bold\">Total Instructors:</span> " + 
-                instructorAccountsTable.size();
+        statusToAdmin = "Admin Account Management Page Load<br>" 
+                        + "<span class=\"bold\">Total Instructors:</span> " + instructorAccountsTable.size();
         
         return createShowPageResult(Const.ViewURIs.ADMIN_ACCOUNT_MANAGEMENT, data);
     }

--- a/src/main/webapp/WEB-INF/tags/admin/navBar.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/navBar.tag
@@ -22,9 +22,10 @@
                     <a href="<%=Const.ActionURIs.ADMIN_HOME_PAGE%>">Create Instructor</a>
                 </li>
                 
+                <!-- The link to Account Management Page will be hidden until it's scalable.
                 <li <c:if test="${fn:contains(data.class,'AdminAccountManagementPage')}">class="active"</c:if>>
                     <a href="<%=Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE%>">Account Management</a>
-                </li>
+                </li>-->
                 
                 <li <c:if test="${fn:contains(data.class,'AdminSearchPage')}">class="active"</c:if>>
                     <a href="<%=Const.ActionURIs.ADMIN_SEARCH_PAGE%>">Search</a>

--- a/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
@@ -35,13 +35,21 @@
         <c:if test="${not empty instructor.viewRecentActionsId}">
             <form method="post" target="blank" action="<%=Const.ActionURIs.ADMIN_ACTIVITY_LOG_PAGE%>">
                 <button type="submit" id="${instructor.viewRecentActionsId}_recentActions"
-                        class="btn btn-link btn-xs recentActionButton">
+                        class="btn btn-link btn-xs optionButton">
                         
                     <span class="glyphicon glyphicon-zoom-in"></span>View Recent Actions
                 </button>
                 <input type="hidden" name="filterQuery" value="${instructor.viewRecentActionsId}">
                 <input type="hidden" name="courseId" value="${instructor.courseId}">
             </form>
+            <c:if test="${not empty instructor.googleId}">
+                <form method="post" target="blank" action="<%=Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE%>">
+                    <button type="submit" id="" class="btn btn-link btn-xs optionButton">
+                        <span class="glyphicon glyphicon-zoom-in"></span>Go to Account Management Page
+                    </button>
+                    <input type="hidden" name="googleId" value="${instructor.googleId}">
+                </form>
+            </c:if>
         </c:if>
     </td>
 </tr>    

--- a/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
@@ -43,7 +43,7 @@
                 <input type="hidden" name="courseId" value="${instructor.courseId}">
             </form>
             <c:if test="${not empty instructor.googleId}">
-                <form method="post" target="blank" action="<%=Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE%>">
+                <form method="get" target="blank" action="<%=Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE%>">
                     <button type="submit" id="" class="btn btn-link btn-xs optionButton">
                         <span class="glyphicon glyphicon-zoom-in"></span>Go to Account Management Page
                     </button>

--- a/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
@@ -45,7 +45,7 @@
             <c:if test="${not empty instructor.googleId}">
                 <form method="get" target="blank" action="<%=Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE%>">
                     <button type="submit" id="" class="btn btn-link btn-xs optionButton">
-                        <span class="glyphicon glyphicon-zoom-in"></span>Go to Account Management Page
+                        <span class="glyphicon glyphicon-edit"></span>Manage this account
                     </button>
                     <input type="hidden" name="googleId" value="${instructor.googleId}">
                 </form>

--- a/src/main/webapp/js/adminSearch.js
+++ b/src/main/webapp/js/adminSearch.js
@@ -45,7 +45,7 @@ $(document).ready(function() {
 		e.stopPropagation();
 	});
 	
-	$(".recentActionButton").click(function(e){
+	$(".optionButton").click(function(e){
 		e.stopPropagation();
 	});
 	

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountManagementPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountManagementPageUiTest.java
@@ -34,29 +34,28 @@ public class AdminAccountManagementPageUiTest extends BaseUiTestCase{
     
     @BeforeClass
     public static void classSetup() throws Exception {
-        // Temporarily disable unit test for Account Management Page.
-        
-        /*printTestClassHeader();
+        printTestClassHeader();
         testData = loadDataBundle("/AdminAccountManagementPageUiTest.json");
         removeAndRestoreTestDataOnServer(testData);
-        browser = BrowserPool.getBrowser();*/
+        browser = BrowserPool.getBrowser();
     }
     
     @Test
     public void testAll(){
-        /*testContent();
+        testContent();
         //no input validation to check
         testViewAccountDetailsLink();
         testViewRecentActionsLink();
         testDeleteInstructorStatusAction();
-        testDeleteInstructorAccountAction();*/
+        testDeleteInstructorAccountAction();
     }
     
     public void testContent() {
         
         ______TS("content: typical page");
         
-        loginToAdminAccountsManagementPage();
+        String instructor1GoogleId = "AAMgtUiT.instr1";
+        loginToAdminAccountsManagementPage(instructor1GoogleId);
         accountsPage.verifyIsCorrectPage();
         assertTrue(accountsPage.isTableVisible());
         
@@ -98,19 +97,19 @@ public class AdminAccountManagementPageUiTest extends BaseUiTestCase{
         
         ______TS("action: delete account");
         
-        browser.driver.get(accountsPageUrl.toAbsoluteString());;
+        String instructor3GoogleId = "AAMgtUiT.instr3";
+        loginToAdminAccountsManagementPage(instructor3GoogleId);
         
-        String googleId = "AAMgtUiT.instr3";
-        accountsPage.clickAndCancelDeleteAccountLink(googleId);
-        assertNotNull(BackDoor.getAccount(googleId));
+        accountsPage.clickAndCancelDeleteAccountLink(instructor3GoogleId);
+        assertNotNull(BackDoor.getAccount(instructor3GoogleId));
         
-        accountsPage.clickAndConfirmDeleteAccountLink(googleId);
-        assertNull(BackDoor.getAccount(googleId));
+        accountsPage.clickAndConfirmDeleteAccountLink(instructor3GoogleId);
+        assertNull(BackDoor.getAccount(instructor3GoogleId));
         
     }
-
-    private void loginToAdminAccountsManagementPage() {
-        accountsPageUrl = createUrl(Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE + "?all=true");
+    
+    private void loginToAdminAccountsManagementPage(String instructorIdToShow) {
+        accountsPageUrl = createUrl(Const.ActionURIs.ADMIN_ACCOUNT_MANAGEMENT_PAGE + "?all=true&googleId=" + instructorIdToShow);
         accountsPage = loginAdminToPageForAdminUiTests(browser, accountsPageUrl, AdminAccountManagementPage.class);
         // Extra 60 seconds of wait as it can take a longer time to load in non-dev environments
         accountsPage.waitForAdminAccountsManagementPageToFinishLoading();
@@ -119,7 +118,7 @@ public class AdminAccountManagementPageUiTest extends BaseUiTestCase{
 
     @AfterClass
     public static void classTearDown() throws Exception {
-        //BrowserPool.release(browser);
+        BrowserPool.release(browser);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountManagementPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountManagementPageUiTest.java
@@ -34,20 +34,22 @@ public class AdminAccountManagementPageUiTest extends BaseUiTestCase{
     
     @BeforeClass
     public static void classSetup() throws Exception {
-        printTestClassHeader();
+        // Temporarily disable unit test for Account Management Page.
+        
+        /*printTestClassHeader();
         testData = loadDataBundle("/AdminAccountManagementPageUiTest.json");
         removeAndRestoreTestDataOnServer(testData);
-        browser = BrowserPool.getBrowser();
+        browser = BrowserPool.getBrowser();*/
     }
     
     @Test
     public void testAll(){
-        testContent();
+        /*testContent();
         //no input validation to check
         testViewAccountDetailsLink();
         testViewRecentActionsLink();
         testDeleteInstructorStatusAction();
-        testDeleteInstructorAccountAction();
+        testDeleteInstructorAccountAction();*/
     }
     
     public void testContent() {
@@ -117,7 +119,7 @@ public class AdminAccountManagementPageUiTest extends BaseUiTestCase{
 
     @AfterClass
     public static void classTearDown() throws Exception {
-        BrowserPool.release(browser);
+        //BrowserPool.release(browser);
     }
     
 }

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -52,11 +52,6 @@
           </a>
         </li>
         <li>
-          <a href="/admin/adminAccountManagementPage">
-            Account Management
-          </a>
-        </li>
-        <li>
           <a href="/admin/adminSearchPage">
             Search
           </a>

--- a/src/test/resources/pages/adminHomePage.html
+++ b/src/test/resources/pages/adminHomePage.html
@@ -53,11 +53,6 @@
           </a>
         </li>
         <li>
-          <a href="/admin/adminAccountManagementPage">
-            Account Management
-          </a>
-        </li>
-        <li>
           <a href="/admin/adminSearchPage">
             Search
           </a>


### PR DESCRIPTION
Fixes #4837

As discussed on Wednesday, I temporarily removed Account Management Page from navbar and added an URL to redirect from Search Page to Account Management Page for each registered instructor.

![screenshot 2016-03-06 04 45 24](https://cloud.githubusercontent.com/assets/8078323/13550341/794566dc-e356-11e5-8a3c-6654817850de.png)

I also disabled unit test for Account Management Page since we have to renovate it sooner or later anyway. 