### PR TITLE
Use a standardized tag to construct the skeleton of error pages #5231

### DIFF
--- a/src/main/webapp/WEB-INF/tags/errorPage.tag
+++ b/src/main/webapp/WEB-INF/tags/errorPage.tag
@@ -1,0 +1,32 @@
+<%@ tag description="Generic TEAMMATES Error Page" %>
+<%@ tag import="teammates.common.util.Const" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="shortcut icon" href="/favicon.png">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TEAMMATES</title>
+    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css">
+    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css">
+    <link rel="stylesheet" href="/stylesheets/teammatesCommon.css" type="text/css">
+    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]--> 
+</head>
+<body>
+    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+        <div class="container">
+            <div class="navbar-header">
+                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
+            </div>
+        </div>
+    </div>
+    <div class="container" id="mainContent">
+        <jsp:doBody />
+    </div>
+    <jsp:include page="<%= Const.ViewURIs.FOOTER %>" />
+</body>
+</html>

--- a/src/main/webapp/deadlineExceededErrorPage.jsp
+++ b/src/main/webapp/deadlineExceededErrorPage.jsp
@@ -1,41 +1,15 @@
-<%@ page import="teammates.common.util.Const"%>
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
-<!DOCTYPE html>
-
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/stylesheets/teammatesCommon.css" type="text/css">
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
+<t:errorPage>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/error.png" style="margin: 0px 10px 10px 0px; height: 90px; float: left;">
+            <p style="text-align: left;">
+                Server failed to respond within a reasonable time. <br>
+                This may be due to an unusually high load at this time.<br> 
+                Please try again in a few minutes. If the problem persists,<br>
+                please inform TEAMMATES <a href="/contact.html">support team</a>. 
+            </p>
         </div>
     </div>
-
-    <div id="mainContent" class="container">
-        <div class="row">
-            <div class="alert alert-warning col-md-4 col-md-offset-4">
-                <img src="/images/error.png"
-                    style="margin: 0px 10px 10px 0px; height: 90px; float: left;">
-                <p style="text-align: left;">
-                    Server failed to respond within a reasonable time. <br>
-                    This may be due to an unusually high load at this time.<br> 
-                    Please try again in a few minutes. If the problem persists,<br>
-                    please inform TEAMMATES <a href="/contact.html">support team</a>. 
-                </p>
-            </div>
-        </div>
-    </div>
-
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/main/webapp/entityNotFoundPage.jsp
+++ b/src/main/webapp/entityNotFoundPage.jsp
@@ -1,55 +1,30 @@
-<%@ page import="teammates.common.util.Const"%>
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
-<!DOCTYPE html>
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css">
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css">
-    <link rel="stylesheet" href="stylesheets/teammatesCommon.css" type="text/css">
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
+<t:errorPage>
+    <div class="row">
+        <div class="alert alert-warning col-md-6 col-md-offset-3">
+            <img src="/images/puzzled.png" style="float: left; margin: 0 10px 10px 0; height: 90px;">
+            <p>
+                <br><br>
+                TEAMMATES could not locate what you were trying to access. <br><br>
+                <br><br>
+                Possible reasons include:
+            </p>
+            <ul>
+                <li>
+                    You clicked on a link received in email, but the link was mangled by the email software. Try copy-pasting the entire link into the Browser address bar.
+                </li>
+                <li>
+                    The entity (e.g. course, session) you were trying to access was deleted by an instructor after the link was sent to you by TEAMMATES.
+                    <br><br>
+                </li>
+            </ul>
+            If the problem persists, contact TEAMMATES support at <a>teammates@comp.nus.edu.sg</a>
+            <br><br>
+            <b>Note: </b>If the problematic link was received via email, remember to copy-paste that email content when contacting TEAMMATES support.
+            <br><br>
+            If you are a registered user you can go back to the <a href="/page/studentHomePage">home page</a>
+            <br><br>
         </div>
     </div>
-    <div id="mainContent" class="container">
-        <div class="row">
-            <div class="alert alert-warning col-md-6 col-md-offset-3">
-                <img src="/images/puzzled.png"
-                    style="float: left; margin: 0 10px 10px 0; height: 90px;">
-                <p>
-                    <br><br>
-                    TEAMMATES could not locate what you were trying to access. <br><br>
-                    <br><br>
-                    Possible reasons include:
-                </p>
-                <ul>
-                    <li>
-                        You clicked on a link received in email, but the link was mangled by the email software. Try copy-pasting the entire link into the Browser address bar.
-                    </li>
-                    <li>
-                        The entity (e.g. course, session) you were trying to access was deleted by an instructor after the link was sent to you by TEAMMATES.
-                        <br><br>
-                    </li>
-                </ul>
-                If the problem persists, contact TEAMMATES support at <a>teammates@comp.nus.edu.sg</a>
-                <br><br>
-                <b>Note: </b>If the problematic link was received via email, remember to copy-paste that email content when contacting TEAMMATES support.
-                <br><br>
-                If you are a registered user you can go back to the <a href="/page/studentHomePage">home page</a>
-                <br><br>
-                <p>
-                </p>
-            </div>
-        </div>
-    </div>
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/main/webapp/errorPage.jsp
+++ b/src/main/webapp/errorPage.jsp
@@ -1,41 +1,15 @@
-<%@ page import="teammates.common.util.Const"%>
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
-<!DOCTYPE html>
-
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css"/>
-    <link rel="stylesheet" href="stylesheets/teammatesCommon.css" type="text/css">
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
-        </div>
-    </div>
-
-    <div id="mainContent" class="container">
+<t:errorPage>
     <br><br>
-        <div class="row">
-            <div class="alert alert-warning col-md-4 col-md-offset-4">
-                <img src="/images/error.png"
-                    style="float: left; margin: 0 10px 10px 0; height: 90px;">
-                <p>
-                    There was an error in our server.<br>
-                    Please try again in a few moments. <br><br>
-                    If the error persists, please <a class="link" href="contact.html" target="_blank"> let us know </a>
-                </p>
-            </div>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/error.png" style="float: left; margin: 0 10px 10px 0; height: 90px;">
+            <p>
+                There was an error in our server.<br>
+                Please try again in a few moments. <br><br>
+                If the error persists, please <a class="link" href="contact.html" target="_blank"> let us know </a>
+            </p>
         </div>
     </div>
-
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/main/webapp/feedbackSessionNotVisible.jsp
+++ b/src/main/webapp/feedbackSessionNotVisible.jsp
@@ -1,48 +1,24 @@
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page import="teammates.common.util.Const"%>
-<%@ page import="teammates.common.datatransfer.FeedbackSessionAttributes"%>
 <% response.setStatus(403);%>
-<!DOCTYPE html>
 <%
     String startTimeString = (String)session.getAttribute(Const.ParamsNames.FEEDBACK_SESSION_NOT_VISIBLE);
     session.removeAttribute(Const.ParamsNames.FEEDBACK_SESSION_NOT_VISIBLE);
+    pageContext.setAttribute("startTimeString", startTimeString);
 %>
-
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css"/>
-    <link rel="stylesheet" href="stylesheets/teammatesCommon.css" type="text/css">
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
+<t:errorPage>
+    <br><br>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/angry.png" style="float: left; height: 90px; margin: 0 10px 10px 0;">
+            <p>
+                Sorry, this session is currently not open for submission.
+                <c:if test="${not empty startTimeString}">
+                    It will be open from ${startTimeString}<br><br>
+                </c:if>
+            </p>
+            <br>
         </div>
     </div>
-
-    <div id="mainContent" class="container">
-        <br><br>
-        <div class="row">
-            <div class="alert alert-warning col-md-4 col-md-offset-4">
-                <img src="/images/angry.png"
-                    style="float: left; height: 90px; margin: 0 10px 10px 0;">
-                <p>
-                    Sorry, this session is currently not open for submission.
-                    <% if (startTimeString != null) { %>
-                        It will be open from <%= startTimeString %><br><br>
-                    <% } %>
-                </p>
-                <br>
-            </div>
-        </div>
-    </div>
-
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/main/webapp/logout.jsp
+++ b/src/main/webapp/logout.jsp
@@ -1,3 +1,4 @@
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ page import="teammates.logic.api.*"%>
 <%@ page import="teammates.common.util.Const"%>
 <%@ page import="teammates.common.util.StringHelper"%>
@@ -16,62 +17,43 @@
             } catch (Exception e) {
             	response.sendRedirect(Logic.getLogoutUrl(nextUrl));
             }
+            pageContext.setAttribute("expectedId", expectedId);
+            pageContext.setAttribute("actualId", actualId);
+            pageContext.setAttribute("logoutUrl", Logic.getLogoutUrl(nextUrl));
+            pageContext.setAttribute("homePage", Const.ActionURIs.STUDENT_HOME_PAGE);
 %>
-            <html>
-                <head>
-                    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css">
-                    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css">
-                    <link rel="stylesheet" href="/stylesheets/teammatesCommon.css" type="text/css">
-                    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-                    <script src="/bootstrap/js/bootstrap.min.js"></script>
-                </head>
-                <body>
-                    <br>
-                    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-                        <div class="container">
-                            <div class="navbar-header">
-                                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-                            </div>
-                        </div>
+            <t:errorPage>
+                <div class="panel panel-primary panel-narrow">
+                    <div class="panel-heading">
+                        <h4>
+                            Google Account Hint 
+                        </h4>
                     </div>
-                    <div class="panel panel-primary panel-narrow">
-                        
-                        <div class="panel-heading">
-                            <h4>
-                                Google Account Hint 
-                            </h4>
-                        </div>
-                        <div class="panel-body">
-                            <p>
-                                The link you provided belongs to a user with Google ID (partially obscured for security) <strong>"<%=expectedId %>"</strong> 
-                                while you are currently logged in as <strong>"<%=actualId %>"</strong>
-                                <br><br>
-                                <ul class="small narrow-slight">
-                                    <li>
-                                        If the Google ID <strong>"<%=expectedId %>"</strong> 
-                                        belongs to you, please proceed to the login page
-                                    </li>
-                                    <br>
-                                    <li>
-                                        If that Google ID does not belong to you, please inform us at 
-                                        <a class="link">teammates@comp.nus.edu.sg</a>. Please also forward us the original email containing the 
-                                        link you clicked, to help us with the troubleshooting.
-                                    </li>
-                                </ul>
-                            </p>
-                        </div>
-                        <div class="panel-footer center-block align-center container-fluid">
-                            <a class="btn btn-primary" href="<%=Logic.getLogoutUrl(nextUrl) %>">
-                                Proceed to Login Page
-                            </a>
-                            <a class="btn btn-default" href="<%=Const.ActionURIs.STUDENT_HOME_PAGE%>">
-                                Go to Home Page
-                            </a>
-                        </div>
+                    <div class="panel-body">
+                        <p>
+                            The link you provided belongs to a user with Google ID (partially obscured for security) <strong>"${expectedId}"</strong> 
+                            while you are currently logged in as <strong>"${actualId}"</strong>.
+                        </p>
+                        <ul class="small narrow-slight">
+                            <li>
+                                If the Google ID <strong>"${expectedId}"</strong> 
+                                belongs to you, please proceed to the login page.
+                            </li>
+                            <li>
+                                If that Google ID does not belong to you, please inform us at 
+                                <a class="link">teammates@comp.nus.edu.sg</a>. Please also forward us the original email containing the 
+                                link you clicked, to help us with the troubleshooting.
+                            </li>
+                        </ul>
                     </div>
-                    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-                </body>
-            
-            </html>
-
+                    <div class="panel-footer center-block align-center container-fluid">
+                        <a class="btn btn-primary" href="${logoutUrl}">
+                            Proceed to Login Page
+                        </a>
+                        <a class="btn btn-default" href="${homePage}">
+                            Go to Home Page
+                        </a>
+                    </div>
+                </div>
+            </t:errorPage>
 <% } %>

--- a/src/main/webapp/pageNotFound.jsp
+++ b/src/main/webapp/pageNotFound.jsp
@@ -1,43 +1,13 @@
-<%@ page import="teammates.common.util.Const"%>
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(404);%>
-<!DOCTYPE html>
-
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/stylesheets/teammatesCommon.css" type="text/css"/>
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
-      <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
-    <![endif]--> 
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
+<t:errorPage>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/error.png" style="float: left; margin: 0 10px 10px 0; height: 90px;">
+            <p>
+                The page you are looking for is not there.<br><br>
+                Make sure that the URL is correct, or go to <a href="/">main page</a><br><br>
+            </p>
         </div>
     </div>
-
-    <div class="container" id="mainContent">
-        <div class="row">
-            <div class="alert alert-warning col-md-4 col-md-offset-4">
-                <img src="/images/error.png" style="float: left; margin: 0 10px 10px 0; height: 90px;">
-                <p>
-                    The page you are looking for is not there.<br><br>
-                    Make sure that the URL is correct, or go to <a href="/">main page</a><br><br>
-                </p>
-            </div>
-        </div>
-    </div>
-
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/main/webapp/unauthorized.jsp
+++ b/src/main/webapp/unauthorized.jsp
@@ -1,41 +1,15 @@
-<%@ page import="teammates.common.util.Const"%>
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(401);%>
-<!DOCTYPE html>
-
-<html>
-<head>
-    <link rel="shortcut icon" href="/favicon.png">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TEAMMATES</title>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap.min.css" type="text/css"/>
-    <link rel="stylesheet" href="/bootstrap/css/bootstrap-theme.min.css" type="text/css"/>
-    <link rel="stylesheet" href="stylesheets/teammatesCommon.css" type="text/css">
-</head>
-<body>
-    <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="container">
-            <div class="navbar-header">
-                <a class="navbar-brand" href="/index.html">TEAMMATES</a>
-            </div>
+<t:errorPage>
+    <br><br>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/angry.png" style="float: left; height: 90px; margin: 0 10px 10px 0;">
+            <p>
+                You are not authorized to view this page. <br> <br>
+                <a href="/logout.jsp">Logout and return to main page.</a>
+            </p>
+            <br>
         </div>
     </div>
-
-    <div id="mainContent" class="container">
-        <br><br>
-        <div class="row">
-            <div class="alert alert-warning col-md-4 col-md-offset-4">
-                <img src="/images/angry.png"
-                    style="float: left; height: 90px; margin: 0 10px 10px 0;">
-                <p>
-                    You are not authorized to view this page. <br> <br>
-                    <a href="/logout.jsp">Logout and return to main page.</a>
-                </p>
-                <br>
-            </div>
-        </div>
-    </div>
-
-    <jsp:include page="<%=Const.ViewURIs.FOOTER%>" />
-</body>
-</html>
+</t:errorPage>

--- a/src/test/resources/pages/entityNotFoundPage.html
+++ b/src/test/resources/pages/entityNotFoundPage.html
@@ -8,7 +8,7 @@
 </title>
 <link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="/bootstrap/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
-<link href="stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
+<link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -62,8 +62,6 @@
       </a>
       <br>
       <br>
-      <p>
-      </p>
     </div>
   </div>
 </div>

--- a/src/test/resources/pages/errorPage.html
+++ b/src/test/resources/pages/errorPage.html
@@ -8,7 +8,7 @@
 </title>
 <link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="/bootstrap/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
-<link href="stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
+<link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">

--- a/src/test/resources/pages/pageNotFound.html
+++ b/src/test/resources/pages/pageNotFound.html
@@ -1,8 +1,8 @@
 <html>
 <head>
 <link href="/favicon.png" rel="shortcut icon">
-<meta content="width=device-width, initial-scale=1.0" name="viewport">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<meta content="width=device-width, initial-scale=1.0" name="viewport">
 <title>
   TEAMMATES
 </title>

--- a/src/test/resources/pages/unauthorized.html
+++ b/src/test/resources/pages/unauthorized.html
@@ -8,7 +8,7 @@
 </title>
 <link href="/bootstrap/css/bootstrap.min.css" rel="stylesheet" type="text/css">
 <link href="/bootstrap/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
-<link href="stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
+<link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
Fixes #5231 

`logout.jsp` has noticeably different look and not captured in tests (because that page is not tested).

Before:
![screen shot 2016-04-16 at 4 56 42 pm](https://cloud.githubusercontent.com/assets/7261051/14580073/59770b80-03f4-11e6-9ba8-41d6a49efa61.png)

After:
![screen shot 2016-04-16 at 4 58 00 pm](https://cloud.githubusercontent.com/assets/7261051/14580076/6c556cf6-03f4-11e6-81a6-10d859e21e5c.png)

Other affected pages are tested and only have minor to no changes.