### PR TITLE
Response deletion warning message sometimes not shown when question edited #6097

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -44,13 +44,23 @@ function readyFeedbackEditPage() {
     // Bind submit actions
     $('form[id|=form_editquestion]').submit(function(event) {
         prepareDescription($(event.currentTarget));
-        if ($(this).attr('editStatus') === 'mustDeleteResponses') {
+        /* if ($(this).attr('editStatus') === 'mustDeleteResponses') { */
+        // bug: warning message sometimes not shown
+        // temporary fix: always show warning message
+        if ($(this).attr('editStatus') === 'mustDeleteResponses'
+                || $(this).attr('editStatus') === 'hasResponses') {
             event.preventDefault();
             var okCallback = function() {
                 event.currentTarget.submit();
             };
+            var tempWarningTitle = 'Warning: Existing responses may be deleted by your action';
+            var tempWarningMessage = '<p>There are existing responses to this question, editing these fields may '
+                    + 'result in <strong>all existing responses for this question to be deleted.</strong></p><p>Are you '
+                    + 'sure you want to continue?</p><em>(If you are not sure, you should choose the \'View Results\' '
+                    + 'option on the \'Sessions\' page and download a copy of the results first.)</em>';
             BootboxWrapper.showModalConfirmation(
-                    WARNING_EDIT_DELETE_RESPONSES, CONFIRM_EDIT_DELETE_RESPONSES, okCallback, null,
+                    /* WARNING_EDIT_DELETE_RESPONSES, CONFIRM_EDIT_DELETE_RESPONSES, okCallback, null, */
+                    tempWarningTitle, tempWarningMessage, okCallback, null,
                     BootboxWrapper.DEFAULT_OK_TEXT, BootboxWrapper.DEFAULT_CANCEL_TEXT,
                     StatusType.DANGER);
         }


### PR DESCRIPTION
Temporarily fixes #6097

The following warning message will always be shown whenever there are existing responses:
(note the change from `will be deleted` to `may be deleted` etc.)
![2016-10-09-025556_1280x800_scrot](https://cloud.githubusercontent.com/assets/14101781/19215280/efdd01cc-8dcb-11e6-81bf-75ce3d295e8a.png)

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->
