### PR TITLE
Copying session fails due to new question type #5966

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
@@ -612,9 +612,13 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             return errors;
         }
         
-        String fqId = responses.get(0).feedbackQuestionId;
+        FeedbackResponseAttributes firstResponse = responses.get(0);
+        String feedbackSessionName = firstResponse.feedbackSessionName;
+        String courseId = firstResponse.courseId;
+        String fqId = firstResponse.feedbackQuestionId;
         FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();
-        FeedbackQuestionAttributes fqa = fqLogic.getFeedbackQuestion(fqId);
+        FeedbackQuestionAttributes fqa = fqLogic.getFeedbackQuestion(
+                feedbackSessionName, courseId, fqId);
         
         int numOfResponseSpecific = fqa.numberOfEntitiesToGiveFeedbackTo;
         int maxResponsesPossible = numRecipients;

--- a/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentSearchResultBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentSearchResultBundle.java
@@ -109,7 +109,7 @@ public class FeedbackResponseCommentSearchResultBundle extends SearchResultBundl
             FeedbackQuestionAttributes question = new Gson().fromJson(
                     doc.getOnlyField(Const.SearchDocumentField.FEEDBACK_QUESTION_ATTRIBUTE).getText(),
                     FeedbackQuestionAttributes.class);
-            if (fqLogic.getFeedbackQuestion(question.getId()) == null) {
+            if (fqLogic.getFeedbackQuestion(question.feedbackSessionName, question.courseId, question.getId()) == null) {
                 frcLogic.deleteDocument(comment);
                 continue;
             }

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1487,9 +1487,11 @@ public class Logic {
      * * All parameters are non-null. <br>
      * 
      */
-    public FeedbackQuestionAttributes getFeedbackQuestion(String feedbackQuestionId) {
+    public FeedbackQuestionAttributes getFeedbackQuestion(String feedbackSessionName,
+                                                          String courseId,
+                                                          String feedbackQuestionId) {
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, feedbackQuestionId);
-        return feedbackQuestionsLogic.getFeedbackQuestion(feedbackQuestionId);
+        return feedbackQuestionsLogic.getFeedbackQuestion(feedbackSessionName, courseId, feedbackQuestionId);
     }
 
     /**
@@ -1754,9 +1756,9 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null.
      */
-    public void deleteFeedbackQuestion(String questionId) {
+    public void deleteFeedbackQuestion(String feedbackSessionName, String courseId, String questionId) {
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, questionId);
-        feedbackQuestionsLogic.deleteFeedbackQuestionCascade(questionId);
+        feedbackQuestionsLogic.deleteFeedbackQuestionCascade(feedbackSessionName, courseId, questionId);
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -317,9 +317,10 @@ public class BackDoorLogic extends Logic {
         return Utils.getTeammatesGson().toJson(fq);
     }
     
-    public String getFeedbackQuestionForIdAsJson(String questionId) {
+    public String getFeedbackQuestionForIdAsJson(
+            String feedbackSessionName, String courseId, String questionId) {
         FeedbackQuestionAttributes fq =
-                feedbackQuestionsLogic.getFeedbackQuestion(questionId);
+                feedbackQuestionsLogic.getFeedbackQuestion(feedbackSessionName, courseId, questionId);
         return Utils.getTeammatesGson().toJson(fq);
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
@@ -257,11 +257,15 @@ public class BackDoorServlet extends HttpServlet {
             int qnNumber = Integer.parseInt(req.getParameter(PARAMETER_FEEDBACK_QUESTION_NUMBER));
             return backDoorLogic.getFeedbackQuestionAsJson(feedbackSessionName, courseId, qnNumber);
         } else if (action.equals(OPERATION_GET_FEEDBACK_QUESTION_FOR_ID_AS_JSON)) {
+            String feedbackSessionName = req.getParameter(PARAMETER_FEEDBACK_SESSION_NAME);
+            String courseId = req.getParameter(PARAMETER_COURSE_ID);
             String questionId = req.getParameter(PARAMETER_FEEDBACK_QUESTION_ID);
-            return backDoorLogic.getFeedbackQuestionForIdAsJson(questionId);
+            return backDoorLogic.getFeedbackQuestionForIdAsJson(feedbackSessionName, courseId, questionId);
         } else if (action.equals(OPERATION_DELETE_FEEDBACK_QUESTION)) {
+            String feedbackSessionName = req.getParameter(PARAMETER_FEEDBACK_SESSION_NAME);
+            String courseId = req.getParameter(PARAMETER_COURSE_ID);
             String questionId = req.getParameter(PARAMETER_FEEDBACK_QUESTION_ID);
-            backDoorLogic.deleteFeedbackQuestion(questionId);
+            backDoorLogic.deleteFeedbackQuestion(feedbackSessionName, courseId, questionId);
         } else if (action.equals(OPERATION_GET_FEEDBACK_RESPONSE_AS_JSON)) {
             String feedbackQuestionId = req.getParameter(PARAMETER_FEEDBACK_QUESTION_ID);
             String giverEmail = req.getParameter(PARAMETER_GIVER_EMAIL);

--- a/src/main/java/teammates/logic/core/CommentsLogic.java
+++ b/src/main/java/teammates/logic/core/CommentsLogic.java
@@ -714,7 +714,8 @@ public class CommentsLogic {
             Map<String, FeedbackQuestionAttributes> feedbackQuestionsTable, FeedbackResponseCommentAttributes frc) {
         FeedbackQuestionAttributes relatedQuestion = feedbackQuestionsTable.get(frc.feedbackQuestionId);
         if (relatedQuestion == null) {
-            relatedQuestion = fqLogic.getFeedbackQuestion(frc.feedbackQuestionId);
+            relatedQuestion = fqLogic.getFeedbackQuestion(
+                    frc.feedbackSessionName, frc.courseId, frc.feedbackQuestionId);
             feedbackQuestionsTable.put(frc.feedbackQuestionId, relatedQuestion);
         }
         return relatedQuestion;

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -483,7 +483,8 @@ public class FeedbackResponsesLogic {
                 getFeedbackResponsesFromGiverForCourse(courseId, userEmail);
 
         for (FeedbackResponseAttributes response : responsesFromUser) {
-            question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
+            question = fqLogic.getFeedbackQuestion(
+                    response.feedbackSessionName, response.courseId, response.feedbackQuestionId);
             if (question.giverType == FeedbackParticipantType.TEAMS
                     || isRecipientTypeTeamMembers(question)) {
                 frDb.deleteEntity(response);
@@ -494,7 +495,8 @@ public class FeedbackResponsesLogic {
                 getFeedbackResponsesForReceiverForCourse(courseId, userEmail);
 
         for (FeedbackResponseAttributes response : responsesToUser) {
-            question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
+            question = fqLogic.getFeedbackQuestion(
+                    response.feedbackSessionName, response.courseId, response.feedbackQuestionId);
             if (isRecipientTypeTeamMembers(question)) {
                 frDb.deleteEntity(response);
             }
@@ -536,8 +538,8 @@ public class FeedbackResponsesLogic {
     public boolean updateFeedbackResponseForChangingTeam(StudentEnrollDetails enrollment,
             FeedbackResponseAttributes response) throws InvalidParametersException, EntityDoesNotExistException {
 
-        FeedbackQuestionAttributes question = fqLogic
-                .getFeedbackQuestion(response.feedbackQuestionId);
+        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                response.feedbackSessionName, response.courseId, response.feedbackQuestionId);
 
         boolean isGiverSameForResponseAndEnrollment = response.giver
                 .equals(enrollment.email);
@@ -642,6 +644,7 @@ public class FeedbackResponsesLogic {
     }
 
     public void deleteFeedbackResponsesForQuestionAndCascade(
+            String feedbackSessionName, String courseId,
             String feedbackQuestionId, boolean hasResponseRateUpdate) {
         List<FeedbackResponseAttributes> responsesForQuestion =
                 getFeedbackResponsesForQuestion(feedbackQuestionId);
@@ -658,8 +661,8 @@ public class FeedbackResponsesLogic {
         }
 
         try {
-            FeedbackQuestionAttributes question = fqLogic
-                    .getFeedbackQuestion(feedbackQuestionId);
+            FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                    feedbackSessionName, courseId, feedbackQuestionId);
             boolean isInstructor = question.giverType == FeedbackParticipantType.SELF
                                    || question.giverType == FeedbackParticipantType.INSTRUCTORS;
             for (String email : emails) {

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -143,6 +143,7 @@ public class FeedbackSessionsLogic {
         copiedFeedbackSession.setCreatedTime(new Date());
         copiedFeedbackSession.setRespondingInstructorList(new HashSet<String>());
         copiedFeedbackSession.setRespondingStudentList(new HashSet<String>());
+        copiedFeedbackSession.setQuestions(new ArrayList<FeedbackQuestionAttributes>());
         fsDb.createEntity(copiedFeedbackSession);
         
         List<FeedbackQuestionAttributes> feedbackQuestions =

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -337,7 +337,8 @@ public class FeedbackSessionsLogic {
                 new HashMap<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>();
         Map<String, Map<String, String>> recipientList = new HashMap<String, Map<String, String>>();
 
-        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(feedbackQuestionId);
+        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                fsa.getFeedbackSessionName(), fsa.getCourseId(), feedbackQuestionId);
         
         InstructorAttributes instructorGiver = instructor;
         StudentAttributes studentGiver = null;
@@ -459,7 +460,8 @@ public class FeedbackSessionsLogic {
                 new HashMap<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>();
         Map<String, Map<String, String>> recipientList = new HashMap<String, Map<String, String>>();
 
-        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(feedbackQuestionId);
+        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                feedbackSessionName, courseId, feedbackQuestionId);
 
         Set<String> hiddenInstructorEmails = null;
 
@@ -1973,7 +1975,8 @@ public class FeedbackSessionsLogic {
                                ? getFeedbackSessionResponseStatus(session, roster, allQuestions)
                                : null;
             } else {
-                FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(questionId);
+                FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(
+                                                        feedbackSessionName, courseId, questionId);
                 if (question != null) {
                     relevantQuestions.put(question.getId(), question);
                     

--- a/src/main/java/teammates/storage/api/BothQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/BothQuestionsDb.java
@@ -66,15 +66,14 @@ public class BothQuestionsDb extends EntitiesDb {
      */
     public FeedbackQuestionAttributes getFeedbackQuestion(
             String feedbackSessionName, String courseId, String feedbackQuestionId) {
-        FeedbackQuestionAttributes oldQuestion = oldQuestionsDb.getFeedbackQuestion(feedbackQuestionId);
-        if (oldQuestion != null) {
-            FeedbackQuestionAttributes newQuestion = newQuestionsDb.getFeedbackQuestion(
-                    oldQuestion.feedbackSessionName, oldQuestion.courseId, oldQuestion.getId());
-            if (newQuestion != null) {
-                return newQuestion;
-            }
+        FeedbackQuestionAttributes newQuestion = newQuestionsDb.getFeedbackQuestion(
+                feedbackSessionName, courseId, feedbackQuestionId);
+
+        if (newQuestion != null) {
+            return newQuestion;
         }
-        return oldQuestion;
+
+        return oldQuestionsDb.getFeedbackQuestion(feedbackQuestionId);
     }
     
     /**
@@ -84,15 +83,14 @@ public class BothQuestionsDb extends EntitiesDb {
      */
     public FeedbackQuestionAttributes getFeedbackQuestion(
                 String feedbackSessionName, String courseId, int questionNumber) {
+        FeedbackQuestionAttributes newQuestion = newQuestionsDb.getFeedbackQuestion(
+                feedbackSessionName, courseId, questionNumber);
+        if (newQuestion != null) {
+            return newQuestion;
+        }
+     
         FeedbackQuestionAttributes oldQuestion =
                 oldQuestionsDb.getFeedbackQuestion(feedbackSessionName, courseId, questionNumber);
-        if (oldQuestion != null) {
-            FeedbackQuestionAttributes newQuestion = newQuestionsDb.getFeedbackQuestion(
-                    oldQuestion.feedbackSessionName, oldQuestion.courseId, oldQuestion.getId());
-            if (newQuestion != null) {
-                return newQuestion;
-            }
-        }
         return oldQuestion;
     }
     

--- a/src/main/java/teammates/storage/api/BothQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/BothQuestionsDb.java
@@ -64,7 +64,8 @@ public class BothQuestionsDb extends EntitiesDb {
      * * All parameters are non-null.
      * @return Null if not found.
      */
-    public FeedbackQuestionAttributes getFeedbackQuestion(String feedbackQuestionId) {
+    public FeedbackQuestionAttributes getFeedbackQuestion(
+            String feedbackSessionName, String courseId, String feedbackQuestionId) {
         FeedbackQuestionAttributes oldQuestion = oldQuestionsDb.getFeedbackQuestion(feedbackQuestionId);
         if (oldQuestion != null) {
             FeedbackQuestionAttributes newQuestion = newQuestionsDb.getFeedbackQuestion(

--- a/src/main/java/teammates/storage/api/BothQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/BothQuestionsDb.java
@@ -12,7 +12,6 @@ import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
-import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.entity.Question;
 import teammates.storage.entity.QuestionsDbPersistenceAttributes;
 
@@ -30,22 +29,18 @@ public class BothQuestionsDb extends EntitiesDb {
     @Override
     public Object createEntity(EntityAttributes entityToAdd)
             throws InvalidParametersException, EntityAlreadyExistsException {
-        FeedbackQuestionAttributes fqa =
-                new FeedbackQuestionAttributes((FeedbackQuestion) oldQuestionsDb.createEntity(entityToAdd));
+        FeedbackQuestionAttributes fqa = (FeedbackQuestionAttributes) entityToAdd;
+        fqa.setId(fqa.makeId());
         return newQuestionsDb.createEntity(new QuestionsDbPersistenceAttributes(fqa));
     }
     
     public void createFeedbackQuestions(Collection<FeedbackQuestionAttributes> questionsToAdd)
             throws InvalidParametersException {
-        // maybe too slow?
-        oldQuestionsDb.createFeedbackQuestions(questionsToAdd);
         List<QuestionsDbPersistenceAttributes> questionsToPersist = new ArrayList<>();
         for (FeedbackQuestionAttributes question : questionsToAdd) {
-            FeedbackQuestion persistedQuestion = (FeedbackQuestion) oldQuestionsDb.getEntity(question);
-            
-            FeedbackQuestionAttributes oldQuestionAttributes = new FeedbackQuestionAttributes(persistedQuestion);
+            question.setId(question.makeId());
             QuestionsDbPersistenceAttributes newQuestionAttributes =
-                    new QuestionsDbPersistenceAttributes(oldQuestionAttributes);
+                    new QuestionsDbPersistenceAttributes(question);
             questionsToPersist.add(newQuestionAttributes);
         }
         newQuestionsDb.createEntities(questionsToPersist);
@@ -59,8 +54,8 @@ public class BothQuestionsDb extends EntitiesDb {
      */
     public FeedbackQuestionAttributes createFeedbackQuestionWithoutIntegrityCheck(
             EntityAttributes entityToAdd) throws InvalidParametersException {
-        FeedbackQuestionAttributes fqa =
-                oldQuestionsDb.createFeedbackQuestionWithoutExistenceCheck(entityToAdd);
+        FeedbackQuestionAttributes fqa = (FeedbackQuestionAttributes) entityToAdd;
+        fqa.setId(fqa.makeId());
         return newQuestionsDb.createFeedbackQuestionWithoutExistenceCheck(fqa);
     }
     

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -322,7 +322,8 @@ public class FeedbackQuestionsDb extends EntitiesDb {
     }
     
     public void adjustQuestionNumbers(int oldQuestionNumber, int newQuestionNumber,
-            List<FeedbackQuestionAttributes> questions) {
+            List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         if (oldQuestionNumber < 0 || newQuestionNumber < 0) {
             Assumption.fail("Invalid question number");
         }
@@ -334,7 +335,8 @@ public class FeedbackQuestionsDb extends EntitiesDb {
         }
     }
     
-    private void increaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions) {
+    private void increaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         for (FeedbackQuestionAttributes question : questions) {
             if (question.questionNumber >= start && question.questionNumber <= end) {
                 adjustQuestionNumberOfQuestion(question, 1);
@@ -342,7 +344,8 @@ public class FeedbackQuestionsDb extends EntitiesDb {
         }
     }
     
-    private void decreaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions) {
+    private void decreaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         for (FeedbackQuestionAttributes question : questions) {
             if (question.questionNumber >= start && question.questionNumber <= end) {
                 adjustQuestionNumberOfQuestion(question, -1);
@@ -350,15 +353,14 @@ public class FeedbackQuestionsDb extends EntitiesDb {
         }
     }
 
-    private void adjustQuestionNumberOfQuestion(FeedbackQuestionAttributes question, int change) {
+    private void adjustQuestionNumberOfQuestion(FeedbackQuestionAttributes question, int change)
+            throws EntityDoesNotExistException {
         FeedbackQuestionAttributes updatedQuestion = question.getCopy();
         updatedQuestion.questionNumber += change;
         try {
             updateFeedbackQuestion(updatedQuestion);
         } catch (InvalidParametersException e) {
             Assumption.fail("Invalid question." + e);
-        } catch (EntityDoesNotExistException e) {
-            Assumption.fail("Question disappeared. " + e);
         }
     }
     

--- a/src/main/java/teammates/storage/api/QuestionsDb.java
+++ b/src/main/java/teammates/storage/api/QuestionsDb.java
@@ -272,7 +272,8 @@ public class QuestionsDb extends EntitiesDb {
     }
 
     private void adjustQuestionNumbersInSession(
-            FeedbackQuestionAttributes questionToSave, int oldQuestionNumber, FeedbackSession session) {
+            FeedbackQuestionAttributes questionToSave, int oldQuestionNumber, FeedbackSession session)
+            throws EntityDoesNotExistException {
         List<FeedbackQuestionAttributes> questionsForAdjustingNumbers = getFeedbackQuestionsForSession(session);
         
         // remove question getting edited
@@ -295,9 +296,11 @@ public class QuestionsDb extends EntitiesDb {
      * @param oldQuestionNumber
      * @param newQuestionNumber
      * @param questions sorted list of question
+     * @throws EntityDoesNotExistException
      */
     public void adjustQuestionNumbers(
-            int oldQuestionNumber, int newQuestionNumber, List<FeedbackQuestionAttributes> questions) {
+            int oldQuestionNumber, int newQuestionNumber, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         adjustQuestionNumbersWithoutCommitting(oldQuestionNumber, newQuestionNumber, questions);
         getPm().close();
     }
@@ -311,9 +314,11 @@ public class QuestionsDb extends EntitiesDb {
      * @param oldQuestionNumber
      * @param newQuestionNumber
      * @param questions
+     * @throws EntityDoesNotExistException
      */
     private void adjustQuestionNumbersWithoutCommitting(
-            int oldQuestionNumber, int newQuestionNumber, List<FeedbackQuestionAttributes> questions) {
+            int oldQuestionNumber, int newQuestionNumber, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         if (oldQuestionNumber <= 0 || newQuestionNumber <= 0) {
             Assumption.fail("Invalid question number");
         }
@@ -325,7 +330,8 @@ public class QuestionsDb extends EntitiesDb {
         }
     }
     
-    private void increaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions) {
+    private void increaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         for (FeedbackQuestionAttributes question : questions) {
             if (question.questionNumber >= start && question.questionNumber <= end) {
                 adjustQuestionNumberOfQuestion(question, 1);
@@ -333,7 +339,8 @@ public class QuestionsDb extends EntitiesDb {
         }
     }
     
-    private void decreaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions) {
+    private void decreaseQuestionNumber(int start, int end, List<FeedbackQuestionAttributes> questions)
+            throws EntityDoesNotExistException {
         for (FeedbackQuestionAttributes question : questions) {
             if (question.questionNumber >= start && question.questionNumber <= end) {
                 adjustQuestionNumberOfQuestion(question, -1);
@@ -341,17 +348,14 @@ public class QuestionsDb extends EntitiesDb {
         }
     }
 
-    private void adjustQuestionNumberOfQuestion(FeedbackQuestionAttributes question, int change) {
+    private void adjustQuestionNumberOfQuestion(FeedbackQuestionAttributes question, int change)
+            throws EntityDoesNotExistException {
         FeedbackQuestionAttributes updatedQuestion = question.getCopy();
         updatedQuestion.questionNumber += change;
         try {
             updateFeedbackQuestionWithoutComitting(updatedQuestion);
         } catch (InvalidParametersException e) {
             Assumption.fail("Invalid question." + e);
-        } catch (EntityDoesNotExistException e) {
-            // this can happen if question is an old question which did not have a Question copy of it
-            // TODO Remove silencing the exception, this is not expected after the migration.
-            log.warning("EntityDoesNotExistException thrown for " + e);
         }
     }
     

--- a/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
+++ b/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
@@ -47,7 +47,8 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
         
         relatedSession = logic.getFeedbackSession(comment.feedbackSessionName, comment.courseId);
         
-        relatedQuestion = logic.getFeedbackQuestion(comment.feedbackQuestionId);
+        relatedQuestion = logic.getFeedbackQuestion(
+                comment.feedbackSessionName, comment.courseId, comment.feedbackQuestionId);
         
         relatedResponse = logic.getFeedbackResponse(comment.feedbackResponseId);
         

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -65,7 +65,8 @@ public class InstructorFeedbackQuestionEditAction extends Action {
     }
 
     private void deleteQuestion(FeedbackQuestionAttributes updatedQuestion) {
-        logic.deleteFeedbackQuestion(updatedQuestion.getId());
+        logic.deleteFeedbackQuestion(
+                updatedQuestion.feedbackSessionName, updatedQuestion.courseId, updatedQuestion.getId());
         statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_QUESTION_DELETED, StatusMessageColor.SUCCESS));
         statusToAdmin = "Feedback Question " + updatedQuestion.questionNumber + " for session:<span class=\"bold\">("
                         + updatedQuestion.feedbackSessionName + ")</span> for Course <span class=\"bold\">["

--- a/src/test/java/teammates/test/cases/automated/SubmissionsAdjustmentTest.java
+++ b/src/test/java/teammates/test/cases/automated/SubmissionsAdjustmentTest.java
@@ -284,8 +284,8 @@ public class SubmissionsAdjustmentTest extends BaseComponentUsingTaskQueueTestCa
                 .getFeedbackResponsesForReceiverForCourse(student.course, student.email);
         
         for (FeedbackResponseAttributes response : studentReceiverResponses) {
-            FeedbackQuestionAttributes question = FeedbackQuestionsLogic.inst()
-                    .getFeedbackQuestion(response.feedbackQuestionId);
+            FeedbackQuestionAttributes question = FeedbackQuestionsLogic.inst().getFeedbackQuestion(
+                            response.feedbackSessionName, response.courseId, response.feedbackQuestionId);
             if (question.recipientType == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
                 returnList.add(response);
             }
@@ -295,8 +295,8 @@ public class SubmissionsAdjustmentTest extends BaseComponentUsingTaskQueueTestCa
                 .getFeedbackResponsesFromGiverForCourse(student.course, student.email);
         
         for (FeedbackResponseAttributes response : studentGiverResponses) {
-            FeedbackQuestionAttributes question = FeedbackQuestionsLogic.inst()
-                    .getFeedbackQuestion(response.feedbackQuestionId);
+            FeedbackQuestionAttributes question = FeedbackQuestionsLogic.inst().getFeedbackQuestion(
+                            response.feedbackSessionName, response.courseId, response.feedbackQuestionId);
             if (question.giverType == FeedbackParticipantType.TEAMS
                     || question.recipientType == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
                 returnList.add(response);

--- a/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
@@ -340,7 +340,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         questionToUpdate.courseId = originalCourseId;
 
         FeedbackQuestionAttributes updatedQuestion =
-                fqLogic.getFeedbackQuestion(questionToUpdate.getId());
+                fqLogic.getFeedbackQuestion(questionToUpdate.feedbackSessionName,
+                                            questionToUpdate.courseId, questionToUpdate.getId());
         assertEquals(updatedQuestion.toString(), questionToUpdate.toString());
         
         ______TS("cascading update, non-destructive changes, existing responses are preserved");
@@ -353,7 +354,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
                         questionToUpdate.getId()).size();
         
         fqLogic.updateFeedbackQuestion(questionToUpdate);
-        updatedQuestion = fqLogic.getFeedbackQuestion(questionToUpdate.getId());
+        updatedQuestion = fqLogic.getFeedbackQuestion(
+                questionToUpdate.feedbackSessionName, questionToUpdate.courseId, questionToUpdate.getId());
         
         assertEquals(updatedQuestion.toString(), questionToUpdate.toString());
         assertEquals(
@@ -368,7 +370,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         assertFalse(frLogic.getFeedbackResponsesForQuestion(questionToUpdate.getId()).isEmpty());
         
         fqLogic.updateFeedbackQuestion(questionToUpdate);
-        updatedQuestion = fqLogic.getFeedbackQuestion(questionToUpdate.getId());
+        updatedQuestion = fqLogic.getFeedbackQuestion(
+                questionToUpdate.feedbackSessionName, questionToUpdate.courseId, questionToUpdate.getId());
         
         assertEquals(updatedQuestion.toString(), questionToUpdate.toString());
         assertEquals(frLogic.getFeedbackResponsesForQuestion(
@@ -377,7 +380,8 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         ______TS("failure: question does not exist");
         
         questionToUpdate = getQuestionFromDatastore("qn3InSession1InCourse1");
-        fqLogic.deleteFeedbackQuestionCascade(questionToUpdate.getId());
+        fqLogic.deleteFeedbackQuestionCascade(
+                questionToUpdate.feedbackSessionName, questionToUpdate.courseId, questionToUpdate.getId());
         
         try {
             fqLogic.updateFeedbackQuestion(questionToUpdate);
@@ -405,7 +409,10 @@ public class FeedbackQuestionsLogicTest extends BaseComponentTestCase {
         //Success case already tested in update
         ______TS("question already does not exist, silently fail");
         
-        fqLogic.deleteFeedbackQuestionCascade("non-existent-question-id");
+        FeedbackQuestionAttributes question = getQuestionFromDatastore("qn2InSession2InCourse2");
+        
+        fqLogic.deleteFeedbackQuestionCascade(
+                question.feedbackSessionName, question.courseId, "non-existent-question-id");
         //No error should be thrown.
         
     }

--- a/src/test/java/teammates/test/cases/storage/BothQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/BothQuestionsDbTest.java
@@ -197,12 +197,14 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("get by id");
 
-        actual = fqDb.getFeedbackQuestion(actual.getId());
+        actual = fqDb.getFeedbackQuestion(expected.feedbackSessionName,
+                expected.courseId, actual.getId());
         assertEquals(expected.toString(), actual.toString());
 
         ______TS("get non-existent question by id");
 
-        actual = fqDb.getFeedbackQuestion("non-existent id");
+        actual = fqDb.getFeedbackQuestion(expected.feedbackSessionName,
+                expected.courseId, "non-existent id");
 
         assertNull(actual);
   

--- a/src/test/java/teammates/test/cases/storage/BothQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/BothQuestionsDbTest.java
@@ -64,10 +64,6 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
         AssertHelper.assertDateIsNow(feedbackQuestion.getCreatedAt());
         AssertHelper.assertDateIsNow(feedbackQuestion.getUpdatedAt());
         
-        FeedbackQuestionAttributes questionInOldDb = oldDb.getFeedbackQuestion(
-                                        feedbackSessionName, courseId, questionNumber);
-        AssertHelper.assertDateIsNow(questionInOldDb.getCreatedAt());
-        AssertHelper.assertDateIsNow(questionInOldDb.getUpdatedAt());
         FeedbackQuestionAttributes questionInNewDb = newDb.getFeedbackQuestion(
                                         feedbackSessionName, courseId, questionNumber);
         AssertHelper.assertDateIsNow(questionInNewDb.getCreatedAt());
@@ -85,10 +81,6 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
         assertFalse(feedbackQuestion.getUpdatedAt().equals(updatedFq.getUpdatedAt()));
         AssertHelper.assertDateIsNow(updatedFq.getUpdatedAt());
         
-        questionInOldDb = oldDb.getFeedbackQuestion(feedbackSessionName, courseId, feedbackQuestion.questionNumber);
-        assertFalse("lastUpdate should be changed",
-                    feedbackQuestion.getUpdatedAt().equals(questionInOldDb.getUpdatedAt()));
-        AssertHelper.assertDateIsNow(questionInOldDb.getUpdatedAt());
         questionInNewDb = newDb.getFeedbackQuestion(feedbackSessionName, courseId, feedbackQuestion.questionNumber);
         assertFalse("lastUpdate should be changed",
                     feedbackQuestion.getUpdatedAt().equals(questionInNewDb.getUpdatedAt()));
@@ -118,18 +110,6 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
         
         fqDb.createEntity(fqa);
         verifyPresentInDatastore(fqa, true);
-
-        ______TS("duplicate - with same id.");
-
-        try {
-            fqDb.createEntity(fqa);
-            
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(QuestionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                                                      fqa.getEntityTypeAsString()) + fqa.getIdentificationString(),
-                                                      e.getMessage());
-        }
 
         ______TS("delete - with id specified");
 
@@ -224,11 +204,10 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
 
         assertEquals(numToCreate, questions.size());
         AssertHelper.assertSameContentIgnoreOrder(expectedQuestions, questions);
-        assertEquals("Both old question and new question type's db should have the same questions",
-                     oldDb.getFeedbackQuestionsForSession(expectedQuestions.get(0).feedbackSessionName,
-                                                          expectedQuestions.get(0).courseId),
-                     newDb.getFeedbackQuestionsForSession(expectedQuestions.get(0).feedbackSessionName,
-                                                          expectedQuestions.get(0).courseId));
+        assertTrue("Old question type's db should not have the questions",
+                   oldDb.getFeedbackQuestionsForSession(
+                          expectedQuestions.get(0).feedbackSessionName,
+                          expectedQuestions.get(0).courseId).isEmpty());
 
         ______TS("null params");
 
@@ -270,38 +249,30 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
                                                       FeedbackParticipantType.INSTRUCTORS);
         
         assertEquals(numOfQuestions[0], questions.size());
-        assertEquals("Both old question and new question type's db should have the same questions",
-                     oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                                            FeedbackParticipantType.INSTRUCTORS),
-                     newDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                                            FeedbackParticipantType.INSTRUCTORS));
+        assertTrue("Old question's db should not have the same questions",
+                   oldDb.getFeedbackQuestionsForGiverType(
+                       fqa.feedbackSessionName, fqa.courseId, FeedbackParticipantType.INSTRUCTORS).isEmpty());
 
         questions = fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName,
                                                           fqa.courseId, FeedbackParticipantType.STUDENTS);
         assertEquals(numOfQuestions[1], questions.size());
-        assertEquals("Both old question and new question type's db should have the same questions",
-                     oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                    FeedbackParticipantType.STUDENTS),
-                     newDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                    FeedbackParticipantType.STUDENTS));
+        assertTrue("Old question's db should not have the same questions",
+                   oldDb.getFeedbackQuestionsForGiverType(
+                       fqa.feedbackSessionName, fqa.courseId, FeedbackParticipantType.STUDENTS).isEmpty());
 
         questions = fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName,
                                                           fqa.courseId, FeedbackParticipantType.SELF);
         assertEquals(numOfQuestions[2], questions.size());
-        assertEquals("Both old question and new question type's db should have the same questions",
-                     oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                                            FeedbackParticipantType.SELF),
-                     newDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                                            FeedbackParticipantType.SELF));
+        assertTrue("Old question's db should not have the same questions",
+                   oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
+                                                          FeedbackParticipantType.SELF).isEmpty());
 
         questions = fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName,
                                                           fqa.courseId, FeedbackParticipantType.TEAMS);
         assertEquals(numOfQuestions[3], questions.size());
-        assertEquals("Both old question and new question type's db should have the same questions",
-                     oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                    FeedbackParticipantType.TEAMS),
-                     newDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
-                                    FeedbackParticipantType.TEAMS));
+        assertTrue("Old question's db should not have the same questions",
+                   oldDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId,
+                                                          FeedbackParticipantType.TEAMS).isEmpty());
 
         ______TS("null params");
 
@@ -402,10 +373,8 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
                                                     modifiedQuestion.courseId,
                                                     modifiedQuestion.questionNumber);
         assertEquals("New question text!", modifiedQuestion.getQuestionDetails().getQuestionText());
-        assertEquals(newDb.getFeedbackQuestion(modifiedQuestion.feedbackSessionName,
-                                               modifiedQuestion.courseId, modifiedQuestion.questionNumber),
-                     oldDb.getFeedbackQuestion(modifiedQuestion.feedbackSessionName,
-                                               modifiedQuestion.courseId, modifiedQuestion.questionNumber));
+        assertNull(oldDb.getFeedbackQuestion(modifiedQuestion.feedbackSessionName,
+                                             modifiedQuestion.courseId, modifiedQuestion.questionNumber));
 
         fqDb.deleteEntity(modifiedQuestion);
     }
@@ -545,14 +514,6 @@ public class BothQuestionsDbTest extends BaseComponentTestCase {
     
     protected static void verifyPresentInDatastore(FeedbackQuestionAttributes expected, boolean wildcardId) {
         BaseComponentTestCase.verifyPresentInDatastore(expected, wildcardId);
-        
-        FeedbackQuestionAttributes expectedCopy = expected.getCopy();
-        FeedbackQuestionAttributes actual = oldDb.getFeedbackQuestion(
-                expectedCopy.feedbackSessionName, expectedCopy.courseId, expectedCopy.questionNumber);
-        if (wildcardId) {
-            expectedCopy.setId(actual.getId());
-        }
-        assertEquals(gson.toJson(expectedCopy), gson.toJson(actual));
         
         FeedbackQuestionAttributes expectedCopy1 = expected.getCopy();
         FeedbackQuestionAttributes actual1 = newDb.getFeedbackQuestion(

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -440,6 +440,24 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
             fqDb.deleteEntity(fqa);
         }
     }
+    
+    protected static void verifyAbsentInDatastore(FeedbackQuestionAttributes fq) {
+        assertNull(fqDb.getFeedbackQuestion(fq.feedbackSessionName, fq.courseId, fq.questionNumber));
+    }
+    
+    protected static void verifyPresentInDatastore(FeedbackQuestionAttributes expected) {
+        verifyPresentInDatastore(expected, false);
+    }
+    
+    protected static void verifyPresentInDatastore(FeedbackQuestionAttributes expected, boolean wildcardId) {
+        FeedbackQuestionAttributes expectedCopy = expected.getCopy();
+        FeedbackQuestionAttributes actual = fqDb.getFeedbackQuestion(
+                expectedCopy.feedbackSessionName, expectedCopy.courseId, expectedCopy.questionNumber);
+        if (wildcardId) {
+            expectedCopy.setId(actual.getId());
+        }
+        assertEquals(gson.toJson(expectedCopy), gson.toJson(actual));
+    }
 
     @AfterClass
     public static void classTearDown() {

--- a/src/test/java/teammates/test/cases/storage/QuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/QuestionsDbTest.java
@@ -33,7 +33,11 @@ public class QuestionsDbTest extends BaseComponentTestCase {
     @BeforeClass
     public static void classSetUp() throws InvalidParametersException, EntityAlreadyExistsException {
         printTestClassHeader();
-        new FeedbackSessionsLogic().createFeedbackSession(getFeedbackSessionAttributes());
+        FeedbackSessionsLogic feedbackSessionsLogic = new FeedbackSessionsLogic();
+        FeedbackSessionAttributes session = getFeedbackSessionAttributes();
+        feedbackSessionsLogic.deleteFeedbackSessionCascade(
+                session.getFeedbackSessionName(), session.getCourseId());
+        feedbackSessionsLogic.createFeedbackSession(session);
     }
     
     @Test

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -79,7 +79,7 @@ public class BackDoorTest extends BaseTestCase {
         // ----------deleting Feedback Question entities-------------------------
         fq = dataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
         verifyPresentInDatastore(fq);
-        status = BackDoor.deleteFeedbackQuestion(fq.getId());
+        status = BackDoor.deleteFeedbackQuestion(fq.courseId, fq.feedbackSessionName, fq.getId());
         assertEquals(Const.StatusCodes.BACKDOOR_STATUS_SUCCESS, status);
         verifyAbsentInDatastore(fq);
 
@@ -378,7 +378,8 @@ public class BackDoorTest extends BaseTestCase {
     }
 
     private void verifyAbsentInDatastore(FeedbackQuestionAttributes fq) {
-        assertEquals("null", BackDoor.getFeedbackQuestionForIdAsJson(fq.getId()));
+        assertEquals("null", BackDoor.getFeedbackQuestionForIdAsJson(
+                fq.courseId, fq.feedbackSessionName, fq.getId()));
     }
     
     private void verifyAbsentInDatastore(FeedbackResponseAttributes fr) {

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -516,10 +516,16 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
                     feedbackEditPage.isCopySubmitButtonEnabled());
         
         // revert back to state expected by tests after this by deleting new copied questions
-        String questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 4).getId();
-        BackDoor.deleteFeedbackQuestion(questionId);
-        questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 3).getId();
-        BackDoor.deleteFeedbackQuestion(questionId);
+        FeedbackQuestionAttributes feedbackQuestionToDelete =
+                BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 4);
+        
+        BackDoor.deleteFeedbackQuestion(
+                feedbackQuestionToDelete.courseId, feedbackQuestionToDelete.feedbackSessionName,
+                feedbackQuestionToDelete.getId());
+        feedbackQuestionToDelete = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 3);
+        BackDoor.deleteFeedbackQuestion(
+                feedbackQuestionToDelete.courseId, feedbackQuestionToDelete.feedbackSessionName,
+                feedbackQuestionToDelete.getId());
         
     }
     
@@ -783,8 +789,10 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickAddQuestionButton();
 
         // Delete the new question through the backdoor so that it still appears in the browser
-        String questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 1).getId();
-        String status = BackDoor.deleteFeedbackQuestion(questionId);
+        FeedbackQuestionAttributes questionToDelete = BackDoor.getFeedbackQuestion(
+                courseId, feedbackSessionName, 1);
+        String status = BackDoor.deleteFeedbackQuestion(
+                questionToDelete.courseId, questionToDelete.feedbackSessionName, questionToDelete.getId());
         assertEquals(Const.StatusCodes.BACKDOOR_STATUS_SUCCESS, status);
 
         // Edit the deleted question and save

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorSubmissionAdjustmentUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorSubmissionAdjustmentUiTest.java
@@ -116,8 +116,8 @@ public class InstructorSubmissionAdjustmentUiTest extends BaseUiTestCase {
                 .getFeedbackResponsesForReceiverForCourse(student.course, student.email);
         
         for (FeedbackResponseAttributes response : studentReceiverResponses) {
-            FeedbackQuestionAttributes question = BackDoor
-                    .getFeedbackQuestion(response.feedbackQuestionId);
+            FeedbackQuestionAttributes question = BackDoor.getFeedbackQuestion(
+                    response.courseId, response.feedbackSessionName, response.feedbackQuestionId);
             if (question.recipientType == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
                 returnList.add(response);
             }
@@ -127,8 +127,8 @@ public class InstructorSubmissionAdjustmentUiTest extends BaseUiTestCase {
                 .getFeedbackResponsesFromGiverForCourse(student.course, student.email);
         
         for (FeedbackResponseAttributes response : studentGiverResponses) {
-            FeedbackQuestionAttributes question = BackDoor
-                    .getFeedbackQuestion(response.feedbackQuestionId);
+            FeedbackQuestionAttributes question = BackDoor.getFeedbackQuestion(
+                    response.courseId, response.feedbackSessionName, response.feedbackQuestionId);
             if (question.giverType == FeedbackParticipantType.TEAMS
                     || question.recipientType == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
                 returnList.add(response);

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -445,13 +445,17 @@ public final class BackDoor {
         return Utils.getTeammatesGson().fromJson(jsonString, FeedbackQuestionAttributes.class);
     }
     
-    public static FeedbackQuestionAttributes getFeedbackQuestion(String questionId) {
-        String jsonString = getFeedbackQuestionForIdAsJson(questionId);
+    public static FeedbackQuestionAttributes getFeedbackQuestion(String courseId,
+            String feedbackSessionName, String questionId) {
+        String jsonString = getFeedbackQuestionForIdAsJson(courseId, feedbackSessionName, questionId);
         return Utils.getTeammatesGson().fromJson(jsonString, FeedbackQuestionAttributes.class);
     }
     
-    public static String getFeedbackQuestionForIdAsJson(String questionId) {
+    public static String getFeedbackQuestionForIdAsJson(String courseId,
+            String feedbackSessionName, String questionId) {
         HashMap<String, Object> params = createParamMap(BackDoorServlet.OPERATION_GET_FEEDBACK_QUESTION_FOR_ID_AS_JSON);
+        params.put(BackDoorServlet.PARAMETER_FEEDBACK_SESSION_NAME, feedbackSessionName);
+        params.put(BackDoorServlet.PARAMETER_COURSE_ID, courseId);
         params.put(BackDoorServlet.PARAMETER_FEEDBACK_QUESTION_ID, questionId);
         return makePostRequest(params);
     }
@@ -472,8 +476,11 @@ public final class BackDoor {
         return makePostRequest(params);
     }
 
-    public static String deleteFeedbackQuestion(String questionId) {
+    public static String deleteFeedbackQuestion(String courseId,
+            String feedbackSessionName, String questionId) {
         HashMap<String, Object> params = createParamMap(BackDoorServlet.OPERATION_DELETE_FEEDBACK_QUESTION);
+        params.put(BackDoorServlet.PARAMETER_FEEDBACK_SESSION_NAME, feedbackSessionName);
+        params.put(BackDoorServlet.PARAMETER_COURSE_ID, courseId);
         params.put(BackDoorServlet.PARAMETER_FEEDBACK_QUESTION_ID, questionId);
         return makePostRequest(params);
     }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -27,7 +27,7 @@ public final class HtmlHelper {
     private static final String REGEX_ENCRYPTED_REGKEY = "[A-F0-9]{32,}";
     private static final String REGEX_ANONYMOUS_PARTICIPANT_HASH = "[0-9]{1,10}";
     private static final String REGEX_BLOB_KEY = "(encoded_gs_key:)?[a-zA-Z0-9-_]{10,}";
-    private static final String REGEX_QUESTION_ID = "[a-zA-Z0-9-_]{40,}";
+    private static final String REGEX_QUESTION_ID_TIMESTAMP = "[0-9]{17}";
     private static final String REGEX_COMMENT_ID = "[0-9]{16}";
     private static final String REGEX_DISPLAY_TIME = "(0[0-9]|1[0-2]):[0-5][0-9] [AP]M( UTC)?";
     private static final String REGEX_ADMIN_INSTITUTE_FOOTER = ".*?";
@@ -422,10 +422,8 @@ public final class HtmlHelper {
                       // anonymous student identifier on results page
                       .replaceAll("Anonymous (student|instructor|team) " + REGEX_ANONYMOUS_PARTICIPANT_HASH,
                                   "Anonymous $1 \\${participant\\.hash}")
-                      // questionid as value
-                      .replaceAll("value=\"" + REGEX_QUESTION_ID + "\"", "value=\"\\${question\\.id}\"")
-                      // questionid as part of responseid
-                      .replaceAll("\"" + REGEX_QUESTION_ID + "%", "\"\\${question\\.id}%")
+                      // questionid
+                      .replaceAll("/" + REGEX_QUESTION_ID_TIMESTAMP, "/\\${question\\.id\\.timestamp}")
                       // commentid in quotes, used as values
                       .replaceAll("\"" + REGEX_COMMENT_ID + "\"", "\"\\${comment\\.id}\"")
                       // commentid in URLs

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
@@ -81,7 +81,7 @@
       </span>
     </div>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IESFPTCourse/First feedback session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -138,7 +138,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="IESFPTCourse/First feedback session/1/${question.id.timestamp}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
             </div>
           </div>
         </div>
@@ -147,7 +147,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="NUMSCALE">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IESFPTCourse/First feedback session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -197,7 +197,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="IESFPTCourse/First feedback session/2/${question.id.timestamp}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
             </div>
           </div>
         </div>

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
@@ -78,7 +78,7 @@
       </span>
     </div>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IESFPTCourse/First feedback session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -135,7 +135,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="IESFPTCourse/First feedback session/1/${question.id.timestamp}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt">
             </div>
           </div>
         </div>
@@ -144,7 +144,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="NUMSCALE">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IESFPTCourse/First feedback session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/godmode.html
+++ b/src/test/resources/pages/godmode.html
@@ -34,8 +34,7 @@
                 <li>Anonymous student 1224044052</li>
                 <li>Anonymous team 1224044052</li>
                 <li>Anonymous instructor 1224044052</li>
-                <li>value="ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA"</li>
-                <li>"ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA%</li>
+                <li>CFeedbackEditUiT.CS2104/First Session/1/20160711090450626</li>
                 <li>"1234567812345678"</li>
                 <li>#1234567812345678</li>
                 <li>responseCommentRow-1234567812345678</li>

--- a/src/test/resources/pages/godmodeExpectedOutput.html
+++ b/src/test/resources/pages/godmodeExpectedOutput.html
@@ -31,8 +31,7 @@
                 <li>Anonymous student ${participant.hash}</li>
                 <li>Anonymous team ${participant.hash}</li>
                 <li>Anonymous instructor ${participant.hash}</li>
-                <li>value="${question.id}"</li>
-                <li>"${question.id}%</li>
+                <li>CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}</li>
                 <li>"${comment.id}"</li>
                 <li>#${comment.id}</li>
                 <li>responseCommentRow-${comment.id}</li>

--- a/src/test/resources/pages/godmodeExpectedPartOutput.html
+++ b/src/test/resources/pages/godmodeExpectedPartOutput.html
@@ -27,8 +27,7 @@
         <li>Anonymous student ${participant.hash}</li>
         <li>Anonymous team ${participant.hash}</li>
         <li>Anonymous instructor ${participant.hash}</li>
-        <li>value="${question.id}"</li>
-        <li>"${question.id}%</li>
+        <li>CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}</li>
         <li>"${comment.id}"</li>
         <li>#${comment.id}</li>
         <li>responseCommentRow-${comment.id}</li>

--- a/src/test/resources/pages/instructorCommentsPageAddFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddFrc.html
@@ -1797,7 +1797,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1886,7 +1886,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -1905,7 +1905,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1994,7 +1994,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2075,9 +2075,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2143,7 +2143,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2271,7 +2271,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2292,7 +2292,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2420,7 +2420,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2441,7 +2441,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2569,7 +2569,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2689,9 +2689,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
@@ -1793,7 +1793,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1882,7 +1882,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -1963,9 +1963,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2031,7 +2031,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2159,7 +2159,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2180,7 +2180,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2308,7 +2308,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2329,7 +2329,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2457,7 +2457,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2577,9 +2577,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageEditFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageEditFrc.html
@@ -1793,7 +1793,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1884,7 +1884,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -1903,7 +1903,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1992,7 +1992,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2073,9 +2073,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2141,7 +2141,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2269,7 +2269,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2290,7 +2290,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2418,7 +2418,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2439,7 +2439,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2567,7 +2567,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2687,9 +2687,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
+++ b/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
@@ -438,7 +438,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfUriCharsCourse/comments.Session with name ,?:@=+$#/1/${question.id.timestamp}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse">
                               <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#">
@@ -527,7 +527,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfUriCharsCourse/comments.Session with name ,?:@=+$#/1/${question.id.timestamp}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse">
                             <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#">
                             <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">
@@ -608,9 +608,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfUriCharsCourse/comments.Session with name ,?:@=+$#/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfUriCharsCourse/comments.Session with name ,?:@=+$#/1/${question.id.timestamp}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse">
                             <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#">
                             <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">

--- a/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
+++ b/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
@@ -1906,7 +1906,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -1995,7 +1995,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2076,9 +2076,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/1/${question.id.timestamp}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2144,7 +2144,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2272,7 +2272,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2293,7 +2293,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2421,7 +2421,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2442,7 +2442,7 @@
                                 </span>
                               </a>
                               <input name="fsindex" type="hidden" value="1">
-                              <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                              <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                               <input name="responsecommentid" type="hidden" value="${comment.id}">
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
@@ -2570,7 +2570,7 @@
                             </div>
                             <input name="responsecommentid" type="hidden" value="${comment.id}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
@@ -2690,9 +2690,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
+                            <input name="responseid" type="hidden" value="comments.idOfTypicalCourse1/comments.First feedback session/2/${question.id.timestamp}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt">
                             <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                             <input name="fsname" type="hidden" value="comments.First feedback session">
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
@@ -1294,7 +1294,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FConstSumOptionQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONSTSUM">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
@@ -1294,7 +1294,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FConstSumOptionQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONSTSUM">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
@@ -1261,7 +1261,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FConstSumRecipientQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONSTSUM">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
@@ -1261,7 +1261,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FConstSumRecipientQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONSTSUM">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
@@ -1180,7 +1180,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FContribQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONTRIB">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
@@ -1181,7 +1181,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FContribQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONTRIB">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
@@ -1180,7 +1180,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FContribQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONTRIB">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionModal.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionModal.html
@@ -61,7 +61,7 @@
                 <td>
                   filled qn
                 </td>
-                <input type="hidden" value="${question.id}">
+                <input type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
                 <input class="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
                 <input class="fsname" type="hidden" value="First Session">
               </tr>

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
@@ -1178,7 +1178,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">
@@ -1584,7 +1584,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="2">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-2" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackEditCopyFail.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyFail.html
@@ -1211,7 +1211,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FeedbackEditCopy.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackEditCopyPage.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyPage.html
@@ -1210,7 +1210,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FeedbackEditCopy.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -813,7 +813,7 @@
             </span>
           </td>
           <td class="session-response-for-test recent">
-            0 / 2
+            0 / 0
           </td>
           <td class="no-print">
             <a class="btn btn-default btn-xs btn-tm-actions session-view-for-test margin-bottom-7px" data-original-title="View the submitted responses for this feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResultsPage?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&user=FeedbackEditCopyinstructor" title="">

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
@@ -1251,7 +1251,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FMcqQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="MCQ">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
@@ -1237,7 +1237,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FMcqQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="MCQ">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
@@ -1251,7 +1251,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FMsqQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="MSQ">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
@@ -1237,7 +1237,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FMsqQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="MSQ">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
@@ -1190,7 +1190,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FNumScaleQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="NUMSCALE">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
@@ -1190,7 +1190,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FNumScaleQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="NUMSCALE">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
@@ -1175,7 +1175,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
@@ -1176,7 +1176,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
@@ -1176,7 +1176,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
@@ -1176,7 +1176,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
@@ -1212,7 +1212,7 @@
     </div>
     <input name="fsname" type="hidden" value="Edit Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRankUiT.CS4221/Edit Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RANK_OPTIONS">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">
@@ -1617,7 +1617,7 @@
     </div>
     <input name="fsname" type="hidden" value="Edit Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRankUiT.CS4221/Edit Session/2/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="2">
     <input name="questiontype" type="hidden" value="RANK_RECIPIENTS">
     <input id="questionedittype-2" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
@@ -1223,7 +1223,7 @@
     </div>
     <input name="fsname" type="hidden" value="Edit Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRankUiT.CS4221/Edit Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RANK_OPTIONS">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">
@@ -1628,7 +1628,7 @@
     </div>
     <input name="fsname" type="hidden" value="Edit Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRankUiT.CS4221/Edit Session/2/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="2">
     <input name="questiontype" type="hidden" value="RANK_RECIPIENTS">
     <input id="questionedittype-2" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -383,7 +383,7 @@
                                       </span>
                                     </a>
                                     <input name="fsindex" type="hidden" value="1">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                    <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                     <input name="responsecommentid" type="hidden" value="${comment.id}">
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
@@ -524,7 +524,7 @@
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -543,7 +543,7 @@
                                       </span>
                                     </a>
                                     <input name="fsindex" type="hidden" value="1">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                    <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                     <input name="responsecommentid" type="hidden" value="${comment.id}">
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
@@ -684,7 +684,7 @@
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -752,9 +752,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -995,9 +995,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1148,9 +1148,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1308,9 +1308,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1449,9 +1449,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1590,9 +1590,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1764,9 +1764,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1963,9 +1963,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2146,9 +2146,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2320,9 +2320,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2568,9 +2568,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2742,9 +2742,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2941,9 +2941,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3115,9 +3115,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3314,9 +3314,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3498,9 +3498,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3639,9 +3639,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3801,9 +3801,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -4085,9 +4085,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -417,9 +417,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -705,9 +705,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -858,9 +858,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1018,9 +1018,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1159,9 +1159,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1300,9 +1300,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1466,9 +1466,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1632,9 +1632,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1838,9 +1838,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2004,9 +2004,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2170,9 +2170,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2367,9 +2367,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2527,9 +2527,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2724,9 +2724,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2921,9 +2921,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3087,9 +3087,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3253,9 +3253,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3429,9 +3429,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3570,9 +3570,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -275,7 +275,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -359,7 +359,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -391,7 +391,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -423,7 +423,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -455,7 +455,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -487,7 +487,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -519,7 +519,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -551,7 +551,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -583,7 +583,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -615,7 +615,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -636,7 +636,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -672,7 +672,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -708,7 +708,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -744,7 +744,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -780,7 +780,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -816,7 +816,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -875,7 +875,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -934,7 +934,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -981,7 +981,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -272,7 +272,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -308,7 +308,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -344,7 +344,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -380,7 +380,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -416,7 +416,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -452,7 +452,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -488,7 +488,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -547,7 +547,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -606,7 +606,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -653,7 +653,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -272,7 +272,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -356,7 +356,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -388,7 +388,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -420,7 +420,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -452,7 +452,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -484,7 +484,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -516,7 +516,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -548,7 +548,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -580,7 +580,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -601,7 +601,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -637,7 +637,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -673,7 +673,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -709,7 +709,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -745,7 +745,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -781,7 +781,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -840,7 +840,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -899,7 +899,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -946,7 +946,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -414,9 +414,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -636,9 +636,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -789,9 +789,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -949,9 +949,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1090,9 +1090,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1231,9 +1231,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1405,9 +1405,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1604,9 +1604,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1787,9 +1787,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1961,9 +1961,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2160,9 +2160,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2334,9 +2334,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2533,9 +2533,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2707,9 +2707,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2906,9 +2906,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3090,9 +3090,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3231,9 +3231,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3393,9 +3393,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3684,9 +3684,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -504,7 +504,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -579,7 +579,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -751,7 +751,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -930,7 +930,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1057,7 +1057,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1184,7 +1184,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1284,7 +1284,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1312,7 +1312,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -1409,7 +1409,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1509,7 +1509,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1537,7 +1537,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -1637,7 +1637,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1665,7 +1665,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -1765,7 +1765,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1937,7 +1937,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2064,7 +2064,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2158,7 +2158,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                               </form>
                             </td>
@@ -2350,7 +2350,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                               </form>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -383,7 +383,7 @@
                                       </span>
                                     </a>
                                     <input name="fsindex" type="hidden" value="0">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                    <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                     <input name="responsecommentid" type="hidden" value="${comment.id}">
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
@@ -459,7 +459,7 @@
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -478,7 +478,7 @@
                                       </span>
                                     </a>
                                     <input name="fsindex" type="hidden" value="0">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                    <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                     <input name="responsecommentid" type="hidden" value="${comment.id}">
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
@@ -554,7 +554,7 @@
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -622,9 +622,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -865,9 +865,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1018,9 +1018,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1178,9 +1178,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1319,9 +1319,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1460,9 +1460,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1634,9 +1634,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1833,9 +1833,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2016,9 +2016,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2190,9 +2190,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2438,9 +2438,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2612,9 +2612,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2811,9 +2811,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2985,9 +2985,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3184,9 +3184,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3368,9 +3368,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3509,9 +3509,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3671,9 +3671,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3955,9 +3955,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel1.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel1.html
@@ -55,7 +55,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/1/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
           </form>
         </td>
@@ -82,7 +82,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/1/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 2">
           </form>
         </td>
@@ -109,7 +109,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/1/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 3">
           </form>
         </td>

--- a/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel2.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel2.html
@@ -55,7 +55,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/2/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
           </form>
         </td>
@@ -85,7 +85,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/2/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
           </form>
         </td>
@@ -115,7 +115,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/2/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
           </form>
         </td>
@@ -145,7 +145,7 @@
             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
             <input name="fsname" type="hidden" value="Fourth Session">
-            <input name="moderatedquestionid" type="hidden" value="${question.id}">
+            <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Fourth Session/2/${question.id.timestamp}">
             <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
           </form>
         </td>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -306,7 +306,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -342,7 +342,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -437,7 +437,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -473,7 +473,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -509,7 +509,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -545,7 +545,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -604,7 +604,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -663,7 +663,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">
@@ -710,7 +710,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="None">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -354,7 +354,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -386,7 +386,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -418,7 +418,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -450,7 +450,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -482,7 +482,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -514,7 +514,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -546,7 +546,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -578,7 +578,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -599,7 +599,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -683,7 +683,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -717,7 +717,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -751,7 +751,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -785,7 +785,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -819,7 +819,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -853,7 +853,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -887,7 +887,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -908,7 +908,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -944,7 +944,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1020,7 +1020,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -1041,7 +1041,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1077,7 +1077,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1113,7 +1113,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1294,7 +1294,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1326,7 +1326,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1360,7 +1360,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1394,7 +1394,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1428,7 +1428,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1462,7 +1462,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1496,7 +1496,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1517,7 +1517,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1705,7 +1705,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1736,7 +1736,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1770,7 +1770,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1804,7 +1804,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1838,7 +1838,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1872,7 +1872,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1906,7 +1906,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1927,7 +1927,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -2063,7 +2063,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2097,7 +2097,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2131,7 +2131,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2165,7 +2165,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2199,7 +2199,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2233,7 +2233,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2267,7 +2267,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2288,7 +2288,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -2435,7 +2435,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2467,7 +2467,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2501,7 +2501,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2535,7 +2535,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2569,7 +2569,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2603,7 +2603,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2637,7 +2637,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -306,7 +306,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -342,7 +342,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -378,7 +378,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -414,7 +414,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -450,7 +450,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -486,7 +486,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -545,7 +545,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -604,7 +604,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">
@@ -651,7 +651,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section B">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -379,7 +379,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -463,7 +463,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -495,7 +495,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -527,7 +527,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -559,7 +559,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -591,7 +591,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -623,7 +623,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -655,7 +655,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -687,7 +687,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -719,7 +719,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -740,7 +740,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -824,7 +824,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -858,7 +858,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -892,7 +892,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -926,7 +926,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -960,7 +960,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -994,7 +994,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1028,7 +1028,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1062,7 +1062,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1083,7 +1083,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1178,7 +1178,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1254,7 +1254,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -1275,7 +1275,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1311,7 +1311,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1347,7 +1347,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1528,7 +1528,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1560,7 +1560,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1594,7 +1594,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1628,7 +1628,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1662,7 +1662,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1696,7 +1696,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1730,7 +1730,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1764,7 +1764,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1785,7 +1785,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1973,7 +1973,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2004,7 +2004,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2038,7 +2038,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2072,7 +2072,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2106,7 +2106,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2140,7 +2140,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2174,7 +2174,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2208,7 +2208,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2229,7 +2229,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2365,7 +2365,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2399,7 +2399,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2433,7 +2433,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2467,7 +2467,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2501,7 +2501,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2535,7 +2535,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2569,7 +2569,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2603,7 +2603,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2624,7 +2624,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2771,7 +2771,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2803,7 +2803,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2837,7 +2837,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2871,7 +2871,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2905,7 +2905,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2939,7 +2939,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2973,7 +2973,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -3007,7 +3007,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
@@ -163,7 +163,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -199,7 +199,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -235,7 +235,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -271,7 +271,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -307,7 +307,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -343,7 +343,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -379,7 +379,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -438,7 +438,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -497,7 +497,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -544,7 +544,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -267,7 +267,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -351,7 +351,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -383,7 +383,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -415,7 +415,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -447,7 +447,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -479,7 +479,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -511,7 +511,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -543,7 +543,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -575,7 +575,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -596,7 +596,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -680,7 +680,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -714,7 +714,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -748,7 +748,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -782,7 +782,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -816,7 +816,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -850,7 +850,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -884,7 +884,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -918,7 +918,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -939,7 +939,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -975,7 +975,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1051,7 +1051,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -1072,7 +1072,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1108,7 +1108,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1144,7 +1144,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1325,7 +1325,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1357,7 +1357,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1391,7 +1391,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1425,7 +1425,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1459,7 +1459,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1493,7 +1493,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1527,7 +1527,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1561,7 +1561,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1582,7 +1582,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1770,7 +1770,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1801,7 +1801,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1835,7 +1835,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1869,7 +1869,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1903,7 +1903,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1937,7 +1937,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1971,7 +1971,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2005,7 +2005,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2026,7 +2026,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2162,7 +2162,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2196,7 +2196,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2230,7 +2230,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2264,7 +2264,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2298,7 +2298,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2332,7 +2332,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2366,7 +2366,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2400,7 +2400,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2421,7 +2421,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2568,7 +2568,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2600,7 +2600,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2634,7 +2634,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2668,7 +2668,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2702,7 +2702,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2736,7 +2736,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2770,7 +2770,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2804,7 +2804,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
@@ -506,9 +506,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -633,9 +633,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -783,9 +783,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%danny.e.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}%tmms.test@gmail.tmt%danny.e.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -983,9 +983,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%emily.f.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}%tmms.test@gmail.tmt%emily.f.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -1150,9 +1150,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%Team 1</option><option value=&quot;dump&quot;></td><td>'&quot;">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}%tmms.test@gmail.tmt%Team 1</option><option value=&quot;dump&quot;></td><td>'&quot;">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -449,7 +449,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                     <input name="fsname" type="hidden" value="Instructor Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                   </form>
                 </td>
@@ -470,7 +470,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -683,7 +683,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                     <input name="fsname" type="hidden" value="Instructor Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                   </form>
                 </td>
@@ -722,7 +722,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                     <input name="fsname" type="hidden" value="Instructor Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                   </form>
                 </td>
@@ -743,7 +743,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -906,7 +906,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                     <input name="fsname" type="hidden" value="Instructor Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                   </form>
                 </td>
@@ -938,7 +938,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                     <input name="fsname" type="hidden" value="Instructor Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                   </form>
                 </td>
@@ -959,7 +959,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1005,7 +1005,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1064,7 +1064,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1110,7 +1110,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1156,7 +1156,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1202,7 +1202,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1248,7 +1248,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1294,7 +1294,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-11" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/11/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -508,9 +508,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -635,9 +635,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}%tmms.test@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -830,9 +830,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%Team 1</option><option value=&quot;dump&quot;></td><td>'&quot;">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}%tmms.test@gmail.tmt%Team 1</option><option value=&quot;dump&quot;></td><td>'&quot;">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -1013,9 +1013,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%danny.e.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}%tmms.test@gmail.tmt%danny.e.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">
@@ -1338,9 +1338,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%tmms.test@gmail.tmt%emily.f.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}%tmms.test@gmail.tmt%emily.f.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                             <input name="fsname" type="hidden" value="Instructor Session">
                             <input name="user" type="hidden" value="FRankUiT.instructor">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -497,7 +497,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                                 <input name="fsname" type="hidden" value="Instructor Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                               </form>
                             </td>
@@ -637,7 +637,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                                 <input name="fsname" type="hidden" value="Instructor Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                               </form>
                             </td>
@@ -832,7 +832,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                                 <input name="fsname" type="hidden" value="Instructor Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                               </form>
                             </td>
@@ -997,7 +997,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                                 <input name="fsname" type="hidden" value="Instructor Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                               </form>
                             </td>
@@ -1307,7 +1307,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRankUiT.CS4221">
                                 <input name="fsname" type="hidden" value="Instructor Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="tmms.test@gmail.tmt">
                               </form>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -408,7 +408,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -3585,7 +3585,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="5">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -3975,7 +3975,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="FRankUiT.CS4221/Instructor Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -451,9 +451,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
@@ -650,9 +650,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%benny.c.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%benny.c.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
@@ -818,9 +818,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%benny.c.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%benny.c.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -247,7 +247,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="false">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -435,7 +435,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="alice.b.tmms@gmail.tmt">
                   </form>
                 </td>
@@ -480,7 +480,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="benny.c.tmms@gmail.tmt">
                   </form>
                 </td>
@@ -525,7 +525,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="benny.c.tmms@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -453,9 +453,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%benny.c.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%benny.c.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
@@ -654,9 +654,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
@@ -830,9 +830,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%benny.c.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                            <input name="responseid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%benny.c.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
                             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -460,7 +460,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="benny.c.tmms@gmail.tmt">
                               </form>
                             </td>
@@ -664,7 +664,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="alice.b.tmms@gmail.tmt">
                               </form>
                             </td>
@@ -705,7 +705,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="benny.c.tmms@gmail.tmt">
                               </form>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -267,7 +267,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.SanitizedTeam/Sanitized Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -478,7 +478,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
                     <input name="fsname" type="hidden" value="Sanitized Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.SanitizedTeam/Sanitized Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -519,7 +519,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
                     <input name="fsname" type="hidden" value="Sanitized Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.SanitizedTeam/Sanitized Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -553,7 +553,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
                     <input name="fsname" type="hidden" value="Sanitized Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.SanitizedTeam/Sanitized Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -594,7 +594,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
                     <input name="fsname" type="hidden" value="Sanitized Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.SanitizedTeam/Sanitized Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -435,9 +435,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -744,9 +744,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -897,9 +897,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1057,9 +1057,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1198,9 +1198,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1339,9 +1339,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1505,9 +1505,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1671,9 +1671,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1877,9 +1877,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2043,9 +2043,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2209,9 +2209,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2406,9 +2406,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2566,9 +2566,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2784,9 +2784,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2981,9 +2981,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3147,9 +3147,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3313,9 +3313,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3489,9 +3489,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3630,9 +3630,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -417,9 +417,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -705,9 +705,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -858,9 +858,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1018,9 +1018,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1159,9 +1159,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1300,9 +1300,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1466,9 +1466,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1632,9 +1632,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1838,9 +1838,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2004,9 +2004,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2170,9 +2170,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2367,9 +2367,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2527,9 +2527,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2724,9 +2724,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2921,9 +2921,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3087,9 +3087,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3253,9 +3253,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3429,9 +3429,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3570,9 +3570,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -354,7 +354,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -386,7 +386,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -418,7 +418,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -450,7 +450,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -482,7 +482,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -514,7 +514,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -546,7 +546,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -578,7 +578,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -610,7 +610,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -631,7 +631,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -715,7 +715,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -749,7 +749,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -783,7 +783,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -817,7 +817,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -851,7 +851,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -885,7 +885,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -919,7 +919,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -953,7 +953,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -974,7 +974,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1069,7 +1069,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1145,7 +1145,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -1166,7 +1166,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1202,7 +1202,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1238,7 +1238,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1419,7 +1419,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1451,7 +1451,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1485,7 +1485,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1519,7 +1519,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1553,7 +1553,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1587,7 +1587,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1621,7 +1621,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1655,7 +1655,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1676,7 +1676,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1864,7 +1864,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1895,7 +1895,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1929,7 +1929,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1963,7 +1963,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1997,7 +1997,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2031,7 +2031,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2065,7 +2065,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2099,7 +2099,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2120,7 +2120,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2256,7 +2256,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2290,7 +2290,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2324,7 +2324,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2358,7 +2358,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2392,7 +2392,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2426,7 +2426,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2460,7 +2460,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2494,7 +2494,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2515,7 +2515,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2662,7 +2662,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2694,7 +2694,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2728,7 +2728,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2762,7 +2762,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2796,7 +2796,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2830,7 +2830,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2864,7 +2864,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2898,7 +2898,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -354,7 +354,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -386,7 +386,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -418,7 +418,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -450,7 +450,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -482,7 +482,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -514,7 +514,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -546,7 +546,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -578,7 +578,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -610,7 +610,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -631,7 +631,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -715,7 +715,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -749,7 +749,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -783,7 +783,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -817,7 +817,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -851,7 +851,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -885,7 +885,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -919,7 +919,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -953,7 +953,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -974,7 +974,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1069,7 +1069,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1145,7 +1145,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -1166,7 +1166,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1202,7 +1202,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1238,7 +1238,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1419,7 +1419,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1451,7 +1451,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1485,7 +1485,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1519,7 +1519,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1553,7 +1553,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1587,7 +1587,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1621,7 +1621,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1655,7 +1655,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1676,7 +1676,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1864,7 +1864,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1895,7 +1895,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1929,7 +1929,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1963,7 +1963,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1997,7 +1997,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2031,7 +2031,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2065,7 +2065,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2099,7 +2099,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2120,7 +2120,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2256,7 +2256,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2290,7 +2290,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2324,7 +2324,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2358,7 +2358,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2392,7 +2392,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2426,7 +2426,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2460,7 +2460,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2494,7 +2494,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -2515,7 +2515,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2662,7 +2662,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2694,7 +2694,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2728,7 +2728,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2762,7 +2762,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2796,7 +2796,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2830,7 +2830,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2864,7 +2864,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2898,7 +2898,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="First Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRGQSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRGQSearch.html
@@ -432,9 +432,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -675,9 +675,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -828,9 +828,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -988,9 +988,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1129,9 +1129,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1270,9 +1270,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1444,9 +1444,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1643,9 +1643,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1826,9 +1826,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2000,9 +2000,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2248,9 +2248,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2422,9 +2422,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2621,9 +2621,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2795,9 +2795,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2994,9 +2994,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3178,9 +3178,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3319,9 +3319,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3481,9 +3481,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3765,9 +3765,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -432,9 +432,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -675,9 +675,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -828,9 +828,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -988,9 +988,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1129,9 +1129,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1270,9 +1270,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1444,9 +1444,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1643,9 +1643,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1826,9 +1826,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2000,9 +2000,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2248,9 +2248,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2422,9 +2422,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2621,9 +2621,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2795,9 +2795,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2994,9 +2994,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3178,9 +3178,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3319,9 +3319,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3481,9 +3481,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3765,9 +3765,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="First Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -414,9 +414,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/3/${question.id.timestamp}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -636,9 +636,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -789,9 +789,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -949,9 +949,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1090,9 +1090,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1231,9 +1231,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1405,9 +1405,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1604,9 +1604,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1787,9 +1787,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1961,9 +1961,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2160,9 +2160,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2334,9 +2334,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.fred.g@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2533,9 +2533,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2707,9 +2707,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2906,9 +2906,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3090,9 +3090,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3231,9 +3231,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3393,9 +3393,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%Team 2">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3684,9 +3684,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 2 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="First Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -928,7 +928,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -1003,7 +1003,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1175,7 +1175,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1354,7 +1354,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1481,7 +1481,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1608,7 +1608,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1708,7 +1708,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1736,7 +1736,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -1833,7 +1833,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2182,7 +2182,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2210,7 +2210,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                                     </form>
                                   </td>
@@ -2310,7 +2310,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2338,7 +2338,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -2438,7 +2438,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -2610,7 +2610,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -2737,7 +2737,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -2831,7 +2831,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                                     </form>
                                   </td>
@@ -3036,7 +3036,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="First Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                                     </form>
                                   </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -504,7 +504,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -579,7 +579,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/2/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -751,7 +751,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -930,7 +930,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1057,7 +1057,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/9/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1184,7 +1184,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1284,7 +1284,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1312,7 +1312,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -1409,7 +1409,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1509,7 +1509,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1537,7 +1537,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -1637,7 +1637,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1665,7 +1665,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -1765,7 +1765,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1937,7 +1937,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2064,7 +2064,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2158,7 +2158,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/4/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                               </form>
                             </td>
@@ -2350,7 +2350,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="First Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/First Session/1/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                               </form>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionA.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -306,7 +306,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -446,7 +446,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -480,7 +480,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -514,7 +514,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -548,7 +548,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -582,7 +582,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -616,7 +616,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -650,7 +650,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -671,7 +671,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -825,7 +825,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -859,7 +859,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -893,7 +893,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -927,7 +927,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -961,7 +961,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -995,7 +995,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1029,7 +1029,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1050,7 +1050,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1214,7 +1214,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1248,7 +1248,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1282,7 +1282,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1316,7 +1316,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1350,7 +1350,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1384,7 +1384,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1418,7 +1418,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1439,7 +1439,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -1606,7 +1606,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1640,7 +1640,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1674,7 +1674,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1708,7 +1708,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1742,7 +1742,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1776,7 +1776,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1810,7 +1810,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1831,7 +1831,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -2023,7 +2023,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2055,7 +2055,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2087,7 +2087,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2119,7 +2119,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2153,7 +2153,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2187,7 +2187,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2221,7 +2221,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2255,7 +2255,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2289,7 +2289,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2323,7 +2323,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2357,7 +2357,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2391,7 +2391,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2425,7 +2425,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2459,7 +2459,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2493,7 +2493,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2527,7 +2527,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2561,7 +2561,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2595,7 +2595,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2629,7 +2629,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2663,7 +2663,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2697,7 +2697,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2731,7 +2731,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2765,7 +2765,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2799,7 +2799,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2833,7 +2833,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2867,7 +2867,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2901,7 +2901,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2922,7 +2922,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -3324,7 +3324,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3358,7 +3358,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3392,7 +3392,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3426,7 +3426,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3467,7 +3467,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3501,7 +3501,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3535,7 +3535,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3569,7 +3569,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3610,7 +3610,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3644,7 +3644,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3678,7 +3678,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3712,7 +3712,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3746,7 +3746,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3780,7 +3780,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -3814,7 +3814,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -3848,7 +3848,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -3882,7 +3882,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -3916,7 +3916,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -3950,7 +3950,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -3984,7 +3984,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4018,7 +4018,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4052,7 +4052,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4086,7 +4086,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4120,7 +4120,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4154,7 +4154,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4175,7 +4175,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -4267,7 +4267,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4296,7 +4296,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4317,7 +4317,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -4489,7 +4489,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -4881,7 +4881,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4912,7 +4912,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4933,7 +4933,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-11" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -5009,7 +5009,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -5030,7 +5030,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-12" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="Section A">
       </form>
       <div class="display-icon pull-right">
@@ -5187,7 +5187,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -492,9 +492,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -640,9 +640,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -755,9 +755,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -884,9 +884,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1012,9 +1012,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1173,9 +1173,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,6, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1324,9 +1324,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1478,9 +1478,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1629,9 +1629,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1780,9 +1780,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1915,9 +1915,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2069,9 +2069,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2204,9 +2204,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="6">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2358,9 +2358,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="6">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2529,9 +2529,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}%Team 1</td></div>'&quot;%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2649,9 +2649,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2890,9 +2890,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -474,9 +474,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -622,9 +622,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -737,9 +737,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -866,9 +866,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -994,9 +994,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1155,9 +1155,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,6, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1306,9 +1306,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1460,9 +1460,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1611,9 +1611,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1762,9 +1762,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1897,9 +1897,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2051,9 +2051,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2186,9 +2186,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="6">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2340,9 +2340,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="6">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2511,9 +2511,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}%Team 1</td></div>'&quot;%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2631,9 +2631,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2783,9 +2783,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
@@ -270,7 +270,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -306,7 +306,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -446,7 +446,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -480,7 +480,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -514,7 +514,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -548,7 +548,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -582,7 +582,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -616,7 +616,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -650,7 +650,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -684,7 +684,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -705,7 +705,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -859,7 +859,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -893,7 +893,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -927,7 +927,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -961,7 +961,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -995,7 +995,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1029,7 +1029,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1063,7 +1063,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1097,7 +1097,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1118,7 +1118,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1282,7 +1282,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1316,7 +1316,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1350,7 +1350,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1384,7 +1384,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1418,7 +1418,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1452,7 +1452,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1486,7 +1486,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1520,7 +1520,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1541,7 +1541,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -1708,7 +1708,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -1742,7 +1742,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -1776,7 +1776,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -1810,7 +1810,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -1844,7 +1844,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -1878,7 +1878,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -1912,7 +1912,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -1946,7 +1946,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -1967,7 +1967,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-6" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -2159,7 +2159,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2191,7 +2191,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2223,7 +2223,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2255,7 +2255,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2289,7 +2289,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -2323,7 +2323,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2357,7 +2357,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2391,7 +2391,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -2425,7 +2425,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2459,7 +2459,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2493,7 +2493,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -2527,7 +2527,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2561,7 +2561,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2595,7 +2595,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2629,7 +2629,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -2663,7 +2663,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2697,7 +2697,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2731,7 +2731,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2765,7 +2765,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -2799,7 +2799,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2833,7 +2833,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2867,7 +2867,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2901,7 +2901,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -2935,7 +2935,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -2969,7 +2969,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -3003,7 +3003,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -3037,7 +3037,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -3071,7 +3071,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -3092,7 +3092,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-7" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -3522,7 +3522,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3556,7 +3556,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3590,7 +3590,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -3624,7 +3624,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3665,7 +3665,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3699,7 +3699,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                   </form>
                 </td>
@@ -3733,7 +3733,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3767,7 +3767,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3808,7 +3808,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                   </form>
                 </td>
@@ -3842,7 +3842,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3876,7 +3876,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3910,7 +3910,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3944,7 +3944,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                   </form>
                 </td>
@@ -3978,7 +3978,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -4012,7 +4012,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -4046,7 +4046,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -4080,7 +4080,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                   </form>
                 </td>
@@ -4114,7 +4114,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4148,7 +4148,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4182,7 +4182,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4216,7 +4216,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                   </form>
                 </td>
@@ -4250,7 +4250,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4284,7 +4284,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4318,7 +4318,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4352,7 +4352,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                   </form>
                 </td>
@@ -4386,7 +4386,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.emily.f@gmail.tmt">
                   </form>
                 </td>
@@ -4407,7 +4407,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-8" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -4499,7 +4499,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4528,7 +4528,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -4549,7 +4549,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-9" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -4721,7 +4721,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-10" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -5141,7 +5141,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -5172,7 +5172,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                   </form>
                 </td>
@@ -5193,7 +5193,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-11" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -5269,7 +5269,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -5295,7 +5295,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 2">
                   </form>
                 </td>
@@ -5321,7 +5321,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 3">
                   </form>
                 </td>
@@ -5342,7 +5342,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-12" name="frshowstats" type="hidden" value="on">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -5499,7 +5499,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                   </form>
                 </td>
@@ -5526,7 +5526,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 2">
                   </form>
                 </td>
@@ -5553,7 +5553,7 @@
                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                     <input name="fsname" type="hidden" value="Second Session">
-                    <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                    <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                     <input name="moderatedperson" type="hidden" value="Team 3">
                   </form>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -466,9 +466,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}%Team 1</td></div>'&quot;%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -597,9 +597,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -855,9 +855,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1003,9 +1003,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1118,9 +1118,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1247,9 +1247,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1375,9 +1375,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1536,9 +1536,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,6, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="0">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1720,9 +1720,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1874,9 +1874,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2023,9 +2023,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="2">
-                                  <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2256,9 +2256,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="3">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2440,9 +2440,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="4">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2680,9 +2680,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2834,9 +2834,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="5">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3018,9 +3018,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="6">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -3172,9 +3172,9 @@
                                     </a>
                                     <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                                   </div>
-                                  <input name="questionid" type="hidden" value="${question.id}">
+                                  <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                   <input name="fsindex" type="hidden" value="6">
-                                  <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                  <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                   <input name="fsname" type="hidden" value="Second Session">
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -448,9 +448,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}%Team 1</td></div>'&quot;%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -579,9 +579,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/9/${question.id.timestamp}%CFResultsUiT.benny.c@gmail.tmt%%GENERAL%">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -816,9 +816,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -964,9 +964,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1079,9 +1079,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1208,9 +1208,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1336,9 +1336,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1497,9 +1497,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,6, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="0">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1681,9 +1681,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1835,9 +1835,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="1">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -1984,9 +1984,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="2">
-                            <input name="responseid" type="hidden" value="${question.id}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}%Team 1</td></div>'&quot;%Team 1</td></div>'&quot;">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2168,9 +2168,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="3">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2352,9 +2352,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="4">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2515,9 +2515,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2669,9 +2669,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="5">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2832,9 +2832,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="6">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
@@ -2986,9 +2986,9 @@
                               </a>
                               <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
                             </div>
-                            <input name="questionid" type="hidden" value="${question.id}">
+                            <input name="questionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                             <input name="fsindex" type="hidden" value="6">
-                            <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                            <input name="responseid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                             <input name="fsname" type="hidden" value="Second Session">
                             <input name="user" type="hidden" value="CFResultsUiT.instr">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -618,7 +618,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                                     </form>
                                   </td>
@@ -646,7 +646,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="Team 2">
                                     </form>
                                   </td>
@@ -674,7 +674,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="Team 3">
                                     </form>
                                   </td>
@@ -1343,7 +1343,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1488,7 +1488,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1643,7 +1643,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1801,7 +1801,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1942,7 +1942,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -1972,7 +1972,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2002,7 +2002,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                                     </form>
                                   </td>
@@ -2095,7 +2095,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -2125,7 +2125,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2155,7 +2155,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                                     </form>
                                   </td>
@@ -2321,7 +2321,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -2351,7 +2351,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2381,7 +2381,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                                     </form>
                                   </td>
@@ -2467,7 +2467,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -2504,7 +2504,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                                     </form>
                                   </td>
@@ -2534,7 +2534,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                                     </form>
                                   </td>
@@ -2628,7 +2628,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                                     </form>
                                   </td>
@@ -2956,7 +2956,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -2986,7 +2986,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                                     </form>
                                   </td>
@@ -3016,7 +3016,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                                     </form>
                                   </td>
@@ -3046,7 +3046,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -3076,7 +3076,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                                     </form>
                                   </td>
@@ -3242,7 +3242,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -3272,7 +3272,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                                     </form>
                                   </td>
@@ -3302,7 +3302,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                                     </form>
                                   </td>
@@ -3332,7 +3332,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                                     </form>
                                   </td>
@@ -3362,7 +3362,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                                     </form>
                                   </td>
@@ -3546,7 +3546,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -3632,7 +3632,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -3760,7 +3760,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>
@@ -3846,7 +3846,7 @@
                                       <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                       <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                       <input name="fsname" type="hidden" value="Second Session">
-                                      <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                      <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                       <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                                     </form>
                                   </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -600,7 +600,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                               </form>
                             </td>
@@ -628,7 +628,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 2">
                               </form>
                             </td>
@@ -656,7 +656,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/12/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 3">
                               </form>
                             </td>
@@ -848,7 +848,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/2/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -993,7 +993,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/3/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1148,7 +1148,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/4/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1306,7 +1306,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/5/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1447,7 +1447,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1477,7 +1477,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1507,7 +1507,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -1600,7 +1600,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1630,7 +1630,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1660,7 +1660,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -1826,7 +1826,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -1856,7 +1856,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -1886,7 +1886,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -1972,7 +1972,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -2009,7 +2009,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt">
                               </form>
                             </td>
@@ -2039,7 +2039,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/7/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.fred.g@gmail.tmt">
                               </form>
                             </td>
@@ -2133,7 +2133,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/11/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="Team 1</td></div>'&quot;">
                               </form>
                             </td>
@@ -2299,7 +2299,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -2329,7 +2329,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                               </form>
                             </td>
@@ -2359,7 +2359,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                               </form>
                             </td>
@@ -2389,7 +2389,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2419,7 +2419,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                               </form>
                             </td>
@@ -2585,7 +2585,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -2615,7 +2615,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt">
                               </form>
                             </td>
@@ -2645,7 +2645,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt">
                               </form>
                             </td>
@@ -2675,7 +2675,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="drop.out@gmail.tmt">
                               </form>
                             </td>
@@ -2705,7 +2705,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/6/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="extra.guy@gmail.tmt">
                               </form>
                             </td>
@@ -2812,7 +2812,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -2898,7 +2898,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -3005,7 +3005,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/8/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>
@@ -3091,7 +3091,7 @@
                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response">
                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                 <input name="fsname" type="hidden" value="Second Session">
-                                <input name="moderatedquestionid" type="hidden" value="${question.id}">
+                                <input name="moderatedquestionid" type="hidden" value="CFResultsUiT.CS2104/Second Session/10/${question.id.timestamp}">
                                 <input name="moderatedperson" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt">
                               </form>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
@@ -1321,7 +1321,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
@@ -1321,7 +1321,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
@@ -1284,7 +1284,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
@@ -1318,7 +1318,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
@@ -1284,7 +1284,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
@@ -1321,7 +1321,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
@@ -1287,7 +1287,7 @@
     </div>
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="FRubricQnUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="RUBRIC">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -180,7 +180,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/Fourth Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
@@ -79,7 +79,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/Second Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -293,7 +293,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="MCQ">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/Second Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -531,7 +531,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="MSQ">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/Second Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -817,7 +817,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="NUMSCALE">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/Second Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -995,7 +995,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="CONSTSUM">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/Second Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1076,7 +1076,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="CONSTSUM">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/Second Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -133,7 +133,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -142,7 +142,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -217,7 +217,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -272,7 +272,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
           <br>
@@ -327,7 +327,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
         </div>
@@ -336,7 +336,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -393,7 +393,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%%GENERAL%">
+              <input name="responseid-3-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%%GENERAL%">
             </div>
           </div>
         </div>
@@ -402,7 +402,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -468,7 +468,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-4-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -517,7 +517,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-4-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -566,7 +566,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-4-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
           <br>
@@ -615,7 +615,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-3" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt">
+              <input name="responseid-4-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt">
             </div>
           </div>
         </div>
@@ -624,7 +624,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="MCQ">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -689,7 +689,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-5-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-5-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -698,7 +698,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -766,7 +766,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -817,7 +817,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-6-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -868,7 +868,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-6-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -877,7 +877,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MSQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -964,7 +964,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-7-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -973,7 +973,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1063,7 +1063,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1136,7 +1136,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-8-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1209,7 +1209,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-8-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1218,7 +1218,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MCQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1333,7 +1333,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-9-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1342,7 +1342,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MSQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1469,7 +1469,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-10-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-10-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1478,7 +1478,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MCQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1553,7 +1553,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-11-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-11-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1562,7 +1562,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MSQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1649,7 +1649,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-12-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-12-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1658,7 +1658,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="NUMSCALE">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1708,7 +1708,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-13-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-13-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1717,7 +1717,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1770,7 +1770,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1806,7 +1806,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-14-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1842,7 +1842,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-14-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1851,7 +1851,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="MCQ">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1946,7 +1946,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-15-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-15-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1955,7 +1955,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MSQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2062,7 +2062,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-16-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-16-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2071,7 +2071,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="CONSTSUM">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2144,7 +2144,7 @@
                 <input id="constSumPoints-17" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-17" type="hidden" value="false">
               </div>
-              <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-17-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2153,7 +2153,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2222,7 +2222,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-18-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2271,7 +2271,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-18-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2321,7 +2321,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-18-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
         </div>
@@ -2330,7 +2330,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2399,7 +2399,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-19-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2448,7 +2448,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-19-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2498,7 +2498,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-19-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
         </div>
@@ -2507,7 +2507,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONSTSUM">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2594,7 +2594,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-20-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2661,7 +2661,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-20-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2728,7 +2728,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-20-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
         </div>
@@ -2737,7 +2737,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="MSQ">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2824,7 +2824,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-21-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-21-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
@@ -79,7 +79,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/Grace Period Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -133,7 +133,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -142,7 +142,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -214,7 +214,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -266,7 +266,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
           <br>
@@ -325,7 +325,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -382,7 +382,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%%GENERAL%">
+              <input name="responseid-3-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%%GENERAL%">
             </div>
           </div>
         </div>
@@ -391,7 +391,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -457,7 +457,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-4-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -506,7 +506,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-4-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -555,7 +555,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-4-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
           <br>
@@ -604,7 +604,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-3" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt">
+              <input name="responseid-4-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt">
             </div>
           </div>
         </div>
@@ -613,7 +613,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="MCQ">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -678,7 +678,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-5-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-5-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -687,7 +687,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -755,7 +755,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -806,7 +806,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-6-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -857,7 +857,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-6-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -866,7 +866,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MSQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -953,7 +953,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-7-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -962,7 +962,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1052,7 +1052,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1125,7 +1125,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-8-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1198,7 +1198,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-8-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1207,7 +1207,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MCQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1312,7 +1312,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-9-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1321,7 +1321,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MSQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1438,7 +1438,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-10-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-10-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1447,7 +1447,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MCQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1532,7 +1532,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-11-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-11-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1541,7 +1541,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MSQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1638,7 +1638,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-12-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-12-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1647,7 +1647,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="NUMSCALE">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1697,7 +1697,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-13-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-13-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1706,7 +1706,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1759,7 +1759,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1795,7 +1795,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-14-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1831,7 +1831,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
+              <input name="responseid-14-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1840,7 +1840,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="MCQ">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1935,7 +1935,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-15-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-15-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1944,7 +1944,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MSQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2051,7 +2051,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-16-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-16-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2060,7 +2060,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="CONSTSUM">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2133,7 +2133,7 @@
                 <input id="constSumPoints-17" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-17" type="hidden" value="false">
               </div>
-              <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-17-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2142,7 +2142,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2214,7 +2214,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-18-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2266,7 +2266,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-18-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2318,7 +2318,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-18-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
           <br>
@@ -2379,7 +2379,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2451,7 +2451,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-19-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2503,7 +2503,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-19-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2555,7 +2555,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="true">
               </div>
-              <input name="responseid-19-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-19-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
           <br>
@@ -2616,7 +2616,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONSTSUM">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2706,7 +2706,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+              <input name="responseid-20-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -2776,7 +2776,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
+              <input name="responseid-20-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -2846,7 +2846,7 @@
                 <input id="constSumPoints-20" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-20" type="hidden" value="true">
               </div>
-              <input name="responseid-20-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
+              <input name="responseid-20-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%Team 3">
             </div>
           </div>
           <br>
@@ -2924,7 +2924,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="MSQ">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -3021,7 +3021,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-21-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-21-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -140,7 +140,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -328,7 +328,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -392,7 +392,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -606,7 +606,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="MCQ">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -679,7 +679,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -855,7 +855,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MSQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -950,7 +950,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1192,7 +1192,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MCQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1315,7 +1315,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MSQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1450,7 +1450,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MCQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1533,7 +1533,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MSQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1628,7 +1628,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="NUMSCALE">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1686,7 +1686,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1817,7 +1817,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="MCQ">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1920,7 +1920,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MSQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2035,7 +2035,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="CONSTSUM">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2116,7 +2116,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2290,7 +2290,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2464,7 +2464,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONSTSUM">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2691,7 +2691,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="MSQ">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -140,7 +140,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -301,7 +301,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -365,7 +365,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -579,7 +579,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="MCQ">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -652,7 +652,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -828,7 +828,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MSQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -923,7 +923,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1165,7 +1165,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MCQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1288,7 +1288,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MSQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1423,7 +1423,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MCQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1506,7 +1506,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MSQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1601,7 +1601,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="NUMSCALE">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1659,7 +1659,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1790,7 +1790,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="MCQ">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1893,7 +1893,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MSQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2008,7 +2008,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="CONSTSUM">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2089,7 +2089,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2161,7 +2161,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2233,7 +2233,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONSTSUM">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2322,7 +2322,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="MSQ">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -133,7 +133,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -142,7 +142,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -217,7 +217,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -272,7 +272,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
           <br>
@@ -327,7 +327,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-2" type="hidden" value="IFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
         </div>
@@ -336,7 +336,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="IFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -400,7 +400,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -466,7 +466,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
+              <input name="responseid-4-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/6/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt">
             </div>
           </div>
           <br>
@@ -616,7 +616,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="MCQ">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="IFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -689,7 +689,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -757,7 +757,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -866,7 +866,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MSQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="IFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -961,7 +961,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1051,7 +1051,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1204,7 +1204,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MCQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="IFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1327,7 +1327,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MSQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="IFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1462,7 +1462,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MCQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="IFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1545,7 +1545,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MSQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="IFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1640,7 +1640,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="NUMSCALE">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1690,7 +1690,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-13-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-13-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1699,7 +1699,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="IFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1830,7 +1830,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="MCQ">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="IFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1933,7 +1933,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MSQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="IFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2048,7 +2048,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="CONSTSUM">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2121,7 +2121,7 @@
                 <input id="constSumPoints-17" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-17" type="hidden" value="false">
               </div>
-              <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
+              <input name="responseid-17-0" type="hidden" value="IFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2130,7 +2130,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="IFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2304,7 +2304,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="IFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2478,7 +2478,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONSTSUM">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="IFSubmitUiT.CS2104/First Session/23/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2705,7 +2705,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="MSQ">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="IFSubmitUiT.CS2104/First Session/24/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
@@ -77,7 +77,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
@@ -72,7 +72,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="IFSubmitUiT.CS2104/Private Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
@@ -73,7 +73,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="FRankUiT.CS4221/Instructor Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -300,7 +300,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="FRankUiT.CS4221/Instructor Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -3477,7 +3477,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="FRankUiT.CS4221/Instructor Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -3771,7 +3771,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="FRankUiT.CS4221/Instructor Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
@@ -1192,7 +1192,7 @@
     </div>
     <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
     <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackUiT.CS1101/Team Peer Evaluation Session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONTRIB">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">
@@ -1615,7 +1615,7 @@
     </div>
     <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
     <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackUiT.CS1101/Team Peer Evaluation Session/2/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="2">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-2" name="questionedittype" type="hidden" value="edit">
@@ -2029,7 +2029,7 @@
     </div>
     <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
     <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackUiT.CS1101/Team Peer Evaluation Session/3/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="3">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-3" name="questionedittype" type="hidden" value="edit">
@@ -2440,7 +2440,7 @@
     </div>
     <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
     <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackUiT.CS1101/Team Peer Evaluation Session/4/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="4">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-4" name="questionedittype" type="hidden" value="edit">
@@ -2857,7 +2857,7 @@
     </div>
     <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
     <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="CFeedbackUiT.CS1101/Team Peer Evaluation Session/5/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="5">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-5" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
@@ -166,7 +166,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-1" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/1/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -211,7 +211,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-2" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/2/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -247,7 +247,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-3" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/3/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -283,7 +283,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-4" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/4/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">
@@ -319,7 +319,7 @@
         <input name="frsorttype" type="hidden" value="question">
         <input id="showStats-5" name="frshowstats" type="hidden" value="off">
         <input name="frindicatemissingresponses" type="hidden" value="true">
-        <input name="questionid" type="hidden" value="${question.id}">
+        <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/5/${question.id.timestamp}">
         <input name="frgroupbysection" type="hidden" value="All">
       </form>
       <div class="display-icon pull-right">

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
@@ -1189,7 +1189,7 @@
     </div>
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT.instr1.gma-demo">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/1/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="1">
     <input name="questiontype" type="hidden" value="CONTRIB">
     <input id="questionedittype-1" name="questionedittype" type="hidden" value="edit">
@@ -1612,7 +1612,7 @@
     </div>
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT.instr1.gma-demo">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/2/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="2">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-2" name="questionedittype" type="hidden" value="edit">
@@ -2026,7 +2026,7 @@
     </div>
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT.instr1.gma-demo">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/3/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="3">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-3" name="questionedittype" type="hidden" value="edit">
@@ -2437,7 +2437,7 @@
     </div>
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT.instr1.gma-demo">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/4/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="4">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-4" name="questionedittype" type="hidden" value="edit">
@@ -2854,7 +2854,7 @@
     </div>
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT.instr1.gma-demo">
-    <input name="questionid" type="hidden" value="${question.id}">
+    <input name="questionid" type="hidden" value="AHPUiT.instr1.gma-demo/Second team feedback session/5/${question.id.timestamp}">
     <input name="questionnum" type="hidden" value="5">
     <input name="questiontype" type="hidden" value="TEXT">
     <input id="questionedittype-5" name="questionedittype" type="hidden" value="edit">

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
@@ -87,7 +87,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="CONTRIB">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -215,7 +215,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/1/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt">
             </div>
           </div>
           <br>
@@ -317,7 +317,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-1-1" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
+              <input name="responseid-1-1" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/1/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -419,7 +419,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-1-2" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
+              <input name="responseid-1-2" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/1/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -521,7 +521,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-1-3" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
+              <input name="responseid-1-3" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/1/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
             </div>
           </div>
         </div>
@@ -530,7 +530,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -596,7 +596,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/2/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt">
             </div>
           </div>
         </div>
@@ -605,7 +605,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -668,7 +668,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-0" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
+              <input name="responseid-3-0" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/3/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -714,7 +714,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-1" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
+              <input name="responseid-3-1" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/3/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -760,7 +760,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-2" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
+              <input name="responseid-3-2" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/3/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
             </div>
           </div>
         </div>
@@ -769,7 +769,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -826,7 +826,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%Team 2">
+              <input name="responseid-4-0" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/4/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%Team 2">
             </div>
           </div>
         </div>
@@ -835,7 +835,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -901,7 +901,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-5-0" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
+              <input name="responseid-5-0" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/5/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -947,7 +947,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-5-1" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
+              <input name="responseid-5-1" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/5/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -993,7 +993,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-5-2" type="hidden" value="${question.id}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
+              <input name="responseid-5-2" type="hidden" value="AHPUiT.instr1.gma-demo/First team feedback session/5/${question.id.timestamp}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt">
             </div>
           </div>
         </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -173,7 +173,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/Fourth Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
@@ -87,7 +87,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/Second Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -195,7 +195,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="MCQ">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/Second Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -315,7 +315,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="MSQ">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/Second Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -459,7 +459,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="NUMSCALE">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/Second Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -147,7 +147,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -156,7 +156,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -231,7 +231,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
           <br>
@@ -283,7 +283,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
           <br>
@@ -335,7 +335,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-2" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
         </div>
@@ -344,7 +344,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -404,7 +404,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%%GENERAL%">
+              <input name="responseid-3-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%%GENERAL%">
             </div>
           </div>
         </div>
@@ -413,7 +413,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -476,7 +476,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-4-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -519,7 +519,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-4-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
         </div>
@@ -528,7 +528,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -585,7 +585,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-5-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-5-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
         </div>
@@ -594,7 +594,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -677,7 +677,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -686,7 +686,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -754,7 +754,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-7-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -802,7 +802,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-7-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
         </div>
@@ -811,7 +811,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -916,7 +916,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -925,7 +925,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1015,7 +1015,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-9-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -1085,7 +1085,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-9-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
         </div>
@@ -1094,7 +1094,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1215,7 +1215,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-10-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-10-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1224,7 +1224,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1357,7 +1357,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-11-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-11-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1366,7 +1366,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1447,7 +1447,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-12-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-12-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1456,7 +1456,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1549,7 +1549,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-13-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-13-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1558,7 +1558,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1614,7 +1614,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1623,7 +1623,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1676,7 +1676,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-15-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-15-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -1709,7 +1709,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-15-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-15-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
         </div>
@@ -1718,7 +1718,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1799,7 +1799,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-16-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-16-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1808,7 +1808,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1901,7 +1901,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-17-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-17-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1910,7 +1910,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1989,7 +1989,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-18-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1998,7 +1998,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2067,7 +2067,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="false">
               </div>
-              <input name="responseid-19-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-19-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -2114,7 +2114,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="false">
               </div>
-              <input name="responseid-19-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-19-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
         </div>
@@ -2123,7 +2123,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2236,7 +2236,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-20-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -2332,7 +2332,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-20-1" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-20-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2341,7 +2341,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
@@ -87,7 +87,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="NUMSCALE">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/Grace Period Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -151,7 +151,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="NUMSCALE">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/Grace Period Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -244,7 +244,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="CONTRIB">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/Grace Period Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageModified.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -147,7 +147,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -156,7 +156,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -228,7 +228,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
           <br>
@@ -277,7 +277,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
           <br>
@@ -333,7 +333,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -393,7 +393,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-3-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%%GENERAL%">
+              <input name="responseid-3-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%%GENERAL%">
             </div>
           </div>
         </div>
@@ -402,7 +402,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -468,7 +468,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-4-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -514,7 +514,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-4-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -567,7 +567,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="0">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -596,7 +596,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -679,7 +679,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -688,7 +688,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -759,7 +759,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-7-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -810,7 +810,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-7-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -869,7 +869,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -974,7 +974,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -983,7 +983,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1076,7 +1076,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-9-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -1149,7 +1149,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-9-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -1230,7 +1230,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1341,7 +1341,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-10-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-10-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1350,7 +1350,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1473,7 +1473,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-11-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-11-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1482,7 +1482,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1573,7 +1573,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-12-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-12-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1582,7 +1582,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1685,7 +1685,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-13-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-13-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1694,7 +1694,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1750,7 +1750,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1759,7 +1759,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1815,7 +1815,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-15-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-15-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -1851,7 +1851,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-15-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-15-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -1895,7 +1895,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1976,7 +1976,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-16-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-16-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1985,7 +1985,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2078,7 +2078,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-17-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-17-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2087,7 +2087,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2166,7 +2166,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-18-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2175,7 +2175,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2247,7 +2247,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="false">
               </div>
-              <input name="responseid-19-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-19-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -2296,7 +2296,7 @@
                 <input id="constSumPoints-19" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-19" type="hidden" value="false">
               </div>
-              <input name="responseid-19-1" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-19-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -2354,7 +2354,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2464,7 +2464,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-20-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2473,7 +2473,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -154,7 +154,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -336,7 +336,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -403,7 +403,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -514,7 +514,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -578,7 +578,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -669,7 +669,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -792,7 +792,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -905,7 +905,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1072,7 +1072,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1201,7 +1201,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1342,7 +1342,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1431,7 +1431,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1532,7 +1532,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1596,7 +1596,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1689,7 +1689,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1778,7 +1778,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1879,7 +1879,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1966,7 +1966,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2089,7 +2089,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2305,7 +2305,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -147,7 +147,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -156,7 +156,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -231,7 +231,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
           <br>
@@ -283,7 +283,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
           <br>
@@ -335,7 +335,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-2" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
         </div>
@@ -344,7 +344,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -411,7 +411,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -474,7 +474,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
+              <input name="responseid-4-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 3">
             </div>
           </div>
           <br>
@@ -524,7 +524,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -588,7 +588,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -671,7 +671,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-6-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -680,7 +680,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -748,7 +748,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-7-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -804,7 +804,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -909,7 +909,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-8-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-8-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -918,7 +918,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1008,7 +1008,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
+              <input name="responseid-9-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team >'&quot;< 1</td></div>'&quot;%Team 2">
             </div>
           </div>
           <br>
@@ -1086,7 +1086,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1215,7 +1215,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1356,7 +1356,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1445,7 +1445,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1546,7 +1546,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1602,7 +1602,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1611,7 +1611,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1704,7 +1704,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1793,7 +1793,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1894,7 +1894,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1973,7 +1973,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-18-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1982,7 +1982,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2105,7 +2105,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2218,7 +2218,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-20-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -2322,7 +2322,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
@@ -77,7 +77,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -156,7 +156,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="CFeedbackEditUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRank.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="FRankUiT.CS4221/Student Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -372,7 +372,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="FRankUiT.CS4221/Student Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -510,7 +510,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="FRankUiT.CS4221/Student Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -651,7 +651,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="FRankUiT.CS4221/Student Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -729,7 +729,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="FRankUiT.CS4221/Student Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1026,7 +1026,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="FRankUiT.CS4221/Student Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1164,7 +1164,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="FRankUiT.CS4221/Student Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="RUBRIC">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -238,7 +238,7 @@
                 </div>
               </div>
               <input id="rubricResponse-1-0" name="responsetext-1-0" type="hidden" value="">
-              <input name="responseid-1-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="FRubricQnUiT.CS2104/Second Session/1/${question.id.timestamp}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
             </div>
           </div>
           <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
@@ -81,7 +81,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="FRankUiT.CS4221/Student Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -232,7 +232,7 @@
                 <input id="rankNumOptions-1" type="hidden" value="4">
                 <input id="rankAreDuplicatesAllowed-1" type="hidden" value="true">
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%tmms.helper1@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="FRankUiT.CS4221/Student Session/1/${question.id.timestamp}%alice.b.tmms@gmail.tmt%tmms.helper1@gmail.tmt">
             </div>
           </div>
           <br>
@@ -372,7 +372,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="FRankUiT.CS4221/Student Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -447,7 +447,7 @@
                 <input id="rankNumOptions-2" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-2" type="hidden" value="false">
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%tmms.helper1@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="FRankUiT.CS4221/Student Session/2/${question.id.timestamp}%alice.b.tmms@gmail.tmt%tmms.helper1@gmail.tmt">
             </div>
           </div>
           <br>
@@ -502,7 +502,7 @@
                 <input id="rankNumOptions-2" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-2" type="hidden" value="false">
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%tmms.test@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="FRankUiT.CS4221/Student Session/2/${question.id.timestamp}%alice.b.tmms@gmail.tmt%tmms.test@gmail.tmt">
             </div>
           </div>
         </div>
@@ -511,7 +511,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="FRankUiT.CS4221/Student Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -652,7 +652,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="FRankUiT.CS4221/Student Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -730,7 +730,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="FRankUiT.CS4221/Student Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -820,7 +820,7 @@
                 <input id="rankNumOptions-5" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-5" type="hidden" value="false">
               </div>
-              <input name="responseid-5-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+              <input name="responseid-5-0" type="hidden" value="FRankUiT.CS4221/Student Session/5/${question.id.timestamp}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -887,7 +887,7 @@
                 <input id="rankNumOptions-5" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-5" type="hidden" value="false">
               </div>
-              <input name="responseid-5-1" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%charlie.d.tmms@gmail.tmt">
+              <input name="responseid-5-1" type="hidden" value="FRankUiT.CS4221/Student Session/5/${question.id.timestamp}%alice.b.tmms@gmail.tmt%charlie.d.tmms@gmail.tmt">
             </div>
           </div>
           <br>
@@ -1029,7 +1029,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="RANK_RECIPIENTS">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="FRankUiT.CS4221/Student Session/6/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1104,7 +1104,7 @@
                 <input id="rankNumOptions-6" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-6" type="hidden" value="true">
               </div>
-              <input name="responseid-6-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%Team 2">
+              <input name="responseid-6-0" type="hidden" value="FRankUiT.CS4221/Student Session/6/${question.id.timestamp}%alice.b.tmms@gmail.tmt%Team 2">
             </div>
           </div>
           <br>
@@ -1159,7 +1159,7 @@
                 <input id="rankNumOptions-6" type="hidden" value="0">
                 <input id="rankAreDuplicatesAllowed-6" type="hidden" value="true">
               </div>
-              <input name="responseid-6-1" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%Team 3">
+              <input name="responseid-6-1" type="hidden" value="FRankUiT.CS4221/Student Session/6/${question.id.timestamp}%alice.b.tmms@gmail.tmt%Team 3">
             </div>
           </div>
         </div>
@@ -1168,7 +1168,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="RANK_OPTIONS">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="FRankUiT.CS4221/Student Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1316,7 +1316,7 @@
                 <input id="rankNumOptions-7" type="hidden" value="4">
                 <input id="rankAreDuplicatesAllowed-7" type="hidden" value="false">
               </div>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
+              <input name="responseid-7-0" type="hidden" value="FRankUiT.CS4221/Student Session/7/${question.id.timestamp}%alice.b.tmms@gmail.tmt%alice.b.tmms@gmail.tmt">
             </div>
           </div>
         </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -168,7 +168,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -241,7 +241,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -423,7 +423,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -490,7 +490,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -601,7 +601,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -759,7 +759,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -850,7 +850,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -973,7 +973,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1086,7 +1086,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1253,7 +1253,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1382,7 +1382,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1523,7 +1523,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1612,7 +1612,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1713,7 +1713,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1777,7 +1777,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1870,7 +1870,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1959,7 +1959,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2060,7 +2060,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2147,7 +2147,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2270,7 +2270,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2700,7 +2700,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -96,7 +96,7 @@
     </div>
     <br>
     <input name="questiontype-1" type="hidden" value="TEXT">
-    <input name="questionid-1" type="hidden" value="${question.id}">
+    <input name="questionid-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}">
     <input name="questionresponsetotal-1" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -162,7 +162,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-1-0" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-1-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/1/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
         </div>
@@ -171,7 +171,7 @@
     <br>
     <br>
     <input name="questiontype-2" type="hidden" value="TEXT">
-    <input name="questionid-2" type="hidden" value="${question.id}">
+    <input name="questionid-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}">
     <input name="questionresponsetotal-2" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -246,7 +246,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-0" type="hidden" value="${question.id}%drop.out@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
+              <input name="responseid-2-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%drop.out@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt">
             </div>
           </div>
           <br>
@@ -298,7 +298,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-1" type="hidden" value="${question.id}%drop.out@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
+              <input name="responseid-2-1" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%drop.out@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt">
             </div>
           </div>
           <br>
@@ -350,7 +350,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-2-2" type="hidden" value="${question.id}%drop.out@gmail.tmt%extra.guy@gmail.tmt">
+              <input name="responseid-2-2" type="hidden" value="SFSubmitUiT.CS2104/First Session/2/${question.id.timestamp}%drop.out@gmail.tmt%extra.guy@gmail.tmt">
             </div>
           </div>
         </div>
@@ -359,7 +359,7 @@
     <br>
     <br>
     <input name="questiontype-3" type="hidden" value="TEXT">
-    <input name="questionid-3" type="hidden" value="${question.id}">
+    <input name="questionid-3" type="hidden" value="SFSubmitUiT.CS2104/First Session/3/${question.id.timestamp}">
     <input name="questionresponsetotal-3" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -426,7 +426,7 @@
     <br>
     <br>
     <input name="questiontype-4" type="hidden" value="TEXT">
-    <input name="questionid-4" type="hidden" value="${question.id}">
+    <input name="questionid-4" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}">
     <input name="questionresponsetotal-4" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -489,7 +489,7 @@
                   words
                 </div>
               </div>
-              <input name="responseid-4-0" type="hidden" value="${question.id}%Team 2%Team 3">
+              <input name="responseid-4-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/4/${question.id.timestamp}%Team 2%Team 3">
             </div>
           </div>
           <br>
@@ -539,7 +539,7 @@
     <br>
     <br>
     <input name="questiontype-5" type="hidden" value="TEXT">
-    <input name="questionid-5" type="hidden" value="${question.id}">
+    <input name="questionid-5" type="hidden" value="SFSubmitUiT.CS2104/First Session/5/${question.id.timestamp}">
     <input name="questionresponsetotal-5" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -697,7 +697,7 @@
     <br>
     <br>
     <input name="questiontype-6" type="hidden" value="MCQ">
-    <input name="questionid-6" type="hidden" value="${question.id}">
+    <input name="questionid-6" type="hidden" value="SFSubmitUiT.CS2104/First Session/7/${question.id.timestamp}">
     <input name="questionresponsetotal-6" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -788,7 +788,7 @@
     <br>
     <br>
     <input name="questiontype-7" type="hidden" value="MCQ">
-    <input name="questionid-7" type="hidden" value="${question.id}">
+    <input name="questionid-7" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}">
     <input name="questionresponsetotal-7" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -856,7 +856,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-7-0" type="hidden" value="${question.id}%Team 2%Team >'&quot;< 1</td></div>'&quot;">
+              <input name="responseid-7-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/8/${question.id.timestamp}%Team 2%Team >'&quot;< 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -912,7 +912,7 @@
     <br>
     <br>
     <input name="questiontype-8" type="hidden" value="MSQ">
-    <input name="questionid-8" type="hidden" value="${question.id}">
+    <input name="questionid-8" type="hidden" value="SFSubmitUiT.CS2104/First Session/9/${question.id.timestamp}">
     <input name="questionresponsetotal-8" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1025,7 +1025,7 @@
     <br>
     <br>
     <input name="questiontype-9" type="hidden" value="MSQ">
-    <input name="questionid-9" type="hidden" value="${question.id}">
+    <input name="questionid-9" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}">
     <input name="questionresponsetotal-9" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1115,7 +1115,7 @@
                   </tr>
                 </tbody>
               </table>
-              <input name="responseid-9-0" type="hidden" value="${question.id}%Team 2%Team >'&quot;< 1</td></div>'&quot;">
+              <input name="responseid-9-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/10/${question.id.timestamp}%Team 2%Team >'&quot;< 1</td></div>'&quot;">
             </div>
           </div>
           <br>
@@ -1193,7 +1193,7 @@
     <br>
     <br>
     <input name="questiontype-10" type="hidden" value="MCQ">
-    <input name="questionid-10" type="hidden" value="${question.id}">
+    <input name="questionid-10" type="hidden" value="SFSubmitUiT.CS2104/First Session/11/${question.id.timestamp}">
     <input name="questionresponsetotal-10" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1322,7 +1322,7 @@
     <br>
     <br>
     <input name="questiontype-11" type="hidden" value="MSQ">
-    <input name="questionid-11" type="hidden" value="${question.id}">
+    <input name="questionid-11" type="hidden" value="SFSubmitUiT.CS2104/First Session/12/${question.id.timestamp}">
     <input name="questionresponsetotal-11" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1463,7 +1463,7 @@
     <br>
     <br>
     <input name="questiontype-12" type="hidden" value="MCQ">
-    <input name="questionid-12" type="hidden" value="${question.id}">
+    <input name="questionid-12" type="hidden" value="SFSubmitUiT.CS2104/First Session/13/${question.id.timestamp}">
     <input name="questionresponsetotal-12" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1552,7 +1552,7 @@
     <br>
     <br>
     <input name="questiontype-13" type="hidden" value="MSQ">
-    <input name="questionid-13" type="hidden" value="${question.id}">
+    <input name="questionid-13" type="hidden" value="SFSubmitUiT.CS2104/First Session/14/${question.id.timestamp}">
     <input name="questionresponsetotal-13" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1653,7 +1653,7 @@
     <br>
     <br>
     <input name="questiontype-14" type="hidden" value="NUMSCALE">
-    <input name="questionid-14" type="hidden" value="${question.id}">
+    <input name="questionid-14" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}">
     <input name="questionresponsetotal-14" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1709,7 +1709,7 @@
               <div class="text-muted form-control-static">
                 [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
               </div>
-              <input name="responseid-14-0" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-14-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/15/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
         </div>
@@ -1718,7 +1718,7 @@
     <br>
     <br>
     <input name="questiontype-15" type="hidden" value="NUMSCALE">
-    <input name="questionid-15" type="hidden" value="${question.id}">
+    <input name="questionid-15" type="hidden" value="SFSubmitUiT.CS2104/First Session/16/${question.id.timestamp}">
     <input name="questionresponsetotal-15" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1811,7 +1811,7 @@
     <br>
     <br>
     <input name="questiontype-16" type="hidden" value="MCQ">
-    <input name="questionid-16" type="hidden" value="${question.id}">
+    <input name="questionid-16" type="hidden" value="SFSubmitUiT.CS2104/First Session/17/${question.id.timestamp}">
     <input name="questionresponsetotal-16" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -1900,7 +1900,7 @@
     <br>
     <br>
     <input name="questiontype-17" type="hidden" value="MSQ">
-    <input name="questionid-17" type="hidden" value="${question.id}">
+    <input name="questionid-17" type="hidden" value="SFSubmitUiT.CS2104/First Session/18/${question.id.timestamp}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2001,7 +2001,7 @@
     <br>
     <br>
     <input name="questiontype-18" type="hidden" value="CONSTSUM">
-    <input name="questionid-18" type="hidden" value="${question.id}">
+    <input name="questionid-18" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}">
     <input name="questionresponsetotal-18" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2080,7 +2080,7 @@
                 <input id="constSumPoints-18" type="hidden" value="100">
                 <input id="constSumUnevenDistribution-18" type="hidden" value="false">
               </div>
-              <input name="responseid-18-0" type="hidden" value="${question.id}%drop.out@gmail.tmt%drop.out@gmail.tmt">
+              <input name="responseid-18-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/19/${question.id.timestamp}%drop.out@gmail.tmt%drop.out@gmail.tmt">
             </div>
           </div>
         </div>
@@ -2089,7 +2089,7 @@
     <br>
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
-    <input name="questionid-19" type="hidden" value="${question.id}">
+    <input name="questionid-19" type="hidden" value="SFSubmitUiT.CS2104/First Session/20/${question.id.timestamp}">
     <input name="questionresponsetotal-19" type="hidden" value="2">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2212,7 +2212,7 @@
     <br>
     <br>
     <input name="questiontype-20" type="hidden" value="CONTRIB">
-    <input name="questionid-20" type="hidden" value="${question.id}">
+    <input name="questionid-20" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}">
     <input name="questionresponsetotal-20" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
@@ -2331,7 +2331,7 @@
                   </option>
                 </select>
               </div>
-              <input name="responseid-20-0" type="hidden" value="${question.id}%drop.out@gmail.tmt%SFSubmitUiT.charlie.d@gmail.tmt">
+              <input name="responseid-20-0" type="hidden" value="SFSubmitUiT.CS2104/First Session/21/${question.id.timestamp}%drop.out@gmail.tmt%SFSubmitUiT.charlie.d@gmail.tmt">
             </div>
           </div>
           <br>
@@ -2643,7 +2643,7 @@
     <br>
     <br>
     <input name="questiontype-21" type="hidden" value="RUBRIC">
-    <input name="questionid-21" type="hidden" value="${question.id}">
+    <input name="questionid-21" type="hidden" value="SFSubmitUiT.CS2104/First Session/22/${question.id.timestamp}">
     <input name="questionresponsetotal-21" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">


### PR DESCRIPTION
Fixes #5966.

Copying session is missing code to remove the questions that are now attached to the FeedbackSession entity.

Also, currently the code writes to both the old and new question type. Occasionally, the interleaving of writes to each entity type somehow seems to cause the writes to be part of the same transaction, causing google app engine to throw an exception.

