### PR TITLE
 AllJsTests line 47: expected failed cases should always be 0 #5098

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/AllJsTests.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AllJsTests.java
@@ -44,7 +44,7 @@ public class AllJsTests extends BaseUiTestCase{
         assertTrue(failedCases == 0);
         assertTrue(totalCases != 0);
         
-        print("As expected, "+ failedCases + " failed tests out of " + totalCases + " tests.");
+        print("As expected, 0 failed tests out of " + totalCases + " tests.");
 
     }
 


### PR DESCRIPTION
Fixes #5098