### PR TITLE
Redundant CSS definition for padding-top-0 #6074

### DIFF
--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -249,10 +249,6 @@ Apply to thead to make headers not bold.
     padding-left: 7px;
 }
 
-.padding-top-0 {
-    padding-top: 0;
-}
-
 .margin-0 {
     margin: 0;
 }
@@ -276,7 +272,7 @@ Apply to thead to make headers not bold.
     overflow: auto;
 }
 
-.padding-top-0.checkbox,.padding-top-0 {
+.padding-top-0, .padding-top-0.checkbox {
     padding-top: 0;
 }
 


### PR DESCRIPTION
Fixes #6074 

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Removed redundant CSS definition for padding-top-0