### PR TITLE
Add new rules to ESLint - indentation for switch/case

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -457,99 +457,99 @@ function hideAllNewQuestionForms() {
 
 function prepareQuestionForm(type) {
     switch (type) {
-        case 'TEXT':
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_TEXT);
-            
-            hideAllNewQuestionForms();
-            break;
-        case 'MCQ':
-            $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_MCQ);
-            
-            hideAllNewQuestionForms();
-            
-            $('#mcqForm').show();
-            break;
-        case 'MSQ':
-            $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_MSQ);
-            
-            hideAllNewQuestionForms();
-            
-            $('#msqForm').show();
-            break;
-        case 'NUMSCALE':
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_NUMSCALE);
-            
-            hideAllNewQuestionForms();
-            
-            $('#numScaleForm').show();
-            $('#' + FEEDBACK_QUESTION_TEXT).attr('placeholder', 'e.g. Rate the class from 1 (very bad) to 5 (excellent)');
-            break;
-        case 'CONSTSUM_OPTION':
-            $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
-            $('#' + FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS + '--1').val('false');
-            $('#constSumOption_Recipient--1').hide();
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONSTSUM_OPTION);
-            
-            hideAllNewQuestionForms();
-            
-            $('#constSumForm').show();
-            break;
-        case 'CONSTSUM_RECIPIENT':
-            $('#' + FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS + '--1').val('true');
-            $('#constSumOption_Option--1').hide();
-            hideConstSumOptionTable(-1);
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONSTSUM_RECIPIENT);
-            
-            hideAllNewQuestionForms();
-            
-            $('#constSumForm').show();
-            var optionText = $('#constSum_labelText--1').text();
-            $('#constSum_labelText--1').text(optionText.replace('option', 'recipient'));
-            var tooltipText = $('#constSum_tooltipText--1').attr('data-original-title');
-            $('#constSum_tooltipText--1').attr('data-original-title', tooltipText.replace('option', 'recipient'));
-            break;
-        case 'CONTRIB':
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONTRIB);
-            
-            hideAllNewQuestionForms();
-            
-            $('#contribForm').show();
-            fixContribQnGiverRecipient();
-            setDefaultContribQnVisibility();
-            setContribQnVisibilityFormat();
-            break;
-        case 'RUBRIC':
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RUBRIC);
-            
-            hideAllNewQuestionForms();
-            
-            $('#rubricForm').show();
-            break;
-        case 'RANK_OPTIONS':
-            $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
-            $('#' + FEEDBACK_QUESTION_RANKTORECIPIENTS + '--1').val('false');
-            $('#rankOption_Recipient--1').hide();
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RANK_OPTION);
-            
-            hideAllNewQuestionForms();
-            
-            $('#rankOptionsForm').show();
-            break;
-        case 'RANK_RECIPIENTS':
-            $('#' + FEEDBACK_QUESTION_RANKTORECIPIENTS + '--1').val('true');
-            $('#rankOption_Option--1').hide();
-            hideRankOptionTable(-1);
-            $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RANK_RECIPIENT);
-            
-            hideAllNewQuestionForms();
-            
-            $('#rankRecipientsForm').show();
-            break;
-        default:
-            // do nothing if the question type is not recognized, which should not happen
-            break;
+    case 'TEXT':
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_TEXT);
+        
+        hideAllNewQuestionForms();
+        break;
+    case 'MCQ':
+        $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_MCQ);
+        
+        hideAllNewQuestionForms();
+        
+        $('#mcqForm').show();
+        break;
+    case 'MSQ':
+        $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_MSQ);
+        
+        hideAllNewQuestionForms();
+        
+        $('#msqForm').show();
+        break;
+    case 'NUMSCALE':
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_NUMSCALE);
+        
+        hideAllNewQuestionForms();
+        
+        $('#numScaleForm').show();
+        $('#' + FEEDBACK_QUESTION_TEXT).attr('placeholder', 'e.g. Rate the class from 1 (very bad) to 5 (excellent)');
+        break;
+    case 'CONSTSUM_OPTION':
+        $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
+        $('#' + FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS + '--1').val('false');
+        $('#constSumOption_Recipient--1').hide();
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONSTSUM_OPTION);
+        
+        hideAllNewQuestionForms();
+        
+        $('#constSumForm').show();
+        break;
+    case 'CONSTSUM_RECIPIENT':
+        $('#' + FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS + '--1').val('true');
+        $('#constSumOption_Option--1').hide();
+        hideConstSumOptionTable(-1);
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONSTSUM_RECIPIENT);
+        
+        hideAllNewQuestionForms();
+        
+        $('#constSumForm').show();
+        var optionText = $('#constSum_labelText--1').text();
+        $('#constSum_labelText--1').text(optionText.replace('option', 'recipient'));
+        var tooltipText = $('#constSum_tooltipText--1').attr('data-original-title');
+        $('#constSum_tooltipText--1').attr('data-original-title', tooltipText.replace('option', 'recipient'));
+        break;
+    case 'CONTRIB':
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_CONTRIB);
+        
+        hideAllNewQuestionForms();
+        
+        $('#contribForm').show();
+        fixContribQnGiverRecipient();
+        setDefaultContribQnVisibility();
+        setContribQnVisibilityFormat();
+        break;
+    case 'RUBRIC':
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RUBRIC);
+        
+        hideAllNewQuestionForms();
+        
+        $('#rubricForm').show();
+        break;
+    case 'RANK_OPTIONS':
+        $('#' + FEEDBACK_QUESTION_NUMBEROFCHOICECREATED + '--1').val(2);
+        $('#' + FEEDBACK_QUESTION_RANKTORECIPIENTS + '--1').val('false');
+        $('#rankOption_Recipient--1').hide();
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RANK_OPTION);
+        
+        hideAllNewQuestionForms();
+        
+        $('#rankOptionsForm').show();
+        break;
+    case 'RANK_RECIPIENTS':
+        $('#' + FEEDBACK_QUESTION_RANKTORECIPIENTS + '--1').val('true');
+        $('#rankOption_Option--1').hide();
+        hideRankOptionTable(-1);
+        $('#questionTypeHeader').append(FEEDBACK_QUESTION_TYPENAME_RANK_RECIPIENT);
+        
+        hideAllNewQuestionForms();
+        
+        $('#rankRecipientsForm').show();
+        break;
+    default:
+        // do nothing if the question type is not recognized, which should not happen
+        break;
     }
 }
 

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -385,7 +385,7 @@ rules:
     # id-match: "off"
 
     # enforce consistent indentation
-    indent: ["error", 4, { "SwitchCase": 1 }]
+    indent: ["error", 4]
 
     # enforce the consistent use of either double or single quotes in JSX attributes
     # jsx-quotes: "off"


### PR DESCRIPTION
It's there before but modified following the Java style guide:
```javascript
switch (case) {

case ABC: // correct
    something();
    break;

    case DEF: // incorrect
        anotherThing();
        break;

default:
    break;
}
```

There's only one instance of switch/case in the entire JS files so it's a very fast fix.