### PR TITLE
Duplicate "the" in java files #6459

### DIFF
--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -152,7 +152,7 @@ public final class AccountsLogic {
 
     /**
      * Institute is set only if it is not null. If it is null, this instructor
-     * is given the the institute of an existing instructor of the same course.
+     * is given the institute of an existing instructor of the same course.
      */
     private void joinCourseForInstructorWithInstitute(String encryptedKey, String googleId, String institute)
             throws JoinCourseException, InvalidParametersException, EntityDoesNotExistException {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -77,7 +77,7 @@ public class AdminActivityLogPageAction extends Action {
         
         // This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
         // to show all testing logs. This will keep showing all logs from testing data despite any action
-        // or change in the page unless the the page is reloaded with "?testdata=false"
+        // or change in the page unless the page is reloaded with "?testdata=false"
         // or simply reloaded with this parameter omitted.
         boolean ifShowTestData = getRequestParamAsBoolean("testdata");
         

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -51,7 +51,7 @@ public class ControllerServlet extends HttpServlet {
 
         try {
             /* We are using the Template Method Design Pattern here.
-             * This method contains the high level logic of the the request processing.
+             * This method contains the high level logic of the request processing.
              * Concrete details of the processing steps are to be implemented by child
              * classes, based on request-specific needs.
              */

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -38,7 +38,7 @@ public class AdminActivityLogPageData extends PageData {
     /**
      * This determines whether the logs with requests contained in "excludedLogRequestURIs" below
      * should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
-     * logs despite any action or change in the page unless the the page is reloaded with "?all=false"
+     * logs despite any action or change in the page unless the page is reloaded with "?all=false"
      * or simply reloaded with this parameter omitted.
      */
     private boolean ifShowAll;
@@ -46,7 +46,7 @@ public class AdminActivityLogPageData extends PageData {
     /**
      * This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
      * to show all testing logs. This will keep showing all logs from testing data despite any action or change in the page
-     * unless the the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted.
+     * unless the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted.
      */
     private boolean ifShowTestData;
     

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
@@ -736,7 +736,7 @@ public class InstructorFeedbackResultsPageData extends PageData {
     }
 
     /**
-     * Builds participant panels for the the specified team, and add to sectionPanel
+     * Builds participant panels for the specified team, and add to sectionPanel
      * @param sectionPanel
      * @param teamName
      * @param teamMembers

--- a/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
@@ -10,7 +10,7 @@ import org.openqa.selenium.support.FindBy;
 public class InstructorCoursesPage extends AppPage {
     /* Explanation: This class follows the 'Page Objects Pattern' and as
      * explained in https://code.google.com/p/selenium/wiki/PageObjects
-     * This class represents an abstraction for the the 'Courses' page as
+     * This class represents an abstraction for the 'Courses' page as
      * shown in the Browser. The test class interact with this object when it
      * wants to perform an action on the web page (e.g., click a button).
      */


### PR DESCRIPTION
Fixes #6459 

Removed all the duplicate "the"s in java files
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->
