### PR TITLE
Delete possibly-conflicting entities in Db tests before test is run #4955

### DIFF
--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -39,6 +39,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
                                               EntityDoesNotExistException {
         
         FeedbackQuestionAttributes fq = getNewFeedbackQuestionAttributes();
+        
+        // remove possibly conflicting entity from the database
+        fqDb.deleteEntity(fq);
+        
         fqDb.createEntity(fq);
         verifyPresentInDatastore(fq, true);
         
@@ -54,8 +58,6 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         ______TS("success : defaultTimeStamp for updatedAt date");
 
         assertEquals(defaultTimeStamp, fq.getUpdatedAt());
-        
-        fqDb.deleteEntity(fq);
     }
 
     @Test
@@ -65,6 +67,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         ______TS("success : created");
 
         FeedbackQuestionAttributes fq = getNewFeedbackQuestionAttributes();
+        
+        // remove possibly conflicting entity from the database
+        fqDb.deleteEntity(fq);
+        
         fqDb.createEntity(fq);
         verifyPresentInDatastore(fq, true);
         
@@ -98,8 +104,6 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         
         // Assert lastUpdate has NOT changed.
         assertEquals(updatedFq.getUpdatedAt(), updatedFqTwo.getUpdatedAt());
-        
-        fqDb.deleteEntity(updatedFqTwo);
     }
       
     @Test
@@ -108,6 +112,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         ______TS("standard success case");
 
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
+        
+        // remove possibly conflicting entity from the database
+        fqDb.deleteEntity(fqa);
+        
         fqDb.createEntity(fqa);
         verifyPresentInDatastore(fqa, true);
 
@@ -150,6 +158,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
     @Test
     public void testGetFeedbackQuestions() throws Exception {
         FeedbackQuestionAttributes expected = getNewFeedbackQuestionAttributes();
+        
+        // remove possibly conflicting entity from the database
+        fqDb.deleteEntity(expected);
+        
         fqDb.createEntity(expected);
 
         ______TS("standard success case");
@@ -191,8 +203,6 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         actual = fqDb.getFeedbackQuestion("non-existent id");
 
         assertNull(actual);
-
-        fqDb.deleteEntity(expected);
     }
 
     @Test
@@ -245,6 +255,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
     @Test
     public void testGetFeedbackQuestionsForGiverType() throws Exception {
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
+        
+        // remove possibly conflicting entity from the database
+        fqDb.deleteEntity(fqa);
+        
         int[] numOfQuestions = createNewQuestionsForDifferentRecipientTypes();
 
         ______TS("standard success case");
@@ -396,6 +410,10 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         for (int i = 1; i <= num; i++) {
             fqa = getNewFeedbackQuestionAttributes();
             fqa.questionNumber = i;
+            
+            // remove possibly conflicting entity from the database
+            fqDb.deleteEntity(fqa);
+            
             fqDb.createEntity(fqa);
             returnVal.add(fqa);
         }

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -51,6 +51,10 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
     @Test
     public void testDefaultTimestamp() throws InvalidParametersException, EntityAlreadyExistsException {
         FeedbackResponseAttributes fra = getNewFeedbackResponseAttributes();
+        
+        // remove possibly conflicting entity from the database
+        frDb.deleteEntity(fra);
+        
         frDb.createEntity(fra);
         verifyPresentInDatastore(fra, true);
         
@@ -66,8 +70,6 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         ______TS("success : defaultTimeStamp for updatedAt date");
         
         assertEquals(defaultTimeStamp, fra.getUpdatedAt());
-        
-        frDb.deleteEntity(fra);
     }
     
     @Test
@@ -76,6 +78,10 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         ______TS("success : created");
 
         FeedbackResponseAttributes fra = getNewFeedbackResponseAttributes();
+        
+        // remove possibly conflicting entity from the database
+        frDb.deleteEntity(fra);
+        
         frDb.createEntity(fra);
         verifyPresentInDatastore(fra, true);
         
@@ -111,9 +117,6 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         
         // Assert lastUpdate has NOT changed.
         assertEquals(updatedFr.getUpdatedAt(), updatedFrTwo.getUpdatedAt());
-        
-        frDb.deleteEntity(updatedFrTwo);
-            
     }
     
     @Test
@@ -123,6 +126,10 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         ______TS("standard success case");
         
         FeedbackResponseAttributes fra = getNewFeedbackResponseAttributes();
+        
+        // remove possibly conflicting entity from the database
+        frDb.deleteEntity(fra);
+        
         frDb.createEntity(fra);
         
         // sets the id for fra
@@ -221,7 +228,6 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         actual = frDb.getFeedbackResponse("non-existent id");
         
         assertNull(actual);
-        
     }
     
     @Test

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -37,20 +37,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
     @Test
     public void testDefaultTimestamp() throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {        
         
-        StudentAttributes s = new StudentAttributes();
-        s.name = "a valid student";
-        s.lastName = "last name of student";
-        s.email = "valid-fresh-student@email.com";
-        s.team = "validTeamNameOfStudent";
-        s.section = "aValidSectionName";
-        s.comments = "";
-        s.googleId = "validGoogleIdForStudent";
-        s.course = "valid-course";
-        
-        // remove possibly conflicting entity from the database
-        studentsDb.deleteStudent(s.course, s.email);
-        
-        studentsDb.createEntity(s);
+        StudentAttributes s = createNewStudent();
         
         StudentAttributes student = studentsDb.getStudentForGoogleId(s.course, s.googleId);
         assertNotNull(student);
@@ -74,20 +61,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
     {        
         ______TS("success : created");
         
-        StudentAttributes s = new StudentAttributes();
-        s.name = "valid student";
-        s.lastName = "student";
-        s.email = "valid-fresh@email.com";
-        s.team = "validTeamName";
-        s.section = "validSectionName";
-        s.comments = "";
-        s.googleId = "validGoogleId";
-        s.course = "valid-course";
-        
-        // remove possibly conflicting entity from the database
-        studentsDb.deleteStudent(s.course, s.email);
-        
-        studentsDb.createEntity(s);
+        StudentAttributes s = createNewStudent();
         
         StudentAttributes student = studentsDb.getStudentForGoogleId(s.course, s.googleId);
         assertNotNull(student);

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -46,6 +46,10 @@ public class StudentsDbTest extends BaseComponentTestCase {
         s.comments = "";
         s.googleId = "validGoogleIdForStudent";
         s.course = "valid-course";
+        
+        // remove possibly conflicting entity from the database
+        studentsDb.deleteStudent(s.course, s.email);
+        
         studentsDb.createEntity(s);
         
         StudentAttributes student = studentsDb.getStudentForGoogleId(s.course, s.googleId);
@@ -63,8 +67,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
         ______TS("success : defaultTimeStamp for updatedAt date");
         
         assertEquals(defaultStudentCreationTimeStamp, student.getUpdatedAt());
-        
-        studentsDb.deleteStudent(s.course, s.email);
     }
     
     @Test
@@ -81,6 +83,10 @@ public class StudentsDbTest extends BaseComponentTestCase {
         s.comments = "";
         s.googleId = "validGoogleId";
         s.course = "valid-course";
+        
+        // remove possibly conflicting entity from the database
+        studentsDb.deleteStudent(s.course, s.email);
+        
         studentsDb.createEntity(s);
         
         StudentAttributes student = studentsDb.getStudentForGoogleId(s.course, s.googleId);
@@ -111,8 +117,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
         
         // Assert lastUpdate has NOT changed.
         assertTrue(updatedStudent.getUpdatedAt().equals(updatedStudent2.getUpdatedAt()));
-        
-        studentsDb.deleteStudent(s.course, s.email);
     }
     
     @Test
@@ -142,6 +146,10 @@ public class StudentsDbTest extends BaseComponentTestCase {
 
         ______TS("success : valid params");
         s.course = "valid-course";
+        
+        // remove possibly conflicting entity from the database
+        studentsDb.deleteStudent(s.course, s.email);
+        
         studentsDb.createEntity(s);
         verifyPresentInDatastore(s);
         StudentAttributes retrievedStudent = studentsDb.getStudentForGoogleId(s.course, s.googleId);
@@ -170,7 +178,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
             assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, a.getMessage());
         }
         
-        studentsDb.deleteStudent(s.course, s.email);
     }
 
     @SuppressWarnings("deprecation")
@@ -283,8 +290,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
         
         StudentAttributes updatedStudent = studentsDb.getStudentForEmail(s.course, s.email);
         assertTrue(updatedStudent.isEnrollInfoSameAs(s));
-        
-        studentsDb.deleteStudent(s.course, s.email);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Fixes #4955 

I have moved the deletion of possibly conflicting entities before test is run in three files. I don't know whether the other files need them since there are no deletion of entities after each tests in each of those files.