### PR TITLE
Remove all regex comparison in HtmlHelper (that is all calls to AssertHelper.isContainsRegex) to make html comparison faster #4383

### DIFF
--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -85,7 +85,7 @@ public final class HtmlHelper {
     }
     
     private static boolean areSameHtmls(String expected, String actual) {
-        return AssertHelper.isContainsRegex(expected, actual);
+        return expected.equals(actual);
     }
     
     /**


### PR DESCRIPTION
Fixes #4383 

Please let me know in case I missed any changes to be made.

<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

