### PR TITLE
Slash is html encoded in csv file #4622

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
@@ -380,7 +380,7 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
                 
                 fragments += FeedbackQuestionFormTemplates.populateTemplate(FeedbackQuestionFormTemplates.CONSTSUM_RESULT_STATS_RECIPIENTFRAGMENT,
                         "${constSumOptionValue}",  Sanitizer.sanitizeForHtml(name),
-                        "${team}", teamName,
+                        "${team}", Sanitizer.sanitizeForHtml(teamName),
                         "${pointsReceived}", pointsReceived,
                         "${averagePoints}", df.format(average));
             

--- a/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleQuestionDetails.java
@@ -217,8 +217,8 @@ public class FeedbackNumericalScaleQuestionDetails extends
 
             fragmentHtml.append(FeedbackQuestionFormTemplates.populateTemplate(
                                     fragmentTemplateToUse,
-                                    "${recipientTeam}", recipientTeam,
-                                    "${recipientName}", recipientName,
+                                    "${recipientTeam}", Sanitizer.sanitizeForHtml(recipientTeam),
+                                    "${recipientName}", Sanitizer.sanitizeForHtml(recipientName),
                                     "${Average}", df.format(average.get(recipient)),
                                     "${Max}", df.format(max.get(recipient)),
                                     "${Min}", df.format(min.get(recipient)),
@@ -383,13 +383,13 @@ public class FeedbackNumericalScaleQuestionDetails extends
         
         // Replace current user name with "You"
         if (!isHiddenRecipient && isRecipientCurrentUser && hasAtLeastTwoResponses){
-            return isRecipientTypeStudent? "You" : "Your Team (" + currentUserTeam + ")";
+            return isRecipientTypeStudent? "You" : "Your Team (" + Sanitizer.sanitizeForHtml(currentUserTeam) + ")";
         }
         
         // Replace general identifier with "General"
         if (!isHiddenRecipient && !isRecipientCurrentUser && 
             hasAtLeastTwoResponsesOtherThanCurrentUser){
-            return isRecipientGeneral ? "General" : recipientName;
+            return isRecipientGeneral ? "General" : Sanitizer.sanitizeForHtml(recipientName);
         }
         return null;
     }
@@ -401,13 +401,13 @@ public class FeedbackNumericalScaleQuestionDetails extends
         
         // Replace current user team with "" when recipient type is not student
         if (!isHiddenRecipient && isRecipientCurrentUser && hasAtLeastTwoResponses){
-            return isRecipientTypeStudent? currentUserTeam : "";
+            return isRecipientTypeStudent? Sanitizer.sanitizeForHtml(currentUserTeam) : "";
         }
         
         // Display other recipients' team name
         if (!isHiddenRecipient && !isRecipientCurrentUser && 
             hasAtLeastTwoResponsesOtherThanCurrentUser){
-            return recipientTeamName;
+            return Sanitizer.sanitizeForHtml(recipientTeamName);
         }
         return null;
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
@@ -87,12 +87,12 @@ public abstract class FeedbackQuestionDetails {
         String recipientEmail = fsrBundle.getDisplayableEmailRecipient(feedbackResponseAttributes);
 
         String detailedResponsesRow = Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverTeamName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(giverFullName)))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(giverLastName)))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverFullName))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverLastName))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverEmail))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientTeamName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(recipientFullName)))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(recipientLastName)))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientFullName))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientLastName))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientEmail))
                                       + "," + fsrBundle.getResponseAnswerCsv(feedbackResponseAttributes, question)
                                       + Const.EOL;

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
@@ -87,12 +87,12 @@ public abstract class FeedbackQuestionDetails {
         String recipientEmail = fsrBundle.getDisplayableEmailRecipient(feedbackResponseAttributes);
 
         String detailedResponsesRow = Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverTeamName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverFullName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverLastName))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(giverFullName)))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(giverLastName)))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(giverEmail))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientTeamName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientFullName))
-                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientLastName))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(recipientFullName)))
+                                      + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(StringHelper.recoverFromSanitizedText(recipientLastName)))
                                       + "," + Sanitizer.sanitizeForCsv(StringHelper.removeExtraSpace(recipientEmail))
                                       + "," + fsrBundle.getResponseAnswerCsv(feedbackResponseAttributes, question)
                                       + Const.EOL;

--- a/src/main/java/teammates/common/datatransfer/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackRankRecipientsQuestionDetails.java
@@ -208,7 +208,7 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
             
             fragments += FeedbackQuestionFormTemplates.populateTemplate(FeedbackQuestionFormTemplates.RANK_RESULT_STATS_RECIPIENTFRAGMENT,
                                                                         "${rankOptionValue}",  Sanitizer.sanitizeForHtml(name),
-                                                                        "${team}", teamName,
+                                                                        "${team}", Sanitizer.sanitizeForHtml(teamName),
                                                                         "${ranksReceived}", ranksReceived,
                                                                         "${averageRank}", df.format(average));
 

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -909,7 +909,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         } else if (name.equals(Const.USER_IS_TEAM)) {
             return getTeamNameForEmail(email);
         } else {
-            return Sanitizer.sanitizeForHtml(name);
+            return name;
         }
     }
 
@@ -922,7 +922,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         } else if (name.equals(Const.USER_IS_TEAM)) {
             return getTeamNameForEmail(email);
         } else {
-            return Sanitizer.sanitizeForHtml(name);
+            return name;
         }
     }
 
@@ -931,7 +931,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         if (teamName == null || email.equals(Const.GENERAL_QUESTION)) {
             return Const.USER_NOBODY_TEXT;
         } else {
-            return Sanitizer.sanitizeForHtml(teamName);
+            return teamName;
         }
     }
     

--- a/src/main/java/teammates/common/util/Sanitizer.java
+++ b/src/main/java/teammates/common/util/Sanitizer.java
@@ -186,7 +186,7 @@ public class Sanitizer {
      * We follow the definition described by RFC 4180:<br>
      * {@link http://tools.ietf.org/html/rfc4180}
      */
-    public static String sanitizeForCsv(String str){ 
+    public static String sanitizeForCsv(String str) {
         return "\"" + str.replace("\"", "\"\"") + "\"";
     }
     

--- a/src/main/webapp/WEB-INF/tags/instructor/results/participantGroupBySecondaryParticipantPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/participantGroupBySecondaryParticipantPanel.tag
@@ -1,5 +1,6 @@
 <%@ tag description="instructorFeedbackResults - participant > participant > question" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 <%@ tag import="teammates.common.util.Const" %>
 
@@ -13,14 +14,14 @@
         <c:choose>
             <c:when test="${groupByParticipantPanel.emailValid}">
                 <div class="middlealign profile-pic-icon-hover inline panel-heading-text" data-link="${groupByParticipantPanel.profilePictureLink}">
-                    <strong>${groupByParticipantPanel.name}</strong>
+                    <strong>${fn:escapeXml(groupByParticipantPanel.name)}</strong>
                     <img src="" alt="No Image Given" class="hidden profile-pic-icon-hidden">
                     <a <c:if test="${not empty groupByParticipantPanel.secondaryParticipantPanels}">class="link-in-dark-bg"</c:if> href="mailto:${groupByParticipantPanel.participantIdentifier}">[${groupByParticipantPanel.participantIdentifier}]</a>
                 </div>
             </c:when>
             <c:otherwise>
                 <div class="inline panel-heading-text">
-                    <strong>${groupByParticipantPanel.name}</strong>
+                    <strong>${fn:escapeXml(groupByParticipantPanel.name)}</strong>
                 </div>
             </c:otherwise>
         </c:choose>

--- a/src/main/webapp/WEB-INF/tags/instructor/results/secondaryParticipantPanelSide.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/secondaryParticipantPanelSide.tag
@@ -1,5 +1,6 @@
 <%@ tag description="instructorFeedbackResults - side of the secondary participant panel" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 <%@ tag import="teammates.common.util.Const" %>
 
@@ -15,12 +16,12 @@
         <c:choose>
             <c:when test="${not empty secondaryParticipantPanelBody.profilePictureLink}">
                 <div class="tablet-bottom-align profile-pic-icon-hover inline-block" data-link="${secondaryParticipantPanelBody.profilePictureLink}">
-                    <strong>${secondaryParticipantPanelBody.secondaryParticipantDisplayableName}</strong>
+                    <strong>${fn:escapeXml(secondaryParticipantPanelBody.secondaryParticipantDisplayableName)}</strong>
                     <img src="" alt="No Image Given" class="hidden profile-pic-icon-hidden">
                 </div>
             </c:when>
             <c:otherwise>
-                <strong>${secondaryParticipantPanelBody.secondaryParticipantDisplayableName}</strong>
+                <strong>${fn:escapeXml(secondaryParticipantPanelBody.secondaryParticipantDisplayableName)}</strong>
             </c:otherwise>
         </c:choose>
             
@@ -31,12 +32,12 @@
         <c:choose>
             <c:when test="${primaryParticipantPanel.emailValid}">
                 <div class="tablet-bottom-align profile-pic-icon-hover inline-block" data-link="${primaryParticipantPanel.profilePictureLink}">
-                    ${primaryParticipantPanel.name}
+                    ${fn:escapeXml(primaryParticipantPanel.name)}
                     <img src="" alt="No Image Given" class="hidden profile-pic-icon-hidden">
                 </div>               
             </c:when>
             <c:otherwise>
-                ${primaryParticipantPanel.name}
+                ${fn:escapeXml(primaryParticipantPanel.name)}
             </c:otherwise>
         </c:choose>
     </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/results/teamPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/teamPanel.tag
@@ -1,5 +1,6 @@
 <%@ tag description="instructorFeedbackResults - team panel containing participant panels, and optionally, statistics tables" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 <%@ tag import="teammates.common.util.Const" %>
 
@@ -20,7 +21,7 @@
 <div class="panel panel-warning">
     <div class="panel-heading">
         <div class="inline panel-heading-text">
-            <strong>${teamName}</strong>                        
+            <strong>${fn:escapeXml(teamName)}</strong>
         </div>
         <div class="pull-right">
             <%-- If team statistics are displayed, then the "Collapse Students" button appears under the team statistics tables --%>
@@ -40,7 +41,7 @@
                 <%-- Statistics Tables for entire team --%>
                 <div class="resultStatistics">
                     <c:if test="${isTeamHasResponses}">
-                        <h3>${teamName} ${statisticsHeaderText}</h3>
+                        <h3>${fn:escapeXml(teamName)} ${statisticsHeaderText}</h3>
                         <hr class="margin-top-0">
                         <c:choose>
                             <%-- Not all questions have statistics, so we still need to test for the non-emptiness of statsTable --%>
@@ -55,7 +56,7 @@
                         </c:choose>
                         <div class="row">
                             <div class="col-sm-9">
-                                <h3>${teamName} ${detailedResponsesHeaderText}</h3>
+                                <h3>${fn:escapeXml(teamName)} ${detailedResponsesHeaderText}</h3>
                             </div>
                             <div class="col-sm-3 h3">
                                 <a class="btn btn-warning btn-xs pull-right" id="collapse-panels-button-team-${teamIndex}" data-toggle="tooltip" title="Collapse or expand all student panels. You can also click on the panel heading to toggle each one individually.">


### PR DESCRIPTION
Fixes #4622.

When sanitizing people's names for csv files, remember to call `StringHelper.recoverFromSanitizedText()` method.

My Concerns:
1. I only changed the codes that caused issue #4622. However, I saw codes that look like `Sanitizer.sanitizeForCsv(humanName)` somewhere else as well. Should I change them accordingly to `Sanitizer.sanitizeForCsv(StringHelper.recoverFromSanitizedText(humanName))`?
2. Alternatively, should I just call `StringHelper.recoverFromSanitizedText()` inside `Sanitizer.sanitizeForCsv()`?