### PR TITLE
Bug report: Client scripts are not runnable #6532

### DIFF
--- a/src/client/java/teammates/client/remoteapi/RemoteApiClient.java
+++ b/src/client/java/teammates/client/remoteapi/RemoteApiClient.java
@@ -1,10 +1,12 @@
 package teammates.client.remoteapi;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
-import javax.jdo.JDOHelper;
 import javax.jdo.PersistenceManager;
 
+import teammates.storage.api.CoursesDb;
+import teammates.storage.api.EntitiesDb;
 import teammates.test.driver.TestProperties;
 
 import com.google.appengine.tools.remoteapi.RemoteApiInstaller;
@@ -12,10 +14,22 @@ import com.google.appengine.tools.remoteapi.RemoteApiOptions;
 
 public abstract class RemoteApiClient {
     
-    protected static final PersistenceManager PM =
-            JDOHelper.getPersistenceManagerFactory("transactions-optional").getPersistenceManager();
+    protected static final PersistenceManager PM = getPm();
     
     private static final String LOCALHOST = "localhost";
+    
+    private static PersistenceManager getPm() {
+        try {
+            // use reflection to bypass the visibility level of the method
+            Method method = EntitiesDb.class.getDeclaredMethod("getPm");
+            method.setAccessible(true);
+            
+            // the method is non-static and EntitiesDb is an abstract class; use any *Db to invoke it
+            return (PersistenceManager) method.invoke(new CoursesDb());
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
     
     protected void doOperationRemotely() throws IOException {
 


### PR DESCRIPTION
Fixes #6532 

**Outline of Solution**

Instead of initializing a second PMF, get the PMF from `EntitiesDb` itself to create the needed `PersistenceManager`.

Tested and confirmed to return everything to normal on dev server.
