### PR TITLE
'email is being used' error while enrolling students #6064

### DIFF
--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -402,13 +402,15 @@ public class StudentsDb extends EntitiesDb {
         
         // Update CourseStudent if it exists.
         CourseStudent courseStudent = getCourseStudentEntityForEmail(courseId, email);
-        CourseStudent courseStudentWithNewEmail = getCourseStudentEntityForEmail(courseId, newEmail);
         if (courseStudent != null) {
-            
-            if (courseStudentWithNewEmail != null && !courseStudentWithNewEmail.equals(courseStudent)) {
-                String error = ERROR_UPDATE_EMAIL_ALREADY_USED
-                        + courseStudentWithNewEmail.getName() + "/" + courseStudentWithNewEmail.getEmail();
-                throw new InvalidParametersException(error);
+            boolean isEmailChanged = !email.equals(newEmail);
+            if (isEmailChanged) {
+                CourseStudent courseStudentWithNewEmail = getCourseStudentEntityForEmail(courseId, newEmail);
+                if (courseStudentWithNewEmail != null) {
+                    String error = ERROR_UPDATE_EMAIL_ALREADY_USED
+                            + courseStudentWithNewEmail.getName() + "/" + courseStudentWithNewEmail.getEmail();
+                    throw new InvalidParametersException(error);
+                }
             }
     
             courseStudent.setEmail(newEmail);


### PR DESCRIPTION
Fixes #6064

We can skip the extra query and check for an existing student if the email isn't changed. There is no change to any test since there is no change in testable behavior.

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

