### PR TITLE
Bug Report: Changing visibility type unchecks all checkbox controls #6656

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
+++ b/src/main/webapp/js/instructorFeedbackEdit/visibilityOptions.js
@@ -130,7 +130,7 @@ function showVisibilityCheckboxesIfCustomOptionSelected($containingForm) {
 }
 
 function uncheckAllVisibilityOptionCheckboxes($containingForm) {
-    $containingForm.find('input[type="checkbox"]').each(function(index, checkbox) {
+    $containingForm.find('input.visibilityCheckbox').each(function(index, checkbox) {
         checkbox.checked = false;
     });
 }

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -804,6 +804,14 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
 
         assertFalse("Expected checkbox to not be checked",
                 feedbackEditPage.isCheckboxChecked("answerCheckbox", "RECEIVER_TEAM_MEMBERS", 1));
+
+        ______TS("Test other checkboxes retain their state (only visibility checkboxes affected)");
+        feedbackEditPage.clickNewQuestionButton();
+        feedbackEditPage.selectNewQuestionType("RANK_OPTIONS");
+        feedbackEditPage.tickDuplicatesAllowedCheckboxForNewQuestion();
+        feedbackEditPage.clickVisibilityDropdownForNewQuestion("ANONYMOUS_TO_RECIPIENT_AND_INSTRUCTORS");
+        assertTrue("Expected checkbox to remain checked",
+                feedbackEditPage.isRankDuplicatesAllowedCheckedForNewQuestion());
     }
 
     private void testAjaxOnVisibilityMessageButton() {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -536,6 +536,10 @@ public class InstructorFeedbackEditPage extends AppPage {
         click(browser.driver.findElement(By.cssSelector("#questionTable-" + qnNumber + " .visibility-options-dropdown "
                                                         + "a[data-option-name=\"" + optionValue + "\"]")));
     }
+    
+    public void clickVisibilityDropdownForNewQuestion(String optionValue) {
+        clickVisibilityDropdown(optionValue, NEW_QUESTION_NUM);
+    }
 
     public void clickAddQuestionButton() {
         click(addNewQuestionButton);
@@ -1077,6 +1081,10 @@ public class InstructorFeedbackEditPage extends AppPage {
     public boolean isRankDuplicatesAllowedChecked(int qnIndex) {
         WebElement checkBox = browser.driver.findElement(By.id("rankAreDuplicatesAllowed-" + qnIndex));
         return checkBox.isSelected();
+    }
+    
+    public boolean isRankDuplicatesAllowedCheckedForNewQuestion() {
+        return isRankDuplicatesAllowedChecked(NEW_QUESTION_NUM);
     }
     
     public void clickAddMoreRankOptionLink(int qnIndex) {


### PR DESCRIPTION
Fixes #6656

**Outline of Solution**

Made `uncheckAllVisibilityOptionCheckboxes` method target only visibility checkboxes via a more specific CSS selector.