### PR TITLE
Eliminate the usage of Selenium's built-in waitForPageToLoad #4825

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/BaseUiTestCase.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/BaseUiTestCase.java
@@ -126,10 +126,9 @@ public class BaseUiTestCase extends BaseTestCase {
     /**
      * Equivalent to clicking the 'logout' link in the top menu of the page.
      */
-    @SuppressWarnings("deprecation")
     protected static void logout(Browser currentBrowser) {
         currentBrowser.driver.get(createUrl(Const.ViewURIs.LOGOUT).toAbsoluteString());
-        currentBrowser.selenium.waitForPageToLoad(TestProperties.inst().TEST_TIMEOUT_PAGELOAD);
+        AppPage.getNewPageInstance(currentBrowser).waitForPageToLoad();
         currentBrowser.isAdminLoggedIn = false;
     }
     

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -477,6 +477,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         ______TS("check response rate before editing question");
 
         InstructorFeedbacksPage feedbacksPage = navigateToInstructorFeedbacksPage();
+        feedbacksPage.waitForAjaxLoaderGifToDisappear();
 
         assertEquals("1 / 1", feedbacksPage.getResponseValue(courseId, feedbackSessionName));
 
@@ -489,6 +490,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         ______TS("check response rate after editing question");
 
         feedbacksPage = navigateToInstructorFeedbacksPage();
+        feedbacksPage.waitForAjaxLoaderGifToDisappear();
 
         assertEquals("0 / 1", feedbacksPage.getResponseValue(courseId, feedbackSessionName));
         

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -41,7 +41,6 @@ public class TestProperties {
     public String FIREFOX_PATH;
     
     public int TEST_TIMEOUT;
-    public String TEST_TIMEOUT_PAGELOAD;
     
     private static TestProperties instance;
     private Properties prop;
@@ -88,7 +87,6 @@ public class TestProperties {
             FIREFOX_PATH = prop.getProperty("test.firefox.path");
             
             TEST_TIMEOUT = Integer.parseInt(prop.getProperty("test.timeout"));
-            TEST_TIMEOUT_PAGELOAD = prop.getProperty("test.timeout") + "000";
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -199,10 +199,17 @@ public abstract class AppPage {
     }
 
     /**
-     * Waits until the page is fully loaded. Times out after 15 seconds.
+     * Waits until the page is fully loaded.
      */
     public void waitForPageToLoad() {
-        browser.selenium.waitForPageToLoad(TestProperties.inst().TEST_TIMEOUT_PAGELOAD);
+        WebDriverWait wait = new WebDriverWait(browser.driver, TestProperties.inst().TEST_TIMEOUT);
+        wait.until(new ExpectedCondition<Boolean>() {
+            public Boolean apply(WebDriver d) {
+                // Check https://developer.mozilla.org/en/docs/web/api/document/readystate
+                // to understand more on a web document's readyState
+                return ((JavascriptExecutor) d).executeScript("return document.readyState").equals("complete");
+            }
+        });
     }
     
     /**

--- a/src/test/java/teammates/test/pageobjects/Browser.java
+++ b/src/test/java/teammates/test/pageobjects/Browser.java
@@ -6,8 +6,6 @@ import java.util.Stack;
 
 import org.openqa.selenium.WebDriver;
 
-import com.thoughtworks.selenium.webdriven.WebDriverBackedSelenium;
-
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
@@ -18,12 +16,10 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import teammates.test.driver.TestProperties;
 
 import com.gargoylesoftware.htmlunit.BrowserVersion;
-import com.thoughtworks.selenium.DefaultSelenium;
 
 /**
  * A programmatic interface to the Browser used to test the app.
  */
-@SuppressWarnings("deprecation")
 public class Browser {
     
     protected ChromeDriverService chromeService = null;
@@ -34,12 +30,6 @@ public class Browser {
      */
     public WebDriver driver;
 
-    /**
-     * A wrapper around the {@code driver} that represents a slightly
-     * higher-level programmatic interface to the Browser instance.
-     */
-    public DefaultSelenium selenium = null;
-    
     /**
      * Indicated to the {@link BrowserPool} that this object is currently being
      * used and not ready to be reused by another test.
@@ -56,7 +46,6 @@ public class Browser {
     public Browser() {
         this.driver = createWebDriver();
         this.driver.manage().window().maximize();
-        this.selenium = new WebDriverBackedSelenium(this.driver, TestProperties.inst().TEAMMATES_URL);
         isInUse = false; 
         isAdminLoggedIn = false;
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
@@ -172,7 +172,7 @@ public class InstructorCourseEditPage extends AppPage {
     
     public void closeModal() {
         WebElement closeButton = browser.driver.findElement(By.className("close"));
-        
+        waitForElementToBeClickable(closeButton);
         closeButton.click();
         try {
             Thread.sleep(1000);


### PR DESCRIPTION
Fixes #4825 

Note that `waitForPageToLoad` is a very important method that can't be decommissioned (trivially), but there is a way to make it work without resorting to Selenium RC and that way is implemented in this PR. Somehow I believe that this is the method used behind the screen by Selenium's `waitForPageToLoad` anyway.

Now we're one step closer to upgrading to Selenium 3, whenever that day is.

Also, I actually have fixed the `AdminSessionsPageUiTest` failure here as well, but #5172 seems to have taken care of it :p