### PR TITLE
instructorFeedbackEdit: page should scroll to status message after saving #5541

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -137,16 +137,12 @@ function bindFeedbackSessionEditFormSubmission() {
                 clearStatusMessages();
             },
             success: function(result) {
-                
                 if (result.hasError) {
                     setStatusMessage(result.statusForAjax, StatusType.DANGER);
                 } else {
                     setStatusMessage(result.statusForAjax, StatusType.SUCCESS);
                     disableEditFS();
                 }
-                
-                // focus on status message
-                scrollToElement($('#statusMessagesToUser'), { offset: ($('.navbar').height() + 30) * -1 });
             }
         });
     });

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -147,6 +147,8 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
                 editedSession.getInstructions(), editedSession.getGracePeriod());
         
         feedbackEditPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_EDITED);
+        assertTrue(feedbackEditPage.isElementInViewport(Const.ParamsNames.STATUS_MESSAGES_LIST));
+
         FeedbackSessionAttributes savedSession = BackDoor.getFeedbackSession(
                 editedSession.getCourseId(), editedSession.getFeedbackSessionName());
         editedSession.setInstructions(new Text("<p>" + editedSession.getInstructionsString() + "</p>"));

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -1003,4 +1003,13 @@ public abstract class AppPage {
         browser.driver.manage().window().maximize();
     }
 
+    /**
+     * Checks if element is in viewport.
+     */
+    public boolean isElementInViewport(String id) {
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
+        String script = "return isWithinView(document.getElementById('" + id + "'));";
+        return (boolean) jsExecutor.executeScript(script);
+    }
+
 }

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -1004,7 +1004,7 @@ public abstract class AppPage {
     }
 
     /**
-     * Checks if element is in viewport.
+     * @return true if the element is in the user's visible area of a web page.
      */
     public boolean isElementInViewport(String id) {
         JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;


### PR DESCRIPTION
Fixes #5541

Scrolling to status message is already included into **setStatusMessage** function.