### PR TITLE
Use proper versioning for all static analysis tools #5972

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
   - tar -xjf /tmp/firefox-46.0.tar.bz2 --directory $TRAVIS_BUILD_DIR/
   - export PATH="$TRAVIS_BUILD_DIR/firefox:$PATH"
   - ./gradlew createConfigs testClasses
-  - npm install eslint@3.0.0
   - ./gradlew downloadStaticAnalysisTools --continue
   - ./gradlew staticAnalysis --continue
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,9 @@ apply plugin: "findbugs"
 apply plugin: "jacoco"
 
 def appengineVersion = "1.9.27"
+def checkstyleVersion = "6.19"
+def pmdVersion = "5.4.1"
+def findbugsVersion = "3.0.1"
 
 buildscript {
     repositories {
@@ -19,6 +22,7 @@ buildscript {
 
 configurations {
     macker
+    staticAnalysis
     enhancer
     exclude
     testExclude
@@ -36,6 +40,11 @@ repositories {
 
 dependencies {
     macker          "de.andrena.tools.macker:macker:1.0.1"
+
+    staticAnalysis  "com.puppycrawl.tools:checkstyle:${checkstyleVersion}",
+                    "net.sourceforge.pmd:pmd-java:${pmdVersion}",
+                    "com.google.code.findbugs:findbugs:${findbugsVersion}",
+                    configurations.macker
 
     appengineSdk    "com.google.appengine:appengine-java-sdk:${appengineVersion}"
 
@@ -277,12 +286,12 @@ task eslint(type: Exec) {
 }
 
 checkstyle {
-    toolVersion = "6.19"
+    toolVersion = checkstyleVersion
     configFile = file("static-analysis/teammates-checkstyle.xml")
 }
 
 pmd {
-    toolVersion = "5.4.1"
+    toolVersion = pmdVersion
     consoleOutput = true
     ruleSetFiles = files("static-analysis/teammates-pmd.xml", "static-analysis/teammates-pmdMain.xml")
     ruleSets = []
@@ -292,7 +301,7 @@ pmdMain.dependsOn compileJava
 pmdTest.dependsOn compileTestJava
 
 findbugs {
-    toolVersion = "3.0.1"
+    toolVersion = findbugsVersion
     visitors = [
         "FindDeadLocalStores"
     ]
@@ -311,10 +320,14 @@ task mackerEmpty(type: Copy) {
     into "static-analysis/macker"
 }
 
+task installEslint(type: Exec) {
+    commandLine "npm", "install", "eslint@3.0.0"
+}
+
 task downloadStaticAnalysisTools {
     description "Downloads all static analysis tools."
     group "Static analysis"
-    dependsOn checkstyleEmpty, pmdEmpty, findbugsEmpty, mackerEmpty
+    dependsOn checkstyleEmpty, pmdEmpty, findbugsEmpty, mackerEmpty, installEslint
 }
 
 task staticAnalysisMain {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
 }
 
 configurations {
-    macker
     staticAnalysis
     enhancer
     exclude
@@ -39,12 +38,10 @@ repositories {
 }
 
 dependencies {
-    macker          "de.andrena.tools.macker:macker:1.0.1"
-
     staticAnalysis  "com.puppycrawl.tools:checkstyle:${checkstyleVersion}",
                     "net.sourceforge.pmd:pmd-java:${pmdVersion}",
                     "com.google.code.findbugs:findbugs:${findbugsVersion}",
-                    configurations.macker
+                    "de.andrena.tools.macker:macker:1.0.1"
 
     appengineSdk    "com.google.appengine:appengine-java-sdk:${appengineVersion}"
 
@@ -99,12 +96,6 @@ dependencies {
 }
 
 sourceSets {
-    empty {
-        // Placeholder empty source for downloading all static analysis tools without running anything
-        java {
-            srcDir "static-analysis"
-        }
-    }
     main {
         java {
             srcDir "src/main/java"
@@ -314,12 +305,6 @@ tasks.withType(FindBugs) {
     }
 }
 
-// workaround to get Macker to be downloaded first
-task mackerEmpty(type: Copy) {
-    from configurations.macker
-    into "static-analysis/macker"
-}
-
 task installEslint(type: Exec) {
     commandLine "npm", "install", "eslint@3.0.0"
 }
@@ -327,7 +312,10 @@ task installEslint(type: Exec) {
 task downloadStaticAnalysisTools {
     description "Downloads all static analysis tools."
     group "Static analysis"
-    dependsOn checkstyleEmpty, pmdEmpty, findbugsEmpty, mackerEmpty, installEslint
+    doFirst {
+        configurations.staticAnalysis.resolve()
+    }
+    finalizedBy installEslint
 }
 
 task staticAnalysisMain {
@@ -340,7 +328,7 @@ task staticAnalysisTest {
 
 task macker << {
     logging.setLevel(LogLevel.INFO)
-    ant.taskdef(name: "macker", classpath: configurations.macker.asPath, classname: "de.andrena.tools.macker.ant.MackerAntTask")
+    ant.taskdef(name: "macker", classpath: configurations.staticAnalysis.asPath, classname: "de.andrena.tools.macker.ant.MackerAntTask")
     ant.macker(failonerror: true, verbose: false) {
         rules(dir: "${projectDir}/static-analysis", includes: "teammates-macker.xml")
         classes(dir: "${buildDir}/classes") {

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -264,7 +264,7 @@ Troubleshooting instructions are given [in this document](troubleshooting-guide.
 * **GitHub** : Used to host the repo and code reviewing.
 * **Gradle** : Build and dependency management tool.
 * **Node.js** : We use Node Package Manager (NPM) from Node.js as a dependency management tool.
-* **CheckStyle, PMD, FindBugs, Macker, ESLint** [all latest stable versions]: Static analysis tools for code quality check. The details of these tools can be found in [this document](staticAnalysis.md).
+* **CheckStyle, PMD, FindBugs, Macker, ESLint**: Static analysis tools for code quality check. The details of these tools can be found in [this document](staticAnalysis.md).
 * [**PowerPointLabs**](http://PowerPointLabs.info) [Sister project]: Used for creating demo videos.
 * Optional: [**HubTurbo**](https://github.com/HubTurbo/HubTurbo/wiki/Getting-Started) [Sister project]: 
   Can be used as a client for accessing the GitHub issue tracker.

--- a/devdocs/staticAnalysis.md
+++ b/devdocs/staticAnalysis.md
@@ -4,9 +4,19 @@
 TEAMMATES uses a number of static analysis tools in order to maintain code quality and measure code coverage.
 This document will cover an overview of these tools and how to run them in local environment.
 
+- [Version numbers](#version-numbers)
 - [Tool stack](#tool-stack)
 - [Running static analysis](#running-static-analysis)
 - [Running code coverage session](#running-code-coverage-session)
+
+## Version numbers
+
+The version number of all the tool stacks are declared in `build.gradle` or `package.json`.
+
+When downloading the plugin for Eclipse, find the plugin version that uses the correct version of the tool, e.g if CheckStyle 6.19 is used find an Eclipse plugin that uses CheckStyle 6.19 as well.
+If the exact version of the plugin cannot be found, using the latest version is allowed, however there is no guarantee that there will be no backward-incompatible changes.
+
+Conversely, when updating any tool, ensure that the tool version is supported by the Eclipse plugin, e.g when upgrading CheckStyle to 6.19 ensure that there is an Eclipse plugin which supports that version as well.
 
 ## Tool stack
 
@@ -79,14 +89,18 @@ The rules to be used are configured in a ruleset file; in TEAMMATES the file can
 Normally, the coverage will be run against all classes specified as the source code, but it can be configured to exclude classes matching certain name patterns.
 The plugin for Eclipse can be found [here](http://eclemma.org).
 
-### ESLint (version 3.0.0)
+### ESLint
 
 [ESLint](http://eslint.org) functions both to enforce coding standard and also to find potential bugs in JavaScript source code.
 The rules to be used are configured in a ruleset file; in TEAMMATES the file can be found [here](../static-analysis/teammates-eslint.yml).
 ESLint is a node.js package, currently not supported for Eclipse Java EE project.
 To set it up, [install node.js](https://nodejs.org/en/download/) if necessary (version 4 or later required) and then install the ESLint package:
 ```
-npm install -g eslint@3.0.0
+./gradlew installEslint
+
+# Alternatively, if you want to install the ESLint module globally, use the install command manually
+# Remember to use the correct tool version
+npm install -g eslint@{version}
 ```
 
 ##### Suppressing ESLint warnings
@@ -125,7 +139,7 @@ The analysis results are immediately reported in Eclipse and you can traverse to
 
 To run Checkstyle analysis on all Java source files with the Eclipse Checkstyle plugin, right click on the Project Folder in the `Project Explorer` window in Eclipse and select `Checkstyle > Check Code with Checkstyle`. The report can be found in the `Markers` window in Eclipse.
 
-To run PMD analysis using the Eclipse PMD plugin, right click on the project under `Project Explorer` and select `PMD > Check Code`. The report can be viewed in the PMD Perspective view under `Violations Overview`. Note that currently, the Eclipse plugin uses a different PMD version from what `build.gradle` is using. 
+To run PMD analysis using the Eclipse PMD plugin, right click on the project under `Project Explorer` and select `PMD > Check Code`. The report can be viewed in the PMD Perspective view under `Violations Overview`.
 
 Alternatively, run the tools via Gradle:
 ```

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -5,6 +5,7 @@
     "bootstrap": "3.1.1",
     "d3": "3.5.17",
     "datamaps": "0.5.7",
+    "eslint": "3.0.0",
     "guillotine": "1.3.1",
     "html5shiv": "3.7.3",
     "jquery": "1.11.3",

--- a/static-analysis/EmptyClass.java
+++ b/static-analysis/EmptyClass.java
@@ -1,8 +1,0 @@
-package an.empty.cls;
-
-/**
- * A placeholder empty class for Gradle to download all static analysis tools.
- */
-public class EmptyClass {
-
-}


### PR DESCRIPTION
Fixes #5972 

The empty class workaround is no longer needed because with the tools declared via Gradle, they can be resolved and downloaded on demand.