### PR TITLE
Add VersionEye to the repo #5599

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 <img src="https://img.shields.io/badge/users-80K%2B-brightgreen.svg"> 
 <img src="https://img.shields.io/badge/universities-700%2B-green.svg"> 
+[![Build Status](https://travis-ci.org/TEAMMATES/teammates.svg?branch=master)](https://travis-ci.org/TEAMMATES/teammates)
+
 <img src="https://img.shields.io/badge/java-110%20KLoC-blue.svg">
-<img src="https://img.shields.io/badge/js-14%20KLoC-blue.svg">
+[![Dependency Status](https://www.versioneye.com/user/projects/579103ca51500e0031886f12/badge.svg)](https://www.versioneye.com/user/projects/579103ca51500e0031886f12)
+
 <img src="https://img.shields.io/badge/html-5%20KLoC-blue.svg">
 <img src="https://img.shields.io/badge/css-7%20KLoC-blue.svg">
-[![Build Status](https://travis-ci.org/TEAMMATES/teammates.svg?branch=master)](https://travis-ci.org/TEAMMATES/teammates)
+<img src="https://img.shields.io/badge/js-14%20KLoC-blue.svg">
+[![Dependency Status](https://www.versioneye.com/user/projects/579103d351500e0039e7b76a/badge.svg)](https://www.versioneye.com/user/projects/579103d351500e0039e7b76a)
+
 
 TEAMMATES is a free online tool for managing peer evaluations and other 
 feedback paths of your students. It is provided as a cloud-based service for 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 <img src="https://img.shields.io/badge/universities-700%2B-green.svg"> 
 [![Build Status](https://travis-ci.org/TEAMMATES/teammates.svg?branch=master)](https://travis-ci.org/TEAMMATES/teammates)
 
-<img src="https://img.shields.io/badge/java-110%20KLoC-blue.svg">
+<img src="https://img.shields.io/badge/java-119%20KLoC-blue.svg">
 [![Dependency Status](https://www.versioneye.com/user/projects/579103ca51500e0031886f12/badge.svg)](https://www.versioneye.com/user/projects/579103ca51500e0031886f12)
 
 <img src="https://img.shields.io/badge/html-5%20KLoC-blue.svg">
-<img src="https://img.shields.io/badge/css-7%20KLoC-blue.svg">
-<img src="https://img.shields.io/badge/js-14%20KLoC-blue.svg">
+<img src="https://img.shields.io/badge/css-2%20KLoC-blue.svg">
+<img src="https://img.shields.io/badge/js-20%20KLoC-blue.svg">
 [![Dependency Status](https://www.versioneye.com/user/projects/579103d351500e0039e7b76a/badge.svg)](https://www.versioneye.com/user/projects/579103d351500e0039e7b76a)
 
 


### PR DESCRIPTION
Fixes #5599 

![screen shot 2016-07-22 at 1 39 39 am](https://cloud.githubusercontent.com/assets/7261051/17032696/3368e800-4fad-11e6-84c3-469911757bf4.png)
Edited (security issues muted, LoCs updated):
![screen shot 2016-07-22 at 1 02 05 pm](https://cloud.githubusercontent.com/assets/7261051/17047079/96ca9c22-500c-11e6-832e-d120b0c7a748.png)
By the way, the organization in VersionEye is independent of GitHub's, i.e I created a separate organization named TEAMMATES and I am the only member. It is possible to create a somewhat official account for TEAMMATES, all that needs to be done is updating the project's badge after it is done.

Otherwise I will simply host and manage the account for the next year or so.

(on an unrelated note, the number of LoCs reflected are inaccurate, especially the CSS one)