### PR TITLE
Add new rules to ESLint - Constructors

### DIFF
--- a/src/main/webapp/js/ajaxResponseRate.js
+++ b/src/main/webapp/js/ajaxResponseRate.js
@@ -1,7 +1,7 @@
 function linkAjaxForResponseRate() {
     var responseRateClickHandler = function(e) {
-        var hyperlinkObject = $(this).clone(),
-            parentOfHyperlinkObject = $(this).parent();
+        var hyperlinkObject = $(this).clone();
+        var parentOfHyperlinkObject = $(this).parent();
         e.preventDefault();
         $.ajax({
             type: 'POST',
@@ -37,8 +37,9 @@ function linkAjaxForResponseRate() {
         var allRows = currentTable.find('tr:has(td)');
         var recentElements = allRows.filter(function(i) {
             return $(allRows[i]).find('td[class*="recent"]').length;
-        }),
-            nonRecentElements = allRows.filter(function(i) {
+        });
+
+        var nonRecentElements = allRows.filter(function(i) {
             return !$(allRows[i]).find('td[class*="recent"]').length;
         });
 

--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -444,13 +444,13 @@ function getPointValue(s, ditchZero) {
  * @return true if it is within the viewport, false otherwise 
  */
 function isWithinView(element) {
-    var viewHeight = window.innerHeight,
-        viewTop = window.scrollY,
-        viewBottom = viewTop + viewHeight;
+    var viewHeight = window.innerHeight;
+    var viewTop = window.scrollY;
+    var viewBottom = viewTop + viewHeight;
     
-    var elementHeight = element.offsetHeight,
-        elementTop = element.offsetTop,
-        elementBottom = elementTop + elementHeight;
+    var elementHeight = element.offsetHeight;
+    var elementTop = element.offsetTop;
+    var elementBottom = elementTop + elementHeight;
     
     return viewHeight >= elementHeight
            ? viewTop <= elementTop && viewBottom >= elementBottom          // all within view
@@ -491,24 +491,24 @@ function scrollToElement(element, options) {
     var defaultOptions = { type: 'top', offset: 0, duration: 0 };
     
     options = options || {};
-    var type = options.type || defaultOptions.type,
-        offset = options.offset !== undefined ? options.offset : defaultOptions.offset,
-        duration = options.duration !== undefined ? options.duration : defaultOptions.duration;
+    var type = options.type || defaultOptions.type;
+    var offset = options.offset !== undefined ? options.offset : defaultOptions.offset;
+    var duration = options.duration !== undefined ? options.duration : defaultOptions.duration;
     
     var isViewType = type === 'view';
     if (isViewType && isWithinView(element)) {
         return;
     }
     
-    var navbar = document.getElementsByClassName('navbar')[0],
-        navbarHeight = navbar ? navbar.offsetHeight : 0;
-    var footer = document.getElementById('footerComponent'),
-        footerHeight = footer ? footer.offsetHeight : 0;
+    var navbar = document.getElementsByClassName('navbar')[0];
+    var navbarHeight = navbar ? navbar.offsetHeight : 0;
+    var footer = document.getElementById('footerComponent');
+    var footerHeight = footer ? footer.offsetHeight : 0;
     var windowHeight = window.innerHeight - navbarHeight - footerHeight;
     
-    var isElementTallerThanWindow = windowHeight < element.offsetHeight,
-        isFromAbove = window.scrollY < element.offsetTop,
-        isAlignedToTop = !isViewType || isElementTallerThanWindow || !isFromAbove;
+    var isElementTallerThanWindow = windowHeight < element.offsetHeight;
+    var isFromAbove = window.scrollY < element.offsetTop;
+    var isAlignedToTop = !isViewType || isElementTallerThanWindow || !isFromAbove;
     
     // default offset - from navbar / footer
     if (options.offset === undefined) {

--- a/src/main/webapp/js/instructorCourseDetails.js
+++ b/src/main/webapp/js/instructorCourseDetails.js
@@ -84,10 +84,11 @@ function toggleDeleteStudentConfirmation(courseId, studentName) {
  * @param el
  */
 function selectElementContents(el) {
-    var body = document.body, range, sel;
+    var body = document.body;
+    var range;
     if (document.createRange && window.getSelection) {
         range = document.createRange();
-        sel = window.getSelection();
+        var sel = window.getSelection();
         sel.removeAllRanges();
         try {
             range.selectNodeContents(el);

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -83,10 +83,10 @@ function filterResults(searchText) {
 
     // a stack that stores parent panels that are pending on 
     // the search result from the child panels to decide show/hide
-    var showStack = new Array();
+    var showStack = [];
 
     // a stack that stores the parent panels that have been traversed so far
-    var parentStack = new Array();
+    var parentStack = [];
 
     for (var p = 0; p < allPanelText.length; p++) {
         var panelText = allPanelText[p];

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -7,10 +7,11 @@
  * @param el
  */
 function selectElementContents(el) {
-    var body = document.body, range, sel;
+    var body = document.body;
+    var range;
     if (document.createRange && window.getSelection) {
         range = document.createRange();
-        sel = window.getSelection();
+        var sel = window.getSelection();
         sel.removeAllRanges();
         try {
             range.selectNodeContents(el);

--- a/src/main/webapp/js/studentProfile.js
+++ b/src/main/webapp/js/studentProfile.js
@@ -70,10 +70,10 @@ $(function() {
 });
 
 function finaliseEditPictureForm(event) {
-    var picture = $('#editableProfilePicture'),
-        transformData = picture.guillotine('getData'),
-        scaledWidth = picture.prop('naturalWidth') * transformData.scale,
-        scaledHeight = picture.prop('naturalHeight') * transformData.scale;
+    var picture = $('#editableProfilePicture');
+    var transformData = picture.guillotine('getData');
+    var scaledWidth = picture.prop('naturalWidth') * transformData.scale;
+    var scaledHeight = picture.prop('naturalHeight') * transformData.scale;
 
     $('#cropBoxLeftX').val(transformData.x);
     $('#cropBoxTopY').val(transformData.y);

--- a/src/main/webapp/js/userMap.js
+++ b/src/main/webapp/js/userMap.js
@@ -115,9 +115,9 @@ function handleData(err, countryCoordinates, userData) {
     });
 
     map.addPlugin('pins', function(layer, data, options) {
-        var self = this,
-            fillData = this.options.fills,
-            svg = this.svg;
+        var self = this;
+        var fillData = this.options.fills;
+        var svg = this.svg;
 
         if (!data || data && !data.slice) {
             handleError();

--- a/static-analysis/teammates.eslintrc
+++ b/static-analysis/teammates.eslintrc
@@ -181,12 +181,13 @@
 
         ////////// Constructors //////////
 
-        "new-parens": 2,            // disallow the omission of parentheses when invoking a constructor with no arguments
-        "no-array-constructor": 2,  // disallow use of the Array constructor
-        "no-new": 2,                // disallow use of new operator when not part of the assignment or comparison
-        "no-new-func": 2,           // disallow use of new operator for Function object
-        "no-new-object": 2,         // disallow use of the Object constructor
-        "no-new-wrappers": 2,       // disallows creating new instances of String, Number, and Boolean
+        "one-var": ["error", "never"],      // allow just one var statement per function
+        "new-parens": 2,                    // disallow the omission of parentheses when invoking a constructor with no arguments
+        "no-array-constructor": 2,          // disallow use of the Array constructor
+        "no-new": 2,                        // disallow use of new operator when not part of the assignment or comparison
+        "no-new-func": 2,                   // disallow use of new operator for Function object
+        "no-new-object": 2,                 // disallow use of the Object constructor
+        "no-new-wrappers": 2,               // disallows creating new instances of String, Number, and Boolean
 
 
         ////////// Stylistic Issues //////////
@@ -202,8 +203,6 @@
         "no-nested-ternary": 0,         // disallow nested ternary expressions (off by default)
         "no-ternary": 0,                // disallow the use of ternary operators (off by default)
         "no-trailing-spaces": 0,        // disallow trailing whitespace at the end of lines
-        "no-wrap-func": 0,              // disallow wrapping of non-IIFE statements in parens
-        "one-var": 0,                   // allow just one var statement per function (off by default)
         "operator-assignment": 0,       // require assignment operator shorthand where possible or prohibit it entirely (off by default)
         "padded-blocks": 0,             // enforce padding within blocks (off by default)
         "quote-props": 0,               // require quotes around object literal property names (off by default)

--- a/static-analysis/teammates.eslintrc
+++ b/static-analysis/teammates.eslintrc
@@ -104,9 +104,6 @@
         "no-multi-spaces": 0,       // disallow use of multiple spaces
         "no-multi-str": 0,          // disallow use of multiline strings
         "no-native-reassign": 0,    // disallow reassignments of native objects
-        "no-new": 0,                // disallow use of new operator when not part of the assignment or comparison
-        "no-new-func": 0,           // disallow use of new operator for Function object
-        "no-new-wrappers": 0,       // disallows creating new instances of String, Number, and Boolean
         "no-octal": 0,              // disallow use of octal literals
         "no-octal-escape": 0,       // disallow use of octal escape sequences in string literals, such as var foo = "Copyright \251";
         "no-process-env": 0,        // disallow use of process.env (off by default)
@@ -174,11 +171,23 @@
         "space-infix-ops": 2,                               // require space around operators
         "space-unary-ops": 2,                               // disallow space before/after unary operators
 
+
         ////////// Naming Conventions //////////
 
         "camelcase": 2,                 // require camel case names
         "new-cap": 2,                   // require a capital letter for constructors
         "no-underscore-dangle": 2,      // disallow dangling underscores in identifiers
+
+
+        ////////// Constructors //////////
+
+        "new-parens": 2,            // disallow the omission of parentheses when invoking a constructor with no arguments
+        "no-array-constructor": 2,  // disallow use of the Array constructor
+        "no-new": 2,                // disallow use of new operator when not part of the assignment or comparison
+        "no-new-func": 2,           // disallow use of new operator for Function object
+        "no-new-object": 2,         // disallow use of the Object constructor
+        "no-new-wrappers": 2,       // disallows creating new instances of String, Number, and Boolean
+
 
         ////////// Stylistic Issues //////////
 
@@ -188,12 +197,9 @@
         "eol-last": 0,                  // enforce newline at the end of file, with no multiple empty lines
         "func-style": 0,                // enforces use of function declarations or expressions (off by default)
         "max-nested-callbacks": 0,      // specify the maximum depth callbacks can be nested (off by default)
-        "new-parens": 0,                // disallow the omission of parentheses when invoking a constructor with no arguments
-        "no-array-constructor": 0,      // disallow use of the Array constructor
         "no-inline-comments": 0,        // disallow comments inline after code (off by default)
         "no-multiple-empty-lines": 0,   // disallow multiple empty lines (off by default)
         "no-nested-ternary": 0,         // disallow nested ternary expressions (off by default)
-        "no-new-object": 0,             // disallow use of the Object constructor
         "no-ternary": 0,                // disallow the use of ternary operators (off by default)
         "no-trailing-spaces": 0,        // disallow trailing whitespace at the end of lines
         "no-wrap-func": 0,              // disallow wrapping of non-IIFE statements in parens


### PR DESCRIPTION
This one revolves around constructors, in particular where the `new` keyword is discouraged.
Also added the "one-var" rule:
```javascript
var a = 1, b = 2; // bad
var a = 1;
var b = 2; // good
```