### PR TITLE
StudentProfilePageUiTest is failing on the live server #4796

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentProfilePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentProfilePageUiTest.java
@@ -171,7 +171,7 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
 
         // Verify with retry after upload picture due to inconsistency of .click in detecting page load
         profilePage.verifyStatusWithRetry(Const.StatusMessages.STUDENT_PROFILE_PICTURE_SAVED, 10);
-        profilePage.isElementVisible("studentPhotoUploader");
+        profilePage.waitForUploadEditModalVisible();
 
         profilePage.editProfilePhoto();
         profilePage.ensureProfileContains("short.name", "e@email.tmt", "inst", "Usual Nationality",
@@ -214,7 +214,10 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
 
         profilePage.fillProfilePic("src/test/resources/images/image_tall.jpg");
         profilePage.uploadPicture();
-        profilePage.isElementVisible("studentPhotoUploader");
+        
+        // Verify with retry after upload picture due to inconsistency of .click in detecting page load
+        profilePage.verifyStatusWithRetry(Const.StatusMessages.STUDENT_PROFILE_PICTURE_SAVED, 10);
+        profilePage.waitForUploadEditModalVisible();
         profilePage.verifyPhotoSize(3074, 156);
 
         String currentPictureKey = BackDoor.getStudentProfile(studentGoogleId).pictureKey;


### PR DESCRIPTION
Fixes #4796 

There should be a wait for the student photo upload modal to re-appear, but lines 174 and 217 waited for it erroneously.
The `verifyStatusWithRetry` on line 218 was added because after uploading photo the modal doesn't immediately disappear so immediate "waiting to appear" will result in false positive.