### PR TITLE
Remove unused parameter in InstructorHomeAjaxCoursePageData.java #6638

### DIFF
--- a/src/main/java/teammates/ui/controller/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorHomeCourseAjaxPageData.java
@@ -27,8 +27,7 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
         super(account);
     }
     
-    public void init(int tableIndex, CourseSummaryBundle courseSummary, InstructorAttributes instructor, int pendingComments,
-                     List<String> sectionNames) {
+    public void init(int tableIndex, CourseSummaryBundle courseSummary, InstructorAttributes instructor, int pendingComments) {
         this.index = tableIndex;
         this.courseTable = createCourseTable(
                 courseSummary.course, instructor, courseSummary.feedbackSessions, pendingComments);


### PR DESCRIPTION
Fixes #6638 
removed the parameter "List<String> sectionNames" from the public void init method because it was not being used.


