### PR TITLE
Remove FeedbackQuestionBundle::getRecipientEmails method #6438

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionBundle.java
@@ -45,14 +45,4 @@ public class FeedbackQuestionBundle {
             this.recipientList.put(entry.getKey(), entry.getValue());
         }
     }
-
-    public Set<String> getRecipientEmails(String feedbackQuestionId) {
-        HashSet<String> result = new HashSet<String>();
-
-        for (Entry<String, String> entry : this.recipientList.entrySet()) {
-            result.add(entry.getKey());
-        }
-
-        return result;
-    }
 }

--- a/src/main/java/teammates/common/datatransfer/FeedbackQuestionBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackQuestionBundle.java
@@ -3,12 +3,9 @@ package teammates.common.datatransfer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
 public class FeedbackQuestionBundle {
     public FeedbackSessionAttributes feedbackSession;


### PR DESCRIPTION
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->



Fixes #6438 
This one just removes the method `getRecipientEmails(String)` method from `FeedbackQuestionBundle.java`. Nothing in the codebase seems to be using this. Its implementation ( removed in this PR) is its only existence in the codebase.
