### PR TITLE
InstructorHomePageUiTest failing on live server #4161

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
@@ -335,6 +335,7 @@ public class InstructorHomePage extends AppPage {
     }
     
     private int getCourseRowId(String courseId) {
+        waitForAjaxLoaderGifToDisappear();
         int id = 0;
         while (isElementPresent(By.id("course-" + id))) {
             if (getElementText(


### PR DESCRIPTION
Fixes #4161 
Take a look at the source of the failure: waiting for `session-1`, instead of the usual `session0`. The failure comes because there is a need to wait for the course table to be loaded, and not waiting will result in the row ID to be `-1` (as shown in the method `getCourseRowId`), so waiting here will (99%) guarantee that the course table is loaded before any processing is done.