### PR TITLE
Add new rules to Checkstyle-Method parameter pad

### DIFF
--- a/src/client/java/teammates/client/scripts/DataGenerator.java
+++ b/src/client/java/teammates/client/scripts/DataGenerator.java
@@ -188,7 +188,7 @@ public class DataGenerator {
     /**
      * @return json string presenting the databundle 
      */
-    public static String output () {
+    public static String output() {
         System.out.println("Start writing to file !");
         String output = "{\n";
         output += allAccounts() + "\n\n";
@@ -279,7 +279,7 @@ public class DataGenerator {
     /**
      * @return Json string presentation for a instructor entity
      */
-    public static String instructor (String objName, String googleId, String courseId, String name, String email) {
+    public static String instructor(String objName, String googleId, String courseId, String name, String email) {
         String result = "\"" + objName + "\":{";
         result += "\"googleId\":\"" + googleId + "\",";
         result += "\"courseId\":\"" + courseId + "\",";
@@ -292,7 +292,7 @@ public class DataGenerator {
     /**
      * @return Json string presentation for a course entity
      */
-    public static String course (String objName, String id, String name) {
+    public static String course(String objName, String id, String name) {
         String result = "\"" + objName + "\":{";
         result += "\"id\":\"" + id + "\",";
         result += "\"name\":\"" + name + "\"";
@@ -303,7 +303,7 @@ public class DataGenerator {
     /**
      * @return Json string presentation for a student entity
      */
-    public static String student (String objName, String email, String name, 
+    public static String student(String objName, String email, String name, 
             String team, String id, String comments, String course, String profile) {
         String result = "\"" + objName + "\":{";
         result += "\"email\":\"" + email + "\",";

--- a/src/client/java/teammates/client/scripts/PerformanceProfiler.java
+++ b/src/client/java/teammates/client/scripts/PerformanceProfiler.java
@@ -70,10 +70,10 @@ public class PerformanceProfiler extends Thread {
     private String reportFilePath;
     private DataBundle data;
     private Gson gson = Utils.getTeammatesGson();
-    private Map<String, ArrayList<Float>> results = new HashMap<String, ArrayList<Float>> ();
+    private Map<String, ArrayList<Float>> results = new HashMap<String, ArrayList<Float>>();
     private Browser browser;
     
-    public PerformanceProfiler (String path) {
+    public PerformanceProfiler(String path) {
         reportFilePath = path;
     }
     
@@ -205,7 +205,7 @@ public class PerformanceProfiler extends Thread {
         String strLine;
         while ((strLine = br.readLine()) != null)
         {
-            System.out.println (strLine);
+            System.out.println(strLine);
             String[] strs = strLine.split("\\|");
             
             String testName = strs[0];

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -402,7 +402,7 @@ public class AccountsLogic {
         profilesDb.deletePicture(key);
     }
 
-    public void updateStudentProfilePicture (String googleId, String newPictureKey)
+    public void updateStudentProfilePicture(String googleId, String newPictureKey)
         throws EntityDoesNotExistException, BlobstoreFailureException {
         profilesDb.updateStudentProfilePicture(googleId, newPictureKey);
         

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -490,8 +490,8 @@ public class FeedbackResponsesLogic {
             FeedbackResponse createdResponseEntity = 
                     (FeedbackResponse) frDb.createEntity(newResponse);
             frDb.deleteEntity(oldResponse);
-            frcLogic.updateFeedbackResponseCommentsForChangingResponseId
-                    (oldResponse.getId(), createdResponseEntity.getId());
+            frcLogic.updateFeedbackResponseCommentsForChangingResponseId(
+                    oldResponse.getId(), createdResponseEntity.getId());
         } catch (EntityAlreadyExistsException e) {
             log.warning("Trying to update an existing response to one that already exists.");
             throw new EntityAlreadyExistsException(Const.StatusMessages.FEEDBACK_RESPONSE_RECIPIENT_ALREADY_EXISTS);

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -41,7 +41,7 @@ public class FeedbackQuestionsDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return Null if not found.
      */
-    public FeedbackQuestionAttributes getFeedbackQuestion (String feedbackQuestionId) {
+    public FeedbackQuestionAttributes getFeedbackQuestion(String feedbackQuestionId) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
 
         FeedbackQuestion fq = getFeedbackQuestionEntity(feedbackQuestionId);

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -55,10 +55,10 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null.
      * @return Null if not found.
      */
-    public FeedbackResponseAttributes getFeedbackResponse (
+    public FeedbackResponseAttributes getFeedbackResponse(
             String feedbackQuestionId, String giverEmail, String receiverEmail) {
         FeedbackResponse feedbackResponse = 
-                getFeedbackResponseEntityWithCheck (feedbackQuestionId, giverEmail, receiverEmail);
+                getFeedbackResponseEntityWithCheck(feedbackQuestionId, giverEmail, receiverEmail);
         if (feedbackResponse == null) {
             return null;
         }
@@ -92,7 +92,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return Null if not found.
      */
-    public FeedbackResponse getFeedbackResponseEntityWithCheck (
+    public FeedbackResponse getFeedbackResponseEntityWithCheck(
             String feedbackQuestionId, String giverEmail, String receiverEmail) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -116,7 +116,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return Null if not found.
      */
-    public FeedbackResponse getFeedbackResponseEntityOptimized (FeedbackResponseAttributes response) {
+    public FeedbackResponse getFeedbackResponseEntityOptimized(FeedbackResponseAttributes response) {
          return (FeedbackResponse) getEntity(response); 
     }
     
@@ -125,7 +125,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesForQuestionInSection (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForQuestionInSection(
             String feedbackQuestionId, String section) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -150,7 +150,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesForQuestion (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForQuestion(
             String feedbackQuestionId) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -397,7 +397,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForQuestion (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForQuestion(
             String feedbackQuestionId, String receiver) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -422,7 +422,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForQuestionInSection (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForQuestionInSection(
             String feedbackQuestionId, String receiver, String section) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -448,7 +448,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForQuestion (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForQuestion(
             String feedbackQuestionId, String giverEmail) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -474,7 +474,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForQuestionInSection (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForQuestionInSection(
             String feedbackQuestionId, String giverEmail, String section) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackQuestionId);
@@ -500,7 +500,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null.
      *  @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForSessionWithinRange (String giverEmail, String feedbackSessionName, String courseId, long range) {
+    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForSessionWithinRange(String giverEmail, String feedbackSessionName, String courseId, long range) {
 
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, giverEmail);
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackSessionName);
@@ -525,7 +525,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForCourse (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesForReceiverForCourse(
             String courseId, String receiver) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
@@ -551,7 +551,7 @@ public class FeedbackResponsesDb extends EntitiesDb {
      * * All parameters are non-null. 
      * @return An empty list if no such responses are found.
      */
-    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForCourse (
+    public List<FeedbackResponseAttributes> getFeedbackResponsesFromGiverForCourse(
             String courseId, String giverEmail) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);

--- a/src/main/java/teammates/storage/api/ProfilesDb.java
+++ b/src/main/java/teammates/storage/api/ProfilesDb.java
@@ -194,7 +194,7 @@ public class ProfilesDb extends EntitiesDb {
      * @param googleId
      * @return
      */
-    private StudentProfile getStudentProfileEntityForLegacyData (String googleId) {
+    private StudentProfile getStudentProfileEntityForLegacyData(String googleId) {
         Key key = KeyFactory.createKey(Account.class.getSimpleName(), googleId);
         try {
             // This method is not testable as loading legacy data into 

--- a/src/main/java/teammates/ui/controller/AdminEmailGroupReceiverListUploadAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailGroupReceiverListUploadAction.java
@@ -197,7 +197,7 @@ public class AdminEmailGroupReceiverListUploadAction extends Action {
         }
     }
 
-    private BlobInfo validateGroupReceiverListFile (BlobInfo groupReceiverListFile) {
+    private BlobInfo validateGroupReceiverListFile(BlobInfo groupReceiverListFile) {
         
         if (!groupReceiverListFile.getContentType().contains("text/")) {
             deleteGroupReceiverListFile(groupReceiverListFile.getBlobKey());

--- a/src/main/java/teammates/ui/controller/AdminEmailImageUploadAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailImageUploadAction.java
@@ -74,7 +74,7 @@ public class AdminEmailImageUploadAction extends Action {
         }
     }
 
-    private BlobInfo validateImage (BlobInfo image) {
+    private BlobInfo validateImage(BlobInfo image) {
         if (image.getSize() > Const.SystemParams.MAX_PROFILE_PIC_SIZE) {
             deleteImage(image.getBlobKey());
             isError = true;

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -85,11 +85,11 @@ public class PageData {
         return Sanitizer.sanitizeForJs(unsanitizedStringLiteral);
     }
     
-    public static String truncate (String untruncatedString, int truncateLength) {
+    public static String truncate(String untruncatedString, int truncateLength) {
         return StringHelper.truncate(untruncatedString, truncateLength);
     }
     
-    public static String displayDateTime (Date date) {
+    public static String displayDateTime(Date date) {
         return TimeHelper.formatTime12H(date);
     }
     

--- a/src/test/java/teammates/test/cases/automated/SubmissionsAdjustmentTest.java
+++ b/src/test/java/teammates/test/cases/automated/SubmissionsAdjustmentTest.java
@@ -248,8 +248,8 @@ public class SubmissionsAdjustmentTest extends BaseComponentUsingTaskQueueTestCa
         StudentAttributes student = dataBundle.students.get("student1InCourse1");
         
         //Verify pre-existing submissions and responses
-        int oldNumberOfResponsesForSession = getAllResponsesForStudentForSession
-                (student, session.feedbackSessionName).size();
+        int oldNumberOfResponsesForSession = 
+                getAllResponsesForStudentForSession(student, session.feedbackSessionName).size();
         assertTrue(oldNumberOfResponsesForSession != 0);
         
         String oldTeam = student.team;
@@ -260,8 +260,9 @@ public class SubmissionsAdjustmentTest extends BaseComponentUsingTaskQueueTestCa
         student.section = newSection;
         
         
-        StudentEnrollDetails enrollDetails = new StudentEnrollDetails
-                (UpdateStatus.MODIFIED, student.course, student.email, oldTeam, newTeam, oldSection, newSection);
+        StudentEnrollDetails enrollDetails = 
+                new StudentEnrollDetails(UpdateStatus.MODIFIED, student.course, student.email, 
+                                         oldTeam, newTeam, oldSection, newSection);
         ArrayList<StudentEnrollDetails> enrollList = new ArrayList<StudentEnrollDetails>();
         enrollList.add(enrollDetails);
         Gson gsonBuilder = Utils.getTeammatesGson();
@@ -277,8 +278,8 @@ public class SubmissionsAdjustmentTest extends BaseComponentUsingTaskQueueTestCa
         FeedbackSubmissionAdjustmentAction responseAdjustmentAction = new FeedbackSubmissionAdjustmentAction(paramMap);
         assertTrue(responseAdjustmentAction.execute());
         
-        int numberOfNewResponses = getAllResponsesForStudentForSession
-                (student, session.feedbackSessionName).size();
+        int numberOfNewResponses = 
+                getAllResponsesForStudentForSession(student, session.feedbackSessionName).size();
         assertEquals(0, numberOfNewResponses);        
     }
 

--- a/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
@@ -438,7 +438,7 @@ public class AccountsLogicTest extends BaseComponentTestCase {
         ______TS("success: instructor joined but account already exists");
         
         AccountAttributes nonInstrAccount = dataBundle.accounts.get("student1InCourse1");
-        InstructorAttributes newIns = new InstructorAttributes (null, instructor.courseId, nonInstrAccount.name, nonInstrAccount.email);
+        InstructorAttributes newIns = new InstructorAttributes(null, instructor.courseId, nonInstrAccount.name, nonInstrAccount.email);
         
         instructorsLogic.createInstructor(newIns);
         key = instructorsLogic.getKeyForInstructor(instructor.courseId, nonInstrAccount.email);
@@ -456,7 +456,7 @@ public class AccountsLogicTest extends BaseComponentTestCase {
         ______TS("success: instructor join and assigned institute when some instructors have not joined course");
         
         instructor = dataBundle.instructors.get("instructor4");
-        newIns = new InstructorAttributes (null, instructor.courseId, "anInstructorWithoutGoogleId", "anInstructorWithoutGoogleId@gmail.com");
+        newIns = new InstructorAttributes(null, instructor.courseId, "anInstructorWithoutGoogleId", "anInstructorWithoutGoogleId@gmail.com");
         
         instructorsLogic.createInstructor(newIns);  
         
@@ -464,7 +464,7 @@ public class AccountsLogicTest extends BaseComponentTestCase {
         nonInstrAccount.email = "newInstructor@gmail.com";
         nonInstrAccount.name = " newInstructor";
         nonInstrAccount.googleId = "newInstructorGoogleId";
-        newIns = new InstructorAttributes (null, instructor.courseId, nonInstrAccount.name, nonInstrAccount.email);
+        newIns = new InstructorAttributes(null, instructor.courseId, nonInstrAccount.name, nonInstrAccount.email);
         
         instructorsLogic.createInstructor(newIns);
         key = instructorsLogic.getKeyForInstructor(instructor.courseId, nonInstrAccount.email);

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -103,7 +103,7 @@ public class FeedbackSessionsLogicTest extends BaseComponentTestCase {
         testDeleteFeedbackSessionsForCourse();
     }
     
-    public void testGetFeedbackSessionsListForInstructor () throws Exception {        
+    public void testGetFeedbackSessionsListForInstructor() throws Exception {        
         List<FeedbackSessionAttributes> finalFsa = new ArrayList<FeedbackSessionAttributes>();
         Collection<FeedbackSessionAttributes> allFsa = dataBundle.feedbackSessions.values();
         
@@ -119,7 +119,7 @@ public class FeedbackSessionsLogicTest extends BaseComponentTestCase {
         
     }
     
-    public void testIsFeedbackSessionHasQuestionForStudents () throws Exception {
+    public void testIsFeedbackSessionHasQuestionForStudents() throws Exception {
         // no need to removeAndRestoreTypicalDataInDatastore() as the previous test does not change the db
         
         FeedbackSessionAttributes sessionWithStudents = dataBundle.feedbackSessions.get("gracePeriodSession");
@@ -131,17 +131,17 @@ public class FeedbackSessionsLogicTest extends BaseComponentTestCase {
             fsLogic.isFeedbackSessionHasQuestionForStudents("nOnEXistEnT session", "someCourse");
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException edne) {
-            assertEquals ("Trying to check a feedback session that does not exist.", 
+            assertEquals("Trying to check a feedback session that does not exist.", 
                     edne.getMessage());
         }
         
         ______TS("session contains students");
         
-        assertTrue (fsLogic.isFeedbackSessionHasQuestionForStudents(sessionWithStudents.feedbackSessionName, sessionWithStudents.courseId));
+        assertTrue(fsLogic.isFeedbackSessionHasQuestionForStudents(sessionWithStudents.feedbackSessionName, sessionWithStudents.courseId));
         
         ______TS("session does not contain students");
         
-        assertFalse (fsLogic.isFeedbackSessionHasQuestionForStudents(sessionWithoutStudents.feedbackSessionName, sessionWithoutStudents.courseId));
+        assertFalse(fsLogic.isFeedbackSessionHasQuestionForStudents(sessionWithoutStudents.feedbackSessionName, sessionWithoutStudents.courseId));
     }
     
     public void testGetFeedbackSessionsClosingWithinTimeLimit() throws Exception {

--- a/src/test/java/teammates/test/cases/logic/TeamEvalResultTest.java
+++ b/src/test/java/teammates/test/cases/logic/TeamEvalResultTest.java
@@ -368,40 +368,40 @@ public class TeamEvalResultTest extends BaseTestCase {
         
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{}, new double[]{})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{}, new double[]{})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{10}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{10}, new double[]{5})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{10}, new double[]{5})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{100, 50, 50}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{50, 100, 50}, new double[]{50, 25, 25})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{50, 100, 50}, new double[]{50, 25, 25})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{200, 100, 100}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{NA, 150, 50}, new double[]{50, 25, 25})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{NA, 150, 50}, new double[]{50, 25, 25})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{NA, NA, NA}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{NA, NA, NA}, new double[]{NA, NA, NA})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{NA, NA, NA}, new double[]{NA, NA, NA})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{100, 50, 50}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{NA, NA, NA}, new double[]{100, 50, 50})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{NA, NA, NA}, new double[]{100, 50, 50})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{100, 100, 400}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{50, 150, NA}, new double[]{50, 50, 200})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{50, 150, NA}, new double[]{50, 50, 200})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{0, 0, NA}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{0, 0, NA}, new double[]{0, 0, NA})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{0, 0, NA}, new double[]{0, 0, NA})));
         
         AssertJUnit.assertEquals(Arrays.toString(new int[]{NA, 25, 75}),
-                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent
-                        (new int[]{25, 25, 75}, new double[]{NA, 50, 150})));
+                Arrays.toString(TeamEvalResult.calculatePerceivedForStudent(
+                        new int[]{25, 25, 75}, new double[]{NA, 50, 150})));
     }
     
     @Test

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackAddActionTest.java
@@ -220,7 +220,7 @@ public class InstructorFeedbackAddActionTest extends BaseActionTest {
         FeedbackSessionsLogic.inst().deleteFeedbackSessionsForCourseCascade(instructor1ofCourse1.courseId);
     }
     
-    private InstructorFeedbackAddAction getAction (String... params) throws Exception {
+    private InstructorFeedbackAddAction getAction(String... params) throws Exception {
         return (InstructorFeedbackAddAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackCopyActionTest.java
@@ -192,7 +192,7 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
     }
     
-    private InstructorFeedbackCopyAction getAction (String... params) throws Exception {
+    private InstructorFeedbackCopyAction getAction(String... params) throws Exception {
         return (InstructorFeedbackCopyAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackEditPageActionTest.java
@@ -82,7 +82,7 @@ public class InstructorFeedbackEditPageActionTest extends BaseActionTest {
         }
     }
     
-    private InstructorFeedbackEditPageAction getAction (String... params) throws Exception {
+    private InstructorFeedbackEditPageAction getAction(String... params) throws Exception {
         return (InstructorFeedbackEditPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackEditSaveActionTest.java
@@ -184,7 +184,7 @@ public class InstructorFeedbackEditSaveActionTest extends BaseActionTest {
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
     }
     
-    private InstructorFeedbackEditSaveAction getAction (String... params) throws Exception {
+    private InstructorFeedbackEditSaveAction getAction(String... params) throws Exception {
         return (InstructorFeedbackEditSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionAddActionTest.java
@@ -885,7 +885,7 @@ public class InstructorFeedbackQuestionAddActionTest extends BaseActionTest {
         AssertHelper.assertLogMessageEquals(expectedLogMessage, action.getLogMessage());
     }
 
-    private InstructorFeedbackQuestionAddAction getAction (String... params) throws Exception {
+    private InstructorFeedbackQuestionAddAction getAction(String... params) throws Exception {
         return (InstructorFeedbackQuestionAddAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionCopyActionTest.java
@@ -153,7 +153,7 @@ public class InstructorFeedbackQuestionCopyActionTest extends BaseActionTest {
         AssertHelper.assertLogMessageEquals(expectedLogMessage, a.getLogMessage());
     }
 
-    private InstructorFeedbackQuestionCopyAction getAction (String... params) throws Exception {
+    private InstructorFeedbackQuestionCopyAction getAction(String... params) throws Exception {
         return (InstructorFeedbackQuestionCopyAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorSubmissionAdjustmentUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorSubmissionAdjustmentUiTest.java
@@ -89,8 +89,8 @@ public class InstructorSubmissionAdjustmentUiTest extends BaseUiTestCase {
         StudentAttributes student = testData.students.get("student1InCourse1");
         
         //Verify pre-existing submissions and responses
-        int oldNumberOfResponsesForSession = getAllResponsesForStudentForSession
-                (student, session.feedbackSessionName).size();
+        int oldNumberOfResponsesForSession = 
+                getAllResponsesForStudentForSession(student, session.feedbackSessionName).size();
         assertTrue(oldNumberOfResponsesForSession != 0);
         
         String newTeam = "Team 1.2";
@@ -101,8 +101,8 @@ public class InstructorSubmissionAdjustmentUiTest extends BaseUiTestCase {
         enrollPage.enroll(enrollString);
         
         
-        int numberOfNewResponses = getAllResponsesForStudentForSession
-                (student, session.feedbackSessionName).size();
+        int numberOfNewResponses = 
+                getAllResponsesForStudentForSession(student, session.feedbackSessionName).size();
         assertEquals(0, numberOfNewResponses);
         
     }

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -263,7 +263,7 @@ public class BackDoor {
         return status;
     }
     
-    public static String uploadAndUpdateStudentProfilePicture (String googleId, String pictureKey) {
+    public static String uploadAndUpdateStudentProfilePicture(String googleId, String pictureKey) {
         HashMap<String, Object> params = createParamMap(BackDoorServlet.OPERATION_EDIT_STUDENT_PROFILE_PICTURE);
         params.put(BackDoorServlet.PARAMETER_GOOGLE_ID, googleId);
         params.put(BackDoorServlet.PARAMETER_PICTURE_DATA, pictureKey);

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -1003,7 +1003,7 @@ public abstract class AppPage {
         client.close();
     }
     
-    public void verifyFieldValue (String fieldId, String expectedValue) {
+    public void verifyFieldValue(String fieldId, String expectedValue) {
         assertEquals(expectedValue,
                 browser.driver.findElement(By.id(fieldId)).getAttribute("value"));
     }

--- a/src/test/java/teammates/test/pageobjects/FeedbackQuestionSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackQuestionSubmitPage.java
@@ -24,7 +24,7 @@ public class FeedbackQuestionSubmitPage extends FeedbackSubmitPage {
         return browser.driver.findElement(By.name("fsname")).getAttribute("value");
     }
     
-    public boolean isCorrectPage (String courseId, String feedbackSessionName) {
+    public boolean isCorrectPage(String courseId, String feedbackSessionName) {
         boolean isCorrectCourseId = this.getCourseId().equals(courseId);
         boolean isCorrectFeedbackSessionName = this.getFeedbackSessionName().equals(feedbackSessionName);
         return isCorrectCourseId && isCorrectFeedbackSessionName && containsExpectedPageContents();

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -27,7 +27,7 @@ public class FeedbackSubmitPage extends AppPage {
         return browser.driver.findElement(By.name("fsname")).getAttribute("value");
     }
     
-    public boolean isCorrectPage (String courseId, String feedbackSessionName) {
+    public boolean isCorrectPage(String courseId, String feedbackSessionName) {
         boolean isCorrectCourseId = this.getCourseId().equals(courseId);
         boolean isCorrectFeedbackSessionName = this.getFeedbackSessionName().equals(feedbackSessionName);
         return isCorrectCourseId && isCorrectFeedbackSessionName && containsExpectedPageContents();

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
@@ -279,22 +279,22 @@ public class InstructorFeedbacksPage extends AppPage {
         button.click();
     }
     
-    public void fillStartTime (Date startTime) {
+    public void fillStartTime(Date startTime) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         fillTimeValueIfNotNull(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE, startTime, startTimeDropdown, js);
     }
     
-    public void fillEndTime (Date endTime) {
+    public void fillEndTime(Date endTime) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         fillTimeValueIfNotNull(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE, endTime, endTimeDropdown, js);
     }
     
-    public void fillVisibleTime (Date visibleTime) {
+    public void fillVisibleTime(Date visibleTime) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         fillTimeValueIfNotNull(Const.ParamsNames.FEEDBACK_SESSION_VISIBLEDATE, visibleTime, visibleTimeDropdown, js);
     }
     
-    public void fillPublishTime (Date publishTime) {
+    public void fillPublishTime(Date publishTime) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         fillTimeValueIfNotNull(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHDATE, publishTime, publishTimeDropdown, js);
     }
@@ -314,7 +314,7 @@ public class InstructorFeedbacksPage extends AppPage {
      * passes consistently, do not try to click on the datepicker element using Selenium as it will
      * result in a test that passes or fail randomly.
     */
-    public void fillTimeValueForDatePickerTest (String timeId, Calendar newValue) throws ParseException {
+    public void fillTimeValueForDatePickerTest(String timeId, Calendar newValue) throws ParseException {
         WebElement dateInputElement = browser.driver.findElement(By.id(timeId));
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
 
@@ -327,21 +327,21 @@ public class InstructorFeedbacksPage extends AppPage {
         js.executeScript("$('.ui-datepicker-current-day').click();");
     }
     
-    public String getValueOfDate (String timeId) {
+    public String getValueOfDate(String timeId) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         return (String) js.executeScript("return $('#" + timeId + "').datepicker('getDate') == null ? "
                                          + "null : "
                                          + "$('#" + timeId + "').datepicker('getDate').toDateString();");
     }
     
-    public String getMinDateOf (String timeId) {
+    public String getMinDateOf(String timeId) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         return (String) js.executeScript("return $('#" + timeId + "').datepicker('option', 'minDate') == null ? "
                                          + "null : "
                                          + "$('#" + timeId + "').datepicker('option', 'minDate').toDateString();");
     }
     
-    public String getMaxDateOf (String timeId) {
+    public String getMaxDateOf(String timeId) {
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         return (String) js.executeScript("return $('#" + timeId + "').datepicker('option', 'maxDate') == null ? "
                                          + "null : "
@@ -474,19 +474,19 @@ public class InstructorFeedbacksPage extends AppPage {
         }
     }
     
-    public boolean verifyHidden (By locator) {
+    public boolean verifyHidden(By locator) {
         return !browser.driver.findElement(locator).isDisplayed();
     }
     
-    public boolean verifyEnabled (By locator) {
+    public boolean verifyEnabled(By locator) {
         return browser.driver.findElement(locator).isEnabled();
     }
     
-    public boolean verifyDisabled (By locator) {
+    public boolean verifyDisabled(By locator) {
         return !browser.driver.findElement(locator).isEnabled();
     }
     
-    public boolean verifyVisible (By locator) {
+    public boolean verifyVisible(By locator) {
         return browser.driver.findElement(locator).isDisplayed();
     }
     
@@ -495,7 +495,7 @@ public class InstructorFeedbacksPage extends AppPage {
     }
     
     
-    public InstructorFeedbackResultsPage loadViewResultsLink (String courseId, String fsName) {
+    public InstructorFeedbackResultsPage loadViewResultsLink(String courseId, String fsName) {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-view-for-test";
         return goToLinkInRow(
@@ -504,7 +504,7 @@ public class InstructorFeedbacksPage extends AppPage {
                 InstructorFeedbackResultsPage.class);
     }
     
-    public FeedbackSubmitPage loadSubmitLink (String courseId, String fsName) {
+    public FeedbackSubmitPage loadSubmitLink(String courseId, String fsName) {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-submit-for-test";
         return goToLinkInRow(
@@ -513,7 +513,7 @@ public class InstructorFeedbacksPage extends AppPage {
                 FeedbackSubmitPage.class);
     }
     
-    public InstructorFeedbackEditPage loadEditLink (String courseId, String fsName) {
+    public InstructorFeedbackEditPage loadEditLink(String courseId, String fsName) {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-edit-for-test";
         return goToLinkInRow(

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -14,6 +14,9 @@
       <property name="allowEmptyMethods" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
     </module>
+    <module name="MethodParamPad">
+      <property name="tokens" value="CTOR_DEF,ENUM_CONSTANT_DEF,METHOD_CALL,METHOD_DEF,LITERAL_NEW,SUPER_CTOR_CALL"/>
+    </module>
   </module>
   <module name="FileTabCharacter"/>
 </module>


### PR DESCRIPTION
Added method parameter pad rule. 

The method parameter pad rule checks that there is no whitespace between the identifier of a method definition, constructor definition, method call, or constructor invocation; and the left parenthesis of the parameter list. 

Example: 
```
// Allowed
String myMethod(param1, param2) {
    // Method body
}

// Not Allowed
String myMethod (param1, param2) {
    // Method body
}
``` 