### PR TITLE
Remove finishRequest in Datastore.java #5891

### DIFF
--- a/src/main/java/teammates/storage/datastore/Datastore.java
+++ b/src/main/java/teammates/storage/datastore/Datastore.java
@@ -5,7 +5,6 @@ import java.util.logging.Logger;
 import javax.jdo.JDOHelper;
 import javax.jdo.PersistenceManager;
 import javax.jdo.PersistenceManagerFactory;
-import javax.jdo.Transaction;
 
 import teammates.common.util.Utils;
 
@@ -51,23 +50,4 @@ public final class Datastore {
         return pm;
     }
 
-    public static void finishRequest() {
-
-        PersistenceManager pm = PER_THREAD_PM.get();
-        
-        if (pm == null) {
-            return;
-        }
-        
-        PER_THREAD_PM.remove();
-
-        if (!pm.isClosed()) {
-            Transaction tx = pm.currentTransaction();
-            if (tx.isActive()) {
-                tx.rollback();
-            }
-            pm.close();
-        }
-
-    }
 }


### PR DESCRIPTION
Fixes #5891 

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Deleted the function named finishRequest from Datastore.java.
This issue was tagged as d.firstTimer.