### PR TITLE
Add new rules to ESLint - Voids

### DIFF
--- a/src/main/webapp/js/administrator.js
+++ b/src/main/webapp/js/administrator.js
@@ -92,7 +92,7 @@ function isGoogleIDValid(googleID) {
     if (googleID.indexOf("\\") >= 0 || googleID.indexOf("'") >= 0
             || googleID.indexOf("\"") >= 0) {
         return false;
-    } else if (googleID.match(/^[a-zA-Z0-9@ .-]*$/) == null) {
+    } else if (googleID.match(/^[a-zA-Z0-9@ .-]*$/) === null) {
         return false;
     } else if (googleID.length > 29) {
         return false;

--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -229,7 +229,7 @@ function sortTable(oneOfTableCell, colIdx, comparator, ascending, row) {
     
     // Iterate through column's contents to decide which comparator to use
     for (var i = row; i < $RowList.length; i++) {
-        if ($RowList[i].cells[colIdx - 1] == undefined || $RowList[i].cells[colIdx - 1] == null) {
+        if ($RowList[i].cells[colIdx - 1] === undefined) {
             continue;
         }
         
@@ -250,7 +250,7 @@ function sortTable(oneOfTableCell, colIdx, comparator, ascending, row) {
         }
     }
     
-    if (comparator == null) {
+    if (comparator === null || comparator === undefined) {
         if (columnType === 1) {
             comparator = sortNum;
         } else if (columnType === 2) {
@@ -466,7 +466,7 @@ function isWithinView(element) {
  *                 400 ms will be used if any other string is supplied.
  */
 function scrollToPosition(scrollPos, duration) {
-    if (duration === undefined) {
+    if (duration === undefined || duration === null) {
         $(window).scrollTop(scrollPos);
     } else {
         $('html, body').animate({ scrollTop: scrollPos }, duration);
@@ -624,7 +624,7 @@ function isValidGoogleId(googleId) {
     // match() retrieve the matches when matching a string against a regular expression.
     var matches = googleId.match(/^([\w-]+(?:\.[\w-]+)*)/);
     
-    isValidNonEmailGoogleId = matches != null && matches[0] === googleId;
+    isValidNonEmailGoogleId = matches !== null && matches[0] === googleId;
     
     var isValidEmailGoogleId = isEmailValid(googleId);
     
@@ -644,7 +644,7 @@ function isValidGoogleId(googleId) {
  * @returns {Boolean}
  */
 function isEmailValid(email) {
-    return email.match(/^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i) != null;
+    return email.match(/^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i) !== null;
 }
 
 /**

--- a/src/main/webapp/js/datepicker.js
+++ b/src/main/webapp/js/datepicker.js
@@ -92,7 +92,7 @@ function getMaxDateForStartDate(endDate) {
 function getMaxDateForVisibleDate(startDate, publishDate) {
     var minDate = 0;
     
-    if (publishDate == null) {
+    if (publishDate === null || publishDate === undefined) {
         minDate = startDate;
     } else if (startDate > publishDate) {
         minDate = publishDate;

--- a/src/main/webapp/js/statusMessage.js
+++ b/src/main/webapp/js/statusMessage.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
     
     var navbar = document.getElementsByClassName('navbar')[0];
     
-    if (navbar != null) {
+    if (navbar !== undefined) {
         navbarHeight = navbar.offsetHeight;
     }
     

--- a/src/main/webapp/js/userMap.js
+++ b/src/main/webapp/js/userMap.js
@@ -20,7 +20,7 @@ function handleData(err, countryCoordinates, userData) {
     userData.forEach(function(entry) {
         var countryName = entry[entry.length - 1];
         var countryCode = getCountryCode(countryName);
-        if (countryCode != null) {
+        if (countryCode !== undefined) {
             countriesObj[countryCode] = countriesObj[countryCode] ? countriesObj[countryCode] + 1 : 1;
         }
     });

--- a/static-analysis/teammates.eslintrc
+++ b/static-analysis/teammates.eslintrc
@@ -68,7 +68,6 @@
         "no-regex-spaces": 0,         // disallow multiple spaces in a regular expression literal
         "no-reserved-keys": 0,        // disallow reserved words being used as object literal keys (off by default)
         "no-sparse-arrays": 0,        // disallow sparse arrays
-        "use-isnan": 0,               // disallow comparisons with the value NaN
         "valid-jsdoc": 0,             // Ensure JSDoc comments are valid (off by default)
         "valid-typeof": 0,            // Ensure that the results of typeof are compared against a valid string
 
@@ -91,7 +90,6 @@
         "no-caller": 0,             // disallow use of arguments.caller or arguments.callee
         "no-div-regex": 0,          // disallow division operators explicitly at beginning of regular expression (off by default)
         "no-empty-label": 0,        // disallow use of labels for anything other then loops and switches
-        "no-eq-null": 0,            // disallow comparisons to null without a type-checking operator (off by default)
         "no-eval": 0,               // disallow use of eval()
         "no-extend-native": 0,      // disallow adding to native types
         "no-extra-bind": 0,         // disallow unnecessary function binding
@@ -116,7 +114,6 @@
         "no-script-url": 0,         // disallow use of javascript: urls.
         "no-self-compare": 0,       // disallow comparisons where both sides are exactly the same (off by default)
         "no-sequences": 0,          // disallow use of comma operator
-        "no-void": 0,               // disallow use of void operator (off by default)
         "no-warning-comments": 0,   // disallow usage of configurable warning terms in comments, e.g. TODO or FIXME (off by default)
         "no-with": 0,               // disallow use of the with statement
         "radix": 0,                 // require use of the second argument for parseInt() (off by default)
@@ -132,6 +129,13 @@
         "strict": 0,          // controls location of Use Strict Directives
 
 
+        ////////// Voids //////////
+
+        "no-eq-null": 2,        // disallow comparisons to null without a type-checking operator
+        "no-undef-init": 2,     // disallow use of undefined when initializing variables
+        "use-isnan": 2,         // disallow comparisons with the value NaN
+
+
         ////////// Variables //////////
 
         "no-catch-shadow": 0,             // disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
@@ -140,8 +144,6 @@
         "no-shadow": 0,                   // disallow declaration of variables already declared in the outer scope
         "no-shadow-restricted-names": 0,  // disallow shadowing of names such as arguments
         "no-undef": 0,                    // disallow use of undeclared variables unless mentioned in a /*global */ block
-        "no-undef-init": 0,               // disallow use of undefined when initializing variables
-        "no-undefined": 0,                // disallow use of undefined variable (off by default)
         "no-unused-vars": 0,              // disallow declaration of variables that are not used in the code
         "no-use-before-define": 0,        // disallow use of variables before they are defined
 


### PR DESCRIPTION
This ruleset involves the theme of void-ness: null, undefined, NaN. Rules added:
- no-eq-null: disallows `a == null`, requires `a === null`
- use-isnan: disallows `a == NaN` (no violations)
- no-undef-init: disallows `var a = undefined;` (also no violations)

The resolution is as follows:
- If the var is user-supplied (e.g function parameter), check for both null and undefined.
- If the var is to check possible array out-of-bounds index access or object non-existent property access, check for undefined.
- If the var is to check regex non-match, check for null.

The last two corresponds to JS' implementation.