### PR TITLE
CI tests skipped after merge branch #6509

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ addons:
 
 before_install:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.txt)|(.png)|(.jpg)|(.gif)|^(LICENSE)|^(docs)'
+      git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md)|(.txt)|(.png)|(.jpg)|(.gif)|^(LICENSE)|^(docs)'
+      status_codes=( ${PIPESTATUS[*]} ); git_diff_status=${status_codes[0]}; grep_status=${status_codes[1]}
+      if [[ $git_diff_status == 0 && $grep_status == 1 ]]
       then
         echo "Only doc files were updated, not running the CI."
         exit


### PR DESCRIPTION
Fixes #6509

Take exit code of `git diff` command into account when deciding whether to skip CI. CI is only skipped if `git diff` returns successfully (code 0) and `grep` command reports no lines selected (code 1). If `git diff` returns with an error (non-zero code), the CI will run normally.