### PR TITLE
Update about.jsp with contributors from V5.88 #5988

### DIFF
--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -715,6 +715,10 @@
                 <li>Paramsothy Sanshayan 
                     [bug reporting/fixing, enhancements]
                 </li>
+                <li>Pratyoush Srivastava
+                    [<a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Apratyoushs"
+                        target="_blank">bug reporting/fixing, enhancements</a>]
+                </li>
                 <li>Prithviraj Billa 
                     [bug reporting/fixing, enhancements]
                 </li>


### PR DESCRIPTION
Fixes #5988 

The [ci skip] commit message allows Travis to skip the build, since this is a change that cannot possibly break any test.