### PR TITLE
Create versions of getRequestParamValue and getRequestParamValues where null is not expected #6526

### DIFF
--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -365,7 +365,7 @@ public final class Assumption {
         return formatted + "expected:<" + expected + "> but was:<" + actual + ">";
     }
 
-    public static void assertPostParamNotNull(String parameterName, String postParameter) {
+    public static <T> void assertPostParamNotNull(String parameterName, T postParameter) {
         if (postParameter == null) {
             throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
                     parameterName));

--- a/src/main/java/teammates/ui/automated/AutomatedAction.java
+++ b/src/main/java/teammates/ui/automated/AutomatedAction.java
@@ -64,7 +64,7 @@ public abstract class AutomatedAction {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the value of the specified parameter.
-     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
+     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     protected String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
@@ -81,7 +81,7 @@ public abstract class AutomatedAction {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the values of the specified parameter.
-     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
+     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     protected String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);

--- a/src/main/java/teammates/ui/automated/AutomatedAction.java
+++ b/src/main/java/teammates/ui/automated/AutomatedAction.java
@@ -3,9 +3,7 @@ package teammates.ui.automated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import teammates.common.exception.NullPostParameterException;
 import teammates.common.util.Assumption;
-import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.Logger;
 import teammates.logic.api.EmailSender;
@@ -66,7 +64,7 @@ public abstract class AutomatedAction {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the value of the specified parameter.
-     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
+     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
      */
     protected String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
@@ -83,14 +81,11 @@ public abstract class AutomatedAction {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the values of the specified parameter.
-     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
+     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
      */
     protected String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);
-        if (values == null) {
-            throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
-                    paramName));
-        }
+        Assumption.assertPostParamNotNull(paramName, values);
         return values;
     }
     

--- a/src/main/java/teammates/ui/automated/AutomatedAction.java
+++ b/src/main/java/teammates/ui/automated/AutomatedAction.java
@@ -3,6 +3,9 @@ package teammates.ui.automated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import teammates.common.exception.NullPostParameterException;
+import teammates.common.util.Assumption;
+import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.Logger;
 import teammates.logic.api.EmailSender;
@@ -58,8 +61,35 @@ public abstract class AutomatedAction {
         return HttpRequestHelper.getValueFromRequestParameterMap(request, paramName);
     }
     
+    /**
+     * Retrieves the value for the specified parameter expected to be present in the http request.
+     *
+     * @param paramName  a constant from the {@link Const.ParamsNames} class.
+     * @return the value of the specified parameter if it exists, asserts otherwise.
+     */
+    protected String getExpectedRequestParamValue(String paramName) {
+        String value = getRequestParamValue(paramName);
+        Assumption.assertPostParamNotNull(paramName, value);
+        return value;
+    }
+    
     protected String[] getRequestParamValues(String paramName) {
         return HttpRequestHelper.getValuesFromRequestParameterMap(request, paramName);
+    }
+    
+    /**
+     * Retrieves the values for the specified parameter expected to be present in the http request.
+     *
+     * @param paramName  a constant from the {@link Const.ParamsNames} class.
+     * @return the values of the specified parameter if it exists, asserts otherwise.
+     */
+    protected String[] getExpectedRequestParamValues(String paramName) {
+        String[] values = getRequestParamValues(paramName);
+        if (values == null) {
+            throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
+                    paramName));
+        }
+        return values;
     }
     
     protected void setForRetry() {

--- a/src/main/java/teammates/ui/automated/AutomatedAction.java
+++ b/src/main/java/teammates/ui/automated/AutomatedAction.java
@@ -60,16 +60,13 @@ public abstract class AutomatedAction {
     }
     
     /**
-     * Retrieves the value for the specified parameter expected to be present in the http request.
+     * Returns the value for the specified parameter expected to be present in the http request.
+     * Assumption: the requested parameter is not null.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the value of the specified parameter.
-     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     protected String getNonNullRequestParamValue(String paramName) {
-        String value = getRequestParamValue(paramName);
-        Assumption.assertPostParamNotNull(paramName, value);
-        return value;
+        return getNonNullRequestParamValues(paramName)[0];
     }
     
     protected String[] getRequestParamValues(String paramName) {
@@ -77,11 +74,10 @@ public abstract class AutomatedAction {
     }
     
     /**
-     * Retrieves the values for the specified parameter expected to be present in the http request.
+     * Returns the values for the specified parameter expected to be present in the http request.
+     * Assumption: the requested parameter is not null.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the values of the specified parameter.
-     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     protected String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);

--- a/src/main/java/teammates/ui/automated/AutomatedAction.java
+++ b/src/main/java/teammates/ui/automated/AutomatedAction.java
@@ -65,9 +65,10 @@ public abstract class AutomatedAction {
      * Retrieves the value for the specified parameter expected to be present in the http request.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the value of the specified parameter if it exists, asserts otherwise.
+     * @return the value of the specified parameter.
+     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
      */
-    protected String getExpectedRequestParamValue(String paramName) {
+    protected String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
         Assumption.assertPostParamNotNull(paramName, value);
         return value;
@@ -81,9 +82,10 @@ public abstract class AutomatedAction {
      * Retrieves the values for the specified parameter expected to be present in the http request.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the values of the specified parameter if it exists, asserts otherwise.
+     * @return the values of the specified parameter.
+     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
      */
-    protected String[] getExpectedRequestParamValues(String paramName) {
+    protected String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);
         if (values == null) {
             throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,

--- a/src/main/java/teammates/ui/automated/FeedbackSessionRemindParticularUsersEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/automated/FeedbackSessionRemindParticularUsersEmailWorkerAction.java
@@ -7,7 +7,6 @@ import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.TeammatesException;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const.ParamsNames;
 import teammates.common.util.EmailWrapper;
 import teammates.logic.api.EmailGenerator;
@@ -29,13 +28,9 @@ public class FeedbackSessionRemindParticularUsersEmailWorkerAction extends Autom
     
     @Override
     public void execute() {
-        String feedbackSessionName = getRequestParamValue(ParamsNames.SUBMISSION_FEEDBACK);
-        Assumption.assertNotNull(feedbackSessionName);
-        
-        String courseId = getRequestParamValue(ParamsNames.SUBMISSION_COURSE);
-        Assumption.assertNotNull(courseId);
-        
-        String[] usersToRemind = getRequestParamValues(ParamsNames.SUBMISSION_REMIND_USERLIST);
+        String feedbackSessionName = getNonNullRequestParamValue(ParamsNames.SUBMISSION_FEEDBACK);
+        String courseId = getNonNullRequestParamValue(ParamsNames.SUBMISSION_COURSE);
+        String[] usersToRemind = getNonNullRequestParamValues(ParamsNames.SUBMISSION_REMIND_USERLIST);
         
         try {
             FeedbackSessionAttributes session = logic.getFeedbackSession(feedbackSessionName, courseId);

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -456,9 +456,10 @@ public abstract class Action {
      * Retrieves the value for the specified parameter expected to be present in the http request.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the value of the specified parameter if it exists, asserts otherwise.
+     * @return the value of the specified parameter.
+     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
      */
-    public String getExpectedRequestParamValue(String paramName) {
+    public String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
         Assumption.assertPostParamNotNull(paramName, value);
         return value;
@@ -475,9 +476,10 @@ public abstract class Action {
      * Retrieves the values for the specified parameter expected to be present in the http request.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the values of the specified parameter if it exists, asserts otherwise.
+     * @return the values of the specified parameter.
+     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
      */
-    public String[] getExpectedRequestParamValues(String paramName) {
+    public String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);
         if (values == null) {
             throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -452,16 +452,13 @@ public abstract class Action {
     }
     
     /**
-     * Retrieves the value for the specified parameter expected to be present in the http request.
-     *
+     * Returns the value for the specified parameter expected to be present in the http request.
+     * Assumption: the requested parameter is not null.
+     * 
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the value of the specified parameter.
-     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     public String getNonNullRequestParamValue(String paramName) {
-        String value = getRequestParamValue(paramName);
-        Assumption.assertPostParamNotNull(paramName, value);
-        return value;
+        return getNonNullRequestParamValues(paramName)[0];
     }
     
     /**
@@ -472,11 +469,10 @@ public abstract class Action {
     }
     
     /**
-     * Retrieves the values for the specified parameter expected to be present in the http request.
+     * Returns the values for the specified parameter expected to be present in the http request.
+     * Assumption: the requested parameter is not null.
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
-     * @return the values of the specified parameter.
-     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     public String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -456,7 +456,7 @@ public abstract class Action {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the value of the specified parameter.
-     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
+     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     public String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
@@ -476,7 +476,7 @@ public abstract class Action {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the values of the specified parameter.
-     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
+     * @throws NullPostParameterException if the parameter is not present in the http request.
      */
     public String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -12,6 +12,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.UserType;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.NullPostParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.ActivityLogEntry;
 import teammates.common.util.Assumption;
@@ -452,10 +453,37 @@ public abstract class Action {
     }
     
     /**
+     * Retrieves the value for the specified parameter expected to be present in the http request.
+     *
+     * @param paramName  a constant from the {@link Const.ParamsNames} class.
+     * @return the value of the specified parameter if it exists, asserts otherwise.
+     */
+    public String getExpectedRequestParamValue(String paramName) {
+        String value = HttpRequestHelper.getValueFromParamMap(requestParameters, paramName);
+        Assumption.assertPostParamNotNull(paramName, value);
+        return value;
+    }
+    
+    /**
      * @return null if the specified parameter was not found in the request.
      */
     public String[] getRequestParamValues(String paramName) {
         return HttpRequestHelper.getValuesFromParamMap(requestParameters, paramName);
+    }
+    
+    /**
+     * Retrieves the values for the specified parameter expected to be present in the http request.
+     *
+     * @param paramName  a constant from the {@link Const.ParamsNames} class.
+     * @return the values of the specified parameter if it exists, asserts otherwise.
+     */
+    public String[] getExpectedRequestParamValues(String paramName) {
+        String[] values = HttpRequestHelper.getValuesFromParamMap(requestParameters, paramName);
+        if (values == null) {
+            throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
+                    paramName));
+        }
+        return values;
     }
     
     public boolean getRequestParamAsBoolean(String paramName) {

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -12,7 +12,6 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.UserType;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
-import teammates.common.exception.NullPostParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.ActivityLogEntry;
 import teammates.common.util.Assumption;
@@ -457,7 +456,7 @@ public abstract class Action {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the value of the specified parameter.
-     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
+     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
      */
     public String getNonNullRequestParamValue(String paramName) {
         String value = getRequestParamValue(paramName);
@@ -477,14 +476,11 @@ public abstract class Action {
      *
      * @param paramName  a constant from the {@link Const.ParamsNames} class.
      * @return the values of the specified parameter.
-     * @throws @link{NullPostParameterException}  if the parameter is not present in the http request.
+     * @throws @link{NullPostParameterException} if the parameter is not present in the http request.
      */
     public String[] getNonNullRequestParamValues(String paramName) {
         String[] values = getRequestParamValues(paramName);
-        if (values == null) {
-            throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
-                    paramName));
-        }
+        Assumption.assertPostParamNotNull(paramName, values);
         return values;
     }
     

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -459,7 +459,7 @@ public abstract class Action {
      * @return the value of the specified parameter if it exists, asserts otherwise.
      */
     public String getExpectedRequestParamValue(String paramName) {
-        String value = HttpRequestHelper.getValueFromParamMap(requestParameters, paramName);
+        String value = getRequestParamValue(paramName);
         Assumption.assertPostParamNotNull(paramName, value);
         return value;
     }
@@ -478,7 +478,7 @@ public abstract class Action {
      * @return the values of the specified parameter if it exists, asserts otherwise.
      */
     public String[] getExpectedRequestParamValues(String paramName) {
-        String[] values = HttpRequestHelper.getValuesFromParamMap(requestParameters, paramName);
+        String[] values = getRequestParamValues(paramName);
         if (values == null) {
             throw new NullPostParameterException(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
                     paramName));

--- a/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
+++ b/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
@@ -15,7 +15,6 @@ import teammates.common.exception.EmailSendingException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.TeammatesException;
-import teammates.common.util.Assumption;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;
@@ -52,14 +51,10 @@ public class AdminInstructorAccountAddAction extends Action {
         // If there is input from the instructorDetailsSingleLine form,
         // that data will be prioritized over the data from the 3-parameter form
         if (data.instructorDetailsSingleLine == null) {
-            data.instructorShortName = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_SHORT_NAME);
-            Assumption.assertNotNull(data.instructorShortName);
-            data.instructorName = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_NAME);
-            Assumption.assertNotNull(data.instructorName);
-            data.instructorEmail = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
-            Assumption.assertNotNull(data.instructorEmail);
-            data.instructorInstitution = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
-            Assumption.assertNotNull(data.instructorInstitution);
+            data.instructorShortName = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_SHORT_NAME);
+            data.instructorName = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_NAME);
+            data.instructorEmail = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_EMAIL);
+            data.instructorInstitution = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_INSTITUTION);
         } else {
             try {
                 String[] instructorInfo = extractInstructorInfo(data.instructorDetailsSingleLine);


### PR DESCRIPTION
Fixes #6526

Outline of solution:

* add getNonNullRequestParamValue and getNonNullRequestParamValues methods to Action and AutomatedAction
* Make Assumption.assertPostParamNotNull accept any type for the post parameter
* Add some usage of these methods