### PR TITLE
Add new rules to Checkstyle-No whitespace after operators

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminEmailLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailLogPageData.java
@@ -232,7 +232,7 @@ public class AdminEmailLogPageData extends PageData {
                 Date d = sdf.parse(values[0] + " 0:00");                          
                 Calendar cal = Calendar.getInstance();
                 cal.setTime(d);
-                cal = TimeHelper.convertToUserTimeZone(cal, - Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE);
+                cal = TimeHelper.convertToUserTimeZone(cal, -Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE);
                 fromDateValue = cal.getTime().getTime();
                 
             } else if (label.equals("before")){
@@ -241,7 +241,7 @@ public class AdminEmailLogPageData extends PageData {
                 Date d = sdf.parse(values[0] + " 23:59");  
                 Calendar cal = Calendar.getInstance();
                 cal.setTime(d);
-                cal = TimeHelper.convertToUserTimeZone(cal, - Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE);
+                cal = TimeHelper.convertToUserTimeZone(cal, -Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE);
                 toDateValue = cal.getTime().getTime();          
             } else if (label.equals("receiver")){
                 isReceiverInQuery = true;

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT"/>
+      <property name="tokens" value="BNOT,DEC"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT,DEC"/>
+      <property name="tokens" value="BNOT,DEC,DOT"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -7,6 +7,9 @@
     <module name="WhitespaceAfter">
       <property name="tokens" value="COMMA"/>
     </module>
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="BNOT"/>
+    </module>
   </module>
   <module name="FileTabCharacter"/>
 </module>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT,DEC,DOT"/>
+      <property name="tokens" value="BNOT,DEC,DOT,INC"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT,DEC,DOT,INC"/>
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS"/>
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -8,7 +8,7 @@
       <property name="tokens" value="COMMA"/>
     </module>
     <module name="NoWhitespaceAfter">
-      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT"/>
+      <property name="tokens" value="BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>


### PR DESCRIPTION
Added no whitespace after rule for bitwise complement `~`, prefix decrement `--`, dot `.`, prefix increment `++`, logical complement `!`, unary minus `-`, unary plus operators `+`.

I'm not sure what the whitespace after policy for typecasts should be like though.