### PR TITLE
admin create account page: data format can be misleading #5162

### DIFF
--- a/src/test/resources/pages/adminHomePage.html
+++ b/src/test/resources/pages/adminHomePage.html
@@ -120,7 +120,7 @@
       <div class="text-muted">
         <span class="glyphicon glyphicon-exclamation-sign glyphicon-primary">
         </span>
-        Add Instructor Details in the format (Name | Email | Institution)
+        Add Instructor Details in the following format:  Name | Email | Institution
       </div>
       <br>
       <textarea class="form-control addInstructorFormControl" id="addInstructorDetailsSingleLine" rows="5" type="text">


### PR DESCRIPTION
Fixes #5162. Removed Brackets in order to avoid confusion.