### PR TITLE
Bug: Student received submission confirmation but the responses are not recorded #6643

### DIFF
--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
@@ -41,13 +41,14 @@
             <c:otherwise>
                 <input type="checkbox" name="sendsubmissionemail">
                 Send me a confirmation email
-                <input type="submit" class="btn btn-primary center-block margin-top-7px"
+                <button type="submit" class="btn btn-primary center-block margin-top-7px"
                        id="response_submit_button" data-toggle="tooltip"
                        data-placement="top" title="<%= Const.Tooltips.FEEDBACK_SESSION_EDIT_SAVE %>"
-                       value="Submit Feedback"
                        <c:if test="${data.preview or (not data.submittable)}">
                            disabled style="background: #66727A;"
                        </c:if>>
+                    Submit Feedback
+                </button>
             </c:otherwise>
         </c:choose>
     </div>

--- a/src/main/webapp/dev/CommonJsTest.js
+++ b/src/main/webapp/dev/CommonJsTest.js
@@ -232,6 +232,32 @@ QUnit.test('checkEvaluationForm()', function(assert) {
     assert.expect(0);
 });
 
+QUnit.test('addLoadingIndicator()', function(assert) {
+    var $fixture = $('#qunit-fixture');
+    $fixture.append('<button>Submit</button>');
+
+    var $button = $('button', $fixture);
+    var buttonText = 'Loading';
+    addLoadingIndicator($button, buttonText);
+
+    assert.equal($button.text(), buttonText, 'Button text changes to ' + buttonText);
+    assert.equal($button.find('img').attr('src'), '/images/ajax-loader.gif', 'Loading gif appended');
+    assert.ok($button.is(':disabled'), 'Button disabled');
+});
+
+QUnit.test('removeLoadingIndicator()', function(assert) {
+    var $fixture = $('#qunit-fixture');
+    $fixture.append('<button>Submit</button>');
+
+    var $button = $('button', $fixture);
+    var buttonText = 'Complete';
+    removeLoadingIndicator($button, buttonText);
+
+    assert.equal($button.text(), buttonText, 'Button text changes to ' + buttonText);
+    assert.equal($button.find('img').length, 0, 'Loading gif removed');
+    assert.notOk($button.is(':disabled'), 'Button enabled');
+});
+
 QUnit.test('sanitizeGoogleId(googleId)', function(assert) {
     assert.equal(sanitizeGoogleId('test  @Gmail.COM  '), 'test', 'test - valid');
     assert.equal(sanitizeGoogleId('  user@hotmail.com  '), 'user@hotmail.com',

--- a/src/main/webapp/js/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/js/feedbackSubmissionsEdit.js
@@ -54,7 +54,11 @@ $(document).ready(function() {
             return false;
         }
 
-        reenableFieldsForSubmission();
+        reenableFieldsForSubmission(); // only enabled inputs will appear in the post data
+
+        // disable button to prevent user from clicking submission button again
+        var $submissionButton = $('#response_submit_button');
+        addLoadingIndicator($submissionButton, '');
     });
 
     formatRecipientLists();

--- a/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
@@ -209,7 +209,9 @@
       <input name="moderatedperson" type="hidden" value="student1InIESFPTCourse@gmail.tmt">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorEditStudentFeedbackPageOpen.html
+++ b/src/test/resources/pages/instructorEditStudentFeedbackPageOpen.html
@@ -203,7 +203,9 @@
       <input name="moderatedperson" type="hidden" value="student1InIESFPTCourse@gmail.tmt">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
@@ -4185,7 +4185,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -404,7 +404,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
@@ -1276,7 +1276,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
@@ -2878,7 +2878,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
@@ -151,7 +151,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
@@ -3076,7 +3076,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
@@ -2840,7 +2840,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
@@ -2471,7 +2471,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
@@ -2849,7 +2849,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
@@ -212,7 +212,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
@@ -142,7 +142,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
@@ -3909,7 +3909,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
@@ -1044,7 +1044,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -279,7 +279,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
@@ -563,7 +563,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
@@ -2686,7 +2686,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
@@ -456,7 +456,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageModified.html
@@ -2679,7 +2679,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
@@ -2658,7 +2658,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
@@ -2670,7 +2670,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
@@ -247,7 +247,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" disabled="" id="response_submit_button" style="background: #66727A;" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRank.html
@@ -1321,7 +1321,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
@@ -384,7 +384,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
@@ -1325,7 +1325,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -3349,7 +3349,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -3305,7 +3305,9 @@
     <div class="bold align-center">
       <input name="sendsubmissionemail" type="checkbox">
       Send me a confirmation email
-      <input class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit" value="Submit Feedback">
+      <button class="btn btn-primary center-block margin-top-7px" data-original-title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" title="" type="submit">
+        Submit Feedback
+      </button>
     </div>
     <br>
     <br>


### PR DESCRIPTION
Fixes #6643 

Details discussion of the bug is in the issue #6643 .

**Outline of Solution**

> 1. Disable the submission button in feedback submission page when user clicks it (to prevent from clicking it again).
> 2. It is not testable to test the behaviour above. I write JS test for the function (`addLoadingIndicator()`) used to disable the button to somehow test the behaviour indirectly.

**Demo**
![demo](https://cloud.githubusercontent.com/assets/13977235/23414081/ae59070e-fe15-11e6-8270-6bc4f72e32af.gif)
