### PR TITLE
Add new rules to ESLint - naming conventions

### DIFF
--- a/devdocs/staticAnalysis.md
+++ b/devdocs/staticAnalysis.md
@@ -49,6 +49,18 @@ To set it up, [install node.js](https://nodejs.org/en/download/) if necessary an
 npm install -g eslint
 ```
 
+##### Suppressing ESLint warnings
+
+To introduce code that violates ESLint rules, wrap the violating code with `/* eslint-disable rule-name */` and re-enable it afterwards
+with `/* eslint-enable rule-name */`. The suppression should be as specific as possible, and the reason for violating the rule should be explained.
+
+An example to suppress the `camelcase` rule is as follows:
+```javascript
+/* eslint-disable camelcase */ // The variable name is provided by an external library, which does not follow camelcase.
+// violating codes go here
+/* eslint-enable camelcase */
+```
+
 ### blanket.js
 
 [blanket.js](http://blanketjs.org) measures code coverage for JavaScript test run.

--- a/src/main/webapp/js/adminEmail.js
+++ b/src/main/webapp/js/adminEmail.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
     
     $(".navbar-fixed-top").css("zIndex", 0);
     
+    /* eslint-disable camelcase */
     tinymce.init({
         selector: "textarea",
         theme: "modern",
@@ -55,7 +56,7 @@ $(document).ready(function() {
         }
         
     });
-    
+    /* eslint-enable camelcase */
     
     $("#adminEmailFile").on("change paste keyup", function() {
         createImageUploadUrl();        

--- a/src/main/webapp/js/adminEmail.js
+++ b/src/main/webapp/js/adminEmail.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     
     $(".navbar-fixed-top").css("zIndex", 0);
     
-    /* eslint-disable camelcase */
+    /* eslint-disable camelcase */ // The property names are determined by external library (tinymce)
     tinymce.init({
         selector: "textarea",
         theme: "modern",

--- a/src/main/webapp/js/administrator.js
+++ b/src/main/webapp/js/administrator.js
@@ -4,7 +4,7 @@
  */
 
 // AJAX
-var xmlhttp = new getXMLObject();
+var xmlhttp = getXMLObject();
 
 // OPERATIONS
 var OPERATION_ADMINISTRATOR_ADDINSTRUCTORINATOR = "administrator_addinstructor";

--- a/src/main/webapp/js/contextualcomments.js
+++ b/src/main/webapp/js/contextualcomments.js
@@ -35,9 +35,9 @@ $(document).ready(function() {
         $('#commentArea').hide();
     });
     
-    $('#comment_recipient_select').change(commentRecipientSelect_changeHandler);
+    $('#comment_recipient_select').change(commentRecipientSelectChangeHandler);
     
-    function commentRecipientSelect_changeHandler() {
+    function commentRecipientSelectChangeHandler() {
         //TODO: replace PERSON/TEAM/SECTION etc with constants in common.js
         var selectedValue = $('#comment_recipient_select option:selected').val();
         if (selectedValue == 'PERSON') {
@@ -102,10 +102,10 @@ $(document).ready(function() {
         $('#button_add_comment').click();
         if (commentRecipient == "team") {
             $('#comment_recipient_select').val('TEAM');
-            commentRecipientSelect_changeHandler();
+            commentRecipientSelectChangeHandler();
         } else if (commentRecipient == "section") {
             $('#comment_recipient_select').val('SECTION');
-            commentRecipientSelect_changeHandler();
+            commentRecipientSelectChangeHandler();
         }
     }
 });

--- a/src/main/webapp/js/contextualcomments.js
+++ b/src/main/webapp/js/contextualcomments.js
@@ -69,15 +69,15 @@ $(document).ready(function() {
     
     function visibilityOptionsHandler(e) {
         var visibilityOptions = [];
-        var _target = $(e.target);
+        var target = $(e.target);
         
-        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
-            _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
-            _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
+        if (target.prop("class").includes("answerCheckbox") && !target.prop("checked")) {
+            target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
+            target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").includes("giverCheckbox") || 
-                _target.prop("class").includes("recipientCheckbox")) && _target.prop("checked")) {
-            _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
+        if ((target.prop("class").includes("giverCheckbox") || 
+                target.prop("class").includes("recipientCheckbox")) && target.prop("checked")) {
+            target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }
         
         $('.answerCheckbox:checked').each(function() {

--- a/src/main/webapp/js/feedbackResponseComments.js
+++ b/src/main/webapp/js/feedbackResponseComments.js
@@ -186,16 +186,16 @@ function registerResponseCommentCheckboxEvent() {
         var table = $(this).parent().parent().parent().parent();
         var form = table.parent().parent().parent();
         var visibilityOptions = [];
-        var _target = $(e.target);
+        var target = $(e.target);
         
-        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
-            _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
-            _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
+        if (target.prop("class").includes("answerCheckbox") && !target.prop("checked")) {
+            target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
+            target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").includes("giverCheckbox") || 
-             _target.prop("class").includes("recipientCheckbox")) &&
-             _target.prop("checked")) {
-            _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
+        if ((target.prop("class").includes("giverCheckbox") || 
+             target.prop("class").includes("recipientCheckbox")) &&
+             target.prop("checked")) {
+            target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }
         
         table.find('.answerCheckbox:checked').each(function() {
@@ -440,16 +440,16 @@ function registerCheckboxEventForVisibilityOptions() {
         var table = $(this).parent().parent().parent().parent();
         var form = table.parent().parent().parent();
         var visibilityOptions = [];
-        var _target = $(e.target);
+        var target = $(e.target);
         
-        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
-            _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
-            _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
+        if (target.prop("class").includes("answerCheckbox") && !target.prop("checked")) {
+            target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
+            target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").includes("giverCheckbox") || 
-             _target.prop("class").includes("recipientCheckbox")) &&
-             _target.prop("checked")) {
-            _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
+        if ((target.prop("class").includes("giverCheckbox") || 
+             target.prop("class").includes("recipientCheckbox")) &&
+             target.prop("checked")) {
+            target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }
         
         table.find('.answerCheckbox:checked').each(function() {

--- a/src/main/webapp/js/googleAnalytics.js
+++ b/src/main/webapp/js/googleAnalytics.js
@@ -1,3 +1,4 @@
+  /* eslint-disable no-underscore-dangle */
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-37652587-1']);
   _gaq.push(['_trackPageview']);

--- a/src/main/webapp/js/googleAnalytics.js
+++ b/src/main/webapp/js/googleAnalytics.js
@@ -1,4 +1,4 @@
-  /* eslint-disable no-underscore-dangle */
+  /* eslint-disable no-underscore-dangle */ // The variable name is determined by external library (googleAnalytics)
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', 'UA-37652587-1']);
   _gaq.push(['_trackPageview']);

--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -1,5 +1,5 @@
 // AJAX
-var xmlhttp = new getXMLObject();
+var xmlhttp = getXMLObject();
 
 // OPERATIONS
 var OPERATION_INSTRUCTORINATOR_LOGIN = "instructor_login";

--- a/src/main/webapp/js/omniComment.js
+++ b/src/main/webapp/js/omniComment.js
@@ -355,15 +355,15 @@ $(document).ready(function() {
         var table = $(this).parent().parent().parent().parent();
         var form = table.parent().parent().parent();
         var visibilityOptions = [];
-        var _target = $(e.target);
+        var target = $(e.target);
         
-        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
-            _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
-            _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
+        if (target.prop("class").includes("answerCheckbox") && !target.prop("checked")) {
+            target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
+            target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").includes("giverCheckbox") || 
-                _target.prop("class").includes("recipientCheckbox")) && _target.prop("checked")) {
-            _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
+        if ((target.prop("class").includes("giverCheckbox") || 
+                target.prop("class").includes("recipientCheckbox")) && target.prop("checked")) {
+            target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }
         
         table.find('.answerCheckbox:checked').each(function() {

--- a/src/main/webapp/js/studentProfile.js
+++ b/src/main/webapp/js/studentProfile.js
@@ -95,7 +95,7 @@ function finaliseUploadPictureForm(event) {
             $('#profileUploadPictureSubmit').html("<img src='../images/ajax-loader.gif'/>");
         },
         error: function() {
-            $('#profileUploadPictureSubmit').Text(initialSubmitMessage);
+            $('#profileUploadPictureSubmit').text(initialSubmitMessage);
             setStatusMessage('There seems to be a network error, please try again later', StatusType.DANGER);
             scrollToTop({ duration: '' });
         },
@@ -107,7 +107,7 @@ function finaliseUploadPictureForm(event) {
                 $('#profilePictureUploadForm').attr('action', data.formUrl);
                 $('#profilePictureUploadForm').submit();
             } else {
-                $('#profileUploadPictureSubmit').Text(initialSubmitMessage);
+                $('#profileUploadPictureSubmit').text(initialSubmitMessage);
                 setStatusMessage('There seems to be a network error, please try again later', StatusType.DANGER);
                 scrollToTop({ duration: '' });
             }

--- a/src/main/webapp/js/studentProfile.js
+++ b/src/main/webapp/js/studentProfile.js
@@ -40,7 +40,7 @@ $(function() {
             //
             // It utilizes an internal method from the library (_offset)
             // to update the (top, left) offset values for the image.
-            /* eslint-disable no-underscore-dangle */
+            /* eslint-disable no-underscore-dangle */ // The method name is determined by external library (guillotine)
             $('#profilePicEditPanUp').click(function() {
                 var data = picture.guillotine('getData');
                 picture.guillotine('instance')._offset(data.x / data.w, (data.y - 10) / data.h);

--- a/src/main/webapp/js/studentProfile.js
+++ b/src/main/webapp/js/studentProfile.js
@@ -40,6 +40,7 @@ $(function() {
             //
             // It utilizes an internal method from the library (_offset)
             // to update the (top, left) offset values for the image.
+            /* eslint-disable no-underscore-dangle */
             $('#profilePicEditPanUp').click(function() {
                 var data = picture.guillotine('getData');
                 picture.guillotine('instance')._offset(data.x / data.w, (data.y - 10) / data.h);
@@ -56,6 +57,7 @@ $(function() {
                 var data = picture.guillotine('getData');
                 picture.guillotine('instance')._offset(data.x / data.w, (data.y + 10) / data.h);
             });
+            /* eslint-enable no-underscore-dangle */
             $('#pictureWidth').val(picture.prop('naturalWidth'));
             $('#pictureHeight').val(picture.prop('naturalHeight'));
             if ($('#profilePic').attr('data-edit') == "true") {

--- a/static-analysis/teammates.eslintrc
+++ b/static-analysis/teammates.eslintrc
@@ -172,17 +172,20 @@
         "space-infix-ops": 2,                               // require space around operators
         "space-unary-ops": 2,                               // disallow space before/after unary operators
 
+        ////////// Naming Conventions //////////
+
+        "camelcase": 2,                 // require camel case names
+        "new-cap": 2,                   // require a capital letter for constructors
+        "no-underscore-dangle": 2,      // disallow dangling underscores in identifiers
+
         ////////// Stylistic Issues //////////
 
         "brace-style": 0,               // enforce one true brace style (off by default)
-        "camelcase": 0,                 // require camel case names
         "comma-style": 0,               // enforce one true comma style (off by default)
         "consistent-this": 0,           // enforces consistent naming when capturing the current execution context (off by default)
         "eol-last": 0,                  // enforce newline at the end of file, with no multiple empty lines
-        "func-names": 0,                // require function expressions to have a name (off by default)
         "func-style": 0,                // enforces use of function declarations or expressions (off by default)
         "max-nested-callbacks": 0,      // specify the maximum depth callbacks can be nested (off by default)
-        "new-cap": 0,                   // require a capital letter for constructors
         "new-parens": 0,                // disallow the omission of parentheses when invoking a constructor with no arguments
         "no-array-constructor": 0,      // disallow use of the Array constructor
         "no-inline-comments": 0,        // disallow comments inline after code (off by default)
@@ -192,7 +195,6 @@
         "no-new-object": 0,             // disallow use of the Object constructor
         "no-ternary": 0,                // disallow the use of ternary operators (off by default)
         "no-trailing-spaces": 0,        // disallow trailing whitespace at the end of lines
-        "no-underscore-dangle": 0,      // disallow dangling underscores in identifiers
         "no-wrap-func": 0,              // disallow wrapping of non-IIFE statements in parens
         "one-var": 0,                   // allow just one var statement per function (off by default)
         "operator-assignment": 0,       // require assignment operator shorthand where possible or prohibit it entirely (off by default)


### PR DESCRIPTION
Three more rules, this time on naming conventions:
- new-cap, disallows things like `new lowerCaseObject()`
- no-underscore-dangle, applies on both variable names and method names
- camelcase, self-explanatory

In some places the rules are suppressed because we're using names provided by external libraries.