### PR TITLE
Add new rules to Checkstyle - Left right curly brace placement

### DIFF
--- a/src/client/java/teammates/client/scripts/ImportData.java
+++ b/src/client/java/teammates/client/scripts/ImportData.java
@@ -47,8 +47,7 @@ public final class ImportData {
         data = gson.fromJson(jsonString, DataBundle.class);
         
         String status = "";
-        do
-        {
+        do {
             long start = System.currentTimeMillis();
             boolean hasAccounts = !data.accounts.isEmpty();
             boolean hasInstructors = !data.instructors.isEmpty();
@@ -85,8 +84,7 @@ public final class ImportData {
      * @param map - HashMap which has data to persist
      * @return status of the Backdoor operation
      */
-    private static String persist(@SuppressWarnings("rawtypes") HashMap map)
-    {
+    private static String persist(@SuppressWarnings("rawtypes") HashMap map) {
         DataBundle bundle = new DataBundle();
         int count = 0;
         @SuppressWarnings("unchecked")
@@ -95,28 +93,23 @@ public final class ImportData {
         Iterator itr = set.iterator();
         
         String type = "";
-        while (itr.hasNext())
-        {
+        while (itr.hasNext()) {
             String key = (String) itr.next();
             Object obj = map.get(key);
             
-            if (obj instanceof AccountAttributes)
-            {
+            if (obj instanceof AccountAttributes) {
                 type = "AccountData";
                 AccountAttributes accountData = (AccountAttributes) obj;
                 bundle.accounts.put(key, accountData);
-            } else if (obj instanceof InstructorAttributes)
-            {
+            } else if (obj instanceof InstructorAttributes) {
                 type = "InstructorData";
                 InstructorAttributes instructorData = (InstructorAttributes) obj;
                 bundle.instructors.put(key, instructorData);
-            } else if (obj instanceof CourseAttributes)
-            {
+            } else if (obj instanceof CourseAttributes) {
                 type = "CourseData";
                 CourseAttributes courseData = (CourseAttributes) obj;
                 bundle.courses.put(key, courseData);
-            } else if (obj instanceof StudentAttributes)
-            {
+            } else if (obj instanceof StudentAttributes) {
                 type = "StudentData";
                 StudentAttributes studentData = (StudentAttributes) obj;
                 bundle.students.put(key, studentData);

--- a/src/client/java/teammates/client/scripts/OfflineBackup.java
+++ b/src/client/java/teammates/client/scripts/OfflineBackup.java
@@ -75,9 +75,7 @@ public class OfflineBackup extends RemoteApiClient {
                 modifiedLogs.add(logMessage);
             }
             in.close();
-        } 
-        
-        catch (IOException e) { 
+        } catch (IOException e) { 
             System.out.println("Error occurred while trying to access modified entity logs: " + e.getMessage());
         } 
         

--- a/src/client/java/teammates/client/scripts/ParallelProfiler.java
+++ b/src/client/java/teammates/client/scripts/ParallelProfiler.java
@@ -23,8 +23,7 @@ public final class ParallelProfiler {
     }
     
     public static void main(String[] args) {
-        for (int i = 0; i < NUM_OF_THREADS; i++)
-        {
+        for (int i = 0; i < NUM_OF_THREADS; i++) {
             (new PerformanceProfiler(TestProperties.TEST_DATA_FOLDER + "/thread" + i + ".txt")).start();
         }
     }

--- a/src/client/java/teammates/client/scripts/PerformanceProfiler.java
+++ b/src/client/java/teammates/client/scripts/PerformanceProfiler.java
@@ -90,8 +90,7 @@ public class PerformanceProfiler extends Thread {
             e1.printStackTrace();
         }
         Browser browser;
-        for (int i = 0; i < NUM_OF_RUNS; i++)
-        {
+        for (int i = 0; i < NUM_OF_RUNS; i++) {
             browser = BrowserPool.getBrowser();
             //overcome initial loading time with the below line
             //getInstructorAsJson();
@@ -130,21 +129,18 @@ public class PerformanceProfiler extends Thread {
             String name = test.name();
             boolean customTimer = test.customTimer();
             Type type = method.getReturnType();
-            if (!results.containsKey(name))
-            {
+            if (!results.containsKey(name)) {
                 results.put(name, new ArrayList<Float>());
             }
             try {
                 float duration = 0;
-                if (type.equals(String.class) && !customTimer)
-                {
+                if (type.equals(String.class) && !customTimer) {
                     long startTime = System.nanoTime();
                     Object retVal = (String) method.invoke(this);
                     long endTime = System.nanoTime();
                     duration = (float) ((endTime - startTime) / 1000000.0); //in miliSecond
                     System.out.print("Name: " + name + "\tTime: " + duration +  "\tVal: " + retVal.toString() + "\n");
-                } else if (type.equals(Long.class) && customTimer)
-                {
+                } else if (type.equals(Long.class) && customTimer) {
                     duration = (float) (((Long) (method.invoke(this))) / 1000000.0);
                     System.out.print("Name: " + name + "\tTime: " + duration + "\n");
                 }
@@ -180,8 +176,7 @@ public class PerformanceProfiler extends Thread {
      * @return HashMap<nameOfTest,durations> of the report stored in filePath 
      * @throws IOException
      */
-    private static HashMap<String, ArrayList<Float>> importReportFile(String filePath) throws IOException 
-    {
+    private static HashMap<String, ArrayList<Float>> importReportFile(String filePath) throws IOException {
         HashMap<String, ArrayList<Float>> results = new HashMap<String, ArrayList<Float>>();
         File reportFile = new File(filePath);
         
@@ -198,8 +193,7 @@ public class PerformanceProfiler extends Thread {
         //Import old data to the HashMap
         BufferedReader br = new BufferedReader(new FileReader(filePath));
         String strLine;
-        while ((strLine = br.readLine()) != null)
-        {
+        while ((strLine = br.readLine()) != null) {
             System.out.println(strLine);
             String[] strs = strLine.split("\\|");
             
@@ -222,8 +216,7 @@ public class PerformanceProfiler extends Thread {
      * @param filePath 
      * @throws IOException
      */
-    private void printResult(String filePath) throws IOException
-    {
+    private void printResult(String filePath) throws IOException {
         List<String> list = new ArrayList<String>();
         for (String str : results.keySet()) {
          list.add(str);
@@ -432,24 +425,20 @@ public class PerformanceProfiler extends Thread {
     }
     
     @PerformanceTest(name = "BD create instructor")
-    public String createInstructor()
-    {
+    public String createInstructor() {
         String status = "";
         Set<String> set = data.instructors.keySet();
-        for (String instructorKey : set)
-        {
+        for (String instructorKey : set) {
             InstructorAttributes instructor = data.instructors.get(instructorKey);
             status += BackDoor.createInstructor(instructor);
         }
         return status;
     }
     @PerformanceTest(name = "BD get instructor")
-    public String getInstructorAsJson()
-    {
+    public String getInstructorAsJson() {
         String status = "";
         Set<String> set = data.instructors.keySet();
-        for (String instructorKey : set)
-        {
+        for (String instructorKey : set) {
             InstructorAttributes instructor = data.instructors.get(instructorKey);
             status += BackDoor.getInstructorAsJson(instructor.googleId, instructor.courseId);
         }
@@ -457,12 +446,10 @@ public class PerformanceProfiler extends Thread {
     }
 
     @PerformanceTest(name = "BD get courses by instructor")
-    public String getCoursesByInstructor()
-    {
+    public String getCoursesByInstructor() {
         String status = "";
         Set<String> set = data.instructors.keySet();
-        for (String instructorKey : set)
-        {
+        for (String instructorKey : set) {
             InstructorAttributes instructor = data.instructors.get(instructorKey);
             String[] courses = BackDoor.getCoursesByInstructorId(instructor.googleId);
             for (String courseName : courses) {
@@ -472,12 +459,10 @@ public class PerformanceProfiler extends Thread {
         return status;
     }
     @PerformanceTest(name = "BD create course")
-    public String createCourse()
-    {
+    public String createCourse() {
         String status = "";
         Set<String> set = data.courses.keySet();
-        for (String courseKey : set)
-        {
+        for (String courseKey : set) {
             CourseAttributes course = data.courses.get(courseKey);
             status += " " + BackDoor.createCourse(course);
         }
@@ -485,12 +470,10 @@ public class PerformanceProfiler extends Thread {
     }
     
     @PerformanceTest(name = "BD get course")
-    public String getCourseAsJson()
-    {
+    public String getCourseAsJson() {
         String status = "";
         Set<String> set = data.courses.keySet();
-        for (String courseKey : set)
-        {
+        for (String courseKey : set) {
             CourseAttributes course = data.courses.get(courseKey);
             status += " " + BackDoor.getCourseAsJson(course.id);
         }
@@ -498,12 +481,10 @@ public class PerformanceProfiler extends Thread {
     }
 
     @PerformanceTest(name = "BD create student")
-    public String createStudent()
-    {
+    public String createStudent() {
         String status = "";
         Set<String> set = data.students.keySet();
-        for (String studentKey : set)
-        {
+        for (String studentKey : set) {
             StudentAttributes student = data.students.get(studentKey);
             status += " " + BackDoor.createStudent(student);
         }
@@ -528,12 +509,10 @@ public class PerformanceProfiler extends Thread {
 //    }
 
     @PerformanceTest(name = "BD get student")
-    public String getStudent()
-    {
+    public String getStudent() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.students.keySet();
-        for (String studentKey : set)
-        {
+        for (String studentKey : set) {
             StudentAttributes student = data.students.get(studentKey);
             status.append(' ').append(BackDoor.getStudentAsJson(student.course, student.email));
         }
@@ -541,12 +520,10 @@ public class PerformanceProfiler extends Thread {
     }
     
     @PerformanceTest(name = "BD get key for student")
-    public String getKeyForStudent()
-    {
+    public String getKeyForStudent() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.students.keySet();
-        for (String studentKey : set)
-        {
+        for (String studentKey : set) {
             StudentAttributes student = data.students.get(studentKey);
             status.append(' ').append(BackDoor.getKeyForStudent(student.course, student.email));
         }
@@ -554,12 +531,10 @@ public class PerformanceProfiler extends Thread {
     }
     
     @PerformanceTest(name = "BD edit student")
-    public String editStudent()
-    {
+    public String editStudent() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.students.keySet();
-        for (String studentKey : set)
-        {
+        for (String studentKey : set) {
             StudentAttributes student = data.students.get(studentKey);
             status.append(' ').append(BackDoor.editStudent(student.email, student));
         }
@@ -567,12 +542,10 @@ public class PerformanceProfiler extends Thread {
     }
 
     @PerformanceTest(name = "BD delete student")
-    public String deleteStudent()
-    {
+    public String deleteStudent() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.students.keySet();
-        for (String studentKey : set)
-        {
+        for (String studentKey : set) {
             StudentAttributes student = data.students.get(studentKey);
             status.append(' ').append(BackDoor.deleteStudent(student.course, student.email));
         }
@@ -580,12 +553,10 @@ public class PerformanceProfiler extends Thread {
     }
 
     @PerformanceTest(name = "BD Delete Course")
-    public String deleteCourse()
-    {
+    public String deleteCourse() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.courses.keySet();
-        for (String courseKey : set)
-        {
+        for (String courseKey : set) {
             CourseAttributes course = data.courses.get(courseKey);
             status.append(' ').append(BackDoor.deleteCourse(course.getId()));
         }
@@ -593,12 +564,10 @@ public class PerformanceProfiler extends Thread {
     }
     
     @PerformanceTest(name = "BD Delete Instructor")
-    public String deleteInstructor()
-    {
+    public String deleteInstructor() {
         StringBuilder status = new StringBuilder();
         Set<String> set = data.instructors.keySet();
-        for (String instructorKey : set)
-        {
+        for (String instructorKey : set) {
             InstructorAttributes instructor = data.instructors.get(instructorKey);
             status.append(BackDoor.deleteInstructor(instructor.email, instructor.courseId));
         }

--- a/src/client/java/teammates/client/scripts/UploadBackupData.java
+++ b/src/client/java/teammates/client/scripts/UploadBackupData.java
@@ -108,8 +108,7 @@ public class UploadBackupData extends RemoteApiClient {
                     Date secondDate = dateFormat.parse(o2);
                     
                     return secondDate.compareTo(firstDate);
-                }
-                catch (ParseException e) {
+                } catch (ParseException e) {
                     return 0;
                 }
             }

--- a/src/main/java/teammates/common/datatransfer/AccountAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/AccountAttributes.java
@@ -95,16 +95,24 @@ public class AccountAttributes extends EntityAttributes {
         String error;
         
         error = validator.getInvalidityInfoForPersonName(name);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldValidator.FieldType.GOOGLE_ID, googleId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldValidator.FieldType.EMAIL, email);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForInstituteName(institute);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         Assumption.assertTrue("Non-null value expected for studentProfile", this.studentProfile != null);
         // only check profile if the account is proper

--- a/src/main/java/teammates/common/datatransfer/AdminEmailAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/AdminEmailAttributes.java
@@ -58,10 +58,14 @@ public class AdminEmailAttributes extends EntityAttributes {
         String error;
         
         error = validator.getInvalidityInfo(FieldType.EMAIL_CONTENT, content);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldType.EMAIL_SUBJECT, subject);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
        
         return errors;
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
@@ -126,13 +126,19 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
         String error;
 
         error = validator.getInvalidityInfoForFeedbackSessionName(feedbackSessionName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.EMAIL, "creator's email", creatorEmail);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         errors.addAll(validator.getValidityInfoForFeedbackParticipantType(giverType, recipientType));
 
@@ -318,11 +324,17 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) { return true; }
+        if (this == obj) {
+            return true;
+        }
 
-        if (obj == null) { return false; }
+        if (obj == null) {
+            return false;
+        }
 
-        if (getClass() != obj.getClass()) { return false; }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
 
         FeedbackQuestionAttributes other = (FeedbackQuestionAttributes) obj;
 

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionDetails.java
@@ -213,7 +213,9 @@ public abstract class FeedbackQuestionDetails {
 
     /** Checks if the question has been skipped. */
     public boolean isQuestionSkipped(String[] answer) {
-        if (answer == null) { return true; }
+        if (answer == null) {
+            return true;
+        }
 
         boolean allAnswersEmpty = true;
 

--- a/src/main/java/teammates/common/datatransfer/FeedbackResponseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackResponseAttributes.java
@@ -110,10 +110,14 @@ public class FeedbackResponseAttributes extends EntityAttributes {
         String error;
         
         error = validator.getInvalidityInfoForFeedbackSessionName(feedbackSessionName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         return errors;
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentAttributes.java
@@ -143,13 +143,19 @@ public class FeedbackResponseCommentAttributes extends EntityAttributes {
         String error;
         
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForFeedbackSessionName(feedbackSessionName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldType.EMAIL, giverEmail);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         //TODO: handle the new attributes showCommentTo and showGiverNameTo
         

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
@@ -173,59 +173,93 @@ public class FeedbackSessionAttributes extends EntityAttributes implements Sessi
         // Check for null fields.
 
         error = validator.getValidityInfoForNonNullField("feedback session name", feedbackSessionName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("course ID", courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("instructions to students", instructions);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("time for the session to become visible", sessionVisibleFromTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("creator's email", creatorEmail);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("session creation time", createdTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         // Early return if any null fields
-        if (!errors.isEmpty()) { return errors; }
+        if (!errors.isEmpty()) {
+            return errors;
+        }
 
         error = validator.getInvalidityInfoForFeedbackSessionName(feedbackSessionName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.EMAIL, "creator's email", creatorEmail);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         // Skip time frame checks if session type is private.
-        if (this.isPrivateSession()) { return errors; }
+        if (this.isPrivateSession()) {
+            return errors;
+        }
 
         error = validator.getValidityInfoForNonNullField("submission opening time", startTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("submission closing time", endTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForNonNullField("time for the responses to become visible", resultsVisibleFromTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         // Early return if any null fields
-        if (!errors.isEmpty()) { return errors; }
+        if (!errors.isEmpty()) {
+            return errors;
+        }
 
         error = validator.getValidityInfoForTimeFrame(FieldType.FEEDBACK_SESSION_TIME_FRAME,
                                                       FieldType.START_TIME, FieldType.END_TIME,
                                                       startTime, endTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getValidityInfoForTimeFrame(FieldType.FEEDBACK_SESSION_TIME_FRAME,
                                                       FieldType.SESSION_VISIBLE_TIME, FieldType.START_TIME,
                                                       sessionVisibleFromTime, startTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         Date actualSessionVisibleFromTime = sessionVisibleFromTime;
 
@@ -236,7 +270,9 @@ public class FeedbackSessionAttributes extends EntityAttributes implements Sessi
         error = validator.getValidityInfoForTimeFrame(FieldType.FEEDBACK_SESSION_TIME_FRAME,
                                                       FieldType.SESSION_VISIBLE_TIME, FieldType.RESULTS_VISIBLE_TIME,
                                                       actualSessionVisibleFromTime, resultsVisibleFromTime);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         return errors;
     }

--- a/src/main/java/teammates/common/datatransfer/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorAttributes.java
@@ -200,20 +200,30 @@ public class InstructorAttributes extends EntityAttributes {
         
         if (googleId != null) {
             error = validator.getInvalidityInfo(FieldType.GOOGLE_ID, googleId);
-            if (!error.isEmpty()) { errors.add(error); }
+            if (!error.isEmpty()) {
+                errors.add(error);
+            }
         }
         
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, courseId);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForPersonName(name);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldType.EMAIL, email);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForPersonName(displayedName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         return errors;
     }

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -204,27 +204,39 @@ public class StudentAttributes extends EntityAttributes {
 
         error = validator.getInvalidityInfo(FieldType.COURSE_ID, course);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.EMAIL, email);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.TEAM_NAME, team);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.SECTION_NAME, section);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfo(FieldType.STUDENT_ROLE_COMMENTS, comments);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         error = validator.getInvalidityInfoForPersonName(name);
 
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
 
         return errors;
     }

--- a/src/main/java/teammates/logic/api/GateKeeper.java
+++ b/src/main/java/teammates/logic/api/GateKeeper.java
@@ -47,7 +47,9 @@ public class GateKeeper {
     public UserType getCurrentUser() {
         User user = getCurrentGoogleUser();
         
-        if (user == null) { return null; }
+        if (user == null) {
+            return null;
+        }
 
         UserType userType = new UserType(user);
 
@@ -85,7 +87,9 @@ public class GateKeeper {
 
     /** Verifies the user is logged in */
     public void verifyLoggedInUserPrivileges() {
-        if (isUserLoggedOn()) { return; }
+        if (isUserLoggedOn()) {
+            return;
+        }
         
         throw new UnauthorizedAccessException("User is not logged in");
     }

--- a/src/main/java/teammates/logic/automated/AdminEmailPrepareTaskQueueWorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/AdminEmailPrepareTaskQueueWorkerServlet.java
@@ -292,8 +292,7 @@ public class AdminEmailPrepareTaskQueueWorkerServlet extends WorkerServlet {
                     }
                 }               
                 
-                if (isNearDeadline())
-                {
+                if (isNearDeadline()) {
                     pauseAndCreateAnNewTask(i, j);
                     log.info("Adding group mail tasks for mail with id " + emailId + "have been paused with list index: " + i + " email index: " + j);
                     return;

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -544,7 +544,9 @@ public class BackDoorLogic extends Logic {
                     break;
                 } else {
                     retryCount++;
-                    if (retryCount % 10 == 0) { log.info("Waiting for delete to persist"); }
+                    if (retryCount % 10 == 0) {
+                        log.info("Waiting for delete to persist");
+                    }
                     ThreadHelper.waitFor(WAIT_DURATION_FOR_DELETE_CHECKING);
                 }
             }

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -237,13 +237,9 @@ public class CoursesLogic {
                 team = new TeamDetailsBundle();
                 team.name = s.team;
                 team.students.add(s);
-            } 
-            // student in the same team as the previous student
-            else if (s.team.equals(team.name)) {
+            } else if (s.team.equals(team.name)) { // student in the same team as the previous student
                 team.students.add(s);
-            } 
-            // first student of subsequent teams (not the first team)
-            else {
+            } else { // first student of subsequent teams (not the first team)
                 sectionDetails.teams.add(team);
                 team = new TeamDetailsBundle();
                 team.name = s.team;
@@ -399,13 +395,9 @@ public class CoursesLogic {
                 team = new TeamDetailsBundle();
                 team.name = s.team;
                 team.students.add(s);
-            } 
-            // student in the same team as the previous student
-            else if (s.team.equals(team.name)) {
+            } else if (s.team.equals(team.name)) { // student in the same team as the previous student
                 team.students.add(s);
-            } 
-            // first student of subsequent teams (not the first team)
-            else {
+            } else { // first student of subsequent teams (not the first team)
                 teams.add(team);
                 team = new TeamDetailsBundle();
                 team.name = s.team;

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -487,8 +487,7 @@ public class Emails {
         return message;
     }
     
-    public MimeMessage generateAdminEmail(String content, String subject, String sendTo) throws MessagingException, UnsupportedEncodingException 
-    {
+    public MimeMessage generateAdminEmail(String content, String subject, String sendTo) throws MessagingException, UnsupportedEncodingException {
 
         MimeMessage message = getEmptyEmailAddressedToEmail(sendTo);
         message.setSubject(subject);

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -326,16 +326,24 @@ public class InstructorsLogic {
         String error;
         
         error = validator.getInvalidityInfoForPersonName(shortName);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForPersonName(name);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfo(FieldValidator.FieldType.EMAIL, email);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         error = validator.getInvalidityInfoForInstituteName(institute);
-        if (!error.isEmpty()) { errors.add(error); }
+        if (!error.isEmpty()) {
+            errors.add(error);
+        }
         
         //No validation for isInstructor and createdAt fields.
         return errors;

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -245,7 +245,9 @@ public class InstructorFeedbackQuestionEditAction extends Action {
     private static List<FeedbackParticipantType> getParticipantListFromParams(String params) {
         List<FeedbackParticipantType> list = new ArrayList<FeedbackParticipantType>();
         
-        if (params.isEmpty()) { return list; }    
+        if (params.isEmpty()) {
+            return list;
+        }
         
         String[] splitString = params.split(",");
         

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -51,8 +51,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
     }
     
     @Test
-    public void testTimestamp() throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException 
-    {        
+    public void testTimestamp() throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {        
         ______TS("success : created");
         
         StudentAttributes s = createNewStudent();

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -124,7 +124,9 @@ public abstract class AppPage {
         this.browser = browser;
         boolean isCorrectPageType = containsExpectedPageContents();
         
-        if (isCorrectPageType) { return; }
+        if (isCorrectPageType) {
+            return;
+        }
         
         // To minimize test failures due to eventual consistency, we try to
         //  reload the page and compare once more.
@@ -135,7 +137,9 @@ public abstract class AppPage {
         this.reloadPage();
         isCorrectPageType = containsExpectedPageContents();
         
-        if (isCorrectPageType) { return; }
+        if (isCorrectPageType) {
+            return;
+        }
         
         System.out.println("######### Not in the correct page! ##########");
         throw new IllegalStateException("Not in the correct page!");

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -47,6 +47,10 @@
     <module name="RightCurly">
       <property name="tokens" value="LITERAL_CATCH,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_TRY"/>
     </module>
+    <module name="RightCurly">
+      <property name="option" value="alone"/>
+      <property name="tokens" value="CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_FOR,INSTANCE_INIT,METHOD_DEF,STATIC_INIT,LITERAL_WHILE"/>
+    </module>
   </module>
   <module name="FileTabCharacter"/>
   <module name="SuppressionCommentFilter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -44,6 +44,9 @@
     <module name="LeftCurly">
       <property name="tokens" value="ANNOTATION_DEF,LITERAL_CATCH,CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_ELSE,ENUM_CONSTANT_DEF,ENUM_DEF,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,INTERFACE_DEF,METHOD_DEF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE"/>
     </module>
+    <module name="RightCurly">
+      <property name="tokens" value="LITERAL_CATCH,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_TRY"/>
+    </module>
   </module>
   <module name="FileTabCharacter"/>
   <module name="SuppressionCommentFilter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -41,6 +41,9 @@
       <property name="allowMultipleEmptyLines" value="false"/>
     </module>
     <module name="ArrayTypeStyle"/>
+    <module name="LeftCurly">
+      <property name="tokens" value="ANNOTATION_DEF,LITERAL_CATCH,CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_ELSE,ENUM_CONSTANT_DEF,ENUM_DEF,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,INTERFACE_DEF,METHOD_DEF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE"/>
+    </module>
   </module>
   <module name="FileTabCharacter"/>
   <module name="SuppressionCommentFilter"/>

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -45,11 +45,11 @@
       <property name="tokens" value="ANNOTATION_DEF,LITERAL_CATCH,CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_ELSE,ENUM_CONSTANT_DEF,ENUM_DEF,LITERAL_FINALLY,LITERAL_FOR,LITERAL_IF,INTERFACE_DEF,METHOD_DEF,LITERAL_SWITCH,LITERAL_SYNCHRONIZED,LITERAL_TRY,LITERAL_WHILE"/>
     </module>
     <module name="RightCurly">
-      <property name="tokens" value="LITERAL_CATCH,LITERAL_ELSE,LITERAL_FINALLY,LITERAL_IF,LITERAL_TRY"/>
+      <property name="tokens" value="LITERAL_CATCH,LITERAL_ELSE,LITERAL_IF,LITERAL_TRY"/>
     </module>
     <module name="RightCurly">
       <property name="option" value="alone"/>
-      <property name="tokens" value="CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_FOR,INSTANCE_INIT,METHOD_DEF,STATIC_INIT,LITERAL_WHILE"/>
+      <property name="tokens" value="CLASS_DEF,CTOR_DEF,LITERAL_DO,LITERAL_FINALLY,LITERAL_FOR,INSTANCE_INIT,METHOD_DEF,STATIC_INIT,LITERAL_WHILE"/>
     </module>
   </module>
   <module name="FileTabCharacter"/>


### PR DESCRIPTION
Added end-of-line left curly brace placement rule. Checks that left curly brace should be at the end of line.

Added same line right curly brace placement rule for `catch`, `else`, `if`, `try` tokens.
Added alone on the line right curly brace placement rule for the rest of the available tokens for the right curly brace placement rule.

For the same line and alone on the line right curly brace options, refer to [here](http://checkstyle.sourceforge.net/property_types.html#rcurly) for more details.

I was confused by the right curly brace placement for the `do` token, as putting it under the same line option gives errors, so I left it under the alone on the line option. 
