### PR TITLE
MailGun cannot send emails on live server #5737

### DIFF
--- a/src/main/resources/jersey-multipart-config.properties
+++ b/src/main/resources/jersey-multipart-config.properties
@@ -1,2 +1,5 @@
+# Jersey library may cause problem in Google App Engine environment when trying to upload big files.
+# This file contains the properties needed to rectify the problem.
+# See http://stackoverflow.com/questions/6301973/multipart-file-upload-on-google-appengine-using-jersey-1-7
 bufferThreshold = -1
 jersey.config.multipart.bufferThreshold = -1

--- a/src/main/resources/jersey-multipart-config.properties
+++ b/src/main/resources/jersey-multipart-config.properties
@@ -1,0 +1,2 @@
+bufferThreshold = -1
+jersey.config.multipart.bufferThreshold = -1


### PR DESCRIPTION
Fixes #5737 

According to [this answer](http://stackoverflow.com/questions/6301973/multipart-file-upload-on-google-appengine-using-jersey-1-7), version 1.x of jersey library require the shorter `bufferThreshold` property (the longer one is for 2.x) but I include both just to be safe, it should not have any side effects.