### PR TITLE
Add new rules to PMD - logging + migrating

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForSanitizedDataInStudentAttributes.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSanitizedDataInStudentAttributes.java
@@ -2,7 +2,6 @@ package teammates.client.scripts;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Level;
 
 import javax.jdo.PersistenceManager;
 
@@ -11,7 +10,6 @@ import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.StringHelper;
-import teammates.common.util.Utils;
 import teammates.logic.core.StudentsLogic;
 import teammates.storage.api.StudentsDb;
 import teammates.storage.datastore.Datastore;
@@ -148,10 +146,10 @@ public class DataMigrationForSanitizedDataInStudentAttributes extends RemoteApiC
                 updateStudent(student.email, student);
             }
         } catch (InvalidParametersException e) {
-            Utils.getLogger().log(Level.INFO, "Student " + student.email + " invalid!");
+            System.out.println("Student " + student.email + " invalid!");
             e.printStackTrace();
         } catch (EntityDoesNotExistException e) {
-            Utils.getLogger().log(Level.INFO, "Student " + student.email + " does not exist!");
+            System.out.println("Student " + student.email + " does not exist!");
             e.printStackTrace();
         }
     }

--- a/src/client/java/teammates/client/scripts/GenerateFeedbackReport.java
+++ b/src/client/java/teammates/client/scripts/GenerateFeedbackReport.java
@@ -1,5 +1,8 @@
 package teammates.client.scripts;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 
 import teammates.client.remoteapi.RemoteApiClient;
@@ -7,7 +10,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.ExceedingRangeException;
 import teammates.logic.api.Logic;
 import teammates.storage.datastore.Datastore;
-import teammates.test.util.FileHelper;
 
 /**
  * Generates the feedback report as a csv.
@@ -25,11 +27,31 @@ public class GenerateFeedbackReport extends RemoteApiClient {
         
         try {
             String fileContent = logic.getFeedbackSessionResultSummaryAsCsv("CourseID", "Session Name", "instructor@email.com");
-            FileHelper.writeToFile("result.csv", fileContent);
+            writeToFile("result.csv", fileContent);
         } catch (EntityDoesNotExistException | ExceedingRangeException e) {
             e.printStackTrace();
         }
         
+    }
+    
+    private void writeToFile(String fileName, String fileContent) {
+        try {
+
+            File file = new File(fileName);
+
+            // if file doesnt exists, then create it
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+
+            FileWriter fw = new FileWriter(file.getAbsoluteFile());
+            BufferedWriter bw = new BufferedWriter(fw);
+            bw.write(fileContent);
+            bw.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
     
 }

--- a/src/client/java/teammates/client/scripts/GenerateLargeScaledData.java
+++ b/src/client/java/teammates/client/scripts/GenerateLargeScaledData.java
@@ -2,7 +2,6 @@ package teammates.client.scripts;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import teammates.client.remoteapi.RemoteApiClient;
 import teammates.common.datatransfer.DataBundle;
@@ -15,7 +14,6 @@ import teammates.test.driver.TestProperties;
 import teammates.common.util.FileHelper;
 
 public class GenerateLargeScaledData extends RemoteApiClient {
-    private static Logger logger = Logger.getLogger(GenerateLargeScaledData.class.getName());
     
     public static void main(String[] args) throws IOException {
         GenerateLargeScaledData dataGenerator = new GenerateLargeScaledData();
@@ -43,7 +41,7 @@ public class GenerateLargeScaledData extends RemoteApiClient {
                 logic.createFeedbackResponse(injectRealIds(response));
                 index++;
                 if (index % 100 == 0) {
-                    logger.info("Create response " + index);
+                    System.out.println("Create response " + index);
                 }
             }
         } catch (Exception e) {

--- a/src/client/java/teammates/client/scripts/OfflineBackup.java
+++ b/src/client/java/teammates/client/scripts/OfflineBackup.java
@@ -1,7 +1,9 @@
 package teammates.client.scripts;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -34,7 +36,6 @@ import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.storage.api.FeedbackResponsesDb;
 import teammates.storage.datastore.Datastore;
 import teammates.test.driver.TestProperties;
-import teammates.test.util.FileHelper;
 
 public class OfflineBackup extends RemoteApiClient {
     protected String backupFileDirectory = "";
@@ -134,7 +135,7 @@ public class OfflineBackup extends RemoteApiClient {
         while (it.hasNext()) {
             String courseId = it.next();
             currentFileName = backupFileDirectory + "/" + courseId + ".json";
-            FileHelper.appendToFile(currentFileName, "{\n");
+            appendToFile(currentFileName, "{\n");
             
             retrieveAndSaveAccountsByCourse(courseId);
             retrieveAndSaveCommentsByCourse(courseId);
@@ -147,7 +148,7 @@ public class OfflineBackup extends RemoteApiClient {
             retrieveAndSaveStudentsByCourse(courseId);
             retrieveAndSaveStudentProfilesByCourse(courseId);
             
-            FileHelper.appendToFile(currentFileName, "\n}"); 
+            appendToFile(currentFileName, "\n}"); 
         }              
     }
     
@@ -161,7 +162,7 @@ public class OfflineBackup extends RemoteApiClient {
             List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
             List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
             
-            FileHelper.appendToFile(currentFileName, "\t\"accounts\":{\n");
+            appendToFile(currentFileName, "\t\"accounts\":{\n");
             
             for (StudentAttributes student : students) {
                 saveStudentAccount(student);
@@ -171,7 +172,7 @@ public class OfflineBackup extends RemoteApiClient {
                 saveInstructorAccount(instructor);
             } 
             
-            FileHelper.appendToFile(currentFileName, "\n\t},\n");
+            appendToFile(currentFileName, "\n\t},\n");
             hasPreviousEntity = false;
         } catch (EntityDoesNotExistException entityException) {
             System.out.println("Error occurred while trying to save accounts within course " + courseId);
@@ -185,13 +186,13 @@ public class OfflineBackup extends RemoteApiClient {
         CommentsDb commentsDb = new CommentsDb();
         List<CommentAttributes> comments = commentsDb.getCommentsForCourse(courseId);
         
-        FileHelper.appendToFile(currentFileName, "\t\"comments\":{\n");
+        appendToFile(currentFileName, "\t\"comments\":{\n");
         
         for (CommentAttributes comment : comments) {
             saveComment(comment);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
   
     /** 
@@ -205,11 +206,11 @@ public class OfflineBackup extends RemoteApiClient {
             return;
         }
         
-        FileHelper.appendToFile(currentFileName, "\t\"courses\":{\n");
-        FileHelper.appendToFile(currentFileName, formatJsonString(course.getJsonString(), course.getId()));
+        appendToFile(currentFileName, "\t\"courses\":{\n");
+        appendToFile(currentFileName, formatJsonString(course.getJsonString(), course.getId()));
         
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     
@@ -221,13 +222,13 @@ public class OfflineBackup extends RemoteApiClient {
         FeedbackQuestionsDb feedbackQuestionDb = new FeedbackQuestionsDb();
         List<FeedbackQuestionAttributes> feedbackQuestions = feedbackQuestionDb.getFeedbackQuestionsForCourse(courseId);
 
-        FileHelper.appendToFile(currentFileName, "\t\"feedbackQuestions\":{\n");
+        appendToFile(currentFileName, "\t\"feedbackQuestions\":{\n");
         
         for (FeedbackQuestionAttributes feedbackQuestion : feedbackQuestions) {
             saveFeedbackQuestion(feedbackQuestion);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     /** 
@@ -238,13 +239,13 @@ public class OfflineBackup extends RemoteApiClient {
         FeedbackResponsesDb feedbackResponsesDb = new FeedbackResponsesDb();
         List<FeedbackResponseAttributes> feedbackResponses = feedbackResponsesDb.getFeedbackResponsesForCourse(courseId);
 
-        FileHelper.appendToFile(currentFileName, "\t\"feedbackResponses\":{\n");
+        appendToFile(currentFileName, "\t\"feedbackResponses\":{\n");
         
         for (FeedbackResponseAttributes feedbackResponse : feedbackResponses) {
             saveFeedbackResponse(feedbackResponse);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     /** 
@@ -255,13 +256,13 @@ public class OfflineBackup extends RemoteApiClient {
         FeedbackResponseCommentsDb feedbackResponseCommentsDb = new FeedbackResponseCommentsDb();
         List<FeedbackResponseCommentAttributes> feedbackResponseComments = feedbackResponseCommentsDb.getFeedbackResponseCommentsForCourse(courseId);
 
-        FileHelper.appendToFile(currentFileName, "\t\"feedbackResponseComments\":{\n");
+        appendToFile(currentFileName, "\t\"feedbackResponseComments\":{\n");
         
         for (FeedbackResponseCommentAttributes feedbackResponseComment : feedbackResponseComments) {
             saveFeedbackResponseComment(feedbackResponseComment);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     /** 
@@ -271,13 +272,13 @@ public class OfflineBackup extends RemoteApiClient {
         Logic logic = new Logic();
         List<FeedbackSessionAttributes> feedbackSessions = logic.getFeedbackSessionsForCourse(courseId);
         
-        FileHelper.appendToFile(currentFileName, "\t\"feedbackSessions\":{\n");
+        appendToFile(currentFileName, "\t\"feedbackSessions\":{\n");
         
         for (FeedbackSessionAttributes feedbackSession : feedbackSessions) {
             saveFeedbackSession(feedbackSession);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     /** 
@@ -287,13 +288,13 @@ public class OfflineBackup extends RemoteApiClient {
         Logic logic = new Logic();
         List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
         
-        FileHelper.appendToFile(currentFileName, "\t\"instructors\":{\n");
+        appendToFile(currentFileName, "\t\"instructors\":{\n");
         
         for (InstructorAttributes instructor : instructors) {
             saveInstructor(instructor);
         }
         hasPreviousEntity = false;
-        FileHelper.appendToFile(currentFileName, "\n\t},\n");
+        appendToFile(currentFileName, "\n\t},\n");
     }
     
     /** 
@@ -304,13 +305,13 @@ public class OfflineBackup extends RemoteApiClient {
             Logic logic = new Logic();
             List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
             
-            FileHelper.appendToFile(currentFileName, "\t\"students\":{\n");
+            appendToFile(currentFileName, "\t\"students\":{\n");
             
             for (StudentAttributes student : students) {
                 saveStudent(student);
             }
             hasPreviousEntity = false;
-            FileHelper.appendToFile(currentFileName, "\n\t},\n");
+            appendToFile(currentFileName, "\n\t},\n");
         } catch (EntityDoesNotExistException exception) {
             System.out.println("Error while trying to save students in course " + courseId);
         }
@@ -325,7 +326,7 @@ public class OfflineBackup extends RemoteApiClient {
             Logic logic = new Logic();
             List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
             
-            FileHelper.appendToFile(currentFileName, "\t\"profiles\":{\n");
+            appendToFile(currentFileName, "\t\"profiles\":{\n");
             
             for (StudentAttributes student : students) {
                 if (student != null && student.googleId != null && !student.googleId.isEmpty()) {
@@ -336,7 +337,7 @@ public class OfflineBackup extends RemoteApiClient {
                 }
             }
             
-            FileHelper.appendToFile(currentFileName, "\n\t}\n");
+            appendToFile(currentFileName, "\n\t}\n");
             hasPreviousEntity = false;
         } catch (EntityDoesNotExistException entityException) {
             System.out.println("Error occurred while trying to save profiles within course " + courseId);
@@ -376,7 +377,7 @@ public class OfflineBackup extends RemoteApiClient {
         }
         
         
-        FileHelper.appendToFile(currentFileName, formatJsonString(account.getJsonString(), account.email));
+        appendToFile(currentFileName, formatJsonString(account.getJsonString(), account.email));
         accountsSaved.add(account.email);
     }
     
@@ -395,40 +396,60 @@ public class OfflineBackup extends RemoteApiClient {
             return;
         }
         
-        FileHelper.appendToFile(currentFileName, formatJsonString(account.getJsonString(), account.email));
+        appendToFile(currentFileName, formatJsonString(account.getJsonString(), account.email));
         accountsSaved.add(account.email);
     }
     
     protected void saveComment(CommentAttributes comment) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(comment.getJsonString(), comment.getCommentId().toString()));
+        appendToFile(currentFileName, formatJsonString(comment.getJsonString(), comment.getCommentId().toString()));
     }   
     
     protected void saveFeedbackQuestion(FeedbackQuestionAttributes feedbackQuestion) {   
-        FileHelper.appendToFile(currentFileName, formatJsonString(feedbackQuestion.getJsonString(), feedbackQuestion.getId()));
+        appendToFile(currentFileName, formatJsonString(feedbackQuestion.getJsonString(), feedbackQuestion.getId()));
     }
     
     protected void saveFeedbackResponse(FeedbackResponseAttributes feedbackResponse) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(feedbackResponse.getJsonString(), feedbackResponse.getId()));
+        appendToFile(currentFileName, formatJsonString(feedbackResponse.getJsonString(), feedbackResponse.getId()));
     }
     
     protected void saveFeedbackResponseComment(FeedbackResponseCommentAttributes feedbackResponseComment) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(feedbackResponseComment.getJsonString(), feedbackResponseComment.getId().toString()));
+        appendToFile(currentFileName, formatJsonString(feedbackResponseComment.getJsonString(), feedbackResponseComment.getId().toString()));
     }
     
     protected void saveFeedbackSession(FeedbackSessionAttributes feedbackSession) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(feedbackSession.getJsonString(), feedbackSession.feedbackSessionName + "%" + feedbackSession.courseId));
+        appendToFile(currentFileName, formatJsonString(feedbackSession.getJsonString(), feedbackSession.feedbackSessionName + "%" + feedbackSession.courseId));
     }
     
     protected void saveInstructor(InstructorAttributes instructor) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(instructor.getJsonString(), instructor.googleId));
+        appendToFile(currentFileName, formatJsonString(instructor.getJsonString(), instructor.googleId));
     }
     
     protected void saveStudent(StudentAttributes student) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(student.getJsonString(), student.googleId));
+        appendToFile(currentFileName, formatJsonString(student.getJsonString(), student.googleId));
     }
     
     protected void saveProfile(StudentProfileAttributes studentProfile) {
-        FileHelper.appendToFile(currentFileName, formatJsonString(studentProfile.getJsonString(), studentProfile.googleId));
+        appendToFile(currentFileName, formatJsonString(studentProfile.getJsonString(), studentProfile.googleId));
     }
 
+    private static void appendToFile(String fileName, String fileContent) {
+        try {
+
+            File file = new File(fileName);
+
+            // if file doesnt exists, then create it
+            if (!file.exists()) {
+                file.createNewFile();
+            }
+
+            FileWriter fw = new FileWriter(file.getAbsoluteFile(), true);
+            BufferedWriter bw = new BufferedWriter(fw);
+            bw.write(fileContent);
+            bw.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    
 }

--- a/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
+++ b/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
@@ -281,7 +281,7 @@ public class StatisticsPerInstitute extends RemoteApiClient {
         Collections.sort(list, new Comparator<InstituteStats>() {
             public int compare(InstituteStats inst1, InstituteStats inst2) {
                 //the two objects are swapped, to sort in descending order
-                return new Integer(inst2.studentTotal).compareTo(new Integer(inst1.studentTotal));
+                return Integer.valueOf(inst2.studentTotal).compareTo(Integer.valueOf(inst1.studentTotal));
             }
         });
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Logger;
 
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
@@ -19,6 +20,8 @@ import teammates.logic.core.TeamEvalResult;
 import teammates.ui.template.InstructorFeedbackResultsResponseRow;
 
 public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails {
+    
+    private static final Logger log = Utils.getLogger();
     
     public boolean isNotSureAllowed;
     
@@ -729,14 +732,14 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         
         // giver type can only be STUDENTS
         if (feedbackQuestionAttributes.giverType != FeedbackParticipantType.STUDENTS) {
-            Utils.getLogger().severe("Unexpected giverType for contribution question: " + feedbackQuestionAttributes.giverType + " (forced to :" + FeedbackParticipantType.STUDENTS + ")");
+            log.severe("Unexpected giverType for contribution question: " + feedbackQuestionAttributes.giverType + " (forced to :" + FeedbackParticipantType.STUDENTS + ")");
             feedbackQuestionAttributes.giverType = FeedbackParticipantType.STUDENTS;
             errorMsg = Const.FeedbackQuestion.CONTRIB_ERROR_INVALID_FEEDBACK_PATH;
         }
         
         // recipient type can only be OWN_TEAM_MEMBERS_INCLUDING_SELF
         if (feedbackQuestionAttributes.recipientType != FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF) {
-            Utils.getLogger().severe("Unexpected recipientType for contribution question: " + feedbackQuestionAttributes.recipientType + " (forced to :" + FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF + ")");
+            log.severe("Unexpected recipientType for contribution question: " + feedbackQuestionAttributes.recipientType + " (forced to :" + FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF + ")");
             feedbackQuestionAttributes.recipientType = FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF;
             errorMsg = Const.FeedbackQuestion.CONTRIB_ERROR_INVALID_FEEDBACK_PATH;
         }

--- a/src/main/java/teammates/common/datatransfer/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackContributionResponseDetails.java
@@ -2,6 +2,7 @@ package teammates.common.datatransfer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import teammates.common.util.Const;
 import teammates.common.util.Sanitizer;
@@ -9,6 +10,9 @@ import teammates.common.util.Utils;
 import teammates.logic.core.TeamEvalResult;
 
 public class FeedbackContributionResponseDetails extends FeedbackResponseDetails {
+    
+    private static final Logger log = Utils.getLogger();
+    
     /**This is the claimed points from giver to recipient.
     */
     private int answer;
@@ -30,7 +34,7 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
             int contribAnswer = Integer.parseInt(answer[0]);
             setAnswer(contribAnswer);
         } catch (NumberFormatException e) {
-            Utils.getLogger().severe("Failed to parse contrib answer to integer - " + answer[0]);
+            log.severe("Failed to parse contrib answer to integer - " + answer[0]);
             throw e;
         }
     }
@@ -91,14 +95,14 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
         
         if (giverIndex == -1 || recipientIndex == -1) {
             if (giverIndex == -1) {
-                Utils.getLogger().severe("getContributionQuestionResponseAnswerHtml - giverIndex is -1\n"
+                log.severe("getContributionQuestionResponseAnswerHtml - giverIndex is -1\n"
                         + "Cannot find giver: " + actualResponse.giverEmail + "\n"
                         + "CourseId: " + feedbackSessionResultsBundle.feedbackSession.courseId + "\n"
                         + "Session Name: " + feedbackSessionResultsBundle.feedbackSession.feedbackSessionName + "\n"
                         + "Response Id: " + actualResponse.getId());
             }
             if (recipientIndex == -1) {
-                Utils.getLogger().severe("getContributionQuestionResponseAnswerHtml - recipientIndex is -1\n"
+                log.severe("getContributionQuestionResponseAnswerHtml - recipientIndex is -1\n"
                         + "Cannot find recipient: " + actualResponse.recipientEmail + "\n"
                         + "CourseId: " + feedbackSessionResultsBundle.feedbackSession.courseId + "\n"
                         + "Session Name: " + feedbackSessionResultsBundle.feedbackSession.feedbackSessionName + "\n"
@@ -144,14 +148,14 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
         
         if (giverIndex == -1 || recipientIndex == -1) {
             if (giverIndex == -1) {
-                Utils.getLogger().severe("getContributionQuestionResponseAnswerCsv - giverIndex is -1\n"
+                log.severe("getContributionQuestionResponseAnswerCsv - giverIndex is -1\n"
                         + "Cannot find giver: " + actualResponse.giverEmail + "\n"
                         + "CourseId: " + feedbackSessionResultsBundle.feedbackSession.courseId + "\n"
                         + "Session Name: " + feedbackSessionResultsBundle.feedbackSession.feedbackSessionName + "\n"
                         + "Response Id: " + actualResponse.getId());
             }
             if (recipientIndex == -1) {
-                Utils.getLogger().severe("getContributionQuestionResponseAnswerCsv - recipientIndex is -1\n"
+                log.severe("getContributionQuestionResponseAnswerCsv - recipientIndex is -1\n"
                         + "Cannot find recipient: " + actualResponse.recipientEmail + "\n"
                         + "CourseId: " + feedbackSessionResultsBundle.feedbackSession.courseId + "\n"
                         + "Session Name: " + feedbackSessionResultsBundle.feedbackSession.feedbackSessionName + "\n"

--- a/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleResponseDetails.java
@@ -1,10 +1,14 @@
 package teammates.common.datatransfer;
 
+import java.util.logging.Logger;
+
 import teammates.common.util.StringHelper;
 import teammates.common.util.Utils;
 
-public class FeedbackNumericalScaleResponseDetails extends
-        FeedbackResponseDetails {
+public class FeedbackNumericalScaleResponseDetails extends FeedbackResponseDetails {
+
+    private static final Logger log = Utils.getLogger();
+    
     private double answer;
     
     public FeedbackNumericalScaleResponseDetails() {
@@ -18,7 +22,7 @@ public class FeedbackNumericalScaleResponseDetails extends
             double numscaleAnswer = Double.parseDouble(answer[0]);
             setAnswer(numscaleAnswer);
         } catch (NumberFormatException e) {
-            Utils.getLogger().severe("Failed to parse numscale answer to double - " + answer[0]);
+            log.severe("Failed to parse numscale answer to double - " + answer[0]);
             throw e;
         }
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -38,7 +38,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
     public Map<String, List<FeedbackResponseCommentAttributes>> responseComments;
     public boolean isComplete;
 
-    protected static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     /**
      * Responses with identities of giver/recipients NOT hidden.

--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -169,7 +169,7 @@ public final class Assumption {
      * is thrown with the given message.
      */
     public static void assertEquals(String message, long expected, long actual) {
-        assertEquals(message, new Long(expected), new Long(actual));
+        assertEquals(message, Long.valueOf(expected), Long.valueOf(actual));
     }
 
     /**
@@ -201,7 +201,7 @@ public final class Assumption {
      * is thrown with the given message.
      */
     public static void assertEquals(String message, byte expected, byte actual) {
-        assertEquals(message, new Byte(expected), new Byte(actual));
+        assertEquals(message, Byte.valueOf(expected), Byte.valueOf(actual));
     }
 
     /**
@@ -231,7 +231,7 @@ public final class Assumption {
      * AssertionFailedError is thrown with the given message.
      */
     public static void assertEquals(String message, short expected, short actual) {
-        assertEquals(message, new Short(expected), new Short(actual));
+        assertEquals(message, Short.valueOf(expected), Short.valueOf(actual));
     }
 
     /**
@@ -246,7 +246,7 @@ public final class Assumption {
      * is thrown with the given message.
      */
     public static void assertEquals(String message, int expected, int actual) {
-        assertEquals(message, new Integer(expected), new Integer(actual));
+        assertEquals(message, Integer.valueOf(expected), Integer.valueOf(actual));
     }
 
     /**

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -15,7 +15,7 @@ import com.google.appengine.api.utils.SystemProperty;
  */
 public class Config {
 
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     private static Config instance = inst();
     private static Properties props;
     

--- a/src/main/java/teammates/common/util/GaeVersionApi.java
+++ b/src/main/java/teammates/common/util/GaeVersionApi.java
@@ -3,6 +3,7 @@ package teammates.common.util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 
 import com.google.appengine.api.modules.ModulesService;
 import com.google.appengine.api.modules.ModulesServiceFactory;
@@ -11,6 +12,8 @@ import com.google.appengine.api.modules.ModulesServiceFactory;
  * Provides access to application versions via Google AppEngine API.
  */
 public class GaeVersionApi {
+    
+    private static final Logger log = Utils.getLogger();
     
     /**
      * Gets all available versions.
@@ -48,7 +51,7 @@ public class GaeVersionApi {
             resultVersions = getSublistOfVersionList(versionList, currentVersionIndex, numVersions);
         } catch (Exception e) {
             resultVersions.add(currentVersion.toStringWithDashes());
-            Utils.getLogger().severe(e.getMessage());
+            log.severe(e.getMessage());
         }
         return resultVersions;
     }

--- a/src/main/java/teammates/common/util/ThreadHelper.java
+++ b/src/main/java/teammates/common/util/ThreadHelper.java
@@ -8,7 +8,7 @@ import teammates.common.exception.TeammatesException;
 
 public final class ThreadHelper {
     public static final int WAIT_DURATION = 20;
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     private ThreadHelper() {
         // utility class

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import javax.mail.internet.MimeMessage;
 import javax.servlet.http.HttpServletRequest;
@@ -47,7 +46,6 @@ import teammates.common.exception.JoinCourseException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.AdminEmailsLogic;
 import teammates.logic.core.CommentsLogic;
@@ -73,9 +71,6 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 public class Logic {
     
     //TODO: sanitizes values received from outside.
-
-    @SuppressWarnings("unused")
-    private static Logger log = Utils.getLogger();
 
     //TODO: remove this constant
     public static final String ERROR_NULL_PARAMETER = "The supplied parameter was null\n";

--- a/src/main/java/teammates/logic/automated/AutomatedRemindersServlet.java
+++ b/src/main/java/teammates/logic/automated/AutomatedRemindersServlet.java
@@ -14,7 +14,7 @@ import teammates.common.util.Utils;
 @SuppressWarnings("serial")
 public abstract class AutomatedRemindersServlet extends HttpServlet {
     
-    protected static Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     protected String servletName = "unspecified";
     protected String action = "unspecified";

--- a/src/main/java/teammates/logic/automated/AutomatedRemindersServlet.java
+++ b/src/main/java/teammates/logic/automated/AutomatedRemindersServlet.java
@@ -1,6 +1,5 @@
 package teammates.logic.automated;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServlet;
@@ -32,6 +31,6 @@ public abstract class AutomatedRemindersServlet extends HttpServlet {
     protected void logMessage(HttpServletRequest request, String message) {
         String url = HttpRequestHelper.getRequestedURL(request);
         ActivityLogEntry activityLogEntry = new ActivityLogEntry(servletName, action, null, message, url);
-        log.log(Level.INFO, activityLogEntry.generateLogMessage());
+        log.info(activityLogEntry.generateLogMessage());
     }
 }

--- a/src/main/java/teammates/logic/automated/CompileLogs.java
+++ b/src/main/java/teammates/logic/automated/CompileLogs.java
@@ -19,7 +19,7 @@ import teammates.common.util.Utils;
 import teammates.logic.core.Emails;
 
 public class CompileLogs {
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     public String doLogExam() {
         LogService logService = LogServiceFactory.getLogService();

--- a/src/main/java/teammates/logic/automated/EmailAction.java
+++ b/src/main/java/teammates/logic/automated/EmailAction.java
@@ -30,7 +30,7 @@ public abstract class EmailAction {
     protected String actionName = "unspecified";
     protected String actionDescription = "unspecified";
     
-    protected static Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     protected Boolean isError = false;
     

--- a/src/main/java/teammates/logic/automated/EmailAction.java
+++ b/src/main/java/teammates/logic/automated/EmailAction.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.mail.MessagingException;
@@ -108,7 +107,7 @@ public abstract class EmailAction {
         }
         
         ActivityLogEntry activityLogEntry = new ActivityLogEntry(actionName, actionDescription, null, message, url);
-        log.log(Level.INFO, activityLogEntry.generateLogMessage());
+        log.info(activityLogEntry.generateLogMessage());
     }
 
     protected void logActivityFailure(HttpServletRequest req, Throwable e) {
@@ -119,7 +118,7 @@ public abstract class EmailAction {
                        + e.getMessage() + "</span>";
         ActivityLogEntry activityLogEntry = new ActivityLogEntry(actionName, actionDescription, null,
                                                                  message, url);
-        log.log(Level.INFO, activityLogEntry.generateLogMessage());
+        log.info(activityLogEntry.generateLogMessage());
         log.severe(e.getMessage());
     }
 

--- a/src/main/java/teammates/logic/automated/EmailWorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/EmailWorkerServlet.java
@@ -1,7 +1,5 @@
 package teammates.logic.automated;
 
-import java.util.logging.Logger;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -9,14 +7,11 @@ import org.seleniumhq.jetty7.server.Response;
 
 import teammates.common.util.Assumption;
 import teammates.common.util.HttpRequestHelper;
-import teammates.common.util.Utils;
 import teammates.common.util.Const.ParamsNames;
 import teammates.logic.core.Emails;
 
 @SuppressWarnings("serial")
 public class EmailWorkerServlet extends WorkerServlet {
-    
-    private static Logger log = Utils.getLogger();
     
     public void doGet(HttpServletRequest req, HttpServletResponse resp) {
         

--- a/src/main/java/teammates/logic/automated/EntityModifiedLogsServlet.java
+++ b/src/main/java/teammates/logic/automated/EntityModifiedLogsServlet.java
@@ -8,6 +8,8 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import teammates.common.exception.TeammatesException;
+
 import com.google.appengine.api.log.AppLogLine;
 import com.google.appengine.api.log.LogQuery;
 import com.google.appengine.api.log.LogService;
@@ -57,7 +59,7 @@ public class EntityModifiedLogsServlet extends AutomatedRemindersServlet {
                 }
             }
         } catch (IOException e) {  
-            e.printStackTrace();
+            log.severe(TeammatesException.toStringWithStackTrace(e));
         }
     }
 }

--- a/src/main/java/teammates/logic/automated/TaskQueueWorkerAction.java
+++ b/src/main/java/teammates/logic/automated/TaskQueueWorkerAction.java
@@ -7,7 +7,7 @@ import javax.servlet.http.HttpServletRequest;
 import teammates.common.util.Utils;
 
 public abstract class TaskQueueWorkerAction {
-    protected static Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     protected HttpServletRequest request;
     
     protected TaskQueueWorkerAction(HttpServletRequest request) {

--- a/src/main/java/teammates/logic/automated/WorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/WorkerServlet.java
@@ -21,7 +21,7 @@ import teammates.common.util.Utils;
 @SuppressWarnings("serial")
 public abstract class WorkerServlet extends HttpServlet {
     
-    protected static Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     protected String servletName = "unspecified";
     protected String action = "unspecified";

--- a/src/main/java/teammates/logic/automated/WorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/WorkerServlet.java
@@ -1,6 +1,5 @@
 package teammates.logic.automated;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServlet;
@@ -39,6 +38,6 @@ public abstract class WorkerServlet extends HttpServlet {
     protected void logMessage(HttpServletRequest request, String message) {
         String url = HttpRequestHelper.getRequestedURL(request);
         ActivityLogEntry activityLogEntry = new ActivityLogEntry(servletName, action, null, message, url);
-        log.log(Level.INFO, activityLogEntry.generateLogMessage());
+        log.info(activityLogEntry.generateLogMessage());
     }
 }

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -46,7 +46,7 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 
 public class BackDoorLogic extends Logic {
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     private static final AccountsDb accountsDb = new AccountsDb();
     private static final CoursesDb coursesDb = new CoursesDb();
     private static final CommentsDb commentsDb = new CommentsDb();

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -35,7 +35,7 @@ public class AccountsLogic {
     private static final AccountsDb accountsDb = new AccountsDb();
     private static final ProfilesDb profilesDb = new ProfilesDb();
     
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     public static AccountsLogic inst() {
         if (instance == null) {

--- a/src/main/java/teammates/logic/core/AdminEmailsLogic.java
+++ b/src/main/java/teammates/logic/core/AdminEmailsLogic.java
@@ -2,7 +2,6 @@ package teammates.logic.core;
 
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
 
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreFailureException;
@@ -11,7 +10,6 @@ import teammates.common.datatransfer.AdminEmailAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
-import teammates.common.util.Utils;
 import teammates.storage.api.AdminEmailsDb;
 
 /**
@@ -22,10 +20,6 @@ import teammates.storage.api.AdminEmailsDb;
 public class AdminEmailsLogic {
     private static AdminEmailsLogic instance;
     private static final AdminEmailsDb adminEmailsDb = new AdminEmailsDb();
-    
-    @SuppressWarnings("unused")
-    // it is used, just not in here, do not remove
-    private static Logger log = Utils.getLogger();
     
     public static AdminEmailsLogic inst() {
         if (instance == null) {

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -49,7 +49,7 @@ import teammates.logic.api.GateKeeper;
  */
 public class Emails {
     //TODO: methods in this class throw too many exceptions. Reduce using a wrapper exception?
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
 
     public static final String SUBJECT_PREFIX_FEEDBACK_SESSION_OPENING = "TEAMMATES: Feedback session now open";
     public static final String SUBJECT_PREFIX_FEEDBACK_SESSION_REMINDER = "TEAMMATES: Feedback session reminder";

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -763,7 +763,6 @@ public class Emails {
             log.log(Level.INFO, emailLogInfo);
         } catch (Exception e) {
             log.severe("Failed to generate log for email: " + getEmailInfo(message));
-            e.printStackTrace();
         }
     }
     
@@ -774,7 +773,6 @@ public class Emails {
             log.log(Level.INFO, emailLogInfo);
         } catch (Exception e) {
             log.severe("Failed to generate log for email: " + getEmailInfo(message));
-            e.printStackTrace();
         }
     }
     

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.mail.Address;
@@ -760,7 +759,7 @@ public class Emails {
         try {
             EmailLogEntry newEntry = new EmailLogEntry(message);
             String emailLogInfo = newEntry.generateLogMessage();
-            log.log(Level.INFO, emailLogInfo);
+            log.info(emailLogInfo);
         } catch (Exception e) {
             log.severe("Failed to generate log for email: " + getEmailInfo(message));
         }
@@ -770,7 +769,7 @@ public class Emails {
         try {
             EmailLogEntry newEntry = new EmailLogEntry(message);
             String emailLogInfo = newEntry.generateLogMessage();
-            log.log(Level.INFO, emailLogInfo);
+            log.info(emailLogInfo);
         } catch (Exception e) {
             log.severe("Failed to generate log for email: " + getEmailInfo(message));
         }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -54,7 +54,7 @@ public class FeedbackSessionsLogic {
 
     private static FeedbackSessionsLogic instance;
 
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
 
     private static final FeedbackSessionsDb fsDb = new FeedbackSessionsDb();
     private static final FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -32,7 +32,7 @@ public class InstructorsLogic {
     private static final CommentsLogic commentsLogic = CommentsLogic.inst();
     private static final FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
     
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     private static InstructorsLogic instance;
     

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -3,7 +3,6 @@ package teammates.logic.core;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.mail.internet.MimeMessage;
 
@@ -56,10 +55,6 @@ public class StudentsLogic {
     private FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
     private AccountsLogic accLogic = AccountsLogic.inst();
     private CommentsLogic commentsLogic = CommentsLogic.inst();
-    
-    @SuppressWarnings("unused")
-    // it is used, just not in here, do not remove
-    private static Logger log = Utils.getLogger();
     
     public static StudentsLogic inst() {
         if (instance == null) {

--- a/src/main/java/teammates/logic/core/TeamEvalResult.java
+++ b/src/main/java/teammates/logic/core/TeamEvalResult.java
@@ -20,7 +20,7 @@ public class TeamEvalResult {
     public static int NSU = Const.POINTS_NOT_SURE;
     /** did Not SuBmit */
     public static int NSB = Const.POINTS_NOT_SUBMITTED;
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
 
     /** submission values originally from students of the team */
     public int[][] claimed;

--- a/src/main/java/teammates/logic/publicresource/PublicResourcesServlet.java
+++ b/src/main/java/teammates/logic/publicresource/PublicResourcesServlet.java
@@ -2,7 +2,6 @@ package teammates.logic.publicresource;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
@@ -59,6 +58,6 @@ public abstract class PublicResourcesServlet extends HttpServlet {
     protected void logMessage(HttpServletRequest request, String message) {
         String url = HttpRequestHelper.getRequestedURL(request);
         ActivityLogEntry activityLogEntry = new ActivityLogEntry(servletName, action, null, message, url);
-        log.log(Level.INFO, activityLogEntry.generateLogMessage());
+        log.info(activityLogEntry.generateLogMessage());
     }
 }

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -3,7 +3,6 @@ package teammates.storage.api;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.JDOObjectNotFoundException;
@@ -22,7 +21,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.StudentProfile;
 
@@ -32,7 +30,6 @@ import teammates.storage.entity.StudentProfile;
  * 
  */
 public class AccountsDb extends EntitiesDb {
-    private static final Logger log = Utils.getLogger();
     
     /**
      * Preconditions: 

--- a/src/main/java/teammates/storage/api/AdminEmailsDb.java
+++ b/src/main/java/teammates/storage/api/AdminEmailsDb.java
@@ -4,7 +4,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -21,11 +20,9 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.AdminEmail;
 
 public class AdminEmailsDb extends EntitiesDb {
-    private static final Logger log = Utils.getLogger();
     
     public Date creatAdminEmail(AdminEmailAttributes adminEmailToAdd) throws InvalidParametersException {
         try {

--- a/src/main/java/teammates/storage/api/CommentsDb.java
+++ b/src/main/java/teammates/storage/api/CommentsDb.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -26,7 +25,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.Sanitizer;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Comment;
 import teammates.storage.search.CommentSearchDocument;
 import teammates.storage.search.CommentSearchQuery;
@@ -38,7 +36,6 @@ import teammates.storage.search.CommentSearchQuery;
 public class CommentsDb extends EntitiesDb {
     
     public static final String ERROR_UPDATE_NON_EXISTENT = "Trying to update non-existent Comment: ";
-    private static final Logger log = Utils.getLogger();
     
     /**
      * This method is for testing only

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -3,7 +3,6 @@ package teammates.storage.api;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -14,7 +13,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Course;
 
 /**
@@ -29,8 +27,6 @@ public class CoursesDb extends EntitiesDb {
      */
 
     public static final String ERROR_UPDATE_NON_EXISTENT_COURSE = "Trying to update a Course that doesn't exist: ";
-    
-    private static final Logger log = Utils.getLogger();
     
     public void createCourses(Collection<CourseAttributes> coursesToAdd) throws InvalidParametersException {
         

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -41,7 +41,7 @@ public abstract class EntitiesDb {
     public static final String ERROR_CREATE_INSTRUCTOR_ALREADY_EXISTS = "Trying to create a Instructor that exists: ";
     public static final String ERROR_TRYING_TO_MAKE_NON_EXISTENT_ACCOUNT_AN_INSTRUCTOR = "Trying to make an non-existent account an Instructor :";
 
-    private static final Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     /**
      * Preconditions: 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -3,7 +3,6 @@ package teammates.storage.api;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -15,12 +14,10 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.storage.entity.FeedbackQuestion;
 
 public class FeedbackQuestionsDb extends EntitiesDb {
     public static final String ERROR_UPDATE_NON_EXISTENT = "Trying to update non-existent Feedback Question : ";
-    private static final Logger log = Utils.getLogger();
     
     public void createFeedbackQuestions(Collection<FeedbackQuestionAttributes> questionsToAdd) throws InvalidParametersException {
         List<EntityAttributes> questionsToUpdate = createEntities(questionsToAdd);

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -24,7 +23,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.storage.entity.FeedbackResponseComment;
 import teammates.storage.search.FeedbackResponseCommentSearchDocument;
 import teammates.storage.search.FeedbackResponseCommentSearchQuery;
@@ -35,8 +33,6 @@ import teammates.storage.search.FeedbackResponseCommentSearchQuery;
  */
 public class FeedbackResponseCommentsDb extends EntitiesDb {
 
-    private static final Logger log = Utils.getLogger();
-    
     /**
      * This method is for testing only
      * @param commentsToAdd

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -16,12 +15,9 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.storage.entity.FeedbackResponse;
 
 public class FeedbackResponsesDb extends EntitiesDb {
-
-    private static final Logger log = Utils.getLogger();
 
     public void createFeedbackResponses(Collection<FeedbackResponseAttributes> responsesToAdd) throws InvalidParametersException {
         List<EntityAttributes> responsesToUpdate = createEntities(responsesToAdd);

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -7,7 +7,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -20,13 +19,11 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.FeedbackSession;
 
 public class FeedbackSessionsDb extends EntitiesDb {
     
     public static final String ERROR_UPDATE_NON_EXISTENT = "Trying to update non-existent Feedback Session : ";
-    private static final Logger log = Utils.getLogger();
 
     public void createFeedbackSessions(Collection<FeedbackSessionAttributes> feedbackSessionsToAdd) throws InvalidParametersException {
         List<EntityAttributes> feedbackSessionsToUpdate = createEntities(feedbackSessionsToAdd);

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -24,7 +23,6 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Instructor;
 import teammates.storage.search.InstructorSearchDocument;
 import teammates.storage.search.InstructorSearchQuery;
@@ -36,8 +34,6 @@ import teammates.storage.search.InstructorSearchQuery;
  */
 public class InstructorsDb extends EntitiesDb {
     
-    private static final Logger log = Utils.getLogger();
-
     /* =========================================================================
      * Methods related to Google Search API
      * =========================================================================

--- a/src/main/java/teammates/storage/api/ProfilesDb.java
+++ b/src/main/java/teammates/storage/api/ProfilesDb.java
@@ -1,7 +1,6 @@
 package teammates.storage.api;
 
 import java.util.Date;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.JDOObjectNotFoundException;
@@ -19,7 +18,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Account;
 import teammates.storage.entity.StudentProfile;
 
@@ -29,9 +27,6 @@ import teammates.storage.entity.StudentProfile;
  * 
  */
 public class ProfilesDb extends EntitiesDb {
-    
-    @SuppressWarnings("unused")
-    private static final Logger log = Utils.getLogger();
     
     /**
      * Gets the datatransfer (*Attributes) version of the profile

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.jdo.JDOHelper;
 import javax.jdo.Query;
@@ -22,7 +21,6 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.Utils;
 import teammates.storage.entity.Student;
 import teammates.storage.search.StudentSearchDocument;
 import teammates.storage.search.StudentSearchQuery;
@@ -40,8 +38,6 @@ public class StudentsDb extends EntitiesDb {
 
     public static final String ERROR_UPDATE_EMAIL_ALREADY_USED = "Trying to update to an email that is already used by: ";
     
-    private static final Logger log = Utils.getLogger();
-
     public void putDocument(StudentAttributes student) {
         putDocument(Const.SearchIndex.STUDENT, new StudentSearchDocument(student));
     }

--- a/src/main/java/teammates/storage/datastore/Datastore.java
+++ b/src/main/java/teammates/storage/datastore/Datastore.java
@@ -17,7 +17,7 @@ import teammates.common.util.Utils;
  */
 public final class Datastore {
     private static PersistenceManagerFactory PMF;
-    private static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     private static final ThreadLocal<PersistenceManager> PER_THREAD_PM = new ThreadLocal<PersistenceManager>();
     
     private Datastore() {

--- a/src/main/java/teammates/storage/search/SearchDocument.java
+++ b/src/main/java/teammates/storage/search/SearchDocument.java
@@ -1,8 +1,5 @@
 package teammates.storage.search;
 
-import java.util.logging.Logger;
-
-import teammates.common.util.Utils;
 import teammates.logic.api.Logic;
 
 import com.google.appengine.api.search.Document;
@@ -11,8 +8,6 @@ import com.google.appengine.api.search.Document;
  * The SearchDocument object that defines how we store {@link Document}
  */
 public abstract class SearchDocument {
-    
-    protected static Logger log = Utils.getLogger();
     
     protected Logic logic;
     

--- a/src/main/java/teammates/storage/search/SearchQuery.java
+++ b/src/main/java/teammates/storage/search/SearchQuery.java
@@ -17,7 +17,7 @@ import teammates.common.util.Utils;
  */
 public class SearchQuery {
 
-    protected static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     protected static final String AND = " AND ";
     protected static final String OR = " OR ";
     protected static final String NOT = " NOT ";

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -30,7 +30,7 @@ import teammates.logic.api.Logic;
  * perform that action.
  */
 public abstract class Action {
-    protected static Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     protected Logic logic;
     

--- a/src/main/java/teammates/ui/controller/ActionFactory.java
+++ b/src/main/java/teammates/ui/controller/ActionFactory.java
@@ -17,7 +17,7 @@ import teammates.common.util.Utils;
  * Is used to generate the matching {@link Action} for a given URI.
  */
 public class ActionFactory {
-    protected static Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
     
     private static HashMap<String, Class<? extends Action>> actionMappings = new HashMap<String, Class<? extends Action>>();
     

--- a/src/main/java/teammates/ui/controller/ActionResult.java
+++ b/src/main/java/teammates/ui/controller/ActionResult.java
@@ -15,12 +15,13 @@ import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Url;
+import teammates.common.util.Utils;
 
 /**
  * The result of executing an {@link Action}.
  */
 public abstract class ActionResult {
-    protected static Logger log;
+    protected static final Logger log = Utils.getLogger();
     
     /** The URI that represents the result. 
      * e.g., "/page/instructorHome" "/jsp/instructorHome.jsp"

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -35,7 +35,7 @@ import com.google.apphosting.api.DeadlineExceededException;
 @SuppressWarnings("serial")
 public class ControllerServlet extends HttpServlet {
 
-    protected static final Logger log = Utils.getLogger();
+    private static final Logger log = Utils.getLogger();
 
     @Override
     public final void doGet(HttpServletRequest req, HttpServletResponse resp)

--- a/src/main/java/teammates/ui/controller/InstructorCourseEnrollResultPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEnrollResultPageData.java
@@ -2,20 +2,17 @@ package teammates.ui.controller;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.datatransfer.StudentAttributes.UpdateStatus;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.ui.template.EnrollResultPanel;
 
 /**
  * PageData: page data for the 'Result' page after enrollment for a course
  */
 public class InstructorCourseEnrollResultPageData extends PageData {
-    protected static final Logger log = Utils.getLogger();
     
     private String courseId;
     private List<StudentAttributes>[] students;

--- a/src/main/java/teammates/ui/controller/InstructorCourseRemindAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseRemindAction.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
-import java.util.logging.Logger;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -19,7 +18,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.StatusMessage;
-import teammates.common.util.Utils;
 import teammates.common.util.Const.StatusMessageColor;
 import teammates.logic.api.GateKeeper;
 
@@ -27,7 +25,6 @@ import teammates.logic.api.GateKeeper;
  * Action: remind instructor or student to register for a course by sending reminder emails
  */
 public class InstructorCourseRemindAction extends Action {
-    protected static final Logger log = Utils.getLogger();
     
     @Override
     public ActionResult execute() throws EntityDoesNotExistException {

--- a/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 
 import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
@@ -12,15 +11,12 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.common.util.Const.StatusMessageColor;
 import teammates.common.util.StatusMessage;
-import teammates.common.util.Utils;
 import teammates.logic.api.GateKeeper;
 
 /**
  * Action: loading of the 'Courses' page for an instructor.
  */
 public class InstructorCoursesPageAction extends Action {
-    /* Explanation: Get a logger to be used for any logging */
-    protected static final Logger log = Utils.getLogger();
 
     @Override
     public ActionResult execute() 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -13,6 +13,7 @@ import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackQuestionType;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
+import teammates.common.exception.TeammatesException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
@@ -130,7 +131,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
             
         } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
                  | InvocationTargetException | InstantiationException e) {
-            e.printStackTrace();
+            log.severe(TeammatesException.toStringWithStackTrace(e));
             // Assumption.fails are not tested
             Assumption.fail("Failed to instantiate Feedback*QuestionDetails instance for "
                             + feedbackQuestionAttributes.questionType.toString() + " question type.");

--- a/src/main/java/teammates/ui/controller/LoginServlet.java
+++ b/src/main/java/teammates/ui/controller/LoginServlet.java
@@ -1,7 +1,6 @@
 package teammates.ui.controller;
 
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -10,7 +9,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import teammates.common.datatransfer.UserType;
 import teammates.common.util.Const;
-import teammates.common.util.Utils;
 import teammates.logic.api.Logic;
 
 @SuppressWarnings("serial")
@@ -18,8 +16,6 @@ import teammates.logic.api.Logic;
  * Servlet to handle Login
  */
 public class LoginServlet extends HttpServlet {
-    
-    protected static final Logger log = Utils.getLogger();
     
     @Override
     public final void doGet(HttpServletRequest req, HttpServletResponse resp)

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -7,6 +7,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.logging.Logger;
 
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.CommentAttributes;
@@ -26,6 +27,7 @@ import teammates.common.util.StatusMessage;
 import teammates.common.util.StringHelper;
 import teammates.common.util.TimeHelper;
 import teammates.common.util.Url;
+import teammates.common.util.Utils;
 import teammates.logic.api.Logic;
 import teammates.ui.template.ElementTag;
 import teammates.ui.template.InstructorFeedbackSessionActions;
@@ -34,7 +36,9 @@ import teammates.ui.template.InstructorFeedbackSessionActions;
  * Data and utility methods needed to render a specific page.
  */
 public class PageData {
-
+    
+    protected static final Logger log = Utils.getLogger();
+    
     public static final String DISABLED = " disabled\" onclick=\"return false\"";
 
     /** The user for whom the pages are displayed (i.e. the 'nominal user'). 

--- a/src/main/java/teammates/ui/controller/RedirectResult.java
+++ b/src/main/java/teammates/ui/controller/RedirectResult.java
@@ -2,20 +2,17 @@ package teammates.ui.controller;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.logging.Logger;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.util.StatusMessage;
-import teammates.common.util.Utils;
 
 /** A 'redirect' type result. That is, the Browser will be required to make 
  * another request to the specified {@code destination}.
  */
 public class RedirectResult extends ActionResult {
-    static Logger log = Utils.getLogger();
     
     public RedirectResult(
             String destination, 

--- a/src/test/java/teammates/test/cases/common/AdminLogQueryTest.java
+++ b/src/test/java/teammates/test/cases/common/AdminLogQueryTest.java
@@ -45,7 +45,7 @@ public class AdminLogQueryTest extends BaseTestCase {
         Long startTime = cal.getTimeInMillis();
         Long endTime = startTime + 3 * 24 * 60 * 60 * 1000; // 3 days later
         AdminLogQuery query = new AdminLogQuery(versionList, startTime, endTime);
-        Long fourHours = new Long(4 * 60 * 60 * 1000);
+        Long fourHours = Long.valueOf(4 * 60 * 60 * 1000);
         query.moveTimePeriodBackward(fourHours); // 4 hours before endTime
         long expectedEndTime = startTime - 1;
         long expectedStartTime = expectedEndTime - fourHours;

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -1,7 +1,6 @@
 package teammates.test.cases.ui.browsertests;
 
 import java.io.File;
-import java.util.logging.Logger;
 
 import org.openqa.selenium.By;
 import org.testng.annotations.AfterClass;
@@ -29,7 +28,6 @@ import teammates.test.util.Priority;
  */
 @Priority(-1)
 public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
-    protected static Logger log = Utils.getLogger();
 
     private static DataBundle testData;
     private static Browser browser;

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -442,13 +442,11 @@ public final class BackDoor {
     public static FeedbackQuestionAttributes getFeedbackQuestion(String courseID,
             String feedbackSessionName, int qnNumber) {
         String jsonString = getFeedbackQuestionAsJson(feedbackSessionName, courseID, qnNumber);
-        Utils.getLogger().info(jsonString);
         return Utils.getTeammatesGson().fromJson(jsonString, FeedbackQuestionAttributes.class);
     }
     
     public static FeedbackQuestionAttributes getFeedbackQuestion(String questionId) {
         String jsonString = getFeedbackQuestionForIdAsJson(questionId);
-        Utils.getLogger().info(jsonString);
         return Utils.getTeammatesGson().fromJson(jsonString, FeedbackQuestionAttributes.class);
     }
     
@@ -489,7 +487,6 @@ public final class BackDoor {
     public static FeedbackResponseAttributes getFeedbackResponse(String feedbackQuestionId,
             String giverEmail, String recipient) {
         String jsonString = getFeedbackResponseAsJson(feedbackQuestionId, giverEmail, recipient);
-        Utils.getLogger().info(jsonString);
         return Utils.getTeammatesGson().fromJson(jsonString, FeedbackResponseAttributes.class);
     }
     

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -89,10 +89,8 @@ public final class TestProperties {
             
             TEST_TIMEOUT = Integer.parseInt(prop.getProperty("test.timeout"));
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (NumberFormatException e) {
-            e.printStackTrace();
+        } catch (IOException | NumberFormatException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -476,7 +476,7 @@ public abstract class AppPage {
      *  {@code Common.TEST_PAGES_FOLDER} folder. In that case, the parameter
      *  value should start with "/". e.g., "/instructorHomePage.html".
      */
-    public void saveCurrentPage(String filePath, String content) throws Exception {
+    public void saveCurrentPage(String filePath, String content) throws IOException {
         FileWriter output = new FileWriter(new File(filePath));
         output.write(content);
         output.close();
@@ -843,25 +843,19 @@ public abstract class AppPage {
         return HtmlHelper.processPageSourceForHtmlComparison(actual);
     }
 
-    private boolean testAndRunGodMode(String filePath, String content, boolean isPart) {
-        if (Boolean.parseBoolean(System.getProperty("godmode"))) {
-            return regenerateHtmlFile(filePath, content, isPart);
-        }
-        return false;
+    private boolean testAndRunGodMode(String filePath, String content, boolean isPart) throws IOException {
+        return Boolean.parseBoolean(System.getProperty("godmode"))
+                && regenerateHtmlFile(filePath, content, isPart);
     }
     
-    private boolean regenerateHtmlFile(String filePath, String content, boolean isPart) {
+    private boolean regenerateHtmlFile(String filePath, String content, boolean isPart) throws IOException {
         if (content == null || content.isEmpty()) { 
             return false;
         }
         
         TestProperties.inst().verifyReadyForGodMode();
-        try {
-            String processedPageSource = HtmlHelper.processPageSourceForExpectedHtmlRegeneration(content, isPart);
-            saveCurrentPage(filePath, processedPageSource);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        String processedPageSource = HtmlHelper.processPageSourceForExpectedHtmlRegeneration(content, isPart);
+        saveCurrentPage(filePath, processedPageSource);
         return true;
     }
     

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.util.List;
-import java.util.logging.Logger;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
@@ -46,7 +45,6 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import teammates.common.util.FileHelper;
 import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
-import teammates.common.util.Utils;
 import teammates.test.driver.AssertHelper;
 import teammates.test.driver.HtmlHelper;
 import teammates.test.driver.TestProperties;
@@ -62,7 +60,6 @@ import teammates.test.driver.TestProperties;
  */
 @SuppressWarnings("deprecation")
 public abstract class AppPage {
-    protected static Logger log = Utils.getLogger();
     private static final By MAIN_CONTENT = By.id("mainContent");
     private static final int VERIFICATION_RETRY_COUNT = 5;
     private static final int VERIFICATION_RETRY_DELAY_IN_MS = 1000;

--- a/src/test/java/teammates/test/pageobjects/BrowserPool.java
+++ b/src/test/java/teammates/test/pageobjects/BrowserPool.java
@@ -101,7 +101,7 @@ public final class BrowserPool {
                 try {
                     this.wait(200);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    throw new RuntimeException(e);
                 }
             }
         }

--- a/src/test/java/teammates/test/util/FileHelper.java
+++ b/src/test/java/teammates/test/util/FileHelper.java
@@ -1,12 +1,6 @@
 package teammates.test.util;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 /**
  * File-related helper methods used for testing. There is another FileHelper on
@@ -18,58 +12,9 @@ public final class FileHelper {
         // utility class
     }
 
-    public static void writeToFile(String fileName, String fileContent) {
-        try {
-
-            File file = new File(fileName);
-
-            // if file doesnt exists, then create it
-            if (!file.exists()) {
-                file.createNewFile();
-            }
-
-            FileWriter fw = new FileWriter(file.getAbsoluteFile());
-            BufferedWriter bw = new BufferedWriter(fw);
-            bw.write(fileContent);
-            bw.close();
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-    
-    public static void appendToFile(String fileName, String fileContent) {
-        try {
-
-            File file = new File(fileName);
-
-            // if file doesnt exists, then create it
-            if (!file.exists()) {
-                file.createNewFile();
-            }
-
-            FileWriter fw = new FileWriter(file.getAbsoluteFile(), true);
-            BufferedWriter bw = new BufferedWriter(fw);
-            bw.write(fileContent);
-            bw.close();
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-    
     public static void deleteFile(String fileName) {
         File file = new File(fileName);
         file.delete();
     }
 
-    public static String readFile(String path, Charset encoding) {
-        byte[] encoded = null;
-        try {
-            encoded = Files.readAllBytes(Paths.get(path));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return new String(encoded, encoding);
-    }
 }

--- a/src/test/java/teammates/test/util/PriorityInterceptor.java
+++ b/src/test/java/teammates/test/util/PriorityInterceptor.java
@@ -1,7 +1,7 @@
 package teammates.test.util;
 
+import java.io.FileNotFoundException;
 import java.lang.reflect.Method;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -9,6 +9,8 @@ import java.util.List;
 import org.testng.IMethodInstance;
 import org.testng.IMethodInterceptor;
 import org.testng.ITestContext;
+
+import teammates.common.util.FileHelper;
 
 /**
  * By default, testng runs all methods in a test in lexical order.
@@ -27,9 +29,9 @@ public class PriorityInterceptor implements IMethodInterceptor {
     static String packageOrder;
     static {
         try {
-            packageOrder = FileHelper.readFile("src\\test\\testng-travis.xml", Charset.defaultCharset());
-        } catch (Exception e) {
-            packageOrder = FileHelper.readFile("src/test/testng-travis.xml", Charset.defaultCharset());
+            packageOrder = FileHelper.readFile("src/test/testng-travis.xml");
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
         }
     }
     


### PR DESCRIPTION
Violations are fixed but rules are not enforced due to various reasons:
- Migrating: PMD docs said that "Don’t use these rules directly, rather, use a wrapper ruleset such as migrating_to_13.xml." so I'm not sure whether to enforce, but the violations only involve instantiations of Long, Short, Byte, Integer.
- Logging: Only relevant for production code because tests don't use logging, and some rules like no `System.out.println` are not applicable to testing at all, and suppressing it will add too many `@SuppressWarnings` or `// NOPMD`. Perhaps it's about time to split the ruleset to production and non-production code.

The `AvoidPrintStackTrace` is particularly useful in revealing some swallowed stack traces.