### PR TITLE
Response deletion warning message not shown when visibility edited #6070

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
+++ b/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
@@ -115,14 +115,14 @@ function showVisibilityCheckboxesIfCustomOptionSelected($containingForm) {
 }
 
 var checkCheckboxCallback = function(index, checkbox) {
-    if (checkbox.checked == false) {
+    if (checkbox.checked === false) {
         $(checkbox).trigger('change');
     }
     checkbox.checked = true;
 };
 
 var uncheckCheckboxCallback = function(index, checkbox) {
-    if (checkbox.checked == true) {
+    if (checkbox.checked === true) {
         $(checkbox).trigger('change');
     }
     checkbox.checked = false;

--- a/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
+++ b/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
@@ -115,10 +115,16 @@ function showVisibilityCheckboxesIfCustomOptionSelected($containingForm) {
 }
 
 var checkCheckboxCallback = function(index, checkbox) {
+    if (checkbox.checked == false) {
+        $(checkbox).trigger('change');
+    }
     checkbox.checked = true;
 };
 
 var uncheckCheckboxCallback = function(index, checkbox) {
+    if (checkbox.checked == true) {
+        $(checkbox).trigger('change');
+    }
     checkbox.checked = false;
 };
 


### PR DESCRIPTION
Fixes #6070 

Failing test NOT yet written because it requires quite a bit of setting up (creating the responses that will cause the "responses will be deleted" message to appear)

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

