### PR TITLE
PMD rules for production code is not enforced #5725

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -281,7 +281,7 @@ checkstyle {
 pmd {
     toolVersion = "5.4.1"
     consoleOutput = true
-    ruleSetFiles = files("static-analysis/teammates-pmd.xml")
+    ruleSetFiles = files("static-analysis/teammates-pmd.xml", "static-analysis/teammates-pmdMain.xml")
     ruleSets = []
 }
 

--- a/src/main/java/teammates/common/exception/EmailSendingException.java
+++ b/src/main/java/teammates/common/exception/EmailSendingException.java
@@ -1,7 +1,7 @@
 package teammates.common.exception;
 
 @SuppressWarnings("serial")
-public class EmailSendingException extends RuntimeException {
+public class EmailSendingException extends TeammatesException {
     
     public EmailSendingException(Exception e) {
         super(e.getMessage());

--- a/src/main/java/teammates/common/exception/EmailSendingException.java
+++ b/src/main/java/teammates/common/exception/EmailSendingException.java
@@ -1,0 +1,10 @@
+package teammates.common.exception;
+
+@SuppressWarnings("serial")
+public class EmailSendingException extends RuntimeException {
+    
+    public EmailSendingException(Exception e) {
+        super(e.getMessage());
+    }
+    
+}

--- a/src/main/java/teammates/logic/automated/AdminEmailWorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/AdminEmailWorkerServlet.java
@@ -56,7 +56,7 @@ public class AdminEmailWorkerServlet extends WorkerServlet {
 
     }
     
-    private void sendAdminEmail(String emailContent, String subject, String receiverEmail) throws Exception {
+    private void sendAdminEmail(String emailContent, String subject, String receiverEmail) {
         
         EmailWrapper email =
                 new EmailGenerator().generateAdminEmail(StringHelper.recoverFromSanitizedText(emailContent),

--- a/src/main/java/teammates/logic/automated/AdminEmailWorkerServlet.java
+++ b/src/main/java/teammates/logic/automated/AdminEmailWorkerServlet.java
@@ -4,6 +4,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import teammates.common.datatransfer.AdminEmailAttributes;
+import teammates.common.exception.EmailSendingException;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const.ParamsNames;
@@ -56,7 +57,7 @@ public class AdminEmailWorkerServlet extends WorkerServlet {
 
     }
     
-    private void sendAdminEmail(String emailContent, String subject, String receiverEmail) {
+    private void sendAdminEmail(String emailContent, String subject, String receiverEmail) throws EmailSendingException {
         
         EmailWrapper email =
                 new EmailGenerator().generateAdminEmail(StringHelper.recoverFromSanitizedText(emailContent),

--- a/src/main/java/teammates/logic/core/EmailSender.java
+++ b/src/main/java/teammates/logic/core/EmailSender.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import teammates.common.exception.EmailSendingException;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -89,18 +90,18 @@ public class EmailSender {
     /**
      * Sends the given {@code message} and generates a log report.
      */
-    public void sendEmailWithLogging(EmailWrapper message) {
+    public void sendEmailWithLogging(EmailWrapper message) throws EmailSendingException {
         sendEmail(message, true);
     }
     
     /**
      * Sends the given {@code message} without generating a log report.
      */
-    public void sendEmailWithoutLogging(EmailWrapper message) {
+    public void sendEmailWithoutLogging(EmailWrapper message) throws EmailSendingException {
         sendEmail(message, false);
     }
     
-    private void sendEmail(EmailWrapper message, boolean isWithLogging) {
+    private void sendEmail(EmailWrapper message, boolean isWithLogging) throws EmailSendingException {
         service.sendEmail(message);
         if (isWithLogging) {
             generateLogReport(message);
@@ -120,7 +121,7 @@ public class EmailSender {
     /**
      * Sends the given {@code errorReport}.
      */
-    public void sendErrorReport(EmailWrapper errorReport) {
+    public void sendErrorReport(EmailWrapper errorReport) throws EmailSendingException {
         sendEmailWithoutLogging(errorReport);
         log.info("Sent crash report: " + errorReport.getInfoForLogging());
     }

--- a/src/main/java/teammates/logic/core/EmailSender.java
+++ b/src/main/java/teammates/logic/core/EmailSender.java
@@ -89,18 +89,18 @@ public class EmailSender {
     /**
      * Sends the given {@code message} and generates a log report.
      */
-    public void sendEmailWithLogging(EmailWrapper message) throws Exception {
+    public void sendEmailWithLogging(EmailWrapper message) {
         sendEmail(message, true);
     }
     
     /**
      * Sends the given {@code message} without generating a log report.
      */
-    public void sendEmailWithoutLogging(EmailWrapper message) throws Exception {
+    public void sendEmailWithoutLogging(EmailWrapper message) {
         sendEmail(message, false);
     }
     
-    private void sendEmail(EmailWrapper message, boolean isWithLogging) throws Exception {
+    private void sendEmail(EmailWrapper message, boolean isWithLogging) {
         service.sendEmail(message);
         if (isWithLogging) {
             generateLogReport(message);
@@ -120,7 +120,7 @@ public class EmailSender {
     /**
      * Sends the given {@code errorReport}.
      */
-    public void sendErrorReport(EmailWrapper errorReport) throws Exception {
+    public void sendErrorReport(EmailWrapper errorReport) {
         sendEmailWithoutLogging(errorReport);
         log.info("Sent crash report: " + errorReport.getInfoForLogging());
     }

--- a/src/main/java/teammates/logic/core/EmailSenderService.java
+++ b/src/main/java/teammates/logic/core/EmailSenderService.java
@@ -26,7 +26,7 @@ public abstract class EmailSenderService {
     /**
      * Sends the email packaged as a {@code wrapper}.
      */
-    public void sendEmail(EmailWrapper wrapper) {
+    public void sendEmail(EmailWrapper wrapper) throws EmailSendingException {
         try {
             sendEmailWithService(wrapper);
         } catch (Exception e) {

--- a/src/main/java/teammates/logic/core/EmailSenderService.java
+++ b/src/main/java/teammates/logic/core/EmailSenderService.java
@@ -2,27 +2,40 @@ package teammates.logic.core;
 
 import java.util.logging.Logger;
 
+import teammates.common.exception.EmailSendingException;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Utils;
 
 /**
  * An email sender interface used by services for sending emails.
  */
-public interface EmailSenderService {
+public abstract class EmailSenderService {
     
-    int SUCCESS_CODE = 200;
+    protected static final int SUCCESS_CODE = 200;
     
-    Logger log = Utils.getLogger();
+    protected static final Logger log = Utils.getLogger();
     
     /**
      * Parses the {@code wrapper} email object to specific implementations of email object
      * used by the service.
      */
-    Object parseToEmail(EmailWrapper wrapper) throws Exception;
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    // accounts for the many different Exceptions from different email services
+    public abstract Object parseToEmail(EmailWrapper wrapper) throws Exception;
     
     /**
      * Sends the email packaged as a {@code wrapper}.
      */
-    void sendEmail(EmailWrapper wrapper) throws Exception;
+    public void sendEmail(EmailWrapper wrapper) {
+        try {
+            sendEmailWithService(wrapper);
+        } catch (Exception e) {
+            throw new EmailSendingException(e);
+        }
+    }
+    
+    @SuppressWarnings("PMD.SignatureDeclareThrowsException")
+    // accounts for the many different Exceptions from different email services
+    protected abstract void sendEmailWithService(EmailWrapper wrapper) throws Exception;
     
 }

--- a/src/main/java/teammates/logic/core/JavamailService.java
+++ b/src/main/java/teammates/logic/core/JavamailService.java
@@ -21,7 +21,7 @@ import teammates.common.util.EmailWrapper;
  * 
  * @see MimeMessage
  */
-public class JavamailService implements EmailSenderService {
+public class JavamailService extends EmailSenderService {
     
     /**
      * {@inheritDoc}
@@ -45,11 +45,8 @@ public class JavamailService implements EmailSenderService {
         return email;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void sendEmail(EmailWrapper wrapper) throws AddressException, MessagingException, IOException {
+    protected void sendEmailWithService(EmailWrapper wrapper) throws AddressException, MessagingException, IOException {
         MimeMessage email = parseToEmail(wrapper);
         Transport.send(email);
     }

--- a/src/main/java/teammates/logic/core/MailgunService.java
+++ b/src/main/java/teammates/logic/core/MailgunService.java
@@ -15,7 +15,7 @@ import teammates.common.util.EmailWrapper;
  * Email sender service provided by Mailgun.
  * Reference: https://cloud.google.com/appengine/docs/java/mail/mailgun
  */
-public class MailgunService implements EmailSenderService {
+public class MailgunService extends EmailSenderService {
     
     /**
      * {@inheritDoc}
@@ -42,11 +42,8 @@ public class MailgunService implements EmailSenderService {
         return formData;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void sendEmail(EmailWrapper wrapper) {
+    protected void sendEmailWithService(EmailWrapper wrapper) {
         FormDataMultiPart email = parseToEmail(wrapper);
         Client client = Client.create();
         client.addFilter(new HTTPBasicAuthFilter("api", Config.MAILGUN_APIKEY));

--- a/src/main/java/teammates/logic/core/MailjetService.java
+++ b/src/main/java/teammates/logic/core/MailjetService.java
@@ -21,7 +21,7 @@ import teammates.common.util.EmailWrapper;
  * @see MailjetRequest
  * @see MailjetResponse
  */
-public class MailjetService implements EmailSenderService {
+public class MailjetService extends EmailSenderService {
     
     /**
      * {@inheritDoc}
@@ -46,11 +46,8 @@ public class MailjetService implements EmailSenderService {
         return request;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void sendEmail(EmailWrapper wrapper) throws MailjetException {
+    protected void sendEmailWithService(EmailWrapper wrapper) throws MailjetException {
         MailjetRequest email = parseToEmail(wrapper);
         MailjetClient mailjet = new MailjetClient(Config.MAILJET_APIKEY, Config.MAILJET_SECRETKEY);
         MailjetResponse response = mailjet.post(email);

--- a/src/main/java/teammates/logic/core/SendgridService.java
+++ b/src/main/java/teammates/logic/core/SendgridService.java
@@ -16,7 +16,7 @@ import teammates.common.util.EmailWrapper;
  * 
  * @see SendGrid
  */
-public class SendgridService implements EmailSenderService {
+public class SendgridService extends EmailSenderService {
     
     /**
      * {@inheritDoc}
@@ -39,11 +39,8 @@ public class SendgridService implements EmailSenderService {
         return email;
     }
     
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void sendEmail(EmailWrapper wrapper) throws SendGridException {
+    protected void sendEmailWithService(EmailWrapper wrapper) throws SendGridException {
         Email email = parseToEmail(wrapper);
         SendGrid sendgrid = new SendGrid(Config.SENDGRID_APIKEY);
         Response response = sendgrid.send(email);


### PR DESCRIPTION
Fixes #5725 

I was already feeling funny when doing the `EmailSenderService` migration because I knew full well that `throws Exception` should not be allowed, but I thought it was another one of PMD's bugs. Now we know why.