### PR TITLE
Test failures in enrollment result due to line endings in HTML attribute value #6201

### DIFF
--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -85,7 +85,8 @@ public final class HtmlHelper {
     }
     
     private static boolean areSameHtmls(String expected, String actual) {
-        return expected.equals(actual);
+        // accounts for the variations in line breaks
+        return expected.replaceAll("[\r\n]", "").equals(actual.replaceAll("[\r\n]", ""));
     }
     
     /**


### PR DESCRIPTION
Fixes #6201 

Manually ensured that dev green is reached in both Windows and OSX.