### PR TITLE
Code base cleanup #6065

### DIFF
--- a/src/client/java/teammates/client/scripts/ParallelProfiler.java
+++ b/src/client/java/teammates/client/scripts/ParallelProfiler.java
@@ -24,7 +24,7 @@ public final class ParallelProfiler {
     
     public static void main(String[] args) {
         for (int i = 0; i < NUM_OF_THREADS; i++) {
-            (new PerformanceProfiler(TestProperties.TEST_DATA_FOLDER + "/thread" + i + ".txt")).start();
+            new PerformanceProfiler(TestProperties.TEST_DATA_FOLDER + "/thread" + i + ".txt").start();
         }
     }
 }

--- a/src/client/java/teammates/client/scripts/PerformanceProfiler.java
+++ b/src/client/java/teammates/client/scripts/PerformanceProfiler.java
@@ -136,12 +136,12 @@ public class PerformanceProfiler extends Thread {
                 float duration = 0;
                 if (type.equals(String.class) && !customTimer) {
                     long startTime = System.nanoTime();
-                    Object retVal = (String) method.invoke(this);
+                    Object retVal = method.invoke(this);
                     long endTime = System.nanoTime();
                     duration = (float) ((endTime - startTime) / 1000000.0); //in miliSecond
                     System.out.print("Name: " + name + "\tTime: " + duration + "\tVal: " + retVal.toString() + "\n");
                 } else if (type.equals(Long.class) && customTimer) {
-                    duration = (float) (((Long) (method.invoke(this))) / 1000000.0);
+                    duration = (float) ((Long) method.invoke(this) / 1000000.0);
                     System.out.print("Name: " + name + "\tTime: " + duration + "\n");
                 }
                 // Add new duration to the arrayList of the test.
@@ -166,7 +166,7 @@ public class PerformanceProfiler extends Thread {
      * @param args
      */
     public static void main(String[] args) {
-        (new PerformanceProfiler(defaultReportPath)).start();
+        new PerformanceProfiler(defaultReportPath).start();
     }
 
     /**

--- a/src/client/java/teammates/client/scripts/RepairFeedbackSessionNameWithExtraWhiteSpace.java
+++ b/src/client/java/teammates/client/scripts/RepairFeedbackSessionNameWithExtraWhiteSpace.java
@@ -13,7 +13,6 @@ import javax.jdo.Query;
 import teammates.client.remoteapi.RemoteApiClient;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.StringHelper;
 import teammates.storage.api.FeedbackSessionsDb;
@@ -86,7 +85,7 @@ public class RepairFeedbackSessionNameWithExtraWhiteSpace extends RemoteApiClien
             if (!coursesAffected.isEmpty()) {
                 showAffectedCourses(coursesAffected);
             }
-        } catch (InvalidParametersException | EntityDoesNotExistException | EntityAlreadyExistsException e) {
+        } catch (InvalidParametersException | EntityAlreadyExistsException e) {
             e.printStackTrace();
         }
     }
@@ -115,7 +114,7 @@ public class RepairFeedbackSessionNameWithExtraWhiteSpace extends RemoteApiClien
      * related questions, responses and feedback response comments.
      */
     private void fixFeedbackSession(FeedbackSession session)
-            throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
+            throws InvalidParametersException, EntityAlreadyExistsException {
         if (feedbackSessionsDb.getFeedbackSession(session.getCourseId(),
                 StringHelper.removeExtraSpace(session.getFeedbackSessionName())) != null) {
             throw new EntityAlreadyExistsException(
@@ -136,8 +135,7 @@ public class RepairFeedbackSessionNameWithExtraWhiteSpace extends RemoteApiClien
     /**
      * Removes extra space in feedbackSessionName in FeedbackResponseComments
      */
-    private void fixFeedbackResponseCommentsOfFeedbackSession(FeedbackSession session)
-            throws InvalidParametersException, EntityDoesNotExistException {
+    private void fixFeedbackResponseCommentsOfFeedbackSession(FeedbackSession session) {
         Query q = getPm().newQuery(FeedbackResponseComment.class);
         
         q.declareParameters("String feedbackSessionNameParam, String courseIdParam");
@@ -158,8 +156,7 @@ public class RepairFeedbackSessionNameWithExtraWhiteSpace extends RemoteApiClien
     /**
      * Removes extra space in feedbackSessionName in FeedbackResponses
      */
-    private void fixFeedbackResponsesOfFeedbackSession(FeedbackSession session)
-            throws InvalidParametersException, EntityDoesNotExistException {
+    private void fixFeedbackResponsesOfFeedbackSession(FeedbackSession session) {
         Query q = getPm().newQuery(FeedbackResponse.class);
         
         q.declareParameters("String feedbackSessionNameParam, String courseIdParam");
@@ -179,8 +176,7 @@ public class RepairFeedbackSessionNameWithExtraWhiteSpace extends RemoteApiClien
     /**
      * Removes extra space in feedbackSessionName in FeedbackQuestions
      */
-    private void fixFeedbackQuestionsOfFeedbackSession(FeedbackSession session)
-            throws InvalidParametersException, EntityDoesNotExistException {
+    private void fixFeedbackQuestionsOfFeedbackSession(FeedbackSession session) {
         Query q = getPm().newQuery(FeedbackQuestion.class);
         
         q.declareParameters("String feedbackSessionNameParam, String courseIdParam");

--- a/src/main/java/teammates/common/datatransfer/CourseDetailsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/CourseDetailsBundle.java
@@ -69,7 +69,7 @@ public class CourseDetailsBundle {
         Collections.sort(courses, new Comparator<CourseDetailsBundle>() {
             @Override
             public int compare(CourseDetailsBundle obj1, CourseDetailsBundle obj2) {
-                return (-1) * obj1.course.createdAt.compareTo(obj2.course.createdAt);
+                return obj2.course.createdAt.compareTo(obj1.course.createdAt);
             }
         });
     }

--- a/src/main/java/teammates/common/datatransfer/CourseSummaryBundle.java
+++ b/src/main/java/teammates/common/datatransfer/CourseSummaryBundle.java
@@ -47,7 +47,7 @@ public class CourseSummaryBundle {
         Collections.sort(courses, new Comparator<CourseSummaryBundle>() {
             @Override
             public int compare(CourseSummaryBundle obj1, CourseSummaryBundle obj2) {
-                return (-1) * obj1.course.createdAt.compareTo(obj2.course.createdAt);
+                return obj2.course.createdAt.compareTo(obj1.course.createdAt);
             }
         });
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumResponseDetails.java
@@ -18,9 +18,9 @@ public class FeedbackConstantSumResponseDetails extends
     public void extractResponseDetails(FeedbackQuestionType questionType,
             FeedbackQuestionDetails questionDetails, String[] answer) {
         List<Integer> constSumAnswer = new ArrayList<Integer>();
-        for (int i = 0; i < answer.length; i++) {
+        for (String element : answer) {
             try {
-                constSumAnswer.add(Integer.parseInt(answer[i]));
+                constSumAnswer.add(Integer.parseInt(element));
             } catch (NumberFormatException e) {
                 constSumAnswer.add(0);
             }

--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumResponseDetails.java
@@ -18,9 +18,9 @@ public class FeedbackConstantSumResponseDetails extends
     public void extractResponseDetails(FeedbackQuestionType questionType,
             FeedbackQuestionDetails questionDetails, String[] answer) {
         List<Integer> constSumAnswer = new ArrayList<Integer>();
-        for (String element : answer) {
+        for (String answerPart : answer) {
             try {
-                constSumAnswer.add(Integer.parseInt(element));
+                constSumAnswer.add(Integer.parseInt(answerPart));
             } catch (NumberFormatException e) {
                 constSumAnswer.add(0);
             }

--- a/src/main/java/teammates/common/datatransfer/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackMcqQuestionDetails.java
@@ -384,7 +384,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
         for (FeedbackResponseAttributes response : responses) {
             String answerString = response.getResponseDetails().getAnswerString();
             boolean isOtherOptionAnswer =
-                    ((FeedbackMcqResponseDetails) (response.getResponseDetails())).isOtherOptionAnswer();
+                    ((FeedbackMcqResponseDetails) response.getResponseDetails()).isOtherOptionAnswer();
             
             if (isOtherOptionAnswer) {
                 if (!answerFrequency.containsKey("Other")) {
@@ -435,7 +435,7 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
         for (FeedbackResponseAttributes response : responses) {
             String answerString = response.getResponseDetails().getAnswerString();
             boolean isOtherOptionAnswer =
-                    ((FeedbackMcqResponseDetails) (response.getResponseDetails())).isOtherOptionAnswer();
+                    ((FeedbackMcqResponseDetails) response.getResponseDetails()).isOtherOptionAnswer();
             
             if (isOtherOptionAnswer) {
                 if (!answerFrequency.containsKey("Other")) {

--- a/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackNumericalScaleQuestionDetails.java
@@ -694,7 +694,7 @@ public class FeedbackNumericalScaleQuestionDetails extends
     private String getPossibleValuesString() {
         double cur = minScale + step;
         int possibleValuesCount = 1;
-        while ((maxScale - cur) >= -1e-9) {
+        while (maxScale - cur >= -1e-9) {
             cur += step;
             possibleValuesCount++;
         }
@@ -711,7 +711,7 @@ public class FeedbackNumericalScaleQuestionDetails extends
         } else {
             possibleValuesString.append(Integer.toString(minScale));
             cur = minScale + step;
-            while ((maxScale - cur) >= -1e-9) {
+            while (maxScale - cur >= -1e-9) {
                 possibleValuesString.append(", ").append(StringHelper.toDecimalFormatString(cur));
                 cur += step;
             }

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionAttributes.java
@@ -93,11 +93,11 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
     }
 
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
     
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     public String getId() {
@@ -329,31 +329,31 @@ public class FeedbackQuestionAttributes extends EntityAttributes implements Comp
         final int prime = 31;
         int result = 1;
 
-        result = prime * result + ((courseId == null) ? 0 : courseId.hashCode());
+        result = prime * result + (courseId == null ? 0 : courseId.hashCode());
 
-        result = prime * result + ((creatorEmail == null) ? 0 : creatorEmail.hashCode());
+        result = prime * result + (creatorEmail == null ? 0 : creatorEmail.hashCode());
 
-        result = prime * result + ((feedbackSessionName == null) ? 0 : feedbackSessionName.hashCode());
+        result = prime * result + (feedbackSessionName == null ? 0 : feedbackSessionName.hashCode());
 
-        result = prime * result + ((giverType == null) ? 0 : giverType.hashCode());
+        result = prime * result + (giverType == null ? 0 : giverType.hashCode());
 
         result = prime * result + numberOfEntitiesToGiveFeedbackTo;
 
         result = prime * result + questionNumber;
 
-        result = prime * result + ((questionMetaData == null) ? 0 : questionMetaData.hashCode());
+        result = prime * result + (questionMetaData == null ? 0 : questionMetaData.hashCode());
 
-        result = prime * result + ((questionDescription == null) ? 0 : questionDescription.hashCode());
+        result = prime * result + (questionDescription == null ? 0 : questionDescription.hashCode());
 
-        result = prime * result + ((questionType == null) ? 0 : questionType.hashCode());
+        result = prime * result + (questionType == null ? 0 : questionType.hashCode());
 
-        result = prime * result + ((recipientType == null) ? 0 : recipientType.hashCode());
+        result = prime * result + (recipientType == null ? 0 : recipientType.hashCode());
 
-        result = prime * result + ((showGiverNameTo == null) ? 0 : showGiverNameTo.hashCode());
+        result = prime * result + (showGiverNameTo == null ? 0 : showGiverNameTo.hashCode());
 
-        result = prime * result + ((showRecipientNameTo == null) ? 0 : showRecipientNameTo.hashCode());
+        result = prime * result + (showRecipientNameTo == null ? 0 : showRecipientNameTo.hashCode());
 
-        result = prime * result + ((showResponsesTo == null) ? 0 : showResponsesTo.hashCode());
+        result = prime * result + (showResponsesTo == null ? 0 : showResponsesTo.hashCode());
 
         return result;
     }

--- a/src/main/java/teammates/common/datatransfer/FeedbackRankOptionsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackRankOptionsResponseDetails.java
@@ -24,9 +24,9 @@ public class FeedbackRankOptionsResponseDetails extends FeedbackRankResponseDeta
                                        FeedbackQuestionDetails questionDetails,
                                        String[] answer) {
         List<Integer> rankAnswer = new ArrayList<Integer>();
-        for (String element : answer) {
+        for (String answerPart : answer) {
             try {
-                rankAnswer.add(Integer.parseInt(element));
+                rankAnswer.add(Integer.parseInt(answerPart));
             } catch (NumberFormatException e) {
                 rankAnswer.add(Const.POINTS_NOT_SUBMITTED);
             }

--- a/src/main/java/teammates/common/datatransfer/FeedbackRankOptionsResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackRankOptionsResponseDetails.java
@@ -24,9 +24,9 @@ public class FeedbackRankOptionsResponseDetails extends FeedbackRankResponseDeta
                                        FeedbackQuestionDetails questionDetails,
                                        String[] answer) {
         List<Integer> rankAnswer = new ArrayList<Integer>();
-        for (int i = 0; i < answer.length; i++) {
+        for (String element : answer) {
             try {
-                rankAnswer.add(Integer.parseInt(answer[i]));
+                rankAnswer.add(Integer.parseInt(element));
             } catch (NumberFormatException e) {
                 rankAnswer.add(Const.POINTS_NOT_SUBMITTED);
             }

--- a/src/main/java/teammates/common/datatransfer/FeedbackResponseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackResponseAttributes.java
@@ -69,9 +69,9 @@ public class FeedbackResponseAttributes extends EntityAttributes {
         this.feedbackQuestionId = fr.getFeedbackQuestionId();
         this.feedbackQuestionType = fr.getFeedbackQuestionType();
         this.giver = fr.getGiverEmail();
-        this.giverSection = (fr.getGiverSection() == null) ? Const.DEFAULT_SECTION : fr.getGiverSection();
+        this.giverSection = fr.getGiverSection() == null ? Const.DEFAULT_SECTION : fr.getGiverSection();
         this.recipient = fr.getRecipientEmail();
-        this.recipientSection = (fr.getRecipientSection() == null) ? Const.DEFAULT_SECTION : fr.getRecipientSection();
+        this.recipientSection = fr.getRecipientSection() == null ? Const.DEFAULT_SECTION : fr.getRecipientSection();
         this.responseMetaData = fr.getResponseMetaData();
         this.createdAt = fr.getCreatedAt();
         this.updatedAt = fr.getUpdatedAt();
@@ -101,11 +101,11 @@ public class FeedbackResponseAttributes extends EntityAttributes {
     }
     
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     @Override

--- a/src/main/java/teammates/common/datatransfer/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackRubricResponseDetails.java
@@ -42,8 +42,8 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
         
         // Parse and extract answers
         String[] subQuestionResponses = rawResponses.split(Pattern.quote(","));
-        for (int i = 0; i < subQuestionResponses.length; i++) {
-            String[] subQuestionIndexAndChoice = subQuestionResponses[i].split(Pattern.quote("-"));
+        for (String subQuestionResponse : subQuestionResponses) {
+            String[] subQuestionIndexAndChoice = subQuestionResponse.split(Pattern.quote("-"));
             
             if (subQuestionIndexAndChoice.length != 2) {
                 // Expected length is 2.

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -1,10 +1,10 @@
 package teammates.common.datatransfer;
 
 import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -330,7 +330,8 @@ public class StudentAttributes extends EntityAttributes {
         }
     }
     
-    public CourseStudent toEntity() {
+    @Override
+    public Object toEntity() {
         return new CourseStudent(email, name, googleId, comments, course, team, section);
     }
     

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -101,10 +101,8 @@ public class StudentAttributes extends EntityAttributes {
         this.lastName = student.getLastName();
         this.comments = Sanitizer.sanitizeTextField(student.getComments());
         this.team = student.getTeamName();
-        this.section = student.getSectionName() == null ? Const.DEFAULT_SECTION
-                                                        : student.getSectionName();
-        this.googleId = student.getGoogleId() == null ? ""
-                                                      : student.getGoogleId();
+        this.section = student.getSectionName() == null ? Const.DEFAULT_SECTION : student.getSectionName();
+        this.googleId = student.getGoogleId() == null ? "" : student.getGoogleId();
         this.key = student.getRegistrationKey();
         
         this.createdAt = student.getCreatedAt();
@@ -379,11 +377,11 @@ public class StudentAttributes extends EntityAttributes {
     }
     
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     /**

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -19,14 +19,12 @@ import teammates.storage.entity.CourseStudent;
 
 public class StudentAttributes extends EntityAttributes {
     public enum UpdateStatus {
-        // @formatter:off
         ERROR(0),
         NEW(1),
         MODIFIED(2),
         UNMODIFIED(3),
         NOT_IN_ENROLL_LIST(4),
         UNKNOWN(5);
-        // @formatter:on
 
         public static final int STATUS_COUNT = 6;
         public final int numericRepresentation;
@@ -53,9 +51,7 @@ public class StudentAttributes extends EntityAttributes {
         }
     }
 
-    // @formatter:off
     // Note: be careful when changing these variables as their names are used in *.json files.
-    // @formatter:on
     public String googleId;
     public String email;
     public String course;

--- a/src/main/java/teammates/common/util/ActivityLogEntry.java
+++ b/src/main/java/teammates/common/util/ActivityLogEntry.java
@@ -235,7 +235,7 @@ public class ActivityLogEntry {
         message = tokens[POSITION_OF_MESSAGE];
         url = tokens[POSITION_OF_URL];
         
-        boolean isLogWithTimeTakenAndId = tokens.length >= (POSITION_OF_ID + 1);
+        boolean isLogWithTimeTakenAndId = tokens.length >= POSITION_OF_ID + 1;
         if (isLogWithTimeTakenAndId) {
             id = tokens[POSITION_OF_ID];
             try {

--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -11,7 +11,7 @@ import teammates.common.exception.NullPostParameterException;
  * support the assertions.is This file is a copy of org.junit.Assert v4.10.
  * Cannot use default java assert due to GAE environment restriction
  * 
- * @see Assert
+ * @see org.junit.Assert
  */
 public final class Assumption {
 

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -5,10 +5,11 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.joda.time.DateTimeZone;
+
 import teammates.common.datatransfer.FeedbackParticipantType;
 
 import com.google.appengine.api.datastore.Text;
-import org.joda.time.DateTimeZone;
 
 /**
  * Used to handle the data validation aspect e.g. validate emails, names, etc.
@@ -724,7 +725,7 @@ public class FieldValidator {
     }
     
     public String getValidityInfoForNonNullField(String fieldName, Object value) {
-        return (value == null) ? NON_NULL_FIELD_ERROR_MESSAGE.replace("${fieldName}", fieldName) : "";
+        return value == null ? NON_NULL_FIELD_ERROR_MESSAGE.replace("${fieldName}", fieldName) : "";
     }
 
     private boolean isUntrimmed(String value) {

--- a/src/main/java/teammates/common/util/HttpRequestHelper.java
+++ b/src/main/java/teammates/common/util/HttpRequestHelper.java
@@ -92,8 +92,8 @@ public final class HttpRequestHelper {
             String param = new String(f.nextElement().toString());
             requestParameters.append(param).append("::");
             String[] parameterValues = request.getParameterValues(param);
-            for (int j = 0; j < parameterValues.length; j++) {
-                requestParameters.append(parameterValues[j]).append("//");
+            for (String parameterValue : parameterValues) {
+                requestParameters.append(parameterValue).append("//");
             }
             requestParameters.setLength(requestParameters.length() - 2);
             requestParameters.append(", ");

--- a/src/main/java/teammates/common/util/Sanitizer.java
+++ b/src/main/java/teammates/common/util/Sanitizer.java
@@ -287,7 +287,7 @@ public final class Sanitizer {
      * @return the trimmed string or null (if the parameter was null).
      */
     private static String trimIfNotNull(String string) {
-        return (string == null) ? null : string.trim();
+        return string == null ? null : string.trim();
     }
     
     /**

--- a/src/main/java/teammates/common/util/StatusMessage.java
+++ b/src/main/java/teammates/common/util/StatusMessage.java
@@ -8,6 +8,7 @@ import teammates.common.util.Const.StatusMessageColor;
  * The {@code StatusMessage} class encapsulates the text of status message
  * and its level of seriousness of the status message (the color of the message).
  */
+@SuppressWarnings("serial")
 public class StatusMessage implements Serializable {
     private String text;
     private String color;

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -307,10 +307,10 @@ public final class StringHelper {
         return result;
     }
     
-    private static String byteArrayToHexString(byte[] b) {
-        StringBuilder sb = new StringBuilder(b.length * 2);
-        for (byte element : b) {
-            int v = element & 0xff;
+    private static String byteArrayToHexString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            int v = b & 0xff;
             if (v < 16) {
                 sb.append('0');
             }

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -309,8 +309,8 @@ public final class StringHelper {
     
     private static String byteArrayToHexString(byte[] b) {
         StringBuilder sb = new StringBuilder(b.length * 2);
-        for (int i = 0; i < b.length; i++) {
-            int v = b[i] & 0xff;
+        for (byte element : b) {
+            int v = element & 0xff;
             if (v < 16) {
                 sb.append('0');
             }
@@ -376,9 +376,9 @@ public final class StringHelper {
 
         StringBuilder result = new StringBuilder();
 
-        for (int i = 0; i < lines.length; i++) {
+        for (String line : lines) {
             
-            List<String> rowData = getTableData(lines[i]);
+            List<String> rowData = getTableData(line);
             
             if (checkIfEmptyRow(rowData)) {
                 continue;
@@ -402,15 +402,15 @@ public final class StringHelper {
 
         boolean inquote = false;
 
-        for (int i = 0; i < chars.length; i++) {
-            if (chars[i] == '"') {
+        for (char c : chars) {
+            if (c == '"') {
                 inquote = !inquote;
             }
 
-            if (chars[i] == '\n' && inquote) {
+            if (c == '\n' && inquote) {
                 buffer.append("<br>");
             } else {
-                buffer.append(chars[i]);
+                buffer.append(c);
             }
         }
 
@@ -524,7 +524,7 @@ public final class StringHelper {
      * @return empty string if null, the string itself otherwise
      */
     public static String convertToEmptyStringIfNull(String str) {
-        return (str == null) ? "" : str;
+        return str == null ? "" : str;
     }
     
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -6,7 +6,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -293,7 +292,7 @@ public final class TimeHelper {
      * Example: If now is 1055, this will return 1100
      */
     public static Date getNextHour() {
-        Calendar cal = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
         cal.add(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);

--- a/src/main/java/teammates/logic/automated/EmailAction.java
+++ b/src/main/java/teammates/logic/automated/EmailAction.java
@@ -147,8 +147,8 @@ public abstract class EmailAction {
         
         for (EmailWrapper email : emails) {
             String recipient = email.getRecipient();
-            String userName = extractUserName((String) email.getContent());
-            String regKey = extractRegistrationKey((String) email.getContent());
+            String userName = extractUserName(email.getContent());
+            String regKey = extractRegistrationKey(email.getContent());
             logData.put(recipient, new EmailData(userName, regKey));
         }
         

--- a/src/main/java/teammates/logic/core/CommentsLogic.java
+++ b/src/main/java/teammates/logic/core/CommentsLogic.java
@@ -8,7 +8,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import teammates.common.datatransfer.CommentAttributes;
 import teammates.common.datatransfer.CommentParticipantType;
@@ -28,7 +27,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.Sanitizer;
-import teammates.common.util.Utils;
 import teammates.storage.api.CommentsDb;
 import teammates.storage.api.InstructorsDb;
 import teammates.storage.api.StudentsDb;
@@ -39,9 +37,6 @@ import teammates.storage.api.StudentsDb;
 public class CommentsLogic {
     
     private static CommentsLogic instance;
-
-    @SuppressWarnings("unused") //used by test
-    private static final Logger log = Utils.getLogger();
 
     private static final CommentsDb commentsDb = new CommentsDb();
 

--- a/src/main/java/teammates/logic/core/EmailGenerator.java
+++ b/src/main/java/teammates/logic/core/EmailGenerator.java
@@ -6,8 +6,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import com.google.appengine.api.log.AppLogLine;
-
 import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
@@ -21,9 +19,11 @@ import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
-import teammates.common.util.TimeHelper;
 import teammates.common.util.Templates.EmailTemplates;
+import teammates.common.util.TimeHelper;
 import teammates.common.util.Utils;
+
+import com.google.appengine.api.log.AppLogLine;
 
 /**
  * Handles operations related to generating emails to be sent from provided templates.

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 
 import teammates.common.datatransfer.CommentSendingState;
 import teammates.common.datatransfer.CourseRoster;
@@ -22,15 +21,12 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
-import teammates.common.util.Utils;
 import teammates.storage.api.FeedbackResponseCommentsDb;
 
 /**
  * Handles the logic related to {@link FeedbackResponseCommentAttributes}.
  */
 public class FeedbackResponseCommentsLogic {
-    @SuppressWarnings("unused") //used by test
-    private static final Logger log = Utils.getLogger();
     
     private static FeedbackResponseCommentsLogic instance;
 

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -853,7 +853,7 @@ public class FeedbackSessionsLogic {
             String section, String filterText, boolean isMissingResponsesShown, boolean isStatsShown)
             throws EntityDoesNotExistException, ExceedingRangeException {
         
-        long indicatedRange = (section == null) ? 2000 : -1;
+        long indicatedRange = section == null ? 2000 : -1;
         FeedbackSessionResultsBundle results = getFeedbackSessionResultsForInstructorInSectionWithinRangeFromView(
                 feedbackSessionName, courseId, userEmail, section,
                 indicatedRange, Const.FeedbackSessionResults.QUESTION_SORT_TYPE);

--- a/src/main/java/teammates/logic/core/MailgunService.java
+++ b/src/main/java/teammates/logic/core/MailgunService.java
@@ -2,14 +2,14 @@ package teammates.logic.core;
 
 import javax.ws.rs.core.MediaType;
 
+import teammates.common.util.Config;
+import teammates.common.util.EmailWrapper;
+
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import com.sun.jersey.multipart.FormDataMultiPart;
-
-import teammates.common.util.Config;
-import teammates.common.util.EmailWrapper;
 
 /**
  * Email sender service provided by Mailgun.

--- a/src/main/java/teammates/logic/core/MailjetService.java
+++ b/src/main/java/teammates/logic/core/MailjetService.java
@@ -4,14 +4,14 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Jsoup;
 
+import teammates.common.util.Config;
+import teammates.common.util.EmailWrapper;
+
 import com.mailjet.client.MailjetClient;
 import com.mailjet.client.MailjetRequest;
 import com.mailjet.client.MailjetResponse;
 import com.mailjet.client.errors.MailjetException;
 import com.mailjet.client.resource.Email;
-
-import teammates.common.util.Config;
-import teammates.common.util.EmailWrapper;
 
 /**
  * Email sender service provided by Mailjet.

--- a/src/main/java/teammates/logic/core/SendgridService.java
+++ b/src/main/java/teammates/logic/core/SendgridService.java
@@ -2,13 +2,13 @@ package teammates.logic.core;
 
 import org.jsoup.Jsoup;
 
+import teammates.common.util.Config;
+import teammates.common.util.EmailWrapper;
+
 import com.sendgrid.SendGrid;
 import com.sendgrid.SendGrid.Email;
 import com.sendgrid.SendGrid.Response;
 import com.sendgrid.SendGridException;
-
-import teammates.common.util.Config;
-import teammates.common.util.EmailWrapper;
 
 /**
  * Email sender service provided by SendGrid.

--- a/src/main/java/teammates/logic/core/TaskQueuesLogic.java
+++ b/src/main/java/teammates/logic/core/TaskQueuesLogic.java
@@ -45,8 +45,8 @@ public class TaskQueuesLogic {
             String name = entry.getKey();
             String[] value = entry.getValue();
             
-            for (int i = 0; i < value.length; i++) {
-                taskToBeAdded = taskToBeAdded.param(name, value[i]);
+            for (String element : value) {
+                taskToBeAdded = taskToBeAdded.param(name, element);
             }
         }
         

--- a/src/main/java/teammates/logic/core/TaskQueuesLogic.java
+++ b/src/main/java/teammates/logic/core/TaskQueuesLogic.java
@@ -43,10 +43,10 @@ public class TaskQueuesLogic {
         
         for (Map.Entry<String, String[]> entry : paramMap.entrySet()) {
             String name = entry.getKey();
-            String[] value = entry.getValue();
+            String[] values = entry.getValue();
             
-            for (String element : value) {
-                taskToBeAdded = taskToBeAdded.param(name, element);
+            for (String value : values) {
+                taskToBeAdded = taskToBeAdded.param(name, value);
             }
         }
         

--- a/src/main/java/teammates/logic/core/TeamEvalResult.java
+++ b/src/main/java/teammates/logic/core/TeamEvalResult.java
@@ -342,12 +342,12 @@ public class TeamEvalResult {
         return output;
     }
 
-    private static double averageColumn(double[][] array, int columnIndex) {
+    private static double averageColumn(double[][] arrayOfArrays, int columnIndex) {
         double sum = 0;
         int count = 0;
         StringBuilder values = new StringBuilder();
-        for (double[] element : array) {
-            double value = element[columnIndex];
+        for (double[] array : arrayOfArrays) {
+            double value = array[columnIndex];
 
             values.append(value).append(' ');
             if (value == NA) {

--- a/src/main/java/teammates/logic/core/TeamEvalResult.java
+++ b/src/main/java/teammates/logic/core/TeamEvalResult.java
@@ -231,9 +231,8 @@ public class TeamEvalResult {
                 isSanitized(doubleToInt(input)));
 
         double sum = NA;
-        for (int i = 0; i < input.length; i++) {
+        for (double value : input) {
 
-            double value = input[i];
             if (value != NA) {
                 sum = sum == NA ? value : sum + value;
             }
@@ -281,8 +280,7 @@ public class TeamEvalResult {
     private static double calculateFactor(double[] input) {
         double actualSum = 0;
         int count = 0;
-        for (int j = 0; j < input.length; j++) {
-            double value = input[j];
+        for (double value : input) {
             int valueAsInt = (int) value;
             if (isSpecialValue(valueAsInt)) {
                 continue;
@@ -297,10 +295,11 @@ public class TeamEvalResult {
         return factor;
     }
 
+    @SuppressWarnings("PMD.AvoidArrayLoops") // the arrays are of different types
     private static double[] intToDouble(int[] input) {
         double[] converted = new double[input.length];
         for (int i = 0; i < input.length; i++) {
-            converted[i] = (double) input[i];
+            converted[i] = input[i];
         }
         return converted;
     }
@@ -316,7 +315,7 @@ public class TeamEvalResult {
     private static int[] doubleToInt(double[] input) {
         int[] converted = new int[input.length];
         for (int i = 0; i < input.length; i++) {
-            converted[i] = (int) (Math.round(input[i]));
+            converted[i] = (int) Math.round(input[i]);
         }
         return converted;
     }
@@ -347,8 +346,8 @@ public class TeamEvalResult {
         double sum = 0;
         int count = 0;
         StringBuilder values = new StringBuilder();
-        for (int j = 0; j < array.length; j++) {
-            double value = array[j][columnIndex];
+        for (double[] element : array) {
+            double value = element[columnIndex];
 
             values.append(value).append(' ');
             if (value == NA) {

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -154,7 +154,7 @@ public class AccountsDb extends EntitiesDb {
             
             // if the student profile has changed then update the store
             // this is to maintain integrity of the modified date.
-            if (!(existingProfile.toString().equals(a.studentProfile.toString()))) {
+            if (!existingProfile.toString().equals(a.studentProfile.toString())) {
                 accountToUpdate.setStudentProfile((StudentProfile) a.studentProfile.toEntity());
             }
         }

--- a/src/main/java/teammates/storage/api/CommentsDb.java
+++ b/src/main/java/teammates/storage/api/CommentsDb.java
@@ -356,20 +356,6 @@ public class CommentsDb extends EntitiesDb {
         getPm().close();
     }
     
-    // for now, this method is not being used as instructor cannot be receiver
-    @SuppressWarnings("unused")
-    private void updateInstructorEmailAsRecipient(String courseId, String oldInstrEmail, String updatedInstrEmail) {
-        List<Comment> recipientComments = this.getCommentEntitiesForRecipients(courseId,
-                                                       CommentParticipantType.INSTRUCTOR, oldInstrEmail);
-        
-        for (Comment recipientComment : recipientComments) {
-            recipientComment.setGiverEmail(updatedInstrEmail);
-        }
-        
-        log.info(Const.SystemParams.COURSE_BACKUP_LOG_MSG + courseId);
-        getPm().close();
-    }
-    
     /*
      * Update student email used in the comment with the new one
      */

--- a/src/main/java/teammates/storage/entity/Comment.java
+++ b/src/main/java/teammates/storage/entity/Comment.java
@@ -105,8 +105,8 @@ public class Comment {
         this.showRecipientNameTo = showRecipientNameTo;
         this.createdAt = date;
         this.commentText = comment;
-        this.lastEditorEmail = (lastEditorEmail == null) ? giverEmail : lastEditorEmail;
-        this.lastEditedAt = (lastEditedAt == null) ? date : lastEditedAt;
+        this.lastEditorEmail = lastEditorEmail == null ? giverEmail : lastEditorEmail;
+        this.lastEditedAt = lastEditedAt == null ? date : lastEditedAt;
     }
 
     public Long getId() {

--- a/src/main/java/teammates/storage/entity/CourseStudent.java
+++ b/src/main/java/teammates/storage/entity/CourseStudent.java
@@ -223,6 +223,7 @@ public class CourseStudent implements StoreCallback {
     /**
      * Called by jdo before storing takes place.
      */
+    @Override
     public void jdoPreStore() {
         this.setLastUpdate(new Date());
     }

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -110,11 +110,11 @@ public class FeedbackQuestion implements StoreCallback {
     }
 
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
     
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     public void setCreatedAt(Date newDate) {

--- a/src/main/java/teammates/storage/entity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponse.java
@@ -164,11 +164,11 @@ public class FeedbackResponse implements StoreCallback {
     }
 
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
 
     public void setCreatedAt(Date newDate) {

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -104,8 +104,8 @@ public class FeedbackResponseComment {
         this.showCommentTo = showCommentTo;
         this.showGiverNameTo = showGiverNameTo;
         this.isVisibilityFollowingFeedbackQuestion = false;
-        this.lastEditorEmail = (lastEditorEmail == null) ? giverEmail : lastEditorEmail;
-        this.lastEditedAt = (lastEditedAt == null) ? createdAt : lastEditedAt;
+        this.lastEditorEmail = lastEditorEmail == null ? giverEmail : lastEditorEmail;
+        this.lastEditedAt = lastEditedAt == null ? createdAt : lastEditedAt;
     }
 
     /** Use only if the comment already persisted

--- a/src/main/java/teammates/storage/search/SearchQuery.java
+++ b/src/main/java/teammates/storage/search/SearchQuery.java
@@ -72,8 +72,8 @@ public class SearchQuery {
         List<String> keywords = new ArrayList<String>();
         StringBuilder key = new StringBuilder();
         boolean isStartQuote = false;
-        for (int i = 0; i < splitStrings.length; i++) {
-            if (splitStrings[i].equals("\"")) {
+        for (String splitString : splitStrings) {
+            if ("\"".equals(splitString)) {
                 if (isStartQuote) {
                     String trimmedKey = key.toString().trim();
                     isStartQuote = false;
@@ -86,9 +86,9 @@ public class SearchQuery {
                 }
             } else {
                 if (isStartQuote) {
-                    key.append(' ').append(splitStrings[i]);
+                    key.append(' ').append(splitString);
                 } else {
-                    keywords.add(splitStrings[i]);
+                    keywords.add(splitString);
                 }
             }
         }

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -127,8 +127,8 @@ public class AdminActivityLogPageData extends PageData {
      * value is converted to lower case before comparing
      */
     private boolean arrayContains(String[] arr, String value) {
-        for (int i = 0; i < arr.length; i++) {
-            if (arr[i].equals(value.toLowerCase().trim())) {
+        for (String element : arr) {
+            if (element.equals(value.toLowerCase().trim())) {
                 return true;
             }
         }
@@ -261,8 +261,8 @@ public class AdminActivityLogPageData extends PageData {
                                .replaceAll(": ", ":")
                                .split("\\|", -1);
          
-        for (int i = 0; i < tokens.length; i++) {
-            String[] pair = tokens[i].split(":", -1);
+        for (String token : tokens) {
+            String[] pair = token.split(":", -1);
             
             if (pair.length != 2) {
                 throw new InvalidParametersException("Invalid format");
@@ -276,8 +276,8 @@ public class AdminActivityLogPageData extends PageData {
                 //version is specified in com.google.appengine.api.log.LogQuery,
                 //it does not belong to the internal class "QueryParameters"
                 //so need to store here for future use
-                for (int j = 0; j < values.length; j++) {
-                    versions.add(values[j].replace(".", "-"));
+                for (String value : values) {
+                    versions.add(value.replace(".", "-"));
                 }
                 
             } else if ("from".equals(label)) {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -126,8 +126,8 @@ public class AdminActivityLogPageData extends PageData {
      * Checks in an array contains a specific value
      * value is converted to lower case before comparing
      */
-    private boolean arrayContains(String[] arr, String value) {
-        for (String element : arr) {
+    private boolean arrayContains(String[] array, String value) {
+        for (String element : array) {
             if (element.equals(value.toLowerCase().trim())) {
                 return true;
             }

--- a/src/main/java/teammates/ui/controller/AdminEmailLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailLogPageData.java
@@ -112,8 +112,8 @@ public class AdminEmailLogPageData extends PageData {
                                .replaceAll(": ", ":")
                                .split("\\|", -1);
        
-        for (int i = 0; i < tokens.length; i++) {
-            String[] pair = tokens[i].split(":", -1);
+        for (String token : tokens) {
+            String[] pair = token.split(":", -1);
             
             if (pair.length != 2) {
                 throw new InvalidParametersException("Invalid format");
@@ -126,8 +126,8 @@ public class AdminEmailLogPageData extends PageData {
                 //version is specified in com.google.appengine.api.log.LogQuery,
                 //it does not belong to the internal class "QueryParameters"
                 //so need to store here for future use
-                for (int j = 0; j < values.length; j++) {
-                    getVersions().add(values[j].replace(".", "-"));
+                for (String value : values) {
+                    getVersions().add(value.replace(".", "-"));
                 }
                 
             } else {

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -284,7 +284,7 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
             response.recipientSection = StudentsLogic.inst().getSectionForTeam(courseId, response.recipient);
         } else if (recipientType == FeedbackParticipantType.STUDENTS) {
             StudentAttributes student = logic.getStudentForEmail(courseId, response.recipient);
-            response.recipientSection = (student == null) ? Const.DEFAULT_SECTION : student.section;
+            response.recipientSection = student == null ? Const.DEFAULT_SECTION : student.section;
         } else {
             response.recipientSection = getUserSectionForCourse();
         }

--- a/src/main/java/teammates/ui/controller/InstructorCourseEnrollPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEnrollPageAction.java
@@ -1,7 +1,6 @@
 package teammates.ui.controller;
 
 import teammates.common.datatransfer.InstructorAttributes;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.StatusMessage;
@@ -13,7 +12,7 @@ import teammates.logic.api.GateKeeper;
 public class InstructorCourseEnrollPageAction extends Action {
     
     @Override
-    public ActionResult execute() throws EntityDoesNotExistException {
+    public ActionResult execute() {
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
         String studentsInfo = getRequestParamValue(Const.ParamsNames.STUDENTS_ENROLLMENT_INFO);
 
@@ -33,7 +32,7 @@ public class InstructorCourseEnrollPageAction extends Action {
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSE_ENROLL, pageData);
     }
 
-    private void addDataLossWarningToStatusToUser(String courseId) throws EntityDoesNotExistException {
+    private void addDataLossWarningToStatusToUser(String courseId) {
         if (hasExistingResponses(courseId)) {
             statusToUser.add(new StatusMessage(Const.StatusMessages.COURSE_ENROLL_POSSIBLE_DATA_LOSS,
                                                Const.StatusMessageColor.WARNING));

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageData.java
@@ -5,8 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
@@ -25,6 +23,8 @@ import teammates.ui.template.FeedbackQuestionVisibilitySettings;
 import teammates.ui.template.FeedbackSessionPreviewForm;
 import teammates.ui.template.FeedbackSessionsAdditionalSettingsFormSegment;
 import teammates.ui.template.FeedbackSessionsForm;
+
+import com.google.appengine.api.datastore.Text;
 
 public class InstructorFeedbackEditPageData extends PageData {
     

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackQuestionDetails;
@@ -18,6 +16,8 @@ import teammates.common.util.Const.StatusMessageColor;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.StatusMessage;
 import teammates.logic.api.GateKeeper;
+
+import com.google.appengine.api.datastore.Text;
 
 public class InstructorFeedbackQuestionAddAction extends Action {
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackQuestionDetails;
@@ -22,6 +20,8 @@ import teammates.common.util.Const.StatusMessageColor;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.StatusMessage;
 import teammates.logic.api.GateKeeper;
+
+import com.google.appengine.api.datastore.Text;
 
 public class InstructorFeedbackQuestionEditAction extends Action {
 

--- a/src/main/java/teammates/ui/controller/InstructorSearchPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorSearchPageAction.java
@@ -118,12 +118,12 @@ public class InstructorSearchPageAction extends Action {
                 boolean isVisibleResponse = true;
                 boolean isNotAllowedForInstructor =
                             instructor == null
-                            || !(instructor.isAllowedForPrivilege(
+                            || !instructor.isAllowedForPrivilege(
                                     response.giverSection, response.feedbackSessionName,
-                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS))
-                            || !(instructor.isAllowedForPrivilege(
+                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS)
+                            || !instructor.isAllowedForPrivilege(
                                     response.recipientSection, response.feedbackSessionName,
-                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS));
+                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS);
                 
                 if (isNotAllowedForInstructor) {
                     isVisibleResponse = false;
@@ -142,7 +142,7 @@ public class InstructorSearchPageAction extends Action {
         Iterator<Entry<String, List<FeedbackQuestionAttributes>>> iterQn =
                 frCommentSearchResults.questions.entrySet().iterator();
         while (iterQn.hasNext()) {
-            String fsName = (String) iterQn.next().getKey();
+            String fsName = iterQn.next().getKey();
             List<FeedbackQuestionAttributes> questionList = frCommentSearchResults.questions.get(fsName);
 
             for (int i = questionList.size() - 1; i >= 0; i--) {

--- a/src/main/java/teammates/ui/controller/InstructorStudentCommentAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentCommentAddAction.java
@@ -81,7 +81,7 @@ public class InstructorStudentCommentAddAction extends Action {
         //TODO: remove fromCommentsPage
         if (isFromCommentsPage) {
             return createRedirectResult(
-                           (new PageData(account).getInstructorCommentsLink())
+                           new PageData(account).getInstructorCommentsLink()
                            + "&" + Const.ParamsNames.COURSE_ID + "=" + courseId);
         } else if (isFromStudentDetailsPage) {
             return createRedirectResult(getCourseStudentDetailsLink(courseId, studentEmail));

--- a/src/main/java/teammates/ui/controller/InstructorStudentCommentClearPendingAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentCommentClearPendingAction.java
@@ -61,8 +61,8 @@ public class InstructorStudentCommentClearPendingAction extends Action {
             statusToAdmin = "Successful: " + account.googleId + " cleared pending comments for course " + courseId;
         }
         
-        return createRedirectResult((new PageData(account).getInstructorCommentsLink()) + "&"
-                                     + Const.ParamsNames.COURSE_ID + "=" + courseId);
+        return createRedirectResult(new PageData(account).getInstructorCommentsLink() + "&"
+                                    + Const.ParamsNames.COURSE_ID + "=" + courseId);
     }
     
     private int getPendingCommentsSize(String courseId) throws EntityDoesNotExistException {

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -3,7 +3,6 @@ package teammates.ui.controller;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
 import java.util.TimeZone;
@@ -859,7 +858,7 @@ public class PageData {
     private static boolean isTimeToBeSelected(Date timeToShowAsSelected, int hourOfTheOption) {
         boolean isEditingExistingFeedbackSession = timeToShowAsSelected != null;
         if (isEditingExistingFeedbackSession) {
-            Calendar cal = GregorianCalendar.getInstance(TimeZone.getTimeZone("UTC"));
+            Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
             cal.setTime(timeToShowAsSelected);
             if (cal.get(Calendar.MINUTE) == 0) {
                 if (cal.get(Calendar.HOUR_OF_DAY) == hourOfTheOption) {

--- a/src/main/java/teammates/ui/datatransfer/InstructorStudentListPageCourseData.java
+++ b/src/main/java/teammates/ui/datatransfer/InstructorStudentListPageCourseData.java
@@ -1,6 +1,8 @@
 package teammates.ui.datatransfer;
 
 import teammates.common.datatransfer.CourseAttributes;
+import teammates.ui.controller.InstructorStudentListPageAction;
+import teammates.ui.controller.InstructorStudentListPageData;
 
 /**
  * Serves as a datatransfer class between {@link InstructorStudentListPageAction}

--- a/src/main/java/teammates/ui/template/FeedbackSubmissionEditQuestion.java
+++ b/src/main/java/teammates/ui/template/FeedbackSubmissionEditQuestion.java
@@ -2,11 +2,11 @@ package teammates.ui.template;
 
 import java.util.List;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackQuestionType;
+
+import com.google.appengine.api.datastore.Text;
 
 public class FeedbackSubmissionEditQuestion {
     private String courseId;

--- a/src/main/resources/feedbackQuestionConstSumResultStatsOptionFragment.html
+++ b/src/main/resources/feedbackQuestionConstSumResultStatsOptionFragment.html
@@ -3,7 +3,7 @@
         ${constSumOptionValue}
     </td>
     <td>
-    	${pointsReceived}
+        ${pointsReceived}
     </td>
     <td>
         ${averagePoints}

--- a/src/main/resources/feedbackQuestionContribSubmissionFormTemplate.html
+++ b/src/main/resources/feedbackQuestionContribSubmissionFormTemplate.html
@@ -1,5 +1,5 @@
 <div class="col-sm-3 mobile-no-padding">
-	<select class="form-control" name="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}" ${disabled}>
-		${contribSelectFragmentsHtml}
-	</select>
+    <select class="form-control" name="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}" ${disabled}>
+        ${contribSelectFragmentsHtml}
+    </select>
 </div>

--- a/src/main/resources/feedbackQuestionRankResultStatsOptionFragment.html
+++ b/src/main/resources/feedbackQuestionRankResultStatsOptionFragment.html
@@ -3,7 +3,7 @@
         ${rankOptionValue}
     </td>
     <td>
-    	${ranksReceived}
+        ${ranksReceived}
     </td>
     <td>
         ${averageRank}

--- a/src/main/resources/feedbackQuestionRankSubmissionFormOptionFragment.html
+++ b/src/main/resources/feedbackQuestionRankSubmissionFormOptionFragment.html
@@ -2,9 +2,9 @@
     <label class="col-sm-2 control-label" ${rankOptionVisibility}>${rankOptionValue}</label>
     <div class="col-sm-3">
         <select class="form-control" ${disabled} 
-        		id="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}-${optionIdx}"
-        		name="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}"
-        		onChange="updateRankMessageQn('${questionIndex}')">
+                id="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}-${optionIdx}"
+                name="${Const.ParamsNames.FEEDBACK_RESPONSE_TEXT}-${questionIndex}-${responseIndex}"
+                onChange="updateRankMessageQn('${questionIndex}')">
             ${options}
         </select>
     </div>

--- a/src/main/resources/feedbackQuestionRankSubmissionFormTemplate.html
+++ b/src/main/resources/feedbackQuestionRankSubmissionFormTemplate.html
@@ -1,14 +1,14 @@
 <div>
     ${rankSubmissionFormOptionFragments}
     <div id="rankInfo-${questionIndex}-${responseIndex}" class="form-group" ${rankOptionVisibility}>
-    	<div class="col-sm-2" ${rankOptionVisibility}>
-    	</div>
-    	<div class="col-sm-3">
-    		<hr class="margin-top-0">
-    		<p class="text-color-blue" id="rankMessage-${questionIndex}-${responseIndex}">
-    		</p>
-    		<hr>
-    	</div>
+        <div class="col-sm-2" ${rankOptionVisibility}>
+        </div>
+        <div class="col-sm-3">
+            <hr class="margin-top-0">
+            <p class="text-color-blue" id="rankMessage-${questionIndex}-${responseIndex}">
+            </p>
+            <hr>
+        </div>
     </div>
     <input type="hidden" id="${Const.ParamsNames.FEEDBACK_QUESTION_RANKTORECIPIENTS}-${questionIndex}" value="${rankToRecipientsValue}">
     <input type="hidden" id="${Const.ParamsNames.FEEDBACK_QUESTION_RANKNUMOPTION}-${questionIndex}" value="${rankNumOptionValue}">

--- a/src/main/resources/feedbackQuestionRubricEditFormBody.html
+++ b/src/main/resources/feedbackQuestionRubricEditFormBody.html
@@ -1,12 +1,12 @@
 <tr id="rubricRow-${questionIndex}-${row}">
     <td>
-    	<div class="col-sm-12 input-group">
-    		<span class="input-group-addon btn btn-default rubricRemoveSubQuestionLink-${questionIndex}" id="rubricRemoveSubQuestionLink-${questionIndex}-${row}" onclick="removeRubricRow(${row},${questionIndex})"
-    		onmouseover="highlightRubricRow(${row}, ${questionIndex}, true)" onmouseout="highlightRubricRow(${row}, ${questionIndex}, false)">
-				<span class="glyphicon glyphicon-remove"></span>
-			</span>
-	    	<textarea class="form-control" rows="3" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICSUBQUESTION}-${questionIndex}-${row}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICSUBQUESTION}-${row}">${subQuestion}</textarea>
-		</div>
+        <div class="col-sm-12 input-group">
+            <span class="input-group-addon btn btn-default rubricRemoveSubQuestionLink-${questionIndex}" id="rubricRemoveSubQuestionLink-${questionIndex}-${row}" onclick="removeRubricRow(${row},${questionIndex})"
+            onmouseover="highlightRubricRow(${row}, ${questionIndex}, true)" onmouseout="highlightRubricRow(${row}, ${questionIndex}, false)">
+                <span class="glyphicon glyphicon-remove"></span>
+            </span>
+            <textarea class="form-control" rows="3" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICSUBQUESTION}-${questionIndex}-${row}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICSUBQUESTION}-${row}">${subQuestion}</textarea>
+        </div>
     </td>
     ${rubricRowBodyFragments}
 </tr>

--- a/src/main/resources/feedbackQuestionRubricEditFormBodyFragment.html
+++ b/src/main/resources/feedbackQuestionRubricEditFormBodyFragment.html
@@ -1,3 +1,3 @@
 <td class="align-center rubricCol-${questionIndex}-${col}">
-	<textarea class="form-control nonDestructive" rows="3" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICDESCRIPTION}-${questionIndex}-${row}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICDESCRIPTION}-${row}-${col}">${description}</textarea>
+    <textarea class="form-control nonDestructive" rows="3" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICDESCRIPTION}-${questionIndex}-${row}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICDESCRIPTION}-${row}-${col}">${description}</textarea>
 </td>

--- a/src/main/resources/feedbackQuestionRubricEditFormHeaderFragment.html
+++ b/src/main/resources/feedbackQuestionRubricEditFormHeaderFragment.html
@@ -1,9 +1,9 @@
 <th class="rubricCol-${questionIndex}-${col}">
-	<div class="col-sm-12 input-group">
-		<input type="text" class="form-control" value="${rubricChoiceValue}" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${col}">
-		<span class="input-group-addon btn btn-default rubricRemoveChoiceLink-${questionIndex}" id="rubricRemoveChoiceLink-${questionIndex}-${col}" onclick="removeRubricCol(${col}, ${questionIndex})"
-		onmouseover="highlightRubricCol(${col}, ${questionIndex}, true)" onmouseout="highlightRubricCol(${col}, ${questionIndex}, false)">
-			<span class="glyphicon glyphicon-remove"></span>
-		</span>
-	</div>
+    <div class="col-sm-12 input-group">
+        <input type="text" class="form-control" value="${rubricChoiceValue}" id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${col}">
+        <span class="input-group-addon btn btn-default rubricRemoveChoiceLink-${questionIndex}" id="rubricRemoveChoiceLink-${questionIndex}-${col}" onclick="removeRubricCol(${col}, ${questionIndex})"
+        onmouseover="highlightRubricCol(${col}, ${questionIndex}, true)" onmouseout="highlightRubricCol(${col}, ${questionIndex}, false)">
+            <span class="glyphicon glyphicon-remove"></span>
+        </span>
+    </div>
 </th>

--- a/src/main/resources/feedbackQuestionRubricResultStatsBody.html
+++ b/src/main/resources/feedbackQuestionRubricResultStatsBody.html
@@ -1,6 +1,6 @@
 <tr>
     <td>
-    	<p>${subQuestion}</p>
+        <p>${subQuestion}</p>
     </td>
     ${rubricRowBodyFragments}
 </tr>

--- a/src/main/resources/feedbackQuestionRubricResultStatsBodyFragment.html
+++ b/src/main/resources/feedbackQuestionRubricResultStatsBodyFragment.html
@@ -1,3 +1,3 @@
 <td>
-	${percentageFrequencyOrAverage}
+    ${percentageFrequencyOrAverage}
 </td>

--- a/src/main/resources/feedbackQuestionRubricResultStatsHeaderFragment.html
+++ b/src/main/resources/feedbackQuestionRubricResultStatsHeaderFragment.html
@@ -1,3 +1,3 @@
 <th>
-	<p>${rubricChoiceValue}</p>
+    <p>${rubricChoiceValue}</p>
 </th>

--- a/src/main/resources/feedbackQuestionRubricSubmissionFormBody.html
+++ b/src/main/resources/feedbackQuestionRubricSubmissionFormBody.html
@@ -1,6 +1,6 @@
 <tr>
     <td>
-    	<p>${subQuestion}</p>
+        <p>${subQuestion}</p>
     </td>
     ${rubricRowBodyFragments}
 </tr>

--- a/src/main/resources/feedbackQuestionRubricSubmissionFormBodyFragment.html
+++ b/src/main/resources/feedbackQuestionRubricSubmissionFormBodyFragment.html
@@ -1,3 +1,3 @@
 <td class="col-md-1">
-	<input class="overlay" type="radio" ${disabled} id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${responseIndex}-${row}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${responseIndex}-${row}" value="${row}-${col}" ${checked}/><span class="color_neutral overlay"> ${description}</span>
+    <input class="overlay" type="radio" ${disabled} id="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${responseIndex}-${row}-${col}" name="${Const.ParamsNames.FEEDBACK_QUESTION_RUBRICCHOICE}-${questionIndex}-${responseIndex}-${row}" value="${row}-${col}" ${checked}/><span class="color_neutral overlay"> ${description}</span>
 </td>

--- a/src/main/resources/feedbackQuestionRubricSubmissionFormHeaderFragment.html
+++ b/src/main/resources/feedbackQuestionRubricSubmissionFormHeaderFragment.html
@@ -1,3 +1,3 @@
 <th class="rubricCol-${questionIndex}-${col}">
-	<p>${rubricChoiceValue}</p>
+    <p>${rubricChoiceValue}</p>
 </th>

--- a/src/main/webapp/BingSiteAuth.xml
+++ b/src/main/webapp/BingSiteAuth.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <users>
-	<user>56A4EF5E6C4299FC31610A80208189B6</user>
+    <user>56A4EF5E6C4299FC31610A80208189B6</user>
 </users>

--- a/src/main/webapp/WEB-INF/queue.xml
+++ b/src/main/webapp/WEB-INF/queue.xml
@@ -97,10 +97,10 @@
   <bucket-size>20</bucket-size> 
   <retry-parameters>
       <task-retry-limit>5</task-retry-limit>
-	  <task-age-limit>1d</task-age-limit>
-	  <min-backoff-seconds>30</min-backoff-seconds>
+      <task-age-limit>1d</task-age-limit>
+      <min-backoff-seconds>30</min-backoff-seconds>
       <max-backoff-seconds>300</max-backoff-seconds>
-	  <max-doublings>0</max-doublings>
+      <max-doublings>0</max-doublings>
   </retry-parameters>  
 </queue>   
 </queue-entries> 

--- a/src/main/webapp/WEB-INF/tags/instructor/comments/search.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/comments/search.tag
@@ -10,26 +10,26 @@
 <div class="well well-plain">
     <div class="row">
         <div class="col-md-12">
-			<form method="get" action="${instructorSearchLink}" name="search_form">
-			    <div class="input-group">
-			        <input type="text" name="<%= Const.ParamsNames.SEARCH_KEY %>"
-			            title="Search for comment"
-			            class="form-control"
-			            placeholder="Any info related to comments"
-			            id="searchBox"> 
-			        <span class="input-group-btn">
-			            <button class="btn btn-default"
-			                type="submit" value="Search"
-			                id="buttonSearch">
-			                Search
-			            </button>
-			        </span>
-			    </div>
-			    <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_STUDENTS %>" value="true">
-			    <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_RESPONSES %>" value="true">
-			    <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-			</form>
-			<comments:filter displayArchive="${displayArchive}" instructorCommentsLink="${instructorCommentsLink}" commentsForStudentsTables="${commentsForStudentsTables}" feedbackSessions="${feedbackSessions}"/>
-		</div>
-	</div>
+            <form method="get" action="${instructorSearchLink}" name="search_form">
+                <div class="input-group">
+                    <input type="text" name="<%= Const.ParamsNames.SEARCH_KEY %>"
+                        title="Search for comment"
+                        class="form-control"
+                        placeholder="Any info related to comments"
+                        id="searchBox"> 
+                    <span class="input-group-btn">
+                        <button class="btn btn-default"
+                            type="submit" value="Search"
+                            id="buttonSearch">
+                            Search
+                        </button>
+                    </span>
+                </div>
+                <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_STUDENTS %>" value="true">
+                <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_RESPONSES %>" value="true">
+                <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+            </form>
+            <comments:filter displayArchive="${displayArchive}" instructorCommentsLink="${instructorCommentsLink}" commentsForStudentsTables="${commentsForStudentsTables}" feedbackSessions="${feedbackSessions}"/>
+        </div>
+    </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/search.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/search.tag
@@ -4,27 +4,27 @@
 <div class="well well-plain">
     <div class="row">
         <div class="col-md-12">
-			<form method="get" action="${data.instructorSearchLink}" 
-			      name="search_form">
-			    <div class="input-group">
-			        <input type="text" id="searchbox"
-			               title="<%= Const.Tooltips.SEARCH_STUDENT %>"
-			               name="<%= Const.ParamsNames.SEARCH_KEY %>"
-			               class="form-control"
-			               data-toggle="tooltip"
-			               data-placement="top"
-			               placeholder="e.g. Charles Shultz, charles@gmail.com">
-			        <span class="input-group-btn">
-			            <button class="btn btn-default" type="submit" value="Search" id="buttonSearch">
-			                Search
-			            </button>
-			        </span> 
-			    </div>
-			    <input type="hidden" name="<%= Const.ParamsNames.SEARCH_STUDENTS %>" value="true">
-			    <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_STUDENTS %>" value="false">
-			    <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_RESPONSES %>" value="false">
-			    <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-			</form>
-		</div>
-	</div>
+            <form method="get" action="${data.instructorSearchLink}" 
+                  name="search_form">
+                <div class="input-group">
+                    <input type="text" id="searchbox"
+                           title="<%= Const.Tooltips.SEARCH_STUDENT %>"
+                           name="<%= Const.ParamsNames.SEARCH_KEY %>"
+                           class="form-control"
+                           data-toggle="tooltip"
+                           data-placement="top"
+                           placeholder="e.g. Charles Shultz, charles@gmail.com">
+                    <span class="input-group-btn">
+                        <button class="btn btn-default" type="submit" value="Search" id="buttonSearch">
+                            Search
+                        </button>
+                    </span> 
+                </div>
+                <input type="hidden" name="<%= Const.ParamsNames.SEARCH_STUDENTS %>" value="true">
+                <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_STUDENTS %>" value="false">
+                <input type="hidden" name="<%= Const.ParamsNames.SEARCH_COMMENTS_FOR_RESPONSES %>" value="false">
+                <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+            </form>
+        </div>
+    </div>
 </div>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -221,7 +221,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <url-pattern>/compileLogs</url-pattern>
     </servlet-mapping>
     
-	<servlet>
+    <servlet>
         <servlet-name>EntityModifiedLogs</servlet-name>
         <servlet-class>teammates.logic.automated.EntityModifiedLogsServlet</servlet-class>
     </servlet>
@@ -229,7 +229,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <servlet-name>EntityModifiedLogs</servlet-name>
         <url-pattern>/entityModifiedLogs</url-pattern>
     </servlet-mapping>
-	
+    
     <servlet>
         <description>Servlet that handles all incoming requests</description>
         <servlet-name>ControllerServlet</servlet-name>

--- a/src/main/webapp/js/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/js/feedbackSubmissionsEdit.js
@@ -959,7 +959,7 @@ function getWarningMessage() {
  * @param charCountId - Id of Label to display length of text area
  */
 function updateTextQuestionWordsCount(textAreaId, wordsCountId, recommendedLength) {
-	
+
     var response = $('#' + textAreaId).val();
     var $wordsCountElement = $('#' + wordsCountId);
 

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -563,7 +563,7 @@ function tallyCheckboxes(questionNum) {
  */
 function showNewQuestionFrame(type) {
     $('#questiontype').val(type);
-	
+
     copyOptions();
     prepareQuestionForm(type);
     $('#questionTable-' + NEW_QUESTION).show();

--- a/src/main/webapp/jsp/instructorFeedbackCopyModal.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackCopyModal.jsp
@@ -21,9 +21,9 @@
                    value="${course.id}">
             <c:choose>
                 <c:when test="${course.id == data.courseId}">
-	                [<span class="text-color-red">${course.id}</span>] : ${course.name}
-	                <br>
-	                <span class="text-color-red small">{Session currently in this course}</span> 
+                    [<span class="text-color-red">${course.id}</span>] : ${course.name}
+                    <br>
+                    <span class="text-color-red small">{Session currently in this course}</span> 
                 </c:when>
                 <c:otherwise>
                     [${course.id}] : ${course.name}

--- a/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
+++ b/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
@@ -9,54 +9,54 @@
 <ts:studentPage pageTitle="TEAMMATES - Student" bodyTitle="" jsIncludes="${jsIncludes}">
     <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
     <br>
-	<div class="panel panel-primary panel-narrow">
-	    <div class="panel-heading">
-	        <h4>Confirm your Google account</h4>
-	    </div>
-	    <div class="panel-body">
-	        <p>
-	            You are currently logged in as <span><strong>${data.account.googleId}</strong></span>.
-	            <c:if test="${data.redirectResult}">
-	                You have been redirected to this page because you navigated to a link for the course <strong>${data.courseId}</strong>, which you have not been registered in.
-	            </c:if>
-	            <br>
-	            <c:choose>
-	                <c:when test="${data.redirectResult}">
-	                    If you wish to register as <strong>${data.account.googleId}</strong>, please confirm below to complete your registration.
-	                    <br>If you wish to register with another Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> or do not wish to register for this course</c:if>, please
-	                    <a href="${data.logoutUrl}">log out</a>, log in with your desired Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> if necessary</c:if>, and navigate to the link again.
-	                    <br>
-	                </c:when>
-	                <c:otherwise>
-	                    If this is not you please <a href="${data.logoutUrl}">log out</a> and re-login using your own Google account.
-	                    <br>If this is you, please confirm below to complete your registration.
-	                    <br>
-	                </c:otherwise>
-	            </c:choose>
-	        </p>
-	        <div class="align-center">
-	            <a href="${data.confirmUrl}" class="btn btn-success" id="button_confirm">
-	                <c:choose>
-	                    <c:when test="${data.redirectResult}">
-	                        Register as <strong>${data.account.googleId}</strong>
-	                    </c:when>
-	                    <c:otherwise>
-	                        Yes, this is my account
-	                    </c:otherwise>
-	                </c:choose>
-	            </a>
-	            <a href="${data.logoutUrl}" class="btn btn-danger" id="button_cancel">
-	                <c:choose>
-	                    <c:when test="${data.redirectResult}">
-	                        Do not register as <strong>${data.account.googleId}</strong>
-	                    </c:when>
-	                    <c:otherwise>
-	                        No, this is not my account
-	                    </c:otherwise>
-	                </c:choose>
-	            </a>
-	        </div>
-	        
-	    </div>
-	</div>
+    <div class="panel panel-primary panel-narrow">
+        <div class="panel-heading">
+            <h4>Confirm your Google account</h4>
+        </div>
+        <div class="panel-body">
+            <p>
+                You are currently logged in as <span><strong>${data.account.googleId}</strong></span>.
+                <c:if test="${data.redirectResult}">
+                    You have been redirected to this page because you navigated to a link for the course <strong>${data.courseId}</strong>, which you have not been registered in.
+                </c:if>
+                <br>
+                <c:choose>
+                    <c:when test="${data.redirectResult}">
+                        If you wish to register as <strong>${data.account.googleId}</strong>, please confirm below to complete your registration.
+                        <br>If you wish to register with another Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> or do not wish to register for this course</c:if>, please
+                        <a href="${data.logoutUrl}">log out</a>, log in with your desired Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> if necessary</c:if>, and navigate to the link again.
+                        <br>
+                    </c:when>
+                    <c:otherwise>
+                        If this is not you please <a href="${data.logoutUrl}">log out</a> and re-login using your own Google account.
+                        <br>If this is you, please confirm below to complete your registration.
+                        <br>
+                    </c:otherwise>
+                </c:choose>
+            </p>
+            <div class="align-center">
+                <a href="${data.confirmUrl}" class="btn btn-success" id="button_confirm">
+                    <c:choose>
+                        <c:when test="${data.redirectResult}">
+                            Register as <strong>${data.account.googleId}</strong>
+                        </c:when>
+                        <c:otherwise>
+                            Yes, this is my account
+                        </c:otherwise>
+                    </c:choose>
+                </a>
+                <a href="${data.logoutUrl}" class="btn btn-danger" id="button_cancel">
+                    <c:choose>
+                        <c:when test="${data.redirectResult}">
+                            Do not register as <strong>${data.account.googleId}</strong>
+                        </c:when>
+                        <c:otherwise>
+                            No, this is not my account
+                        </c:otherwise>
+                    </c:choose>
+                </a>
+            </div>
+            
+        </div>
+    </div>
 </ts:studentPage>

--- a/src/main/webapp/motd-pptlabs-2015-apr.html
+++ b/src/main/webapp/motd-pptlabs-2015-apr.html
@@ -6,26 +6,26 @@
 <title>TEAMMATES</title>
 </head>
 <body>
-	<div class="col-sm-12">
-    	
-    	<table>
-    	<tr>
-    		<td width="55%">
-    			<p><strong>PowerPointLabs: Another useful product <mark>from the TEAMMATES team</mark>.</strong>
-    			<p> PowerPointLabs is a free PowerPoint add-in for creating better slides with less effort.
-    			<p> <blockquote><small><strong>Features:</strong> Zoom and pan animations, generate motion path animations by specifying start and end positions, 
-    			create spotlights, magnifying glass effect, highlight bullet points, generate audio narrations from slide notes, and more... </small></blockquote>
-    			
-    			<p>Download from <a href="http://PowerPointLabs.info" target="_blank">http://PowerPointLabs.info</a>
-    		</td>
-    		<td width="5%"><td>
-    		<td width="40%" align="center">
-    		<img alt="Zoom and pan in PowerPoint" src="http://www.comp.nus.edu.sg/~pptlabs/img/zoom-to-area.gif" width="200px">
-    		<br><br> Example feature: Pan and Zoom.
-    		</td>
-    	</tr>
-    	</table>
-    	
-	</div>
+    <div class="col-sm-12">
+        
+        <table>
+        <tr>
+            <td width="55%">
+                <p><strong>PowerPointLabs: Another useful product <mark>from the TEAMMATES team</mark>.</strong>
+                <p> PowerPointLabs is a free PowerPoint add-in for creating better slides with less effort.
+                <p> <blockquote><small><strong>Features:</strong> Zoom and pan animations, generate motion path animations by specifying start and end positions, 
+                create spotlights, magnifying glass effect, highlight bullet points, generate audio narrations from slide notes, and more... </small></blockquote>
+                
+                <p>Download from <a href="http://PowerPointLabs.info" target="_blank">http://PowerPointLabs.info</a>
+            </td>
+            <td width="5%"><td>
+            <td width="40%" align="center">
+            <img alt="Zoom and pan in PowerPoint" src="http://www.comp.nus.edu.sg/~pptlabs/img/zoom-to-area.gif" width="200px">
+            <br><br> Example feature: Pan and Zoom.
+            </td>
+        </tr>
+        </table>
+        
+    </div>
 </body>
 </html>

--- a/src/main/webapp/stylesheets/datepicker.css
+++ b/src/main/webapp/stylesheets/datepicker.css
@@ -1,1 +1,140 @@
-/* DatePicker Container */.ui-datepicker {	width: 216px;	height: auto;	margin: 5px auto 0;	font: 9pt Arial, sans-serif;	-webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);	-moz-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);	box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);}.ui-datepicker a {	text-decoration: none;}/* DatePicker Table */.ui-datepicker table {	width: 100%;}.ui-datepicker-header {	background: url('../images/dark_leather.png') repeat 0 0 #000;	color: #e0e0e0;	font-weight: bold;	-webkit-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, 2);	-moz-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);	box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);	text-shadow: 1px -1px 0px #000;	filter: dropshadow(color=#000, offx=1, offy=-1);	line-height: 30px;	border-width: 1px 0 0 0;	border-style: solid;	border-color: #111;}.ui-datepicker-title {	text-align: center;}.ui-datepicker-prev, .ui-datepicker-next {	display: inline-block;	width: 30px;	height: 30px;	text-align: center;	cursor: pointer;	background-image: url('../images/arrow.png');	background-repeat: no-repeat;	line-height: 600%;	overflow: hidden;}.ui-datepicker-prev {	float: left;	background-position: center -30px;}.ui-datepicker-next {	float: right;	background-position: center 0px;}.ui-datepicker thead {	background-color: #f7f7f7;	background-image: -moz-linear-gradient(top,  #f7f7f7 0%, #f1f1f1 100%);	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f7f7f7), color-stop(100%,#f1f1f1));	background-image: -webkit-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);	background-image: -o-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);	background-image: -ms-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);	background-image: linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#f1f1f1',GradientType=0 );	border-bottom: 1px solid #bbb;}.ui-datepicker th {	text-transform: uppercase;	font-size: 6pt;	padding: 5px 0;	color: #666666;	text-shadow: 1px 0px 0px #fff;	filter: dropshadow(color=#fff, offx=1, offy=0);}.ui-datepicker tbody td {	padding: 0;	border-right: 1px solid #bbb;}.ui-datepicker tbody td:last-child {	border-right: 0px;}.ui-datepicker tbody tr {	border-bottom: 1px solid #bbb;}.ui-datepicker tbody tr:last-child {	border-bottom: 0px;}.ui-datepicker td span, .ui-datepicker td a {	display: inline-block;	font-weight: bold;	text-align: center;	width: 30px;	height: 30px;	line-height: 30px;	color: #666666;	text-shadow: 1px 1px 0px #fff;	filter: dropshadow(color=#fff, offx=1, offy=1);}.ui-datepicker-calendar .ui-state-default {	background: #ededed;	background: -moz-linear-gradient(top,  #ededed 0%, #dedede 100%);	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ededed), color-stop(100%,#dedede));	background: -webkit-linear-gradient(top,  #ededed 0%,#dedede 100%);	background: -o-linear-gradient(top,  #ededed 0%,#dedede 100%);	background: -ms-linear-gradient(top,  #ededed 0%,#dedede 100%);	background: linear-gradient(top,  #ededed 0%,#dedede 100%);	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ededed', endColorstr='#dedede',GradientType=0 );	-webkit-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);	-moz-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);	box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);}.ui-datepicker-calendar .ui-state-hover {	background: #f7f7f7;}.ui-datepicker-calendar .ui-state-active {	background: #6eafbf;	-webkit-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);	-moz-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);	box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);	color: #e0e0e0;	text-shadow: 0px 1px 0px #4d7a85;	filter: dropshadow(color=#4d7a85, offx=0, offy=1);	border: 1px solid #55838f;	position: relative;	margin: -1px;}.ui-datepicker-unselectable .ui-state-default {	background: #f4f4f4;	color: #b4b3b3;}.ui-datepicker-calendar td:first-child .ui-state-active {	width: 29px;	margin-left: 0;}.ui-datepicker-calendar td:last-child .ui-state-active {	width: 29px;	margin-right: 0;}.ui-datepicker-calendar tr:last-child .ui-state-active {	height: 29px;	margin-bottom: 0;}
+/* DatePicker Container */
+.ui-datepicker {
+	width: 216px;
+	height: auto;
+	margin: 5px auto 0;
+	font: 9pt Arial, sans-serif;
+	-webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+	-moz-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+	box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+}
+.ui-datepicker a {
+	text-decoration: none;
+}
+/* DatePicker Table */
+.ui-datepicker table {
+	width: 100%;
+}
+.ui-datepicker-header {
+	background: url('../images/dark_leather.png') repeat 0 0 #000;
+	color: #e0e0e0;
+	font-weight: bold;
+	-webkit-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, 2);
+	-moz-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
+	box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
+	text-shadow: 1px -1px 0px #000;
+	filter: dropshadow(color=#000, offx=1, offy=-1);
+	line-height: 30px;
+	border-width: 1px 0 0 0;
+	border-style: solid;
+	border-color: #111;
+}
+.ui-datepicker-title {
+	text-align: center;
+}
+.ui-datepicker-prev, .ui-datepicker-next {
+	display: inline-block;
+	width: 30px;
+	height: 30px;
+	text-align: center;
+	cursor: pointer;
+	background-image: url('../images/arrow.png');
+	background-repeat: no-repeat;
+	line-height: 600%;
+	overflow: hidden;
+}
+.ui-datepicker-prev {
+	float: left;
+	background-position: center -30px;
+}
+.ui-datepicker-next {
+	float: right;
+	background-position: center 0px;
+}
+.ui-datepicker thead {
+	background-color: #f7f7f7;
+	background-image: -moz-linear-gradient(top,  #f7f7f7 0%, #f1f1f1 100%);
+	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f7f7f7), color-stop(100%,#f1f1f1));
+	background-image: -webkit-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+	background-image: -o-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+	background-image: -ms-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+	background-image: linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#f1f1f1',GradientType=0 );
+	border-bottom: 1px solid #bbb;
+}
+.ui-datepicker th {
+	text-transform: uppercase;
+	font-size: 6pt;
+	padding: 5px 0;
+	color: #666666;
+	text-shadow: 1px 0px 0px #fff;
+	filter: dropshadow(color=#fff, offx=1, offy=0);
+}
+.ui-datepicker tbody td {
+	padding: 0;
+	border-right: 1px solid #bbb;
+}
+.ui-datepicker tbody td:last-child {
+	border-right: 0px;
+}
+.ui-datepicker tbody tr {
+	border-bottom: 1px solid #bbb;
+}
+.ui-datepicker tbody tr:last-child {
+	border-bottom: 0px;
+}
+.ui-datepicker td span, .ui-datepicker td a {
+	display: inline-block;
+	font-weight: bold;
+	text-align: center;
+	width: 30px;
+	height: 30px;
+	line-height: 30px;
+	color: #666666;
+	text-shadow: 1px 1px 0px #fff;
+	filter: dropshadow(color=#fff, offx=1, offy=1);
+}
+.ui-datepicker-calendar .ui-state-default {
+	background: #ededed;
+	background: -moz-linear-gradient(top,  #ededed 0%, #dedede 100%);
+	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ededed), color-stop(100%,#dedede));
+	background: -webkit-linear-gradient(top,  #ededed 0%,#dedede 100%);
+	background: -o-linear-gradient(top,  #ededed 0%,#dedede 100%);
+	background: -ms-linear-gradient(top,  #ededed 0%,#dedede 100%);
+	background: linear-gradient(top,  #ededed 0%,#dedede 100%);
+	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ededed', endColorstr='#dedede',GradientType=0 );
+	-webkit-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+	-moz-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+	box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+}
+.ui-datepicker-calendar .ui-state-hover {
+	background: #f7f7f7;
+}
+.ui-datepicker-calendar .ui-state-active {
+	background: #6eafbf;
+	-webkit-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+	-moz-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+	box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+	color: #e0e0e0;
+	text-shadow: 0px 1px 0px #4d7a85;
+	filter: dropshadow(color=#4d7a85, offx=0, offy=1);
+	border: 1px solid #55838f;
+	position: relative;
+	margin: -1px;
+}
+.ui-datepicker-unselectable .ui-state-default {
+	background: #f4f4f4;
+	color: #b4b3b3;
+}
+.ui-datepicker-calendar td:first-child .ui-state-active {
+	width: 29px;
+	margin-left: 0;
+}
+.ui-datepicker-calendar td:last-child .ui-state-active {
+	width: 29px;
+	margin-right: 0;
+}
+.ui-datepicker-calendar tr:last-child .ui-state-active {
+	height: 29px;
+	margin-bottom: 0;
+}

--- a/src/main/webapp/stylesheets/datepicker.css
+++ b/src/main/webapp/stylesheets/datepicker.css
@@ -1,140 +1,140 @@
 /* DatePicker Container */
 .ui-datepicker {
-	width: 216px;
-	height: auto;
-	margin: 5px auto 0;
-	font: 9pt Arial, sans-serif;
-	-webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
-	-moz-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
-	box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+    width: 216px;
+    height: auto;
+    margin: 5px auto 0;
+    font: 9pt Arial, sans-serif;
+    -webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+    -moz-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
+    box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, .5);
 }
 .ui-datepicker a {
-	text-decoration: none;
+    text-decoration: none;
 }
 /* DatePicker Table */
 .ui-datepicker table {
-	width: 100%;
+    width: 100%;
 }
 .ui-datepicker-header {
-	background: url('../images/dark_leather.png') repeat 0 0 #000;
-	color: #e0e0e0;
-	font-weight: bold;
-	-webkit-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, 2);
-	-moz-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
-	box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
-	text-shadow: 1px -1px 0px #000;
-	filter: dropshadow(color=#000, offx=1, offy=-1);
-	line-height: 30px;
-	border-width: 1px 0 0 0;
-	border-style: solid;
-	border-color: #111;
+    background: url('../images/dark_leather.png') repeat 0 0 #000;
+    color: #e0e0e0;
+    font-weight: bold;
+    -webkit-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, 2);
+    -moz-box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
+    box-shadow: inset 0px 1px 1px 0px rgba(250, 250, 250, .2);
+    text-shadow: 1px -1px 0px #000;
+    filter: dropshadow(color=#000, offx=1, offy=-1);
+    line-height: 30px;
+    border-width: 1px 0 0 0;
+    border-style: solid;
+    border-color: #111;
 }
 .ui-datepicker-title {
-	text-align: center;
+    text-align: center;
 }
 .ui-datepicker-prev, .ui-datepicker-next {
-	display: inline-block;
-	width: 30px;
-	height: 30px;
-	text-align: center;
-	cursor: pointer;
-	background-image: url('../images/arrow.png');
-	background-repeat: no-repeat;
-	line-height: 600%;
-	overflow: hidden;
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    text-align: center;
+    cursor: pointer;
+    background-image: url('../images/arrow.png');
+    background-repeat: no-repeat;
+    line-height: 600%;
+    overflow: hidden;
 }
 .ui-datepicker-prev {
-	float: left;
-	background-position: center -30px;
+    float: left;
+    background-position: center -30px;
 }
 .ui-datepicker-next {
-	float: right;
-	background-position: center 0px;
+    float: right;
+    background-position: center 0px;
 }
 .ui-datepicker thead {
-	background-color: #f7f7f7;
-	background-image: -moz-linear-gradient(top,  #f7f7f7 0%, #f1f1f1 100%);
-	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f7f7f7), color-stop(100%,#f1f1f1));
-	background-image: -webkit-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
-	background-image: -o-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
-	background-image: -ms-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
-	background-image: linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#f1f1f1',GradientType=0 );
-	border-bottom: 1px solid #bbb;
+    background-color: #f7f7f7;
+    background-image: -moz-linear-gradient(top,  #f7f7f7 0%, #f1f1f1 100%);
+    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#f7f7f7), color-stop(100%,#f1f1f1));
+    background-image: -webkit-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+    background-image: -o-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+    background-image: -ms-linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+    background-image: linear-gradient(top,  #f7f7f7 0%,#f1f1f1 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#f7f7f7', endColorstr='#f1f1f1',GradientType=0 );
+    border-bottom: 1px solid #bbb;
 }
 .ui-datepicker th {
-	text-transform: uppercase;
-	font-size: 6pt;
-	padding: 5px 0;
-	color: #666666;
-	text-shadow: 1px 0px 0px #fff;
-	filter: dropshadow(color=#fff, offx=1, offy=0);
+    text-transform: uppercase;
+    font-size: 6pt;
+    padding: 5px 0;
+    color: #666666;
+    text-shadow: 1px 0px 0px #fff;
+    filter: dropshadow(color=#fff, offx=1, offy=0);
 }
 .ui-datepicker tbody td {
-	padding: 0;
-	border-right: 1px solid #bbb;
+    padding: 0;
+    border-right: 1px solid #bbb;
 }
 .ui-datepicker tbody td:last-child {
-	border-right: 0px;
+    border-right: 0px;
 }
 .ui-datepicker tbody tr {
-	border-bottom: 1px solid #bbb;
+    border-bottom: 1px solid #bbb;
 }
 .ui-datepicker tbody tr:last-child {
-	border-bottom: 0px;
+    border-bottom: 0px;
 }
 .ui-datepicker td span, .ui-datepicker td a {
-	display: inline-block;
-	font-weight: bold;
-	text-align: center;
-	width: 30px;
-	height: 30px;
-	line-height: 30px;
-	color: #666666;
-	text-shadow: 1px 1px 0px #fff;
-	filter: dropshadow(color=#fff, offx=1, offy=1);
+    display: inline-block;
+    font-weight: bold;
+    text-align: center;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
+    color: #666666;
+    text-shadow: 1px 1px 0px #fff;
+    filter: dropshadow(color=#fff, offx=1, offy=1);
 }
 .ui-datepicker-calendar .ui-state-default {
-	background: #ededed;
-	background: -moz-linear-gradient(top,  #ededed 0%, #dedede 100%);
-	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ededed), color-stop(100%,#dedede));
-	background: -webkit-linear-gradient(top,  #ededed 0%,#dedede 100%);
-	background: -o-linear-gradient(top,  #ededed 0%,#dedede 100%);
-	background: -ms-linear-gradient(top,  #ededed 0%,#dedede 100%);
-	background: linear-gradient(top,  #ededed 0%,#dedede 100%);
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ededed', endColorstr='#dedede',GradientType=0 );
-	-webkit-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
-	-moz-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
-	box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+    background: #ededed;
+    background: -moz-linear-gradient(top,  #ededed 0%, #dedede 100%);
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ededed), color-stop(100%,#dedede));
+    background: -webkit-linear-gradient(top,  #ededed 0%,#dedede 100%);
+    background: -o-linear-gradient(top,  #ededed 0%,#dedede 100%);
+    background: -ms-linear-gradient(top,  #ededed 0%,#dedede 100%);
+    background: linear-gradient(top,  #ededed 0%,#dedede 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ededed', endColorstr='#dedede',GradientType=0 );
+    -webkit-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+    -moz-box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
+    box-shadow: inset 1px 1px 0px 0px rgba(250, 250, 250, .5);
 }
 .ui-datepicker-calendar .ui-state-hover {
-	background: #f7f7f7;
+    background: #f7f7f7;
 }
 .ui-datepicker-calendar .ui-state-active {
-	background: #6eafbf;
-	-webkit-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
-	-moz-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
-	box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
-	color: #e0e0e0;
-	text-shadow: 0px 1px 0px #4d7a85;
-	filter: dropshadow(color=#4d7a85, offx=0, offy=1);
-	border: 1px solid #55838f;
-	position: relative;
-	margin: -1px;
+    background: #6eafbf;
+    -webkit-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+    -moz-box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+    box-shadow: inset 0px 0px 10px 0px rgba(0, 0, 0, .1);
+    color: #e0e0e0;
+    text-shadow: 0px 1px 0px #4d7a85;
+    filter: dropshadow(color=#4d7a85, offx=0, offy=1);
+    border: 1px solid #55838f;
+    position: relative;
+    margin: -1px;
 }
 .ui-datepicker-unselectable .ui-state-default {
-	background: #f4f4f4;
-	color: #b4b3b3;
+    background: #f4f4f4;
+    color: #b4b3b3;
 }
 .ui-datepicker-calendar td:first-child .ui-state-active {
-	width: 29px;
-	margin-left: 0;
+    width: 29px;
+    margin-left: 0;
 }
 .ui-datepicker-calendar td:last-child .ui-state-active {
-	width: 29px;
-	margin-right: 0;
+    width: 29px;
+    margin-right: 0;
 }
 .ui-datepicker-calendar tr:last-child .ui-state-active {
-	height: 29px;
-	margin-bottom: 0;
+    height: 29px;
+    margin-bottom: 0;
 }

--- a/src/main/webapp/stylesheets/teammates.css
+++ b/src/main/webapp/stylesheets/teammates.css
@@ -275,13 +275,13 @@ h2.subcaption {
 }
 
 .coreTeamDetailsCell{
-	vertical-align: middle; 
-	padding-left:10px;
+    vertical-align: middle; 
+    padding-left:10px;
 }
 
 .coreTeamPhotoCell{
-	padding-left:35px;
-	padding-bottom:5px;
+    padding-left:35px;
+    padding-bottom:5px;
 }
 
 #footer {

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -321,7 +321,7 @@ Apply to thead to make headers not bold.
 }
 
 .word-wrap-break {
-	word-wrap: break-word;
+    word-wrap: break-word;
 }
 
 .text-strike {
@@ -421,7 +421,7 @@ Apply to thead to make headers not bold.
 }
 
 .text-box-error {
-	border:2px solid red;
+    border:2px solid red;
 }
 
 /* Code to morph navbar to hamburger at tablet size (992px) instead of phone size (768px) */
@@ -791,7 +791,7 @@ Apply to thead to make headers not bold.
 }
 
 .fixed-table-layout {
-	table-layout: fixed;
+    table-layout: fixed;
 }
 
 .question-description {

--- a/src/main/webapp/test-student-motd.html
+++ b/src/main/webapp/test-student-motd.html
@@ -7,9 +7,9 @@
 <title>TEAMMATES</title>
 </head>
 <body>
-	<div class="col-sm-12">
-    	<h1>Test student Message of the day! =)<h1>
-    	<img alt="Overview of TEAMMATES - anonymous peer feedback and confidential peer evaluations" src="/images/overview.png" width="350px">
-	</div>
+    <div class="col-sm-12">
+        <h1>Test student Message of the day! =)</h1>
+        <img alt="Overview of TEAMMATES - anonymous peer feedback and confidential peer evaluations" src="/images/overview.png" width="350px">
+    </div>
 </body>
 </html>

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionClosedReminderTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionClosedReminderTest.java
@@ -38,7 +38,7 @@ public class FeedbackSessionClosedReminderTest extends BaseComponentUsingTaskQue
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_TYPE));
             
-            EmailType typeOfMail = EmailType.valueOf((String) paramMap.get(ParamsNames.EMAIL_TYPE));
+            EmailType typeOfMail = EmailType.valueOf(paramMap.get(ParamsNames.EMAIL_TYPE));
             assertEquals(EmailType.FEEDBACK_CLOSED, typeOfMail);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_FEEDBACK));

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionClosingReminderTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionClosingReminderTest.java
@@ -37,7 +37,7 @@ public class FeedbackSessionClosingReminderTest extends BaseComponentUsingTaskQu
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_TYPE));
             
-            EmailType typeOfMail = EmailType.valueOf((String) paramMap.get(ParamsNames.EMAIL_TYPE));
+            EmailType typeOfMail = EmailType.valueOf(paramMap.get(ParamsNames.EMAIL_TYPE));
             assertEquals(EmailType.FEEDBACK_CLOSING, typeOfMail);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_FEEDBACK));

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionEmailTaskQueueTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionEmailTaskQueueTest.java
@@ -256,7 +256,7 @@ public class FeedbackSessionEmailTaskQueueTest extends BaseComponentUsingTaskQue
     }
     
     @Test
-    public void testSendFeedbackSessionUnpublishedEmail() throws Exception {
+    public void testSendFeedbackSessionUnpublishedEmail() {
         // this method tests a function from FeedbackSessionLogic.java
         
         FeedbackSessionsEmailTaskQueueCallback.resetTaskCount();

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionOpeningReminderTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionOpeningReminderTest.java
@@ -36,7 +36,7 @@ public class FeedbackSessionOpeningReminderTest extends BaseComponentUsingTaskQu
             HashMap<String, String> paramMap = HttpRequestHelper.getParamMap(request);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_TYPE));
-            EmailType typeOfMail = EmailType.valueOf((String) paramMap.get(ParamsNames.EMAIL_TYPE));
+            EmailType typeOfMail = EmailType.valueOf(paramMap.get(ParamsNames.EMAIL_TYPE));
             assertEquals(EmailType.FEEDBACK_OPENING, typeOfMail);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_FEEDBACK));

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionPublishedReminderTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionPublishedReminderTest.java
@@ -38,7 +38,7 @@ public class FeedbackSessionPublishedReminderTest extends BaseComponentUsingTask
             HashMap<String, String> paramMap = HttpRequestHelper.getParamMap(request);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_TYPE));
-            EmailType typeOfMail = EmailType.valueOf((String) paramMap.get(ParamsNames.EMAIL_TYPE));
+            EmailType typeOfMail = EmailType.valueOf(paramMap.get(ParamsNames.EMAIL_TYPE));
             assertEquals(EmailType.FEEDBACK_PUBLISHED, typeOfMail);
             
             assertTrue(paramMap.containsKey(ParamsNames.EMAIL_FEEDBACK));

--- a/src/test/java/teammates/test/cases/automated/FeedbackSessionUnpublishedMailTest.java
+++ b/src/test/java/teammates/test/cases/automated/FeedbackSessionUnpublishedMailTest.java
@@ -10,10 +10,10 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
+import teammates.common.util.Const.ParamsNames;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.TimeHelper;
-import teammates.common.util.Const.ParamsNames;
 import teammates.logic.automated.EmailAction;
 import teammates.logic.automated.FeedbackSessionUnpublishedMailAction;
 import teammates.logic.core.CoursesLogic;

--- a/src/test/java/teammates/test/cases/common/FeedbackResponseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/common/FeedbackResponseAttributesTest.java
@@ -5,8 +5,6 @@ import java.util.Date;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.FeedbackResponseAttributes;
-import teammates.common.exception.EntityAlreadyExistsException;
-import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.test.cases.BaseTestCase;
 
@@ -25,7 +23,7 @@ public class FeedbackResponseAttributesTest extends BaseTestCase {
     }
     
     @Test
-    public void testDefaultTimestamp() throws InvalidParametersException, EntityAlreadyExistsException {
+    public void testDefaultTimestamp() {
         FeedbackResponseAttributesWithModifiableTimestamp fra =
                 new FeedbackResponseAttributesWithModifiableTimestamp();
         

--- a/src/test/java/teammates/test/cases/common/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/common/FieldValidatorTest.java
@@ -9,12 +9,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.util.FieldValidator;
 import teammates.common.util.StringHelper;
 import teammates.common.util.TimeHelper;
 import teammates.test.cases.BaseTestCase;
+
+import com.google.appengine.api.datastore.Text;
 
 public class FieldValidatorTest extends BaseTestCase {
 

--- a/src/test/java/teammates/test/cases/common/InstructorFeedbackResultsResponseRowTest.java
+++ b/src/test/java/teammates/test/cases/common/InstructorFeedbackResultsResponseRowTest.java
@@ -1,11 +1,10 @@
 package teammates.test.cases.common;
 
-import org.testng.annotations.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import teammates.test.cases.BaseTestCase;
 import teammates.ui.template.InstructorFeedbackResultsResponseRow;

--- a/src/test/java/teammates/test/cases/common/StudentAttributesFactoryTest.java
+++ b/src/test/java/teammates/test/cases/common/StudentAttributesFactoryTest.java
@@ -18,15 +18,13 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         printTestClassHeader();
     }
 
-    @SuppressWarnings("unused")
     @Test
     public void testConstructor() throws Exception {
         String headerRow = null;
-        StudentAttributesFactory saf = null;
 
         ______TS("Failure case: null parameter");
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             ignoreExpectedException();
@@ -35,7 +33,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: not satisfy the minimum requirement of fields");
         headerRow = "name \t email";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
@@ -45,7 +43,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: missing 'Name' field");
         headerRow = "section \t team \t email";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Name</mark>",
@@ -55,7 +53,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: missing 'Team' field");
         headerRow = "section \t name \t email";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
@@ -65,7 +63,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: missing 'Email' field");
         headerRow = "section \t team \t name";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Email</mark>",
@@ -75,7 +73,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: repeated required columns");
         headerRow = "name \t email \t team \t comments \t name";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, e.getMessage());
@@ -85,7 +83,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
         ______TS("Failure case: repeated required columns");
         headerRow = "name \t email \t team \t comments \t section \t email \t team \t comments \t section ";
         try {
-            saf = new StudentAttributesFactory(headerRow);
+            new StudentAttributesFactory(headerRow);
             signalFailureToDetectException();
         } catch (EnrollException e) {
             assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, e.getMessage());

--- a/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
@@ -9,9 +9,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.log.AppLogLine;
-import com.google.appengine.api.log.LogService.LogLevel;
-
 import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
@@ -28,6 +25,9 @@ import teammates.logic.core.InstructorsLogic;
 import teammates.logic.core.StudentsLogic;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.EmailChecker;
+
+import com.google.appengine.api.log.AppLogLine;
+import com.google.appengine.api.log.LogService.LogLevel;
 
 /**
  * SUT: {@link EmailGenerator}

--- a/src/test/java/teammates/test/cases/logic/EmailSenderTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailSenderTest.java
@@ -12,11 +12,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.mailjet.client.MailjetRequest;
-import com.mailjet.client.resource.Email;
-import com.sendgrid.SendGrid;
-import com.sun.jersey.multipart.FormDataMultiPart;
-
 import teammates.common.util.EmailWrapper;
 import teammates.logic.core.EmailSender;
 import teammates.logic.core.JavamailService;
@@ -24,6 +19,11 @@ import teammates.logic.core.MailgunService;
 import teammates.logic.core.MailjetService;
 import teammates.logic.core.SendgridService;
 import teammates.test.cases.BaseComponentTestCase;
+
+import com.mailjet.client.MailjetRequest;
+import com.mailjet.client.resource.Email;
+import com.sendgrid.SendGrid;
+import com.sun.jersey.multipart.FormDataMultiPart;
 
 /**
  * SUT: {@link EmailSender}

--- a/src/test/java/teammates/test/cases/logic/StudentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/StudentsLogicTest.java
@@ -1200,7 +1200,7 @@ public class StudentsLogicTest extends BaseComponentTestCase {
                                            StudentsLogic.inst(), new Object[] { lines, courseId });
     }
         
-    @AfterClass()
+    @AfterClass
     public static void classTearDown() {
         AccountsLogic.inst().deleteAccountCascade(dataBundle.students.get("student4InCourse1").googleId);
         printTestClassFooter();

--- a/src/test/java/teammates/test/cases/logic/TeamEvalResultTest.java
+++ b/src/test/java/teammates/test/cases/logic/TeamEvalResultTest.java
@@ -22,7 +22,6 @@ public class TeamEvalResultTest extends BaseTestCase {
 
     // CHECKSTYLE.OFF:SingleSpaceSeparator vertical alignment of values for readability
     @Test
-    // @formatter:off
     public void testCalculatePoints() {
         
         int[][] input = {
@@ -464,7 +463,6 @@ public class TeamEvalResultTest extends BaseTestCase {
                 new double[]{1, 2, NSB, 4, NSU, 6, NA},
                 new double[]{1.0, 2.0, 3.0, NA, 5.0, 6.0});
     }
-    // @formatter:on
 
     //--------------------------------------------------------------------
     

--- a/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
@@ -7,8 +7,6 @@ import java.util.List;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.blobstore.BlobKey;
-
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.StudentProfileAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -20,6 +18,8 @@ import teammates.storage.api.AccountsDb;
 import teammates.storage.api.ProfilesDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
+
+import com.google.appengine.api.blobstore.BlobKey;
 
 public class AccountsDbTest extends BaseComponentTestCase {
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -1,8 +1,8 @@
 package teammates.test.cases.storage;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.testng.annotations.AfterClass;
@@ -753,7 +753,6 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
                 "Empty feedback session", "idOfTypicalCourse1", "Section 1").isEmpty());
     }
     
-    @SuppressWarnings("static-access")
     @Test
     public void testUpdateFeedbackResponse() throws Exception {
 
@@ -808,7 +807,7 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         requestParameters.put("responsetext-1-0", new String[] { "New answer text!" });
         
         String[] answer = {"New answer text!"};
-        frd = frd.createResponseDetails(
+        frd = FeedbackResponseDetails.createResponseDetails(
                     answer, FeedbackQuestionType.TEXT,
                     null, requestParameters, 1, 0);
         modifiedResponse.setResponseDetails(frd);

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -5,8 +5,6 @@ import java.io.IOException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.blobstore.BlobKey;
-
 import teammates.common.datatransfer.AccountAttributes;
 import teammates.common.datatransfer.StudentProfileAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -18,6 +16,8 @@ import teammates.storage.api.EntitiesDb;
 import teammates.storage.api.ProfilesDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
+
+import com.google.appengine.api.blobstore.BlobKey;
 
 public class ProfilesDbTest extends BaseComponentTestCase {
     

--- a/src/test/java/teammates/test/cases/ui/AdminAccountDeletePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/AdminAccountDeletePageActionTest.java
@@ -47,6 +47,6 @@ public class AdminAccountDeletePageActionTest extends BaseActionTest {
     }
 
     private AdminAccountDeleteAction getAction(String... params) {
-        return (AdminAccountDeleteAction) (gaeSimulation.getActionObject(uri, params));
+        return (AdminAccountDeleteAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/AdminAccountDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/AdminAccountDetailsPageActionTest.java
@@ -49,7 +49,7 @@ public class AdminAccountDetailsPageActionTest extends BaseActionTest {
     }
 
     private AdminAccountDetailsPageAction getAction(String... params) {
-        return (AdminAccountDetailsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (AdminAccountDetailsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/AdminAccountManagementPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/AdminAccountManagementPageActionTest.java
@@ -40,7 +40,7 @@ public class AdminAccountManagementPageActionTest extends BaseActionTest {
     }
 
     private AdminAccountManagementPageAction getAction(String... params) {
-        return (AdminAccountManagementPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (AdminAccountManagementPageAction) gaeSimulation.getActionObject(uri, params);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/AdminHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/AdminHomePageActionTest.java
@@ -4,7 +4,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
-import teammates.ui.controller.Action;
+import teammates.ui.controller.AdminHomePageAction;
 import teammates.ui.controller.AdminHomePageData;
 import teammates.ui.controller.ShowPageResult;
 
@@ -25,7 +25,7 @@ public class AdminHomePageActionTest extends BaseActionTest {
         ______TS("Normal case: starting with a blank adminHome page");
         final String adminUserId = "admin.user";
         gaeSimulation.loginAsAdmin(adminUserId);
-        final Action a = getAction();
+        final AdminHomePageAction a = getAction();
         
         final ShowPageResult result = (ShowPageResult) a.executeAndPostProcess();
         assertEquals(Const.ViewURIs.ADMIN_HOME, result.destination);
@@ -39,8 +39,8 @@ public class AdminHomePageActionTest extends BaseActionTest {
         
     }
     
-    private Action getAction(String... parameters) {
-        return (Action) gaeSimulation.getActionObject(uri, parameters);
+    private AdminHomePageAction getAction(String... parameters) {
+        return (AdminHomePageAction) gaeSimulation.getActionObject(uri, parameters);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/AdminInstructorAccountAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/AdminInstructorAccountAddActionTest.java
@@ -9,7 +9,6 @@ import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.logic.api.Logic;
 import teammates.logic.core.CommentsLogic;
-import teammates.ui.controller.Action;
 import teammates.ui.controller.AdminHomePageData;
 import teammates.ui.controller.AdminInstructorAccountAddAction;
 import teammates.ui.controller.AjaxResult;
@@ -66,7 +65,7 @@ public class AdminInstructorAccountAddActionTest extends BaseActionTest {
         final String emailWithSpaces = "   " + email + "   ";
         final String instituteWithSpaces = "   " + institute + "   ";
 
-        Action a = getAction(
+        AdminInstructorAccountAddAction a = getAction(
                 Const.ParamsNames.INSTRUCTOR_SHORT_NAME, newInstructorShortNameWithSpaces,
                 Const.ParamsNames.INSTRUCTOR_NAME, nameWithSpaces,
                 Const.ParamsNames.INSTRUCTOR_EMAIL, emailWithSpaces,
@@ -159,8 +158,8 @@ public class AdminInstructorAccountAddActionTest extends BaseActionTest {
                                      a, new Object[] { instructorEmailOrProposedCourseId, maximumIdLength });
     }
 
-    private Action getAction(String... parameters) {
-        return (Action) gaeSimulation.getActionObject(uri, parameters);
+    private AdminInstructorAccountAddAction getAction(String... parameters) {
+        return (AdminInstructorAccountAddAction) gaeSimulation.getActionObject(uri, parameters);
     }
 
     private String getDemoCourseIdRoot(String instructorEmail) {

--- a/src/test/java/teammates/test/cases/ui/FeedbackSessionStatsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/FeedbackSessionStatsPageActionTest.java
@@ -73,6 +73,6 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
     }
     
     private FeedbackSessionStatsPageAction getAction(String... params) {
-        return (FeedbackSessionStatsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (FeedbackSessionStatsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCommentsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCommentsPageActionTest.java
@@ -111,6 +111,6 @@ public class InstructorCommentsPageActionTest extends BaseActionTest {
     }
     
     private InstructorCommentsPageAction getAction(String... params) {
-        return (InstructorCommentsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCommentsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseAddActionTest.java
@@ -9,7 +9,7 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.logic.core.CoursesLogic;
 import teammates.test.driver.AssertHelper;
-import teammates.ui.controller.Action;
+import teammates.ui.controller.InstructorCourseAddAction;
 import teammates.ui.controller.InstructorCoursesPageData;
 import teammates.ui.controller.ShowPageResult;
 
@@ -45,9 +45,9 @@ public class InstructorCourseAddActionTest extends BaseActionTest {
         ______TS("Error: Invalid parameter for Course ID");
         
         String invalidCourseId = "ticac,tpa1,id";
-        Action addAction = getAction(Const.ParamsNames.COURSE_ID, invalidCourseId,
-                                     Const.ParamsNames.COURSE_NAME, "ticac tpa1 name",
-                                     Const.ParamsNames.COURSE_TIME_ZONE, "UTC");
+        InstructorCourseAddAction addAction = getAction(Const.ParamsNames.COURSE_ID, invalidCourseId,
+                                                        Const.ParamsNames.COURSE_NAME, "ticac tpa1 name",
+                                                        Const.ParamsNames.COURSE_TIME_ZONE, "UTC");
         ShowPageResult pageResult = (ShowPageResult) addAction.executeAndPostProcess();
         
         assertEquals(Const.ViewURIs.INSTRUCTOR_COURSES + "?error=true&user=idOfInstructor1OfCourse1",
@@ -178,7 +178,7 @@ public class InstructorCourseAddActionTest extends BaseActionTest {
         assertEquals(expected, pageResult.getStatusMessage());
     }
     
-    private Action getAction(String... parameters) {
-        return (Action) gaeSimulation.getActionObject(uri, parameters);
+    private InstructorCourseAddAction getAction(String... parameters) {
+        return (InstructorCourseAddAction) gaeSimulation.getActionObject(uri, parameters);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseArchiveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseArchiveActionTest.java
@@ -185,7 +185,7 @@ public class InstructorCourseArchiveActionTest extends BaseActionTest {
     }
     
     private InstructorCourseArchiveAction getAction(String... params) {
-        return (InstructorCourseArchiveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseArchiveAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseDeleteActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseDeleteActionTest.java
@@ -110,6 +110,6 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
     }
     
     private InstructorCourseDeleteAction getAction(String... params) {
-        return (InstructorCourseDeleteAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseDeleteAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseDetailsPageActionTest.java
@@ -172,6 +172,6 @@ public class InstructorCourseDetailsPageActionTest extends BaseActionTest {
     }
 
     private InstructorCourseDetailsPageAction getAction(String... params) {
-        return (InstructorCourseDetailsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseDetailsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseEditPageActionTest.java
@@ -128,7 +128,7 @@ public class InstructorCourseEditPageActionTest extends BaseActionTest {
     }
     
     private InstructorCourseEditPageAction getAction(String... params) {
-        return (InstructorCourseEditPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseEditPageAction) gaeSimulation.getActionObject(uri, params);
     }
     
     private void verifySameInstructorList(List<InstructorAttributes> list1, List<CourseEditInstructorPanel> list2) {

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseEditSaveActionTest.java
@@ -161,6 +161,6 @@ public class InstructorCourseEditSaveActionTest extends BaseActionTest {
     }
 
     private InstructorCourseEditSaveAction getAction(String... params) {
-        return (InstructorCourseEditSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseEditSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseEnrollPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseEnrollPageActionTest.java
@@ -124,6 +124,6 @@ public class InstructorCourseEnrollPageActionTest extends BaseActionTest {
     }
 
     private InstructorCourseEnrollPageAction getAction(String... params) {
-        return (InstructorCourseEnrollPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseEnrollPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseEnrollSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseEnrollSaveActionTest.java
@@ -287,7 +287,7 @@ public class InstructorCourseEnrollSaveActionTest extends BaseActionTest {
     }
     
     private InstructorCourseEnrollSaveAction getAction(String... params) {
-        return (InstructorCourseEnrollSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseEnrollSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseJoinActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseJoinActionTest.java
@@ -113,6 +113,6 @@ public class InstructorCourseJoinActionTest extends BaseActionTest {
     }
     
     private InstructorCourseJoinAction getAction(String... params) {
-        return (InstructorCourseJoinAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseJoinAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseJoinAuthenticatedActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseJoinAuthenticatedActionTest.java
@@ -180,6 +180,6 @@ public class InstructorCourseJoinAuthenticatedActionTest extends BaseActionTest 
     }
     
     private InstructorCourseJoinAuthenticatedAction getAction(String... params) {
-        return (InstructorCourseJoinAuthenticatedAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseJoinAuthenticatedAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDeleteActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDeleteActionTest.java
@@ -36,7 +36,7 @@ public class InstructorCourseStudentDeleteActionTest extends BaseActionTest {
                 Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.email
         };
         
-        InstructorCourseStudentDeleteAction action = (InstructorCourseStudentDeleteAction) getAction(submissionParams);
+        InstructorCourseStudentDeleteAction action = getAction(submissionParams);
         RedirectResult redirectResult = (RedirectResult) action.executeAndPostProcess();
         
         assertEquals(Const.ActionURIs.INSTRUCTOR_COURSE_DETAILS_PAGE, redirectResult.destination);
@@ -52,7 +52,7 @@ public class InstructorCourseStudentDeleteActionTest extends BaseActionTest {
     }
     
     private InstructorCourseStudentDeleteAction getAction(String... params) {
-        return (InstructorCourseStudentDeleteAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseStudentDeleteAction) gaeSimulation.getActionObject(uri, params);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditPageActionTest.java
@@ -84,7 +84,7 @@ public class InstructorCourseStudentDetailsEditPageActionTest extends BaseAction
     }
     
     private InstructorCourseStudentDetailsEditPageAction getAction(String... params) {
-        return (InstructorCourseStudentDetailsEditPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseStudentDetailsEditPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditSaveActionTest.java
@@ -271,7 +271,7 @@ public class InstructorCourseStudentDetailsEditSaveActionTest extends BaseAction
     }
     
     private InstructorCourseStudentDetailsEditSaveAction getAction(String... params) {
-        return (InstructorCourseStudentDetailsEditSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseStudentDetailsEditSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsPageActionTest.java
@@ -83,7 +83,7 @@ public class InstructorCourseStudentDetailsPageActionTest extends BaseActionTest
     }
     
     private InstructorCourseStudentDetailsPageAction getAction(String... params) {
-        return (InstructorCourseStudentDetailsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseStudentDetailsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentListDownloadActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentListDownloadActionTest.java
@@ -138,6 +138,6 @@ public class InstructorCourseStudentListDownloadActionTest extends BaseActionTes
     }
     
     private InstructorCourseStudentListDownloadAction getAction(String... params) {
-        return (InstructorCourseStudentListDownloadAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCourseStudentListDownloadAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCoursesPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCoursesPageActionTest.java
@@ -125,7 +125,7 @@ public class InstructorCoursesPageActionTest extends BaseActionTest {
     }
 
     private InstructorCoursesPageAction getAction(String... params) {
-        return (InstructorCoursesPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorCoursesPageAction) gaeSimulation.getActionObject(uri, params);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorEditInstructorFeedbackPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorEditInstructorFeedbackPageActionTest.java
@@ -122,6 +122,6 @@ public class InstructorEditInstructorFeedbackPageActionTest extends BaseActionTe
     }
 
     private InstructorEditInstructorFeedbackPageAction getAction(String... params) {
-        return (InstructorEditInstructorFeedbackPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorEditInstructorFeedbackPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorEditInstructorFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorEditInstructorFeedbackSaveActionTest.java
@@ -419,6 +419,6 @@ public class InstructorEditInstructorFeedbackSaveActionTest extends BaseActionTe
     }
     
     private InstructorEditInstructorFeedbackSaveAction getAction(String... params) {
-        return (InstructorEditInstructorFeedbackSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorEditInstructorFeedbackSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorEditStudentFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorEditStudentFeedbackSaveActionTest.java
@@ -177,14 +177,8 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, moderatedStudentEmail
         };
         
-        InstructorEditStudentFeedbackSaveAction a;
-        @SuppressWarnings("unused")
-        // unused but still needed to allow detection of exception
-        RedirectResult r;
-        
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
@@ -200,8 +194,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
@@ -222,8 +215,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
@@ -261,12 +253,8 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, moderatedStudentEmail
         };
         
-        InstructorEditStudentFeedbackSaveAction a;
-        RedirectResult r;
-        
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                                  + instructorHelper.email + "] for privilege "
@@ -293,8 +281,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                                  + instructorHelper.email + "] for privilege "
@@ -326,8 +313,8 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
                 Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, moderatedStudentEmail
         };
         
-        a = getAction(submissionParams);
-        r = (RedirectResult) a.executeAndPostProcess();
+        InstructorEditStudentFeedbackSaveAction a = getAction(submissionParams);
+        RedirectResult r = (RedirectResult) a.executeAndPostProcess();
         
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
@@ -362,8 +349,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                              + instructorHelper2.email + "] for privilege [canmodifysessioncommentinsection] "
@@ -465,8 +451,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         try {
-            a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            getAction(submissionParams).executeAndPostProcess();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [Another feedback session] is not accessible to instructor ["
                              + instructorHelper3.email + "] for privilege ["
@@ -505,13 +490,9 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         };
         
         InstructorEditStudentFeedbackSaveAction a;
-        @SuppressWarnings("unused")
-        // unused but still needed to allow detection of exception
-        RedirectResult r;
-        
         try {
             a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            a.executeAndPostProcess();
             signalFailureToDetectException("Did not detect that this instructor cannot access this particular question.");
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] question [" + fr.feedbackQuestionId + "] "
@@ -540,7 +521,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         
         try {
             a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            a.executeAndPostProcess();
             signalFailureToDetectException("Did not detect that this instructor cannot access this particular question.");
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] question [" + fr.feedbackQuestionId + "] "
@@ -569,7 +550,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         
         try {
             a = getAction(submissionParams);
-            r = (RedirectResult) a.executeAndPostProcess();
+            a.executeAndPostProcess();
             signalFailureToDetectException("Did not detect that this instructor cannot access this particular question.");
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] question [" + fr.feedbackQuestionId + "] "
@@ -619,6 +600,6 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
     }
     
     private InstructorEditStudentFeedbackSaveAction getAction(String... params) {
-        return (InstructorEditStudentFeedbackSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorEditStudentFeedbackSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionVisibilityMessageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackQuestionVisibilityMessageActionTest.java
@@ -52,7 +52,7 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         InstructorFeedbackQuestionVisibilityMessageAction a = getAction(typicalParams);
-        ActionResult r = (ActionResult) a.executeAndPostProcess();
+        ActionResult r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
 
@@ -76,7 +76,7 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         a = getAction(customParams);
-        r = (ActionResult) a.executeAndPostProcess();
+        r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
 
@@ -103,7 +103,7 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         a = getAction(customParams);
-        r = (ActionResult) a.executeAndPostProcess();
+        r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
 
@@ -130,7 +130,7 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         a = getAction(customParams);
-        r = (ActionResult) a.executeAndPostProcess();
+        r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
 
@@ -162,7 +162,7 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         a = getAction(privateParams);
-        r = (ActionResult) a.executeAndPostProcess();
+        r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
 
@@ -186,12 +186,12 @@ public class InstructorFeedbackQuestionVisibilityMessageActionTest extends BaseA
         };
 
         a = getAction(privateParams);
-        r = (ActionResult) a.executeAndPostProcess();
+        r = a.executeAndPostProcess();
 
         assertFalse(r.isError);
     }
 
     private InstructorFeedbackQuestionVisibilityMessageAction getAction(String... params) {
-        return (InstructorFeedbackQuestionVisibilityMessageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackQuestionVisibilityMessageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackRemindParticularStudentsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackRemindParticularStudentsPageActionTest.java
@@ -66,9 +66,6 @@ public class InstructorFeedbackRemindParticularStudentsPageActionTest extends
     }
     
     private InstructorFeedbackRemindParticularStudentsPageAction getAction(String... params) {
-
-        return (InstructorFeedbackRemindParticularStudentsPageAction) (gaeSimulation
-                .getActionObject(uri, params));
-
+        return (InstructorFeedbackRemindParticularStudentsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentAddActionTest.java
@@ -274,6 +274,6 @@ public class InstructorFeedbackResponseCommentAddActionTest extends
     }
     
     private InstructorFeedbackResponseCommentAddAction getAction(String... params) {
-        return (InstructorFeedbackResponseCommentAddAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackResponseCommentAddAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentDeleteActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentDeleteActionTest.java
@@ -144,6 +144,6 @@ public class InstructorFeedbackResponseCommentDeleteActionTest extends BaseActio
     }
     
     private InstructorFeedbackResponseCommentDeleteAction getAction(String... params) {
-        return (InstructorFeedbackResponseCommentDeleteAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackResponseCommentDeleteAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentEditActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackResponseCommentEditActionTest.java
@@ -327,6 +327,6 @@ public class InstructorFeedbackResponseCommentEditActionTest extends BaseActionT
     }
     
     private InstructorFeedbackResponseCommentEditAction getAction(String... params) {
-        return (InstructorFeedbackResponseCommentEditAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackResponseCommentEditAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditPageActionTest.java
@@ -191,6 +191,6 @@ public class InstructorFeedbackSubmissionEditPageActionTest extends BaseActionTe
     }
 
     private InstructorFeedbackSubmissionEditPageAction getAction(String... params) {
-        return (InstructorFeedbackSubmissionEditPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackSubmissionEditPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditSaveActionTest.java
@@ -584,6 +584,6 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
     }
 
     private InstructorFeedbackSubmissionEditSaveAction getAction(String... params) {
-        return (InstructorFeedbackSubmissionEditSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbackSubmissionEditSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbacksPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbacksPageActionTest.java
@@ -120,7 +120,7 @@ public class InstructorFeedbacksPageActionTest extends BaseActionTest {
     }
 
     private InstructorFeedbacksPageAction getAction(String... params) {
-        return (InstructorFeedbacksPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorFeedbacksPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorHomePageActionTest.java
@@ -178,7 +178,7 @@ public class InstructorHomePageActionTest extends BaseActionTest {
     }
     
     private InstructorHomePageAction getAction(String... params) {
-        return (InstructorHomePageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorHomePageAction) gaeSimulation.getActionObject(uri, params);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentCommentAddActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentCommentAddActionTest.java
@@ -454,6 +454,6 @@ public class InstructorStudentCommentAddActionTest extends BaseActionTest {
     }
     
     private InstructorStudentCommentAddAction getAction(String... params) {
-        return (InstructorStudentCommentAddAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentCommentAddAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentCommentEditActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentCommentEditActionTest.java
@@ -523,6 +523,6 @@ public class InstructorStudentCommentEditActionTest extends BaseActionTest {
     }
     
     private InstructorStudentCommentEditAction getAction(String... params) {
-        return (InstructorStudentCommentEditAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentCommentEditAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentListAjaxPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentListAjaxPageActionTest.java
@@ -54,7 +54,7 @@ public class InstructorStudentListAjaxPageActionTest extends BaseActionTest {
     }
 
     private InstructorStudentListAjaxPageAction getAction(String... params) {
-        return (InstructorStudentListAjaxPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentListAjaxPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentListPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentListPageActionTest.java
@@ -131,7 +131,7 @@ public class InstructorStudentListPageActionTest extends BaseActionTest {
     }
 
     private InstructorStudentListPageAction getAction(String... params) {
-        return (InstructorStudentListPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentListPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentRecordsAjaxPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentRecordsAjaxPageActionTest.java
@@ -74,7 +74,7 @@ public class InstructorStudentRecordsAjaxPageActionTest extends BaseActionTest {
     }
 
     private InstructorStudentRecordsAjaxPageAction getAction(String... params) {
-        return (InstructorStudentRecordsAjaxPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentRecordsAjaxPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorStudentRecordsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorStudentRecordsPageActionTest.java
@@ -177,7 +177,7 @@ public class InstructorStudentRecordsPageActionTest extends BaseActionTest {
     }
 
     private InstructorStudentRecordsPageAction getAction(String... params) {
-        return (InstructorStudentRecordsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (InstructorStudentRecordsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
@@ -74,6 +74,6 @@ public class StudentCommentsPageActionTest extends BaseActionTest {
     }
     
     private StudentCommentsPageAction getAction(String... params) {
-        return (StudentCommentsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentCommentsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/StudentCourseDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCourseDetailsPageActionTest.java
@@ -10,7 +10,6 @@ import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.datatransfer.StudentProfileAttributes;
-import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 import teammates.logic.core.InstructorsLogic;
@@ -118,7 +117,7 @@ public class StudentCourseDetailsPageActionTest extends BaseActionTest {
     }
 
     @Test
-    public void testTeamMemberDetailsOnViewTeamPage() throws EntityDoesNotExistException {
+    public void testTeamMemberDetailsOnViewTeamPage() {
         AccountAttributes student = dataBundle.accounts.get("student1InCourse1");
         
         String[] submissionParams = createValidParamsForProfile();

--- a/src/test/java/teammates/test/cases/ui/StudentCourseDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCourseDetailsPageActionTest.java
@@ -170,7 +170,7 @@ public class StudentCourseDetailsPageActionTest extends BaseActionTest {
     }
     
     private StudentCourseDetailsPageAction getAction(String... params) {
-        return (StudentCourseDetailsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentCourseDetailsPageAction) gaeSimulation.getActionObject(uri, params);
     }
     
     private StudentProfileEditSaveAction getStudentProfileEditSaveAction(String[] submissionParams) {

--- a/src/test/java/teammates/test/cases/ui/StudentCourseJoinActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCourseJoinActionTest.java
@@ -126,8 +126,7 @@ public class StudentCourseJoinActionTest extends BaseActionTest {
     }
 
     private StudentCourseJoinAction getAction(String... params) {
-        return (StudentCourseJoinAction) (gaeSimulation.getActionObject(uri,
-                params));
+        return (StudentCourseJoinAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/StudentCourseJoinAuthenticatedActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCourseJoinAuthenticatedActionTest.java
@@ -274,9 +274,6 @@ public class StudentCourseJoinAuthenticatedActionTest extends BaseActionTest {
     }
 
     private StudentCourseJoinAuthenticatedAction getAction(String... params) {
-
-        return (StudentCourseJoinAuthenticatedAction) (gaeSimulation
-                .getActionObject(uri, params));
-
+        return (StudentCourseJoinAuthenticatedAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
@@ -74,8 +74,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         StudentFeedbackResultsPageAction pageAction = getAction(submissionParams);
 
         try {
-            @SuppressWarnings("unused")
-            ShowPageResult pageResult = getShowPageResult(pageAction);
+            getShowPageResult(pageAction);
         } catch (UnauthorizedAccessException exception) {
             assertEquals("This feedback session is not yet visible.", exception.getMessage());
         }
@@ -91,8 +90,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         pageAction = getAction(submissionParams);
 
         try {
-            @SuppressWarnings("unused")
-            ShowPageResult pageResult = getShowPageResult(pageAction);
+            getShowPageResult(pageAction);
         } catch (UnauthorizedAccessException exception) {
             assertEquals("Feedback session [First feedback session] is not accessible to student "
                          + "[" + student1InCourse1.email + "]", exception.getMessage());
@@ -214,6 +212,6 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
     }
 
     private StudentFeedbackResultsPageAction getAction(String... params) {
-        return (StudentFeedbackResultsPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentFeedbackResultsPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackSubmissionEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackSubmissionEditPageActionTest.java
@@ -217,6 +217,6 @@ public class StudentFeedbackSubmissionEditPageActionTest extends BaseActionTest 
     }
 
     private StudentFeedbackSubmissionEditPageAction getAction(String... params) {
-        return (StudentFeedbackSubmissionEditPageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentFeedbackSubmissionEditPageAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackSubmissionEditSaveActionTest.java
@@ -895,6 +895,6 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
     }
 
     private StudentFeedbackSubmissionEditSaveAction getAction(String... params) {
-        return (StudentFeedbackSubmissionEditSaveAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentFeedbackSubmissionEditSaveAction) gaeSimulation.getActionObject(uri, params);
     }
 }

--- a/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
@@ -166,7 +166,7 @@ public class StudentHomePageActionTest extends BaseActionTest {
     }
 
     private StudentHomePageAction getAction(String... params) {
-        return (StudentHomePageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentHomePageAction) gaeSimulation.getActionObject(uri, params);
     }
     
 }

--- a/src/test/java/teammates/test/cases/ui/StudentProfileCreateFormUrlActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentProfileCreateFormUrlActionTest.java
@@ -72,7 +72,7 @@ public class StudentProfileCreateFormUrlActionTest extends BaseActionTest {
     }
 
     private StudentProfileCreateFormUrlAction getAction(String... params) {
-        return (StudentProfileCreateFormUrlAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentProfileCreateFormUrlAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/StudentProfileEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentProfileEditSaveActionTest.java
@@ -100,7 +100,8 @@ public class StudentProfileEditSaveActionTest extends BaseActionTest {
         String[] submissionParams = createValidParamsForProfile();
         StudentProfileAttributes expectedProfile = getProfileAttributesFrom(submissionParams);
         expectedProfile.googleId = student.googleId;
-                StudentProfileEditSaveAction action = getAction(addUserIdToParams(student.googleId, submissionParams));
+        
+        StudentProfileEditSaveAction action = getAction(addUserIdToParams(student.googleId, submissionParams));
         RedirectResult result = (RedirectResult) action.executeAndPostProcess();
         
         assertFalse(result.isError);

--- a/src/test/java/teammates/test/cases/ui/StudentProfilePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentProfilePageActionTest.java
@@ -91,7 +91,7 @@ public class StudentProfilePageActionTest extends BaseActionTest {
     }
 
     private StudentProfilePageAction getAction(String... params) {
-        return (StudentProfilePageAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentProfilePageAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/StudentProfilePictureActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentProfilePictureActionTest.java
@@ -231,7 +231,7 @@ public class StudentProfilePictureActionTest extends BaseActionTest {
     }
 
     private StudentProfilePictureAction getAction(String... params) {
-        return (StudentProfilePictureAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentProfilePictureAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/StudentProfilePictureEditActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentProfilePictureEditActionTest.java
@@ -224,7 +224,7 @@ public class StudentProfilePictureEditActionTest extends BaseActionTest {
     }
 
     private StudentProfilePictureEditAction getAction(String... params) {
-        return (StudentProfilePictureEditAction) (gaeSimulation.getActionObject(uri, params));
+        return (StudentProfilePictureEditAction) gaeSimulation.getActionObject(uri, params);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/browsertests/AllAccessControlUiTests.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AllAccessControlUiTests.java
@@ -4,7 +4,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.util.AppUrl;
@@ -44,10 +43,6 @@ public class AllAccessControlUiTests extends BaseUiTestCase {
 
     private static InstructorAttributes otherInstructor;
 
-    // both TEST_INSTRUCTOR and TEST_STUDENT are from this course
-    @SuppressWarnings("unused")
-    private static CourseAttributes ownCourse;
-    
     @BeforeClass
     public static void classSetup() {
 
@@ -56,7 +51,6 @@ public class AllAccessControlUiTests extends BaseUiTestCase {
         testData = loadDataBundle("/AllAccessControlUiTest.json");
         
         otherInstructor = testData.instructors.get("instructor1OfCourse2");
-        ownCourse = testData.courses.get("typicalCourse1");
 
         browser = BrowserPool.getBrowser();
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -767,8 +767,8 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         // check if the rows match the given order of values
         resultsPage.click(sortIcon);
         StringBuilder searchString = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            searchString.append(values[i]).append("{*}");
+        for (String value : values) {
+            searchString.append(value).append("{*}");
         }
         resultsPage.verifyContains(searchString.toString());
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/SystemErrorEmailReportTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/SystemErrorEmailReportTest.java
@@ -107,7 +107,7 @@ public class SystemErrorEmailReportTest extends BaseUiTestCase {
         print("This exception is handled by system, make sure you don't receive any emails. ");
     }
 
-    @AfterClass()
+    @AfterClass
     public static void classTearDown() {
         printTestClassFooter();
         BrowserPool.release(browser);

--- a/src/test/java/teammates/test/cases/ui/browsertests/TableSortTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/TableSortTest.java
@@ -158,8 +158,8 @@ public class TableSortTest extends BaseUiTestCase {
         };
 
         StringBuilder searchString = new StringBuilder();
-        for (int i = 0; i < idList.length; i++) {
-            searchString.append(idList[i]).append("{*}");
+        for (String element : idList) {
+            searchString.append(element).append("{*}");
         }
         page.verifyContains(searchString.toString());
 
@@ -183,8 +183,8 @@ public class TableSortTest extends BaseUiTestCase {
         };
 
         searchString = new StringBuilder();
-        for (int i = 0; i < reversedIdList.length; i++) {
-            searchString.append(reversedIdList[i]).append("{*}");
+        for (String element : reversedIdList) {
+            searchString.append(element).append("{*}");
         }
         page.verifyContains(searchString.toString());
     }
@@ -193,8 +193,8 @@ public class TableSortTest extends BaseUiTestCase {
         //check if the rows match the given order of values
         page.click(sortIcon);
         StringBuilder searchString = new StringBuilder();
-        for (int i = 0; i < values.length; i++) {
-            searchString.append(values[i]).append("{*}");
+        for (String value : values) {
+            searchString.append(value).append("{*}");
         }
         page.verifyContains(searchString.toString());
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/TableSortTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/TableSortTest.java
@@ -158,8 +158,8 @@ public class TableSortTest extends BaseUiTestCase {
         };
 
         StringBuilder searchString = new StringBuilder();
-        for (String element : idList) {
-            searchString.append(element).append("{*}");
+        for (String id : idList) {
+            searchString.append(id).append("{*}");
         }
         page.verifyContains(searchString.toString());
 
@@ -183,8 +183,8 @@ public class TableSortTest extends BaseUiTestCase {
         };
 
         searchString = new StringBuilder();
-        for (String element : reversedIdList) {
-            searchString.append(element).append("{*}");
+        for (String id : reversedIdList) {
+            searchString.append(id).append("{*}");
         }
         page.verifyContains(searchString.toString());
     }

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -158,8 +158,7 @@ public final class AssertHelper {
         assertLogMessageEquals(expected, actual, studentEmail + "%" + courseId);
     }
     
-    @SuppressWarnings("rawtypes")
-    public static void assertSameContentIgnoreOrder(List a, List b) {
+    public static void assertSameContentIgnoreOrder(List<?> a, List<?> b) {
 
         String expectedListAsString = Joiner.on("\t").join(a);
         String actualListAsString = Joiner.on("\t").join(b);

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -63,15 +63,14 @@ public final class HtmlHelper {
     
     private static boolean assertSameHtml(String expected, String actual, boolean isPart,
                                           boolean isDifferenceToBeShown) {
-        String processedExpected = standardizeLineBreaks(expected);
         String processedActual = convertToStandardHtml(actual, isPart);
 
-        if (areSameHtmls(processedExpected, processedActual)) {
+        if (areSameHtmls(expected, processedActual)) {
             return true;
         }
         
         // the first failure might be caused by non-standardized conversion
-        processedExpected = convertToStandardHtml(expected, isPart);
+        String processedExpected = convertToStandardHtml(expected, isPart);
 
         if (areSameHtmls(processedExpected, processedActual)) {
             return true;
@@ -79,8 +78,8 @@ public final class HtmlHelper {
         
         // if it still fails, then it is a failure after all
         if (isDifferenceToBeShown) {
-            assertEquals("<expected>\n" + processedExpected + "</expected>",
-                         "<actual>\n" + processedActual + "</actual>");
+            assertEquals("<expected>" + Const.EOL + processedExpected + "</expected>",
+                         "<actual>" + Const.EOL + processedActual + "</actual>");
         }
         return false;
     }
@@ -89,15 +88,6 @@ public final class HtmlHelper {
         return AssertHelper.isContainsRegex(expected, actual);
     }
     
-    /**
-     * {@link FileHelper#readFile} uses the system's line separator as line break,
-     * while {@link #convertToStandardHtml} uses LF <code>\n</code> character.
-     * Standardize by replacing each line separator with LF character.
-     */
-    private static String standardizeLineBreaks(String expected) {
-        return expected.replace(Const.EOL, "\n");
-    }
-
     /**
      * Transform the HTML text to follow a standard format.
      * Element attributes are reordered in alphabetical order.
@@ -141,7 +131,7 @@ public final class HtmlHelper {
         text = Sanitizer.sanitizeForHtmlTag(text);
         // line breaks in text are removed as they are ignored in HTML
         // the lines separated by line break will be joined with a single whitespace character
-        return text.isEmpty() ? "" : indentation + text + "\n";
+        return text.isEmpty() ? "" : indentation + text + Const.EOL;
     }
 
     private static String convertElementNode(Node currentNode, String indentation, boolean isPart) {
@@ -187,15 +177,15 @@ public final class HtmlHelper {
     }
     
     private static String generateStudentMotdPlaceholder(String indentation) {
-        return indentation + "${studentmotd.container}\n";
+        return indentation + "${studentmotd.container}" + Const.EOL;
     }
     
     private static String generateTimeZoneSelectorPlaceholder(String indentation) {
-        return indentation + "${timezone.options}\n";
+        return indentation + "${timezone.options}" + Const.EOL;
     }
     
     // private static String generateTinymceStylePlaceholder(String indentation) {
-    //     return indentation + "${tinymce.style}\n";
+    //     return indentation + "${tinymce.style}" + Const.EOL;
     // }
     
     private static String generateNodeStringRepresentation(Node currentNode, String indentation, boolean isPart) {
@@ -310,7 +300,7 @@ public final class HtmlHelper {
         }
         
         // close the tag
-        openingTag.append(">\n");
+        openingTag.append('>').append(Const.EOL);
         return openingTag.toString();
     }
     
@@ -326,7 +316,7 @@ public final class HtmlHelper {
     }
     
     private static String getNodeClosingTag(String currentNodeName) {
-        return "</" + currentNodeName + ">\n";
+        return "</" + currentNodeName + ">" + Const.EOL;
     }
 
     private static boolean isVoidElement(String elementName) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
@@ -398,14 +398,14 @@ public class InstructorFeedbacksPage extends AppPage {
     public WebElement getViewResponseLink(String courseId, String sessionName) {
         int sessionRowId = getFeedbackSessionRowId(courseId, sessionName);
         return browser.driver.findElement(
-                By.xpath("//tbody/tr[" + (int) (sessionRowId + 1)
+                By.xpath("//tbody/tr[" + (sessionRowId + 1)
                 + "]/td[contains(@class,'session-response-for-test')]/a"));
     }
     
     public String getResponseValue(String courseId, String sessionName) {
         int sessionRowId = getFeedbackSessionRowId(courseId, sessionName);
         return browser.driver.findElement(
-                By.xpath("//tbody/tr[" + (int) (sessionRowId + 1)
+                By.xpath("//tbody/tr[" + (sessionRowId + 1)
                 + "]/td[contains(@class,'session-response-for-test')]")).getText();
     }
     
@@ -490,7 +490,7 @@ public class InstructorFeedbacksPage extends AppPage {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-view-for-test";
         return goToLinkInRow(
-                By.xpath("//tbody/tr[" + (int) (sessionRowId + 1)
+                By.xpath("//tbody/tr[" + (sessionRowId + 1)
                 + "]//a[contains(@class,'" + className + "')]"),
                 InstructorFeedbackResultsPage.class);
     }
@@ -499,7 +499,7 @@ public class InstructorFeedbacksPage extends AppPage {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-submit-for-test";
         return goToLinkInRow(
-                By.xpath("//tbody/tr[" + (int) (sessionRowId + 1)
+                By.xpath("//tbody/tr[" + (sessionRowId + 1)
                 + "]//a[contains(@class,'" + className + "')]"),
                 FeedbackSubmitPage.class);
     }
@@ -508,7 +508,7 @@ public class InstructorFeedbacksPage extends AppPage {
         int sessionRowId = getFeedbackSessionRowId(courseId, fsName);
         String className = "session-edit-for-test";
         return goToLinkInRow(
-                By.xpath("//tbody/tr[" + (int) (sessionRowId + 1)
+                By.xpath("//tbody/tr[" + (sessionRowId + 1)
                 + "]//a[contains(@class,'" + className + "')]"),
                 InstructorFeedbackEditPage.class);
     }
@@ -520,7 +520,7 @@ public class InstructorFeedbacksPage extends AppPage {
     private WebElement getLinkAtTableRow(String className, int rowIndex) {
         return browser.driver.findElement(
                 By.xpath("//table[contains(@id,'table-sessions')]//tbody/tr["
-                + (int) (rowIndex + 1) + "]//a[contains(@class,'" + className + "')]"));
+                + (rowIndex + 1) + "]//a[contains(@class,'" + className + "')]"));
     }
 
     private int getFeedbackSessionRowId(String courseId, String sessionName) {

--- a/src/test/java/teammates/test/util/PriorityInterceptor.java
+++ b/src/test/java/teammates/test/util/PriorityInterceptor.java
@@ -50,13 +50,11 @@ public class PriorityInterceptor implements IMethodInterceptor {
                 return result;
             }
             
-            @SuppressWarnings({ "rawtypes", "unchecked" })
             private int getClassPriority(IMethodInstance mi) {
                 int result = 0;
                 Method method = mi.getMethod().getMethod();
-                Class cls = method.getDeclaringClass();
-                Priority classPriority = (Priority) cls
-                        .getAnnotation(Priority.class);
+                Class<?> cls = method.getDeclaringClass();
+                Priority classPriority = cls.getAnnotation(Priority.class);
                 if (classPriority != null) {
                     result = classPriority.value();
                 }

--- a/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
+++ b/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
@@ -20,7 +20,7 @@
             ${test.student1}
           </strong>
         </span>
-        . 	 	                You have been redirected to this page because you navigated to a link for the course
+        . You have been redirected to this page because you navigated to a link for the course
         <strong>
           SFResultsUiT.CS2104
         </strong>


### PR DESCRIPTION
Fixes #6065 

Most of the stuffs done can be identified via commit messages. Here are some explanations where necessary:
- 2nd commit: the two files `datepicker.css` and `StudentProfileEditSaveActionTest.java` contains `\r` (not `\n`, not `\r\n`) which is not an acceptable line break. In addition, the standardizing-line-break in `HtmlHelper` is unnecessary as the system's line break can be used to do the job.
- 5th commit: no longer relevant.
- 6th commit: either there are workarounds so they are not needed or they are simply unnecessary.
- 7th commit: Eclipse has this "Clean Up..." option under "Source" menu, which has some seriously good functions.
