### PR TITLE
Update about.jsp with contributors from V5.97 #6682

### DIFF
--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -404,6 +404,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Fazil</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ahalfdreamer"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Dong Yanfei</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -437,6 +442,11 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
+                    <td>Jarvis Nguyen</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajarvis57"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Jiang Sheng</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3AGisonrg"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -451,12 +461,27 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Joshua Lee</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Alejolly"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>@julian1990</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajulian1990"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Karan Kamath</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
                     <td>Karandeep Singh Bhatia</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Akaran173"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Koh Xian Hui</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3AXianHuiKoh"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -528,6 +553,11 @@
                 <tr>
                     <td>Nguyen Quang Phuc</td>
                     <td>bug reporting/fixing, enhancements</td>
+                </tr>
+                <tr>
+                    <td>Nguyen Quoc Dat</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aacruis"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Nguyen Truong Duy</td>
@@ -658,6 +688,11 @@
                 <tr>
                     <td>Sudarsan Gopalaswami Padmanabhan</td>
                     <td>bug reporting/fixing, enhancements</td>
+                </tr>
+                <tr>
+                    <td>Suhas Bhatt</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Asuhas355"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Sujeet</td>
@@ -861,6 +896,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Billy Zafack</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ABillyZafack"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Bruno Mendes</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Abrnomendes"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -882,6 +922,11 @@
                 <tr>
                     <td>Dhiren Patil</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Adp80"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Dilan Tharaka</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Atharakamd"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -940,6 +985,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Jaspreet Singh</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajp111"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Jayant Jain</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -973,6 +1023,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Liew Ken Hua</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Akenhua-l"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Lim Jia Yee</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajia1"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -990,6 +1045,11 @@
                 <tr>
                     <td>Malinda Kumarasinghe</td>
                     <td>bug reporting/fixing, enhancements</td>
+                </tr>
+                <tr>
+                    <td>Manish Vishnoi</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Amanishvishnoi2"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Manvi Jain</td>
@@ -1027,6 +1087,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Mukesh Gupta</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Amukesh14149"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Nguyen Khac Tung</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Atungnk1993"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -1036,6 +1101,11 @@
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ANWuensche"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>                
+                <tr>
+                    <td>Nilaksha Perera</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ANilaksha"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
                 <tr>
                     <td>Nilesh Suthar</td>
                     <td>bug reporting/fixing, enhancements</td>
@@ -1094,6 +1164,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Savin Varshney</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Asaav"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Shekhar Reddy</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3AShekharReddy4"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -1101,6 +1176,11 @@
                 <tr>
                     <td>Shiv Kandikuppa</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ashiv12095"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Shubham Jain</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ashubhampkj"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -1113,8 +1193,18 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
+                    <td>Supun Harsha Priyadarshana</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Asupunharsha"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Tarun Bansal</td>
                     <td>bug reporting/fixing, enhancements</td>
+                </tr>
+                <tr>
+                    <td>@theaverageguy</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Atheaverageguy"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Ujjwal Wahi</td>
@@ -1133,6 +1223,11 @@
                 <tr>
                     <td>Venkatesan Harish</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aharishv7"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Wang Yuqing</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ayuqingw"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -283,7 +283,7 @@
                 <li>Zhang Xialin (Area Lead, Snr Developer)</li>
                 <li>Huy Nguyen (Area Lead, Snr Developer)</li>
                 <li>Gerald Goh (Project Lead, Snr Developer)</li>
-                <li>Xiaoni Lai (Project Lead, Snr Developer)</li>
+                <li>Lai Xiaoni (Project Lead, Snr Developer)</li>
             </ol>
         </section>
 
@@ -352,7 +352,7 @@
                 </tr>
                 <tr>
                     <td>Chi Cheng</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3AChi-Cheng-Leon"
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Acc-leon"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -386,7 +386,7 @@
                 </tr>
                 <tr>
                     <td>Devang Gaur</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Adrunken-saint"
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Adg711"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -414,11 +414,6 @@
                 <tr>
                     <td>Foo Yong Jie</td>
                     <td>bug reporting/fixing, enhancements</td>
-                </tr>
-                <tr>
-                    <td>Gautam Dudeja</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Amt10589"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Guan Xiaokang</td>
@@ -697,7 +692,7 @@
                 </tr>
                 <tr>
                     <td>Tang Ning</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Agithub-tn"
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aningt"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -844,7 +839,7 @@
                 <tr>
                     <td>Anthony Schneider</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ABr35Ba56"
-                          target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Aravind Putrevu</td>
@@ -869,6 +864,10 @@
                     <td>Bruno Mendes</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Abrnomendes"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Chan Junwei</td>
+                    <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
                     <td>Chao Song</td>
@@ -898,6 +897,11 @@
                 <tr>
                     <td>Gable Heng</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Agableh"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Gautam Dudeja</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3AtheDiablo"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -945,10 +949,6 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
-                    <td>Junwei Chan</td>
-                    <td>bug reporting/fixing, enhancements</td>
-                </tr>
-                <tr>
                     <td>Justin Ouyang</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -965,11 +965,6 @@
                 <tr>
                     <td>Kevin Thich</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ak-thich"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
-                    <td>Khac Tung</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Atungnk1993"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -1024,11 +1019,16 @@
                 <tr>
                     <td>Megan Belle</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aonealml"
-                          target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Meng Lingyao</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Alingyaomeng1"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Nguyen Khac Tung</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Atungnk1993"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -1052,7 +1052,7 @@
                 <tr>
                     <td>Pratyush Talreja</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3APratyushTalreja"
-                          target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Prithviraj Billa</td>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -151,12 +151,16 @@
         </section>
 
         <section class="row">
-            <h3>Past Committers:</h3>
+            <h3>Committers:</h3>
             <ol>
-                <li>John Kevin Tjahjadi (Jan 2016 - May 2016)</li>
-                <li>Kenneth Ho Chee Chong (Jan 2016 - May 2016)</li>
-                <li>Su Sumei (Jan 2016 - May 2016)</li>
-                <li>Wong Yu Xuan (Jan 2016 - May 2016)</li>
+                <li>Ch'ng Ming Shin (Jan 2017 - )</li>
+                <li>Dickson Tan (Jan 2017 - )</li>
+                <li>John Yong (Jan 2017 - )</li>
+                <li>Lee Yi Min (Jan 2017 - )</li>
+                <li>Li Kai (Jan 2017 - )</li>
+                <li>Samson Tan (Jan 2017 - )</li>
+                <li>Thenaesh Elango (Jan 2017 - )</li>
+                <li>Xiao Pu (Jan 2017 - )</li>
             </ol>
         </section>
 
@@ -288,6 +292,16 @@
         </section>
 
         <section class="row">
+            <h3>Past Committers:</h3>
+            <ol>
+                <li>John Kevin Tjahjadi (Jan 2016 - May 2016)</li>
+                <li>Kenneth Ho Chee Chong (Jan 2016 - May 2016)</li>
+                <li>Su Sumei (Jan 2016 - May 2016)</li>
+                <li>Wong Yu Xuan (Jan 2016 - May 2016)</li>
+            </ol>
+        </section>
+
+        <section class="row">
             <h3>Contributors:</h3>
             <table class="ordered-table">
                 <tr class="skip"><th colspan="2">Multiple contributions</th></tr>
@@ -360,11 +374,6 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
-                    <td>Chng Ming Shin</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aablyx"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
                     <td>Chong Kok Wei</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -387,11 +396,6 @@
                 <tr>
                     <td>Devang Gaur</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Adg711"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
-                    <td>Dickson Tan</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ANeurrone"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -456,11 +460,6 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
-                    <td>John Yong</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Awhipermr5"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
                     <td>Joshua Lee</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Alejolly"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -494,22 +493,12 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
-                    <td>Lee Yi Min</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aleeyimin"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
                     <td>Le Minh Khue</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
                     <td>Le Viet Tien</td>
                     <td>bug reporting/fixing, enhancements</td>
-                </tr>
-                <tr>
-                    <td>Li Kai</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ali-kai"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Lian Wenhui Florine</td>
@@ -632,11 +621,6 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
-                    <td>Samson Tan</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Asamsontmr"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
                     <td>Shawn Teo Chee Yong</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -745,11 +729,6 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
-                    <td>Thenaesh Elango</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Athenaesh"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
-                </tr>
-                <tr>
                     <td>Thng Kai Yuan</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Athngkaiyuan"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -773,11 +752,6 @@
                 <tr>
                     <td>Xia Lu</td>
                     <td>bug reporting/fixing, enhancements</td>
-                </tr>
-                <tr>
-                    <td>Xiao Pu</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Axpdavid"
-                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Y V S S Santosh</td>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -706,6 +706,11 @@
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
+                    <td>Taras Sakharchuk</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ALimeTheCoder"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Teo Yock Swee Terence</td>
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
@@ -814,6 +819,11 @@
                 <tr>
                     <td>Alexandr Kolymago</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajusttimki"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Aman Dhaliwal</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Aa-dhaliwal"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -943,6 +953,11 @@
                     <td>bug reporting/fixing, enhancements</td>
                 </tr>
                 <tr>
+                    <td>Kaitlyn Wehrheim</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Akwehrheim"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
                     <td>Kenny Zhao</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Akennyzha"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
@@ -965,6 +980,11 @@
                 <tr>
                     <td>Lim Jia Yee</td>
                     <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Ajia1"
+                        target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
+                </tr>
+                <tr>
+                    <td>Logan Smith</td>
+                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3Asmithla1"
                         target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
@@ -1091,11 +1111,6 @@
                 <tr>
                     <td>Steven Khong</td>
                     <td>bug reporting/fixing, enhancements</td>
-                </tr>
-                <tr>
-                    <td>Taras Sakharchuk</td>
-                    <td><a href="https://github.com/TEAMMATES/teammates/issues?q=involves%3ALimeTheCoder"
-                          target="_blank" rel="noopener noreferrer">bug reporting/fixing, enhancements</a></td>
                 </tr>
                 <tr>
                     <td>Tarun Bansal</td>


### PR DESCRIPTION
Fixes #6682 

**Outline of Solution**

[Preview of about.jsp page after this change](https://teammates-wkurniawan07.appspot.com/about.jsp).

- Commit 1: as per usual, just by tracing this milestone's contributors.
- Commit 2: wrong names (missing/misplaced surnames etc.) were traced manually, outdated GitHub username were found by listing the usernames in the textbox for opening new issues and observing which ones did not get hyperlinked.
- Commit 3: did a `git log` for 10000 entries and checked with `about.jsp` on the usernames that are not listed (automated). Traced on GitHub manually to find out whether single or multiple contributions.
- Commit~~s~~ 4 ~~and 5~~: as per how the community structure is like currently.

If some things need not be done on this PR, I will undo the relevant commits.
