### PR TITLE
Add new rules to ESLint - no negated condition

### DIFF
--- a/src/main/webapp/js/adminActivityLog.js
+++ b/src/main/webapp/js/adminActivityLog.js
@@ -37,10 +37,10 @@ function submitLocalTimeAjaxRequest(time, googleId, role, entry) {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
-                    $(link).parent().html(originalTime + '<mark><br>' + data.logLocalTime + '</mark>');
-                } else {
+                if (data.isError) {
                     $(localTimeDisplay).html('Loading error, please retry');
+                } else {
+                    $(link).parent().html(originalTime + '<mark><br>' + data.logLocalTime + '</mark>');
                 }
                 
                 setStatusMessage(data.statusForAjax, StatusType.INFO);
@@ -69,17 +69,17 @@ function submitFormAjax(searchTimeOffset) {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
+                if (data.isError) {
+                    setFormErrorMessage(button, data.errorMessage);
+                } else {
                     // Inject new log row
                     var logs = data.logs;
-                    jQuery.each(logs, function(i, value) {
+                    $.each(logs, function(i, value) {
                         lastLogRow.after(value.logInfoAsHtml);
                         lastLogRow = $('#logsTable tr:last');
                     });
                     
                     updateInfoForRecentActionButton();
-                } else {
-                    setFormErrorMessage(button, data.errorMessage);
                 }
 
                 setStatusMessage(data.statusForAjax, StatusType.INFO);

--- a/src/main/webapp/js/adminEmail.js
+++ b/src/main/webapp/js/adminEmail.js
@@ -94,13 +94,12 @@ function createGroupReceiverListUploadUrl() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
+                if (data.isError) {
+                    setErrorMessage(data.ajaxStatus);
+                } else {
                     $('#adminEmailReceiverListForm').attr('action', data.nextUploadUrl);
                     setStatusMessage(data.ajaxStatus);
                     submitGroupReceiverListUploadFormAjax();
-                    
-                } else {
-                    setErrorMessage(data.ajaxStatus);
                 }
             }, 500);
         }
@@ -129,16 +128,13 @@ function submitGroupReceiverListUploadFormAjax() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
-                    if (data.isFileUploaded) {
-                        setStatusMessage(data.ajaxStatus, StatusType.SUCCESS);
-                        $('#groupReceiverListFileKey').val(data.groupReceiverListFileKey);
-                        $('#groupReceiverListFileKey').show();
-                        $('#groupReceiverListFileSize').val(data.groupReceiverListFileSize);
-                    } else {
-                        setErrorMessage(data.ajaxStatus);
-                    }
-                   
+                if (data.isError) {
+                    setErrorMessage(data.ajaxStatus);
+                } else if (data.isFileUploaded) {
+                    setStatusMessage(data.ajaxStatus, StatusType.SUCCESS);
+                    $('#groupReceiverListFileKey').val(data.groupReceiverListFileKey);
+                    $('#groupReceiverListFileKey').show();
+                    $('#groupReceiverListFileSize').val(data.groupReceiverListFileSize);
                 } else {
                     setErrorMessage(data.ajaxStatus);
                 }
@@ -162,13 +158,12 @@ function createImageUploadUrl() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
+                if (data.isError) {
+                    setErrorMessage(data.ajaxStatus);
+                } else {
                     $('#adminEmailFileForm').attr('action', data.nextUploadUrl);
                     setStatusMessage(data.ajaxStatus);
                     submitImageUploadFormAjax();
-                    
-                } else {
-                    setErrorMessage(data.ajaxStatus);
                 }
             }, 500);
 
@@ -199,15 +194,12 @@ function submitImageUploadFormAjax() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
-                    if (data.isFileUploaded) {
-                        url = data.fileSrcUrl;
-                        callbackFunction(url, { alt: PLACEHOLDER_IMAGE_UPLOAD_ALT_TEXT });
-                        setStatusMessage(data.ajaxStatus, StatusType.SUCCESS);
-                    } else {
-                        setErrorMessage(data.ajaxStatus);
-                    }
-                   
+                if (data.isError) {
+                    setErrorMessage(data.ajaxStatus);
+                } else if (data.isFileUploaded) {
+                    url = data.fileSrcUrl;
+                    callbackFunction(url, { alt: PLACEHOLDER_IMAGE_UPLOAD_ALT_TEXT });
+                    setStatusMessage(data.ajaxStatus, StatusType.SUCCESS);
                 } else {
                     setErrorMessage(data.ajaxStatus);
                 }

--- a/src/main/webapp/js/adminEmailLog.js
+++ b/src/main/webapp/js/adminEmailLog.js
@@ -64,7 +64,9 @@ function submitFormAjax(offset) {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
+                if (data.isError) {
+                    setFormErrorMessage(button, data.errorMessage);
+                } else {
                     // Inject new log row
                     var logs = data.logs;
                     $.each(logs, function(i, value) {
@@ -73,9 +75,6 @@ function submitFormAjax(offset) {
                         bindClickAction();
                         clickOlderButtonIfNeeded();
                     });
-                    
-                } else {
-                    setFormErrorMessage(button, data.errorMessage);
                 }
                                
                 setStatusMessage(data.statusForAjax, StatusType.INFO);

--- a/src/main/webapp/js/adminSearch.js
+++ b/src/main/webapp/js/adminSearch.js
@@ -80,16 +80,14 @@ function submitResetGoogleIdAjaxRequest(studentCourseId, studentEmail, wrongGoog
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
-                    if (data.isGoogleIdReset) {
-                        googleIdEntry.html('');
-                        $(button).hide();
-                    } else {
-                        googleIdEntry.html(originalGoogleIdEntry);
-                        $(button).html(originalButton);
-                    }
-                } else {
+                if (data.isError) {
                     $(button).html('An Error Occurred, Please Retry');
+                } else if (data.isGoogleIdReset) {
+                    googleIdEntry.html('');
+                    $(button).hide();
+                } else {
+                    googleIdEntry.html(originalGoogleIdEntry);
+                    $(button).html(originalButton);
                 }
                                
                 setStatusMessage(data.statusForAjax, StatusType.INFO);

--- a/src/main/webapp/js/checkBrowserVersion.js
+++ b/src/main/webapp/js/checkBrowserVersion.js
@@ -22,6 +22,7 @@ function checkBrowserVersion() {
     var verOffset;
     var supported = true;
 
+    /* eslint-disable no-negated-condition */ // usage of .contains() equivalent requires !==
     // In MSIE, the true version is after "MSIE" in userAgent
     if ((verOffset = nAgt.indexOf('MSIE')) !== -1) {
         browserName = MICROSOFT_INTERNET_EXPLORER;
@@ -63,6 +64,7 @@ function checkBrowserVersion() {
         fullVersion = 0;
         supported = false;
     }
+    /* eslint-enable no-negated-condition */
     
     if (!supported) {
         var message = document.getElementById('browserMessage');

--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -488,8 +488,8 @@ function scrollToElement(element, options) {
     
     options = options || {};
     var type = options.type || defaultOptions.type;
-    var offset = options.offset !== undefined ? options.offset : defaultOptions.offset;
-    var duration = options.duration !== undefined ? options.duration : defaultOptions.duration;
+    var offset = options.offset || defaultOptions.offset;
+    var duration = options.duration || defaultOptions.duration;
     
     var isViewType = type === 'view';
     if (isViewType && isWithinView(element)) {
@@ -836,10 +836,10 @@ function toggleSingleCollapse(e) {
     }
     var glyphIcon = $(this).find('.glyphicon');
     var className = $(glyphIcon[0]).attr('class');
-    if (className.indexOf('glyphicon-chevron-up') !== -1) {
-        hideSingleCollapse($(e.currentTarget).attr('data-target'));
-    } else {
+    if (className.indexOf('glyphicon-chevron-up') === -1) {
         showSingleCollapse($(e.currentTarget).attr('data-target'));
+    } else {
+        hideSingleCollapse($(e.currentTarget).attr('data-target'));
     }
 }
 

--- a/src/main/webapp/js/feedbackResponseComments.js
+++ b/src/main/webapp/js/feedbackResponseComments.js
@@ -32,32 +32,30 @@ var addCommentHandler = function(e) {
             submitButton.text('Add');
         },
         success: function(data) {
-            if (!data.isError) {
-                if (isInCommentsPage()) {
-                    reloadFeedbackResponseComments(formObject, panelHeading);
-                } else {
-                    // Inject new comment row
-                    addFormRow.parent().attr('class', 'list-group');
-                    addFormRow.before(data);
-                    removeUnwantedVisibilityOptions(commentId);
-
-                    // Reset add comment form
-                    formObject.find('textarea').prop('disabled', false);
-                    formObject.find('textarea').val('');
-                    submitButton.text('Add');
-                    submitButton.prop('disabled', false);
-                    cancelButton.prop('disabled', false);
-                    removeFormErrorMessage(submitButton);
-                    addFormRow.prev().find('div[id^=plainCommentText]').css('margin-left', '15px');
-                    addFormRow.prev().show();
-                    addFormRow.hide();
-                }
-            } else {
+            if (data.isError) {
                 formObject.find('textarea').prop('disabled', false);
                 setFormErrorMessage(submitButton, data.errorMessage);
                 submitButton.text('Add');
                 submitButton.prop('disabled', false);
                 cancelButton.prop('disabled', false);
+            } else if (isInCommentsPage()) {
+                reloadFeedbackResponseComments(formObject, panelHeading);
+            } else {
+                // Inject new comment row
+                addFormRow.parent().attr('class', 'list-group');
+                addFormRow.before(data);
+                removeUnwantedVisibilityOptions(commentId);
+
+                // Reset add comment form
+                formObject.find('textarea').prop('disabled', false);
+                formObject.find('textarea').val('');
+                submitButton.text('Add');
+                submitButton.prop('disabled', false);
+                cancelButton.prop('disabled', false);
+                removeFormErrorMessage(submitButton);
+                addFormRow.prev().find('div[id^=plainCommentText]').css('margin-left', '15px');
+                addFormRow.prev().show();
+                addFormRow.hide();
             }
         }
     });
@@ -91,31 +89,29 @@ var editCommentHandler = function(e) {
             cancelButton.prop('disabled', false);
         },
         success: function(data) {
-            if (!data.isError) {
-                if (isInCommentsPage()) {
-                    reloadFeedbackResponseComments(formObject, panelHeading);
-                } else {
-                    // Update editted comment
-                    displayedText.html(data.comment.commentText.value);
-                    updateVisibilityOptionsForResponseComment(formObject, data);
-                    commentBar.show();
-                    
-                    // Reset edit comment form
-                    formObject.find('textarea').prop('disabled', false);
-                    formObject.find('textarea').val(data.comment.commentText.value);
-                    submitButton.text('Save');
-                    submitButton.prop('disabled', false);
-                    cancelButton.prop('disabled', false);
-                    removeFormErrorMessage(submitButton);
-                    formObject.hide();
-                    displayedText.show();
-                }
-            } else {
+            if (data.isError) {
                 formObject.find('textarea').prop('disabled', false);
                 setFormErrorMessage(submitButton, data.errorMessage);
                 submitButton.text('Save');
                 submitButton.prop('disabled', false);
                 cancelButton.prop('disabled', false);
+            } else if (isInCommentsPage()) {
+                reloadFeedbackResponseComments(formObject, panelHeading);
+            } else {
+                // Update editted comment
+                displayedText.html(data.comment.commentText.value);
+                updateVisibilityOptionsForResponseComment(formObject, data);
+                commentBar.show();
+                
+                // Reset edit comment form
+                formObject.find('textarea').prop('disabled', false);
+                formObject.find('textarea').val(data.comment.commentText.value);
+                submitButton.text('Save');
+                submitButton.prop('disabled', false);
+                cancelButton.prop('disabled', false);
+                removeFormErrorMessage(submitButton);
+                formObject.hide();
+                displayedText.show();
             }
         }
     });
@@ -147,27 +143,25 @@ var deleteCommentHandler = function(e) {
             submitButton.html('<span class="glyphicon glyphicon-trash glyphicon-primary"></span>');
         },
         success: function(data) {
-            if (!data.isError) {
-                if (isInCommentsPage()) {
-                    reloadFeedbackResponseComments(formObject, panelHeading);
-                } else {
-                    var numberOfItemInFrCommentList = deletedCommentRow.parent().children('li');
-                    if (numberOfItemInFrCommentList.length <= 2) {
-                        deletedCommentRow.parent().hide();
-                    }
-                    if (frCommentList.find('li').length <= 1) {
-                        frCommentList.hide();
-                    }
-                    deletedCommentRow.remove();
-                    frCommentList.parent().find('div.delete_error_msg').remove();
-                }
-            } else {
+            if (data.isError) {
                 if (editForm.is(':visible')) {
                     setFormErrorMessage(editForm.find('div > a'), data.errorMessage);
                 } else if (frCommentList.parent().find('div.delete_error_msg').length === 0) {
                     frCommentList.after('<div class="delete_error_msg alert alert-danger">' + data.errorMessage + '</div>');
                 }
                 submitButton.html('<span class="glyphicon glyphicon-trash glyphicon-primary"></span>');
+            } else if (isInCommentsPage()) {
+                reloadFeedbackResponseComments(formObject, panelHeading);
+            } else {
+                var numberOfItemInFrCommentList = deletedCommentRow.parent().children('li');
+                if (numberOfItemInFrCommentList.length <= 2) {
+                    deletedCommentRow.parent().hide();
+                }
+                if (frCommentList.find('li').length <= 1) {
+                    frCommentList.hide();
+                }
+                deletedCommentRow.remove();
+                frCommentList.parent().find('div.delete_error_msg').remove();
             }
         }
     });
@@ -396,13 +390,13 @@ function loadFeedbackResponseComments(user, courseId, fsName, fsIndx, clickedEle
     $clickedElement.find('div[class^="placeholder-img-loading"]').html("<img src='/images/ajax-loader.gif'/>");
     
     panelBody.load(url, function(response, status) {
-        if (status !== 'success') {
-            panelBody.find('div[class^="placeholder-error-msg"]').removeClass('hidden');
-        } else {
+        if (status === 'success') {
             updateBadgeForPendingComments(parseInt(panelBody.children(':first').text()));
             panelBody.children(':first').remove();
 
             $clickedElement.addClass('loaded');
+        } else {
+            panelBody.find('div[class^="placeholder-error-msg"]').removeClass('hidden');
         }
 
         if (isClicked) {

--- a/src/main/webapp/js/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/js/feedbackSubmissionsEdit.js
@@ -557,10 +557,10 @@ function updateConstSumMessageQn(qnNum) {
     }
 
     function updateSumBasedOn(pointsAllocated) {
-        if (!isNumber(pointsAllocated)) {
-            pointsAllocated = 0;
-        } else {
+        if (isNumber(pointsAllocated)) {
             allNotNumbers = false;
+        } else {
+            pointsAllocated = 0;
         }
 
         sum += pointsAllocated;

--- a/src/main/webapp/js/instructorCourseDetails.js
+++ b/src/main/webapp/js/instructorCourseDetails.js
@@ -30,12 +30,12 @@ function submitFormAjax() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
-                    var table = data.studentListHtmlTableAsString;
-                    content.html('<small>' + table + '</small>');
-                } else {
+                if (data.isError) {
                     ajaxStatus.html(data.errorMessage);
                     content.html('<button class="btn btn-info" onclick="submitFormAjax()"> retry</button>');
+                } else {
+                    var table = data.studentListHtmlTableAsString;
+                    content.html('<small>' + table + '</small>');
                 }
 
                 setStatusMessage(data.statusForAjax);

--- a/src/main/webapp/js/instructorCourseEdit.js
+++ b/src/main/webapp/js/instructorCourseEdit.js
@@ -118,10 +118,10 @@ function setAddSectionLevelLink(instrNum) {
             break;
         }
     }
-    if (!foundNewLink) {
-        $('#addSectionLevelForInstructor' + instrNum).hide();
-    } else {
+    if (foundNewLink) {
         $('#addSectionLevelForInstructor' + instrNum).show();
+    } else {
+        $('#addSectionLevelForInstructor' + instrNum).hide();
     }
 }
 

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -738,11 +738,11 @@ function bindCopyButton() {
         e.preventDefault();
         
         var questionRows = $('#copyTableModal >tbody>tr');
-        if (!questionRows.length) {
-            setStatusMessage(FEEDBACK_QUESTION_COPY_INVALID, StatusType.DANGER);
-        } else {
+        if (questionRows.length) {
             setStatusMessage('', StatusType.WARNING);
             $('#copyModal').modal('show');
+        } else {
+            setStatusMessage(FEEDBACK_QUESTION_COPY_INVALID, StatusType.DANGER);
         }
        
         return false;
@@ -766,11 +766,11 @@ function bindCopyButton() {
             }
         });
 
-        if (!hasRowSelected) {
+        if (hasRowSelected) {
+            $('#copyModalForm').submit();
+        } else {
             setStatusMessage('No questions are selected to be copied', StatusType.DANGER);
             $('#copyModal').modal('hide');
-        } else {
-            $('#copyModalForm').submit();
         }
 
         return false;

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -44,13 +44,13 @@ function submitFormAjax() {
         },
         success: function(data) {
             setTimeout(function() {
-                if (!data.isError) {
+                if (data.isError) {
+                    ajaxStatus.html(data.errorMessage);
+                    content.html('<button class="btn btn-info" onclick="submitFormAjax()"> retry</button>');
+                } else {
                     var table = data.sessionResultsHtmlTableAsString;
                     content.html('<small>' + table + '</small>');
                     ajaxStatus.html(data.ajaxStatus);
-                } else {
-                    ajaxStatus.html(data.errorMessage);
-                    content.html('<button class="btn btn-info" onclick="submitFormAjax()"> retry</button>');
                 }
                 setStatusMessage(data.statusForAjax);
             }, 500);
@@ -128,13 +128,13 @@ function filterResults(searchText) {
                 // increment counter to skip child panels that have been shown
                 p += childrenSize;
             }
-        } else if (!hasChild) {
-            // current panel text does not match with search text & current panel has no child panels
-            $(panel).hide();
-        } else {
+        } else if (hasChild) {
             // current panel text does not match with search text & current panel has child panels
             // add current panel to pending parent panel stack
             showStack.push(panel);
+        } else {
+            // current panel text does not match with search text & current panel has no child panels
+            $(panel).hide();
         }
 
         if (hasChild) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
@@ -37,10 +37,10 @@ $(document).ready(function() {
                 } else {
                     var appendedSection = $(data).find('#sectionBody-0').html();
                     $(data).remove();
-                    if (typeof appendedSection !== 'undefined') {
-                        $(panelBody[0]).html(appendedSection);
-                    } else {
+                    if (typeof appendedSection === 'undefined') {
                         $(panelBody[0]).html('There are no responses for this feedback session yet or you do not have access to the responses collected so far.');
+                    } else {
+                        $(panelBody[0]).html(appendedSection);
                     }
                 }
 

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
@@ -37,10 +37,10 @@ $(document).ready(function() {
                 } else {
                     var appendedSection = $(data).find('#sectionBody-0').html();
                     $(data).remove();
-                    if (typeof appendedSection !== 'undefined') {
-                        $(panelBody[0]).html(appendedSection);
-                    } else {
+                    if (typeof appendedSection === 'undefined') {
                         $(panelBody[0]).html('There are no responses for this feedback session yet or you do not have access to the responses collected so far.');
+                    } else {
+                        $(panelBody[0]).html(appendedSection);
                     }
                 }
 

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
@@ -27,14 +27,14 @@ $(document).ready(function() {
                 var appendedQuestion = $(data).find('#questionBody-0').html();
                 var $panelBody = $(panelBody[0]);
                 $(data).remove();
-                if (typeof appendedQuestion !== 'undefined') {
+                if (typeof appendedQuestion === 'undefined') {
+                    $panelBody.removeClass('padding-0');
+                    $panelBody.html('There are too many responses for this question. Please view the responses one section at a time.');
+                } else {
                     if (appendedQuestion.indexOf('resultStatistics') === -1) {
                         $panelBody.removeClass('padding-0');
                     }
                     $panelBody.html(appendedQuestion);
-                } else {
-                    $panelBody.removeClass('padding-0');
-                    $panelBody.html('There are too many responses for this question. Please view the responses one section at a time.');
                 }
                 
                 bindErrorImages($panelBody.find('.profile-pic-icon-hover, .profile-pic-icon-click'));

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
@@ -37,10 +37,10 @@ $(document).ready(function() {
                 } else {
                     var appendedSection = $(data).find('#sectionBody-0').html();
                     $(data).remove();
-                    if (typeof appendedSection !== 'undefined') {
-                        $(panelBody[0]).html(appendedSection);
-                    } else {
+                    if (typeof appendedSection === 'undefined') {
                         $(panelBody[0]).html('There are no responses for this feedback session yet or you do not have access to the responses collected so far.');
+                    } else {
+                        $(panelBody[0]).html(appendedSection);
                     }
                 }
 

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
@@ -37,10 +37,10 @@ $(document).ready(function() {
                 } else {
                     var appendedSection = $(data).find('#sectionBody-0').html();
                     $(data).remove();
-                    if (typeof appendedSection !== 'undefined') {
-                        $(panelBody[0]).html(appendedSection);
-                    } else {
+                    if (typeof appendedSection === 'undefined') {
                         $(panelBody[0]).html('There are no responses for this feedback session yet or you do not have access to the responses collected so far.');
+                    } else {
+                        $(panelBody[0]).html(appendedSection);
                     }
                 }
 

--- a/src/main/webapp/js/instructorStudentListAjax.js
+++ b/src/main/webapp/js/instructorStudentListAjax.js
@@ -61,17 +61,17 @@ var seeMoreRequest = function(e) {
     
     if ($(panelHeading).attr('class').indexOf('ajax_submit') === -1) {
         clearStatusMessages();
-        if ($(panelCollapse[0]).attr('class').indexOf('checked') !== -1) {
+        if ($(panelCollapse[0]).attr('class').indexOf('checked') === -1) {
+            $(panelCollapse).collapse('show');
+            $(panelCollapse[0]).addClass('checked');
+            $(courseCheck).prop('checked', true);
+        } else {
             $(panelCollapse[0]).collapse('hide');
             $(panelHeading).addClass('ajax_submit');
             $(panelBody[0]).html('');
             $(panelCollapse[0]).removeClass('checked');
             $(courseCheck).prop('checked', false);
             numStudents -= courseNumStudents;
-        } else {
-            $(panelCollapse).collapse('show');
-            $(panelCollapse[0]).addClass('checked');
-            $(courseCheck).prop('checked', true);
         }
         checkCourseBinding(courseCheck);
     } else if (numStudents < STUDENT_LIMIT) {

--- a/src/main/webapp/js/omniComment.js
+++ b/src/main/webapp/js/omniComment.js
@@ -85,12 +85,12 @@ $(document).ready(function() {
         if ($("input[id^='panel_check']:checked").length === 0) {
             $('#no-comment-panel').show();
             // if all is checked, show giver and status for better user experience
-            if (!$('#panel_all').prop('checked')) {
-                $('#giver_all').parent().parent().hide();
-                $('#status_all').parent().parent().hide();
-            } else {
+            if ($('#panel_all').prop('checked')) {
                 $('#giver_all').parent().parent().show();
                 $('#status_all').parent().parent().show();
+            } else {
+                $('#giver_all').parent().parent().hide();
+                $('#status_all').parent().parent().hide();
             }
         } else {
             $('#no-comment-panel').hide();

--- a/src/main/webapp/js/studentProfile.js
+++ b/src/main/webapp/js/studentProfile.js
@@ -102,16 +102,16 @@ function finaliseUploadPictureForm() {
             scrollToTop({ duration: '' });
         },
         success: function(data) {
-            if (!data.isError) {
+            if (data.isError) {
+                $('#profileUploadPictureSubmit').text(initialSubmitMessage);
+                setStatusMessage('There seems to be a network error, please try again later', StatusType.DANGER);
+                scrollToTop({ duration: '' });
+            } else {
                 $('#profilePictureUploadForm').attr('enctype', 'multipart/form-data');
                 // for IE compatibility
                 $('#profilePictureUploadForm').attr('encoding', 'multipart/form-data');
                 $('#profilePictureUploadForm').attr('action', data.formUrl);
                 $('#profilePictureUploadForm').submit();
-            } else {
-                $('#profileUploadPictureSubmit').text(initialSubmitMessage);
-                setStatusMessage('There seems to be a network error, please try again later', StatusType.DANGER);
-                scrollToTop({ duration: '' });
             }
         }
     });

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -457,7 +457,7 @@ rules:
     no-multiple-empty-lines: "error"
 
     # disallow negated conditions
-    no-negated-condition: "error" # recommended by Google
+    no-negated-condition: "error"
 
     # disallow nested ternary expressions
     no-nested-ternary: "error"

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -454,7 +454,7 @@ rules:
     no-mixed-spaces-and-tabs: "error"
 
     # disallow multiple empty lines
-    # no-multiple-empty-lines: "off"
+    no-multiple-empty-lines: "error"
 
     # disallow negated conditions
     no-negated-condition: "error" # recommended by Google

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -457,7 +457,7 @@ rules:
     # no-multiple-empty-lines: "off"
 
     # disallow negated conditions
-    no-negated-condition: "off" # recommended by Google
+    no-negated-condition: "error" # recommended by Google
 
     # disallow nested ternary expressions
     no-nested-ternary: "error"


### PR DESCRIPTION
The rule is a parallel of PMD's ConfusingTernary rule. It's recommended by Google's style guide so we shouldn't go wrong with it.

Also enforced the no-multiple-empty-lines rule. It was fixed some time back but not enforced, but since Checkstyle enforced it for Java we might as well enforce it in JS too.