### PR TITLE
Make instructor feedback edit page resilient to duplicate question numbers #5208

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
@@ -278,6 +278,13 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
         if (this.questionNumber != o.questionNumber) {
             return Integer.compare(this.questionNumber, o.questionNumber);
         }
+        /**
+         * Although question numbers ought to be unique in a feedback session,
+         * eventual consistency can result in duplicate questions numbers. 
+         * Therefore, to ensure that the question order is always consistent to the user,
+         * compare feedbackQuestionId, which is guaranteed to be unique,
+         * when the questionNumbers are the same. 
+         */
         return this.feedbackQuestionId.compareTo(o.feedbackQuestionId);
     }
 

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
@@ -273,9 +273,12 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
     public int compareTo(FeedbackQuestionAttributes o) {
         if (o == null) {
             return 1;
-        } else {
+        }
+        
+        if (this.questionNumber != o.questionNumber) {
             return Integer.compare(this.questionNumber, o.questionNumber);
         }
+        return this.feedbackQuestionId.compareTo(o.feedbackQuestionId);
     }
 
     @Override

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -2,7 +2,6 @@ package teammates.logic.backdoor;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -146,7 +145,7 @@ public class BackDoorLogic extends Logic {
         
         HashMap<String, FeedbackQuestionAttributes> questions = dataBundle.feedbackQuestions;
         List<FeedbackQuestionAttributes> questionList = new ArrayList<FeedbackQuestionAttributes>(questions.values());
-        Collections.sort(questionList);
+        
         for(FeedbackQuestionAttributes question : questionList){
             question.removeIrrelevantVisibilityOptions();
         }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -238,7 +238,7 @@ public class FeedbackQuestionsLogic {
             questions.addAll(fqDb.getFeedbackQuestionsForGiverType(
                             feedbackSessionName, courseId, INSTRUCTORS));
         }
-        
+        Collections.sort(questions);
         return questions;
     }
     
@@ -275,7 +275,7 @@ public class FeedbackQuestionsLogic {
         questions.addAll(fqDb.getFeedbackQuestionsForGiverType(feedbackSessionName,
                 courseId, SELF));
         
-        
+        Collections.sort(questions);
         return questions;
     }
     
@@ -319,6 +319,7 @@ public class FeedbackQuestionsLogic {
                 fqDb.getFeedbackQuestionsForGiverType(
                         feedbackSessionName, courseId, TEAMS));
         
+        Collections.sort(questions);
         return questions;
     }
     

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
@@ -129,6 +129,7 @@ public class InstructorFeedbackEditPageData extends PageData {
         qnForm.setFeedbackSessionName(feedbackSessionName);
         qnForm.setQuestion(question);
         qnForm.setQuestionNumberSuffix("-" + questionIndex);
+        qnForm.setQuestionIndex(questionIndex);
         
         qnForm.setQuestionNumberOptions(getQuestionNumberOptions(questionsSize));
         

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.FeedbackQuestionDetails;
 import teammates.common.datatransfer.FeedbackQuestionType;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
@@ -126,10 +127,14 @@ public class InstructorFeedbackEditPageData extends PageData {
         qnForm.setAction(Const.ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_EDIT);
         qnForm.setCourseId(courseId);
         
+        FeedbackQuestionDetails questionDetails = question.getQuestionDetails();
         qnForm.setFeedbackSessionName(feedbackSessionName);
-        qnForm.setQuestion(question);
+        qnForm.setQuestionText(questionDetails.questionText);
         qnForm.setQuestionNumberSuffix("-" + questionIndex);
         qnForm.setQuestionIndex(questionIndex);
+        qnForm.setQuestionId(question.getId());
+        qnForm.setQuestionTypeDisplayName(questionDetails.getQuestionTypeDisplayName());
+        qnForm.setQuestionType(question.questionType);
         
         qnForm.setQuestionNumberOptions(getQuestionNumberOptions(questionsSize));
         
@@ -169,7 +174,7 @@ public class InstructorFeedbackEditPageData extends PageData {
         
         qnForm.setQuestionHasResponses(questionHasResponses.get(question.getId()));
         
-        qnForm.setQuestionSpecificEditFormHtml(question.getQuestionDetails().getQuestionSpecificEditFormHtml(questionIndex));
+        qnForm.setQuestionSpecificEditFormHtml(questionDetails.getQuestionSpecificEditFormHtml(questionIndex));
         qnForm.setEditable(false);
         
         qnForms.add(qnForm);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
@@ -49,10 +49,11 @@ public class InstructorFeedbackEditPageData extends PageData {
         buildFsForm(feedbackSession);
         
         qnForms = new ArrayList<FeedbackQuestionEditForm>();
-        for (FeedbackQuestionAttributes question : questions) {
+        for (int i = 0; i < questions.size(); i++) {
+            FeedbackQuestionAttributes question = questions.get(i);
             buildExistingQuestionForm(feedbackSession.feedbackSessionName, 
                                       questions.size(), questionHasResponses, 
-                                      instructor.courseId, question);
+                                      instructor.courseId, question, i + 1);
         }
         
         buildNewQuestionForm(feedbackSession, questions.size() + 1);
@@ -119,14 +120,15 @@ public class InstructorFeedbackEditPageData extends PageData {
     private void buildExistingQuestionForm(String feedbackSessionName,
                                            int questionsSize,
                                            Map<String, Boolean> questionHasResponses,
-                                           String courseId, FeedbackQuestionAttributes question) {
+                                           String courseId, FeedbackQuestionAttributes question,
+                                           int questionIndex) {
         FeedbackQuestionEditForm qnForm = new FeedbackQuestionEditForm();
         qnForm.setAction(Const.ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_EDIT);
         qnForm.setCourseId(courseId);
         
         qnForm.setFeedbackSessionName(feedbackSessionName);
         qnForm.setQuestion(question);
-        qnForm.setQuestionNumberSuffix("-" + question.questionNumber);
+        qnForm.setQuestionNumberSuffix("-" + questionIndex);
         
         qnForm.setQuestionNumberOptions(getQuestionNumberOptions(questionsSize));
         
@@ -166,7 +168,7 @@ public class InstructorFeedbackEditPageData extends PageData {
         
         qnForm.setQuestionHasResponses(questionHasResponses.get(question.getId()));
         
-        qnForm.setQuestionSpecificEditFormHtml(question.getQuestionDetails().getQuestionSpecificEditFormHtml(question.questionNumber));
+        qnForm.setQuestionSpecificEditFormHtml(question.getQuestionDetails().getQuestionSpecificEditFormHtml(questionIndex));
         qnForm.setEditable(false);
         
         qnForms.add(qnForm);

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -162,7 +162,7 @@ public class FeedbackQuestionEditForm {
     /**
      * @return empty string is questionIndex is 0 (uninitialised), otherwise the value of the questionIndex
      * @see {@link #getQuestionIndex}. An example of use of this will be if 
-     *      the html id of the form of a new question is not indexed  
+     *      the html id of elements in the form of a new question is not suffixed by question index  
      */
     public String getQuestionIndexIfNonZero() {
         return questionIndex == 0 ? "" : String.valueOf(questionIndex);

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -156,6 +156,10 @@ public class FeedbackQuestionEditForm {
         return questionIndex;
     }
     
+    public String getQuestionIndexIfNonZero() {
+        return questionIndex == 0 ? "" : String.valueOf(questionIndex);
+    }
+    
     public void setAction(String action) {
         this.actionLink = action;
     }

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -29,7 +29,9 @@ public class FeedbackQuestionEditForm {
     private List<ElementTag> questionNumberOptions;
     
     private FeedbackQuestionAttributes question;
+    private int questionIndex;
     
+
     //TODO use element tags or a new class instead of having html in java
     private String questionSpecificEditFormHtml;
     
@@ -150,7 +152,15 @@ public class FeedbackQuestionEditForm {
     public String getAction() {
         return actionLink;
     }
-
+    
+    public void setQuestionIndex(int questionIndex) {
+        this.questionIndex = questionIndex;
+    }
+    
+    public int getQuestionIndex() {
+        return questionIndex;
+    }
+    
     public void setAction(String action) {
         this.actionLink = action;
     }

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
-import teammates.common.datatransfer.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.FeedbackQuestionType;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.util.Const;
 
@@ -20,16 +20,17 @@ public class FeedbackQuestionEditForm {
     private String feedbackSessionName;
     
     private String questionNumberSuffix;
-    
+    private String questionText;
+    private String questionTypeDisplayName;
+    private FeedbackQuestionType questionType;
+    private int questionIndex;
+
     // Used for adding a new question
     private String questionTypeOptions;
     private String doneEditingLink;
     
     private boolean isQuestionHasResponses;
     private List<ElementTag> questionNumberOptions;
-    
-    private FeedbackQuestionAttributes question;
-    private int questionIndex;
     
 
     //TODO use element tags or a new class instead of having html in java
@@ -38,6 +39,8 @@ public class FeedbackQuestionEditForm {
     private boolean isEditable;
     private FeedbackQuestionFeedbackPathSettings feedbackPathSettings;
     private FeedbackQuestionVisibilitySettings visibilitySettings;
+
+    private String questionId;
     
     public static FeedbackQuestionEditForm getNewQnForm(String doneEditingLink, FeedbackSessionAttributes feedbackSession,
                                                         String questionTypeChoiceOptions, List<ElementTag> giverOptions,
@@ -113,14 +116,6 @@ public class FeedbackQuestionEditForm {
         this.feedbackSessionName = feedbackSessionName;
     }
     
-    public FeedbackQuestionAttributes getQuestion() {
-        return question;
-    }
-    
-    public void setQuestion(FeedbackQuestionAttributes question) {
-        this.question = question;
-    }
-    
     public boolean isQuestionHasResponses() {
         return isQuestionHasResponses;
     }
@@ -146,7 +141,7 @@ public class FeedbackQuestionEditForm {
     }
    
     public String getQuestionText() {
-        return question.getQuestionDetails().questionText;
+        return questionText;
     }
 
     public String getAction() {
@@ -213,4 +208,32 @@ public class FeedbackQuestionEditForm {
         this.isEditable = isEditable;
     }
 
+    public void setQuestionId(String questionId) {
+        this.questionId = questionId;
+    }
+    
+    public String getQuestionId() {
+        return this.questionId;
+    }
+
+    public String getQuestionTypeDisplayName() {
+        return questionTypeDisplayName;
+    }
+
+    public void setQuestionTypeDisplayName(String questionTypeDisplayName) {
+        this.questionTypeDisplayName = questionTypeDisplayName;
+    }
+    
+    public void setQuestionText(String questionText) {
+        this.questionText = questionText;
+    }
+    
+    public void setQuestionType(FeedbackQuestionType questionType) {
+        this.questionType = questionType;
+    }
+    
+    public String getQuestionType() {
+        return this.questionType.toString();
+    }
+    
 }

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -151,11 +151,19 @@ public class FeedbackQuestionEditForm {
     public void setQuestionIndex(int questionIndex) {
         this.questionIndex = questionIndex;
     }
-    
+
+    /**
+     * @see {@link #getQuestionIndexIfNonZero}
+     */
     public int getQuestionIndex() {
         return questionIndex;
     }
     
+    /**
+     * @return empty string is questionIndex is 0 (uninitialised), otherwise the value of the questionIndex
+     * @see {@link #getQuestionIndex}. An example of use of this will be if 
+     *      the html id of the form of a new question is not indexed  
+     */
     public String getQuestionIndexIfNonZero() {
         return questionIndex == 0 ? "" : String.valueOf(questionIndex);
     }

--- a/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
+++ b/src/main/java/teammates/ui/template/FeedbackQuestionEditForm.java
@@ -160,7 +160,7 @@ public class FeedbackQuestionEditForm {
     }
     
     /**
-     * @return empty string is questionIndex is 0 (uninitialised), otherwise the value of the questionIndex
+     * @return empty string if questionIndex is 0 (uninitialised), otherwise the value of the questionIndex
      * @see {@link #getQuestionIndex}. An example of use of this will be if 
      *      the html id of elements in the form of a new question is not suffixed by question index  
      */

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
@@ -13,10 +13,10 @@
 
 <form class="form-horizontal form_question" role="form" method="post"
     action="${fqForm.action}"
-    id="form_editquestion-${fqForm.question.questionNumber}" name="form_editquestions"
-    onsubmit="tallyCheckboxes(${fqForm.question.questionNumber})"
+    id="form_editquestion-${fqForm.questionIndex}" name="form_editquestions"
+    onsubmit="tallyCheckboxes(${fqForm.questionIndex})"
     ${ fqForm.questionHasResponses ? 'editStatus="hasResponses"' : '' }>
-    <div class="panel panel-primary questionTable" id="questionTable${fqForm.question.questionNumber}">
+    <div class="panel panel-primary questionTable" id="questionTable${fqForm.questionIndex}">
         <div class="panel-heading">
             <div class="row">
                 <div class="col-sm-7">
@@ -24,7 +24,7 @@
                         <strong>Question</strong>
                         <select class="questionNumber nonDestructive text-primary"
                             name="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>"
-                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>-${fqForm.question.questionNumber}">
+                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>-${fqForm.questionIndex}">
                             <c:forEach items="${fqForm.questionNumberOptions}" var="option">
                                 <option ${option.attributesToString}>
                                     ${option.content}
@@ -37,32 +37,32 @@
                 <div class="col-sm-5 mobile-margin-top-10px">
                     <span class="mobile-no-pull pull-right">
                         <a class="btn btn-primary btn-xs"
-                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_GETLINK %>-${fqForm.question.questionNumber}"
+                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_GETLINK %>-${fqForm.questionIndex}"
                             data-toggle="tooltip" data-placement="top"
                             title="<%= Const.Tooltips.FEEDBACK_QUESTION_GETLINK %>"
-                            onclick="getQuestionLink(${fqForm.question.questionNumber})">
+                            onclick="getQuestionLink(${fqForm.questionIndex})">
                             Get Link
                         </a>
                         <a class="btn btn-primary btn-xs"
-                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTEXT %>-${fqForm.question.questionNumber}"
+                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTEXT %>-${fqForm.questionIndex}"
                             data-toggle="tooltip" data-placement="top"
                             title="<%= Const.Tooltips.FEEDBACK_QUESTION_EDIT %>"
-                            onclick="enableEdit(${fqForm.question.questionNumber},${numQn})">
+                            onclick="enableEdit(${fqForm.questionIndex},${numQn})">
                             Edit
                         </a>
                         <a class="btn btn-primary btn-xs" style="display:none"
-                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_SAVECHANGESTEXT %>-${fqForm.question.questionNumber}">
+                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_SAVECHANGESTEXT %>-${fqForm.questionIndex}">
                             Save Changes
                         </a>
                         <a class="btn btn-primary btn-xs" style="display:none"
-                            onclick="cancelEdit(${fqForm.question.questionNumber})"
-                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_CANCELEDIT %>-${fqForm.question.questionNumber}"
+                            onclick="cancelEdit(${fqForm.questionIndex})"
+                            id="<%= Const.ParamsNames.FEEDBACK_QUESTION_CANCELEDIT %>-${fqForm.questionIndex}"
                             data-toggle="tooltip" data-placement="top"
                             title="<%= Const.Tooltips.FEEDBACK_QUESTION_CANCEL %>">
                             Cancel
                         </a>
                         <a class="btn btn-primary btn-xs"
-                            onclick="deleteQuestion(${fqForm.question.questionNumber})"
+                            onclick="deleteQuestion(${fqForm.questionIndex})"
                             data-toggle="tooltip" data-placement="top"
                             title="<%= Const.Tooltips.FEEDBACK_QUESTION_DELETE %>">
                             Delete
@@ -77,7 +77,7 @@
                     <%-- Do not add whitespace between the opening and closing tags --%>
                     <textarea class="form-control textvalue nonDestructive" rows="5"
                         name="<%= Const.ParamsNames.FEEDBACK_QUESTION_TEXT %>"
-                        id="<%= Const.ParamsNames.FEEDBACK_QUESTION_TEXT %>-${fqForm.question.questionNumber}"
+                        id="<%= Const.ParamsNames.FEEDBACK_QUESTION_TEXT %>-${fqForm.questionIndex}"
                         data-toggle="tooltip" data-placement="top"
                         title="<%= Const.Tooltips.FEEDBACK_QUESTION_INPUT_INSTRUCTIONS %>"
                         tabindex="9"
@@ -92,7 +92,7 @@
             
             <div>
                 <span class="pull-right">
-                    <input id="button_question_submit-${fqForm.question.questionNumber}"
+                    <input id="button_question_submit-${fqForm.questionIndex}"
                            type="submit" class="btn btn-primary"
                            value="Save Changes" tabindex="0"
                            style="display:none">
@@ -103,9 +103,9 @@
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${fqForm.feedbackSessionName}">
     <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${fqForm.courseId}">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${fqForm.question.id}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>" value="${fqForm.question.questionNumber}">
+    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>" value="${fqForm.questionIndex}">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_TYPE %>" value="${fqForm.question.questionType}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>" id="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>-${fqForm.question.questionNumber}" value="edit">
+    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>" id="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>-${fqForm.questionIndex}" value="edit">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO %>" >
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO %>" >
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO %>" >

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
@@ -31,7 +31,7 @@
                                 </option>
                             </c:forEach>
                         </select>
-                        &nbsp;${fqForm.question.questionDetails.questionTypeDisplayName}
+                        &nbsp;${fqForm.questionTypeDisplayName}
                     </span>
                 </div>
                 <div class="col-sm-5 mobile-margin-top-10px">
@@ -102,9 +102,9 @@
     </div>
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${fqForm.feedbackSessionName}">
     <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${fqForm.courseId}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${fqForm.question.id}">
+    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${fqForm.questionId}">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBER %>" value="${fqForm.questionIndex}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_TYPE %>" value="${fqForm.question.questionType}">
+    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_TYPE %>" value="${fqForm.questionType}">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>" id="<%= Const.ParamsNames.FEEDBACK_QUESTION_EDITTYPE %>-${fqForm.questionIndex}" value="edit">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO %>" >
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO %>" >

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionFeedbackPathSettings.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionFeedbackPathSettings.tag
@@ -49,9 +49,9 @@
             </select>
         </div>
     </div>
-    <div class="col-sm-12 row numberOfEntitiesElements${fqForm.question.questionNumber}">
-        <label id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text-${fqForm.question.questionNumber}" class="control-label col-sm-4 small">
-            The maximum number of <span id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text_inner-${fqForm.question.questionNumber}"></span> each respondant should give feedback to:
+    <div class="col-sm-12 row numberOfEntitiesElements${fqForm.questionIndex}">
+        <label id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text-${fqForm.questionIndex}" class="control-label col-sm-4 small">
+            The maximum number of <span id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text_inner-${fqForm.questionIndex}"></span> each respondant should give feedback to:
         </label>
         <div class="col-sm-8 form-control-static">
             <div class="col-sm-4 col-md-3 col-lg-2 margin-bottom-7px">

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionFeedbackPathSettings.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionFeedbackPathSettings.tag
@@ -49,9 +49,9 @@
             </select>
         </div>
     </div>
-    <div class="col-sm-12 row numberOfEntitiesElements${fqForm.questionIndex}">
-        <label id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text-${fqForm.questionIndex}" class="control-label col-sm-4 small">
-            The maximum number of <span id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text_inner-${fqForm.questionIndex}"></span> each respondant should give feedback to:
+    <div class="col-sm-12 row numberOfEntitiesElements${fqForm.questionIndexIfNonZero}">
+        <label id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text-${fqForm.questionIndexIfNonZero}" class="control-label col-sm-4 small">
+            The maximum number of <span id="<%= Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES %>_text_inner-${fqForm.questionIndexIfNonZero}"></span> each respondant should give feedback to:
         </label>
         <div class="col-sm-8 form-control-static">
             <div class="col-sm-4 col-md-3 col-lg-2 margin-bottom-7px">

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionVisibilityOptions.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionVisibilityOptions.tag
@@ -58,18 +58,18 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex} centered"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndexIfNonZero} centered"
                         name="receiverLeaderCheckbox" type="checkbox"
                         value="<%= FeedbackParticipantType.RECEIVER %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.RECEIVER %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndexIfNonZero}"
                         name="receiverFollowerCheckbox" type="checkbox"
                         value="<%= FeedbackParticipantType.RECEIVER %>" disabled
                         <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
@@ -82,17 +82,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
@@ -104,15 +104,15 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndexIfNonZero}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndexIfNonZero}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndexIfNonZero}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
             </tr>
@@ -123,17 +123,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndexIfNonZero}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndexIfNonZero}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndexIfNonZero}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
@@ -145,17 +145,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndexIfNonZero}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionVisibilityOptions.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionVisibilityOptions.tag
@@ -58,18 +58,18 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.question.questionNumber} centered"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex} centered"
                         name="receiverLeaderCheckbox" type="checkbox"
                         value="<%= FeedbackParticipantType.RECEIVER %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.RECEIVER %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
                         name="receiverFollowerCheckbox" type="checkbox"
                         value="<%= FeedbackParticipantType.RECEIVER %>" disabled
                         <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_RECEIVER]}"> checked</c:if> >
@@ -82,17 +82,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                         <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_OWN_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
@@ -104,15 +104,15 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.question.questionNumber}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.question.questionNumber}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.question.questionNumber}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}" type="checkbox" value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_RECEIVER_TEAM_MEMBERS]}"> checked</c:if> >
                 </td>
             </tr>
@@ -123,17 +123,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
                     type="checkbox" value="<%= FeedbackParticipantType.STUDENTS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_STUDENTS]}"> checked</c:if> >
                 </td>
@@ -145,17 +145,17 @@
                     </div>
                 </td>
                 <td>
-                    <input class="visibilityCheckbox answerCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox answerCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.responseVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox giverCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox giverCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.giverNameVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>
                 <td>
-                    <input class="visibilityCheckbox recipientCheckbox${fqForm.question.questionNumber}"
+                    <input class="visibilityCheckbox recipientCheckbox${fqForm.questionIndex}"
                         type="checkbox" value="<%= FeedbackParticipantType.INSTRUCTORS %>" <c:if test="${!fqForm.editable}">disabled</c:if>
                     <c:if test="${fqForm.visibilitySettings.recipientNameVisibleFor[FEEDBACK_INSTRUCTORS]}"> checked</c:if> >
                 </td>

--- a/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
@@ -446,8 +446,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         ______TS("Get questions created for instructors and self");
         
         expectedQuestions = new ArrayList<FeedbackQuestionAttributes>();
-        expectedQuestions.add(getQuestionFromDatastore("qn4InSession1InCourse1"));
         expectedQuestions.add(getQuestionFromDatastore("qn3InSession1InCourse1"));
+        expectedQuestions.add(getQuestionFromDatastore("qn4InSession1InCourse1"));
         actualQuestions = 
                     fqLogic.getFeedbackQuestionsForInstructor("First feedback session", "idOfTypicalCourse1", "instructor1@course1.tmt");
         
@@ -537,8 +537,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         ______TS("Get questions created for students and teams");
         
         expectedQuestions = new ArrayList<FeedbackQuestionAttributes>();
-        expectedQuestions.add(getQuestionFromDatastore("team.members.feedback"));
         expectedQuestions.add(getQuestionFromDatastore("team.feedback"));
+        expectedQuestions.add(getQuestionFromDatastore("team.members.feedback"));
         actualQuestions = 
                     fqLogic.getFeedbackQuestionsForStudents("Second feedback session", "idOfTypicalCourse1");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -412,9 +412,10 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
                                                                      feedbackSessionName, 
                                                                      2);
         assertEquals(2, secondQuestion.questionNumber);
+        int originalSecondQuestionNumber = secondQuestion.questionNumber; 
         
         // edit so that both questions have the same question number
-        secondQuestion.questionNumber = 1;
+        secondQuestion.questionNumber = firstQuestion.questionNumber;
         BackDoor.editFeedbackQuestion(secondQuestion);
         
         // verify both can be edited
@@ -423,7 +424,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         assertTrue(feedbackEditPage.clickEditQuestionButton(2));
         
         // fix inconsistent state
-        secondQuestion.questionNumber = 2;
+        secondQuestion.questionNumber = originalSecondQuestionNumber;
         BackDoor.editFeedbackQuestion(secondQuestion);
         feedbackEditPage = getFeedbackEditPage();
     }

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -13,6 +13,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackQuestionType;
 import teammates.common.datatransfer.FeedbackResponseAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
@@ -397,6 +398,34 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.selectQuestionNumber(2, 1);        
         feedbackEditPage.clickSaveExistingQuestionButton(2);
         assertEquals(Const.StatusMessages.FEEDBACK_QUESTION_EDITED, feedbackEditPage.getStatus());
+        
+        ______TS("questions still editable even if questions numbers became inconsistent");
+        
+        FeedbackQuestionAttributes firstQuestion = 
+                                        BackDoor.getFeedbackQuestion(courseId, 
+                                                                     feedbackSessionName, 
+                                                                     1);
+        assertEquals(1, firstQuestion.questionNumber);
+
+        FeedbackQuestionAttributes secondQuestion = 
+                                        BackDoor.getFeedbackQuestion(courseId, 
+                                                                     feedbackSessionName, 
+                                                                     2);
+        assertEquals(2, secondQuestion.questionNumber);
+        
+        // edit so that both questions have the same question number
+        secondQuestion.questionNumber = 1;
+        BackDoor.editFeedbackQuestion(secondQuestion);
+        
+        // verify both can be edited
+        feedbackEditPage = getFeedbackEditPage();
+        assertTrue(feedbackEditPage.clickEditQuestionButton(1));
+        assertTrue(feedbackEditPage.clickEditQuestionButton(2));
+        
+        // fix inconsistent state
+        secondQuestion.questionNumber = 2;
+        BackDoor.editFeedbackQuestion(secondQuestion);
+        feedbackEditPage = getFeedbackEditPage();
     }
 
     private void testCopyQuestion() throws Exception {

--- a/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbackEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbackEditPageDataTest.java
@@ -129,11 +129,11 @@ public class InstructorFeedbackEditPageDataTest extends BaseTestCase{
         assertEquals(fs.courseId, questionForms.get(0).getCourseId());
         assertEquals(fs.feedbackSessionName, questionForms.get(0).getFeedbackSessionName());
 
-        assertEquals(dataBundle.feedbackQuestions
-                               .get("qn1InSession1InCourse1")
-                               .getQuestionDetails().questionText, 
-                     questionForms.get(0)
-                                  .getQuestionText());
+        String questionTextOfFirstQuestion = dataBundle.feedbackQuestions
+                                                       .get("qn1InSession1InCourse1")
+                                                       .getQuestionDetails().questionText;
+        assertEquals(questionTextOfFirstQuestion, 
+                     questionForms.get(0).getQuestionText());
         assertEquals(3, questionForms.get(0).getQuestionNumberOptions().size());
         assertEquals("What is the best selling point of your product?", questionForms.get(0).getQuestionText());
         

--- a/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbackEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbackEditPageDataTest.java
@@ -129,7 +129,11 @@ public class InstructorFeedbackEditPageDataTest extends BaseTestCase{
         assertEquals(fs.courseId, questionForms.get(0).getCourseId());
         assertEquals(fs.feedbackSessionName, questionForms.get(0).getFeedbackSessionName());
 
-        assertEquals(dataBundle.feedbackQuestions.get("qn1InSession1InCourse1"), questionForms.get(0).getQuestion());
+        assertEquals(dataBundle.feedbackQuestions
+                               .get("qn1InSession1InCourse1")
+                               .getQuestionDetails().questionText, 
+                     questionForms.get(0)
+                                  .getQuestionText());
         assertEquals(3, questionForms.get(0).getQuestionNumberOptions().size());
         assertEquals("What is the best selling point of your product?", questionForms.get(0).getQuestionText());
         


### PR DESCRIPTION
Fixes #5208.

~~Waiting to see if travis passes. Tests are incoming~~

Changed the use of question numbers on the edit page to be based on questionIndex instead, which is determined from the position of the question in the sorted question list. 
Questions are now sorted by questionId, if the question numbers are the same, so that if duplicate question numbers occur, the user will always see them in the same order.

A minimal test, which have been verified to fail on the master branch, is added. However, checking for the actual contents of the page is difficult, since the order of questions is determined by questionId (assigned by the database), so that was omitted. 

A more complete treatment will be required and done separately, by setting the order of questions as a property of the session instead.