### PR TITLE
Add version number to ESLint #5822

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - tar -xjf /tmp/firefox-38.0.5.tar.bz2 --directory $TRAVIS_BUILD_DIR/
   - export PATH="$TRAVIS_BUILD_DIR/firefox:$PATH"
   - ./gradlew createConfigs testClasses
-  - npm install eslint
+  - npm install eslint@3.0.0
   - ./gradlew downloadStaticAnalysisTools --continue
   - ./gradlew staticAnalysis --continue
 

--- a/devdocs/staticAnalysis.md
+++ b/devdocs/staticAnalysis.md
@@ -79,14 +79,14 @@ The rules to be used are configured in a ruleset file; in TEAMMATES the file can
 Normally, the coverage will be run against all classes specified as the source code, but it can be configured to exclude classes matching certain name patterns.
 The plugin for Eclipse can be found [here](http://eclemma.org).
 
-### ESLint
+### ESLint (version 3.0.0)
 
 [ESLint](http://eslint.org) functions both to enforce coding standard and also to find potential bugs in JavaScript source code.
 The rules to be used are configured in a ruleset file; in TEAMMATES the file can be found [here](../static-analysis/teammates-eslint.yml).
 ESLint is a node.js package, currently not supported for Eclipse Java EE project.
-To set it up, [install node.js](https://nodejs.org/en/download/) if necessary and then install the ESLint package:
+To set it up, [install node.js](https://nodejs.org/en/download/) if necessary (version 4 or later required) and then install the ESLint package:
 ```
-npm install -g eslint
+npm install -g eslint@3.0.0
 ```
 
 ##### Suppressing ESLint warnings

--- a/src/main/webapp/js/adminAccountManagement.js
+++ b/src/main/webapp/js/adminAccountManagement.js
@@ -1,6 +1,6 @@
 var entryPerPage = 200;
 
-var start = 0;
+var begin = 0;
 var end = 0;
 var total = 0;
 
@@ -68,7 +68,7 @@ function caculateTotalPages() {
 }
 
 function updateEntriesCount() {
-    var newText = start + '~' + (end > total ? total : end);
+    var newText = begin + '~' + Math.min(end, total);
     
     $('span#currentPageEntryCount').text(newText);
     $('span#totalEntryCount').text(total);
@@ -80,10 +80,10 @@ function hideAllEntries() {
 
 function showFirstPage() {
     hideAllEntries();
-    start = 1;
+    begin = 1;
     end = entryPerPage;
     currentPage = 1;
-    showEntryInInterval(start, end);
+    showEntryInInterval(begin, end);
 }
 
 function showEntryInInterval(start, end) {
@@ -106,9 +106,9 @@ function reLabelOrderedAccountEntries() {
 }
 
 function showEntriesForSelectedPage() {
-    start = (currentPage - 1) * entryPerPage + 1;
-    end = start + entryPerPage - 1;
-    showEntryInInterval(start, end);
+    begin = (currentPage - 1) * entryPerPage + 1;
+    end = begin + entryPerPage - 1;
+    showEntryInInterval(begin, end);
     
 }
 

--- a/src/main/webapp/js/instructorCourseEnrollPage.js
+++ b/src/main/webapp/js/instructorCourseEnrollPage.js
@@ -1,4 +1,3 @@
-
 var loadUpFunction = function() {
     var typingErrMsg = 'Please use | character ( shift+\\ ) to seperate fields, or copy from your existing spreadsheet.';
     var notified = false;

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -21,7 +21,6 @@ $(document).ready(function() {
     hideUncommonPanels();
 });
 
-
 /**
  * This function is called on edit page load.
  */

--- a/src/main/webapp/js/userMap.js
+++ b/src/main/webapp/js/userMap.js
@@ -1,4 +1,3 @@
-
 function handleError() {
     var contentHolder = d3.select('#contentHolder');
     contentHolder.html('');

--- a/static-analysis/teammates-eslint.yml
+++ b/static-analysis/teammates-eslint.yml
@@ -16,9 +16,6 @@ rules:
 
     # Possible Errors
 
-    # require or disallow trailing commas
-    comma-dangle: ["error", "never"]
-
     # disallow assignment operators in conditional expressions
     no-cond-assign: ["error", "except-parens"]
 
@@ -79,6 +76,9 @@ rules:
     # disallow calling global object properties as functions
     no-obj-calls: "error"
 
+    # Disallow use of Object.prototypes builtins directly
+    # no-prototype-builtins: "off"
+
     # disallow multiple spaces in regular expression literals
     no-regex-spaces: "error"
 
@@ -92,7 +92,7 @@ rules:
     no-unreachable: "error"
 
     # disallow control flow statements in finally blocks
-    # no-unsafe-finally: "off"
+    no-unsafe-finally: "error"
 
     # require calls to isNaN() when checking for NaN
     use-isnan: "error"
@@ -214,7 +214,7 @@ rules:
     # no-multi-str: "off"
 
     # disallow reassigning native objects
-    # no-native-reassign: "off"
+    no-native-reassign: "error"
 
     # disallow new operators outside of assignments or comparisons
     no-new: "error"
@@ -232,7 +232,7 @@ rules:
     # no-octal-escape: "off"
 
     # disallow reassigning function parameters
-    no-param-reassign: "error"
+    no-param-reassign: ["error", { "props": false }]
 
     # disallow usage of __proto__ property
     # no-proto: "off"
@@ -354,6 +354,9 @@ rules:
     # enforce camelcase naming convention
     camelcase: "error"
 
+    # require or disallow trailing commas
+    comma-dangle: ["error", "never"]
+
     # enforce consistent spacing before and after commas
     comma-spacing: "error"
 
@@ -408,6 +411,9 @@ rules:
     # enforce a maximum line length
     max-len: ["error", 125]
 
+    # enforce a maximum file length
+    # max-lines: "off"
+
     # enforce a maximum depth that callbacks can be nested
     # max-nested-callbacks: "off"
 
@@ -450,11 +456,14 @@ rules:
     # disallow if statements as the only statement in else blocks
     no-lonely-if: "error"
 
+    # disallow mixes of different operators
+    # no-mixed-operators: "off"
+
     # disallow mixed spaces and tabs for indentation
     no-mixed-spaces-and-tabs: "error"
 
     # disallow multiple empty lines
-    no-multiple-empty-lines: "error"
+    no-multiple-empty-lines: ["error", { "max": 1, "maxBOF": 0, "maxEOF": 1}]
 
     # disallow negated conditions
     no-negated-condition: "error"
@@ -488,6 +497,9 @@ rules:
 
     # disallow whitespace before properties
     no-whitespace-before-property: "error"
+
+    # enforce consistent line breaks inside braces
+    # object-curly-newline: "off"
 
     # enforce consistent spacing inside braces
     object-curly-spacing: ["error", "always"]
@@ -545,6 +557,9 @@ rules:
 
     # enforce consistent spacing after the // or /* in a comment
     spaced-comment: ["error", "always"]
+
+    # require or disallow Unicode BOM
+    # unicode-bom: "off"
 
     # require parenthesis around regex literals
     # wrap-regex: "off"


### PR DESCRIPTION
Fixes #5822 

Version 3.0.0 is a major release from their side and [their documentation](http://eslint.org/docs/user-guide/migrating-to-3.0.0) comprehensively lines out what needs to be done to migrate, all of which have been done via this PR (in particular updating the rules list and specifying the minimum node.js version).