### PR TITLE
Bug report: User map does not load #6621

### DIFF
--- a/src/main/webapp/js/userMapData.json
+++ b/src/main/webapp/js/userMapData.json
@@ -497,7 +497,7 @@
       "Vrije Universiteit Amsterdam",
       "Windesheim Honours College",
       "Zuyd Hogeschool",
-      "Zuyd University of Applied Sciences",
+      "Zuyd University of Applied Sciences"
     ],
     "New Zealand": [
       "Auckland University of Technology",


### PR DESCRIPTION
Fixes #6621 

**Outline of Solution**

There is an entry with trailing comma in `userMapData.json` which is not a valid JSON syntax. Fixing it fixes the problem.