### PR TITLE
EmailTemplates contains ${joinFragment} placeholders that are unused #4967

### DIFF
--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -371,7 +371,6 @@ public class Emails {
         emailBody = emailBody.replace("${courseName}", c.name);
         emailBody = emailBody.replace("${courseId}", c.id);
         emailBody = emailBody.replace("${feedbackSessionName}", fs.feedbackSessionName);
-        emailBody = emailBody.replace("${joinFragment}", "");
         emailBody = emailBody.replace("${deadline}",
                 TimeHelper.formatTime12H(fs.endTime));
         emailBody = emailBody.replace("${instructorFragment}", "");
@@ -412,7 +411,6 @@ public class Emails {
 
         String emailBody = template;
 
-        emailBody = emailBody.replace("${joinFragment}", "");
         emailBody = emailBody.replace("${userName}", i.name);
         emailBody = emailBody.replace("${courseName}", c.name);
         emailBody = emailBody.replace("${courseId}", c.id);
@@ -447,7 +445,6 @@ public class Emails {
 
         String emailBody = template;
 
-        emailBody = emailBody.replace("${joinFragment}", "");
         emailBody = emailBody.replace("${userName}", i.name);
         emailBody = emailBody.replace("${courseName}", c.name);
         emailBody = emailBody.replace("${courseId}", c.id);

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -2,7 +2,6 @@ Hello ${userName},
 
 <p/>
 ${instructorFragment}
-${joinFragment}
 
 <p/>
 The following feedback session ${status}.

--- a/src/main/resources/userEmailTemplate-feedbackSessionClosing.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionClosing.html
@@ -2,7 +2,6 @@ Hello ${userName},
 
 <p/>
 ${instructorFragment}
-${joinFragment}
 
 <p/>
 The following feedback session ${status}.

--- a/src/main/resources/userEmailTemplate-feedbackSessionPublished.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionPublished.html
@@ -2,7 +2,6 @@ Hello ${userName},
 
 <p/>
 ${instructorFragment}
-${joinFragment}
 
 <p/>
 The feedback responses for the following feedback session is now open for viewing.


### PR DESCRIPTION
Fixes #4967 