### PR TITLE
AdminHomePageUiTest failing frequently #5004

### DIFF
--- a/src/test/java/teammates/test/pageobjects/AdminHomePage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminHomePage.java
@@ -58,7 +58,7 @@ public class AdminHomePage extends AppPage {
         }
 
         submitButton.click();
-        waitForAjaxLoaderGifToDisappear();
+        waitForElementToBeClickable(submitButton);
         return this;
     }
 
@@ -67,7 +67,7 @@ public class AdminHomePage extends AppPage {
             fillTextBox(detailsSingleLineTextBox, instructorDetails);
         }
         submitButtonDetailsSingleLineForm.click();
-        waitForAjaxLoaderGifToDisappear();
+        waitForElementToBeClickable(submitButtonDetailsSingleLineForm);
     }
     
     public String getMessageFromResultTable(int index) {

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -204,6 +204,11 @@ public abstract class AppPage {
         wait.until(ExpectedConditions.visibilityOf(element));
     }
     
+    public void waitForElementToBeClickable(WebElement element) {
+        WebDriverWait wait = new WebDriverWait(browser.driver, TestProperties.inst().TEST_TIMEOUT);
+        wait.until(ExpectedConditions.elementToBeClickable(element));
+    }
+
     public void waitForElementsVisibility(List<WebElement> elements) {
         WebDriverWait wait = new WebDriverWait(browser.driver, TestProperties.inst().TEST_TIMEOUT);
         wait.until(ExpectedConditions.visibilityOfAllElements(elements));


### PR DESCRIPTION
Fixes #5004 

Wasn't entirely sure why the fix works because if the previous one is subjected to race conditions (it "waits for the ajax loader gif to disappear before it even appears"), this one has the chance to be as well (i.e it "waits for the button to be clickable even before it becomes unclickable"), but apparently it doesn't happen.

This will also fix the `InvalidElementStateException` that occasionally appears at later line of the same test.