### PR TITLE
 Disable submit buttons after form submission #5582 

### DIFF
--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -161,6 +161,15 @@ $(document).on('ajaxComplete ready', function() {
     if (isTouchDevice()) {
         $tooltips.tooltip('disable');
     }
+    
+    $('form').submit(function() {
+        $(this).find("button[type='submit']").prop('disabled',true);
+     });
+    
+    $('[id^="button_submit"]').click(function() {
+        console.log("Yes");
+        $(this).prop('disabled',true);
+     });
 });
 
 /**


### PR DESCRIPTION
Fixes #5582

Handles submit buttons within forms. 
Also handles submit buttons not included in forms, under the assumption that they have the `id` attribute in the format of `"button_submit_XXX".` 
 