### PR TITLE
AccessControlUtil: Comments Page Slice

### DIFF
--- a/src/main/java/teammates/logic/api/AccessControlUtil.java
+++ b/src/main/java/teammates/logic/api/AccessControlUtil.java
@@ -1,5 +1,86 @@
 package teammates.logic.api;
 
-public class AccessControlUtil {
+import java.util.Iterator;
+import java.util.List;
 
+import teammates.common.datatransfer.CommentAttributes;
+import teammates.common.datatransfer.CommentParticipantType;
+import teammates.common.datatransfer.InstructorAttributes;
+import teammates.common.datatransfer.StudentAttributes;
+import teammates.common.util.Const;
+
+public class AccessControlUtil {
+    private Logic logic = new Logic();
+    private static AccessControlUtil instance;
+    
+    public static AccessControlUtil inst() {
+        if (instance == null) {
+            instance = new AccessControlUtil();
+        }
+        return instance;
+    }
+    
+    public boolean isInstructorAllowedToViewComment(InstructorAttributes instructor, CommentAttributes comment) {
+        if (instructor == null || comment == null) {
+            return false;
+        }
+        
+        // trivial case: instructor is comment giver
+        if (comment.giverEmail.equals(instructor.email)) {
+            return true;
+        }
+        
+        return isInstructorAllowedForPrivilegeOnComment(
+                instructor, comment, Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_COMMENT_IN_SECTIONS);
+    }
+    
+    public boolean isInstructorAllowedToModifyComment(InstructorAttributes instructor, CommentAttributes comment) {
+        if (instructor == null || comment == null) {
+            return false;
+        }
+        
+        // trivial case: instructor is comment giver
+        if (comment.giverEmail.equals(instructor.email)) {
+            return true;
+        }
+        
+        return isInstructorAllowedForPrivilegeOnComment(
+                instructor, comment, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COMMENT_IN_SECTIONS);
+    }
+    
+    private boolean isInstructorAllowedForPrivilegeOnComment(InstructorAttributes instructor, CommentAttributes comment,
+                                                             String privilegeName) {
+        // TODO: remember to come back and change this if
+        // CommentAttributes.recipients can have multiple recipients later
+        
+        String courseId = instructor.courseId;
+        String recipient = null;
+        if (!comment.recipients.isEmpty()) {
+            Iterator<String> iterator = comment.recipients.iterator();
+            recipient = iterator.next();
+        }
+        if (comment.recipientType == CommentParticipantType.COURSE) {
+            return instructor.isAllowedForPrivilege(privilegeName);
+        } else if (comment.recipientType == CommentParticipantType.SECTION) {
+            return instructor.isAllowedForPrivilege(recipient, privilegeName);
+        } else if (comment.recipientType == CommentParticipantType.TEAM) {
+            String section = "";
+            List<StudentAttributes> students = logic.getStudentsForTeam(recipient, courseId);
+            if (!students.isEmpty()) {
+                section = students.get(0).section;
+            }
+            return instructor.isAllowedForPrivilege(section, privilegeName);
+        } else if (comment.recipientType == CommentParticipantType.PERSON) {
+            String section = "";
+            StudentAttributes student = logic.getStudentForEmail(courseId, recipient);
+            if (student != null) {
+                section = student.section;
+            }
+            return instructor.isAllowedForPrivilege(section, privilegeName);
+        } else {
+            // TODO: implement this if instructor is later allowed to be added
+            // to recipients
+            return false;
+        }
+    }
 }

--- a/src/main/java/teammates/logic/api/AccessControlUtil.java
+++ b/src/main/java/teammates/logic/api/AccessControlUtil.java
@@ -9,6 +9,7 @@ import teammates.common.datatransfer.CommentParticipantType;
 import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.common.util.Sanitizer;
 
 public class AccessControlUtil {
     private Logic logic = new Logic();
@@ -139,7 +140,8 @@ public class AccessControlUtil {
     }
     
     private boolean isStudentTeamRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
-        return CommentParticipantType.TEAM.equals(comment.recipientType) && comment.recipients.contains(student.team);
+        return CommentParticipantType.TEAM.equals(comment.recipientType)
+                && comment.recipients.contains(Sanitizer.sanitizeForHtml(student.team));
     }
     
     private boolean isStudentInSameTeamAsRecipientOfComment(

--- a/src/main/java/teammates/logic/api/AccessControlUtil.java
+++ b/src/main/java/teammates/logic/api/AccessControlUtil.java
@@ -15,7 +15,7 @@ public class AccessControlUtil {
     private Logic logic = new Logic();
     private static AccessControlUtil instance;
     
-    public static int COMMENT_PERMISSIONS_IS_DISPLAYED_INDEX = 0;
+    public static int COMMENT_PERMISSIONS_COMMENT_IS_DISPLAYED_INDEX = 0;
     public static int COMMENT_PERMISSIONS_GIVER_IS_DISPLAYED_INDEX = 1;
     public static int COMMENT_PERMISSIONS_RECIPIENT_IS_DISPLAYED_INDEX = 2;
     
@@ -28,6 +28,9 @@ public class AccessControlUtil {
         return instance;
     }
     
+    /**
+     * Checks if the instructor has permission to view the given comment.
+     */
     public boolean isInstructorAllowedToViewComment(InstructorAttributes instructor, CommentAttributes comment) {
         if (instructor == null || comment == null) {
             return false;
@@ -41,7 +44,10 @@ public class AccessControlUtil {
         return isInstructorAllowedForPrivilegeOnComment(
                 instructor, comment, Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_COMMENT_IN_SECTIONS);
     }
-    
+
+    /**
+     * Checks if the instructor has permission to modify the given comment.
+     */
     public boolean isInstructorAllowedToModifyComment(InstructorAttributes instructor, CommentAttributes comment) {
         if (instructor == null || comment == null) {
             return false;
@@ -55,7 +61,11 @@ public class AccessControlUtil {
         return isInstructorAllowedForPrivilegeOnComment(
                 instructor, comment, Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COMMENT_IN_SECTIONS);
     }
-    
+
+    /**
+     * Checks if the instructor has the associated permission for the comment.
+     * Preconditions: No parameter is null.
+     */
     private boolean isInstructorAllowedForPrivilegeOnComment(InstructorAttributes instructor, CommentAttributes comment,
                                                              String privilegeName) {
         // TODO: remember to come back and change this if
@@ -94,11 +104,22 @@ public class AccessControlUtil {
             return false;
         }
     }
-    
+
+    /**
+     * Returns a {@code List} of boolean values representing the permissions a student has for a given comment.
+     */
     public List<Boolean> getVisibilityPermissionsOnCommentForStudent(
             CommentAttributes comment, StudentAttributes student, List<String> teammatesEmails,
             List<String> sectionStudentsEmails, List<String> teamsInSection) {
-        List<Boolean> permissions;
+        
+        List<Boolean> permissions = new ArrayList<Boolean>();
+        for (int i = 0; i < COMMENT_PERMISSIONS_TOTAL_SIZE; i++) {
+            permissions.add(false);
+        };
+        
+        if (comment == null || student == null) {
+            return permissions;
+        }
         
         // the following if-else if-else blocks rely on their ordering to properly classify the comment
         // eg. a comment directed at the student's team will not be classified as "in the same section as student"
@@ -127,10 +148,6 @@ public class AccessControlUtil {
             
         // comment not in same course as student, so student should not be able to view the comment
         } else {
-            permissions = new ArrayList<Boolean>();
-            for (int i = 0; i < COMMENT_PERMISSIONS_TOTAL_SIZE; i++) {
-                permissions.add(false);
-            }
         }
         return permissions;
     }
@@ -189,14 +206,22 @@ public class AccessControlUtil {
         return comment.courseId.equals(student.course);
     }
     
+    /**
+     * Checks if the recipient of the comment is found in the provided list of emails/names.
+     * Preconditions: comment is not null.
+     */
     private boolean isCommentRecipientPresentInList(CommentAttributes comment, List<String> candidateRecipients) {
-        if (!comment.recipients.isEmpty()) {
+        if (!comment.recipients.isEmpty() && candidateRecipients != null) {
             String commentRecipient = comment.recipients.iterator().next();
             return candidateRecipients.contains(commentRecipient);
         }
         return false;
     }
     
+    /**
+     * Returns a {@code List} of boolean values representing the permissions a comment has for a specific participant type.
+     * Preconditions: No parameter is null.
+     */
     private List<Boolean> getPermissionsForComment(
             CommentAttributes comment, CommentParticipantType participantType, boolean isRecipientOfComment) {
         List<Boolean> permissions = new ArrayList<Boolean>();
@@ -204,7 +229,7 @@ public class AccessControlUtil {
             permissions.add(false);
         }
         
-        permissions.set(COMMENT_PERMISSIONS_IS_DISPLAYED_INDEX, comment.showCommentTo.contains(participantType));
+        permissions.set(COMMENT_PERMISSIONS_COMMENT_IS_DISPLAYED_INDEX, comment.showCommentTo.contains(participantType));
         permissions.set(COMMENT_PERMISSIONS_GIVER_IS_DISPLAYED_INDEX, comment.showGiverNameTo.contains(participantType));
         // if the person is the recipient of the comment, do not hide the recipient name
         permissions.set(COMMENT_PERMISSIONS_RECIPIENT_IS_DISPLAYED_INDEX,

--- a/src/main/java/teammates/logic/api/AccessControlUtil.java
+++ b/src/main/java/teammates/logic/api/AccessControlUtil.java
@@ -1,5 +1,6 @@
 package teammates.logic.api;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -12,6 +13,12 @@ import teammates.common.util.Const;
 public class AccessControlUtil {
     private Logic logic = new Logic();
     private static AccessControlUtil instance;
+    
+    public static int COMMENT_PERMISSIONS_IS_DISPLAYED_INDEX = 0;
+    public static int COMMENT_PERMISSIONS_GIVER_IS_DISPLAYED_INDEX = 1;
+    public static int COMMENT_PERMISSIONS_RECIPIENT_IS_DISPLAYED_INDEX = 2;
+    
+    public static int COMMENT_PERMISSIONS_TOTAL_SIZE = 3;
     
     public static AccessControlUtil inst() {
         if (instance == null) {
@@ -54,11 +61,14 @@ public class AccessControlUtil {
         // CommentAttributes.recipients can have multiple recipients later
         
         String courseId = instructor.courseId;
-        String recipient = null;
-        if (!comment.recipients.isEmpty()) {
-            Iterator<String> iterator = comment.recipients.iterator();
-            recipient = iterator.next();
+        
+        // unexpected case: comment has no recipients
+        if (comment.recipients.isEmpty()) {
+            return false;
         }
+        Iterator<String> iterator = comment.recipients.iterator();
+        String recipient = iterator.next();
+        
         if (comment.recipientType == CommentParticipantType.COURSE) {
             return instructor.isAllowedForPrivilege(privilegeName);
         } else if (comment.recipientType == CommentParticipantType.SECTION) {
@@ -82,5 +92,121 @@ public class AccessControlUtil {
             // to recipients
             return false;
         }
+    }
+    
+    public List<Boolean> getVisibilityPermissionsOnCommentForStudent(
+            CommentAttributes comment, StudentAttributes student, List<String> teammatesEmails,
+            List<String> sectionStudentsEmails, List<String> teamsInSection) {
+        List<Boolean> permissions;
+        
+        // the following if-else if-else blocks rely on their ordering to properly classify the comment
+        // eg. a comment directed at the student's team will not be classified as "in the same section as student"
+        
+        // individual student level
+        if (isStudentRecipientOfComment(comment, student)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.PERSON, true);
+            
+        // team level
+        } else if (isStudentTeamRecipientOfComment(comment, student)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.TEAM, true);
+        } else if (isStudentInSameTeamAsRecipientOfComment(comment, student, teammatesEmails)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.TEAM, false);
+
+        // section level
+        } else if (isStudentSectionRecipientOfComment(comment, student)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.SECTION, true);
+        } else if (isStudentInSameSectionAsRecipientOfComment(comment, student, sectionStudentsEmails, teamsInSection)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.SECTION, false);
+
+        // course level
+        } else if (isStudentCourseRecipientOfComment(comment, student)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.COURSE, true);
+        } else if (isStudentInSameCourseAsRecipientOfComment(comment, student)) {
+            permissions = getPermissionsForComment(comment, CommentParticipantType.COURSE, false);
+            
+        // comment not in same course as student, so student should not be able to view the comment
+        } else {
+            permissions = new ArrayList<Boolean>();
+            for (int i = 0; i < COMMENT_PERMISSIONS_TOTAL_SIZE; i++) {
+                permissions.add(false);
+            }
+        }
+        return permissions;
+    }
+    
+    private boolean isStudentRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
+        return CommentParticipantType.PERSON.equals(comment.recipientType) && comment.recipients.contains(student.email);
+    }
+    
+    private boolean isStudentTeamRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
+        return CommentParticipantType.TEAM.equals(comment.recipientType) && comment.recipients.contains(student.team);
+    }
+    
+    private boolean isStudentInSameTeamAsRecipientOfComment(
+            CommentAttributes comment, StudentAttributes student, List<String> teammatesEmails) {
+        // if recipient type is not a student, this comment is not directed at a teammate
+        if (!CommentParticipantType.PERSON.equals(comment.recipientType)) {
+            return false;
+        }
+        
+        return isCommentRecipientPresentInList(comment, teammatesEmails);
+    }
+    
+    private boolean isStudentSectionRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
+        return CommentParticipantType.SECTION.equals(comment.recipientType) && comment.recipients.contains(student.section);
+    }
+    
+    private boolean isStudentInSameSectionAsRecipientOfComment(
+            CommentAttributes comment, StudentAttributes student,
+            List<String> sectionStudentsEmails, List<String> teamsInSection) {
+        // if recipient type is not a student or team, this comment is not directed at a recipient in the
+        // same section as the student
+        if (!CommentParticipantType.PERSON.equals(comment.recipientType)
+                && !CommentParticipantType.TEAM.equals(comment.recipientType)) {
+            return false;
+        }
+        
+        // check if student is in same section
+        if (CommentParticipantType.PERSON.equals(comment.recipientType)
+                && isCommentRecipientPresentInList(comment, sectionStudentsEmails)) {
+            return true;
+            
+        // check if team is in same section
+        } else if (isCommentRecipientPresentInList(comment, teamsInSection)) {
+            return true;
+        }
+        
+        return false;
+    }
+    
+    private boolean isStudentCourseRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
+        return CommentParticipantType.COURSE.equals(comment.recipientType) && comment.courseId.equals(student.course);
+    }
+    
+    private boolean isStudentInSameCourseAsRecipientOfComment(CommentAttributes comment, StudentAttributes student) {
+        return comment.courseId.equals(student.course);
+    }
+    
+    private boolean isCommentRecipientPresentInList(CommentAttributes comment, List<String> candidateRecipients) {
+        if (!comment.recipients.isEmpty()) {
+            String commentRecipient = comment.recipients.iterator().next();
+            return candidateRecipients.contains(commentRecipient);
+        }
+        return false;
+    }
+    
+    private List<Boolean> getPermissionsForComment(
+            CommentAttributes comment, CommentParticipantType participantType, boolean isRecipientOfComment) {
+        List<Boolean> permissions = new ArrayList<Boolean>();
+        for (int i = 0; i < COMMENT_PERMISSIONS_TOTAL_SIZE; i++) {
+            permissions.add(false);
+        }
+        
+        permissions.set(COMMENT_PERMISSIONS_IS_DISPLAYED_INDEX, comment.showCommentTo.contains(participantType));
+        permissions.set(COMMENT_PERMISSIONS_GIVER_IS_DISPLAYED_INDEX, comment.showGiverNameTo.contains(participantType));
+        // if the person is the recipient of the comment, do not hide the recipient name
+        permissions.set(COMMENT_PERMISSIONS_RECIPIENT_IS_DISPLAYED_INDEX,
+                        isRecipientOfComment || comment.showRecipientNameTo.contains(participantType));
+        return permissions;
     }
 }

--- a/src/main/java/teammates/logic/core/CommentsLogic.java
+++ b/src/main/java/teammates/logic/core/CommentsLogic.java
@@ -416,7 +416,7 @@ public class CommentsLogic {
     
     private void addCommentToList(
             CommentAttributes commentToAdd, List<CommentAttributes> comments, List<Boolean> permissionsForComment) {
-        if (permissionsForComment.get(AccessControlUtil.COMMENT_PERMISSIONS_IS_DISPLAYED_INDEX)) {
+        if (permissionsForComment.get(AccessControlUtil.COMMENT_PERMISSIONS_COMMENT_IS_DISPLAYED_INDEX)) {
             boolean isGiverDisplayed =
                     permissionsForComment.get(AccessControlUtil.COMMENT_PERMISSIONS_GIVER_IS_DISPLAYED_INDEX);
             boolean isRecipientDisplayed =

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -24,6 +24,7 @@ import teammates.common.util.Sanitizer;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Utils;
+import teammates.logic.api.AccessControlUtil;
 import teammates.logic.api.Logic;
 
 /** An 'action' to be performed by the system. If the logged in user is allowed
@@ -46,6 +47,8 @@ public abstract class Action {
     public StudentAttributes student;
     
     protected Logic logic;
+    
+    protected AccessControlUtil accessControlUtil;
     
     /** The full request URL e.g., {@code /page/instructorHome?user=abc&course=c1} */
     protected String requestUrl;
@@ -88,6 +91,7 @@ public abstract class Action {
         request = req;
         requestUrl = HttpRequestHelper.getRequestedUrl(request);
         logic = new Logic();
+        accessControlUtil = new AccessControlUtil();
         requestParameters = request.getParameterMap();
         session = request.getSession();
         


### PR DESCRIPTION
Part of #3046.

This PR currently only covers student comments in both InstructorCommentsPage and StudentCommentsPage, and does not cover feedback response comments yet. This may be covered in a separate PR if this gets too large.

Methods shifted from `InstructorCommentsPageAction` is a simple shifting of methods from one class to another.

Methods shifted from `CommentsLogic` (as part of a method call from `StudentCommentsPageAction`) is a more significant rewriting of the code, and is more in line with my idea for how the `AccessControlUtil` class should be like.

`InstructorCommentsPageUiTest`, `StudentCommentsPageUiTest`, and `CommentsLogicTest` have passed locally.
