### PR TITLE
Remove unused methods in datepicker.js #6693

### DIFF
--- a/src/main/webapp/js/datepicker.js
+++ b/src/main/webapp/js/datepicker.js
@@ -73,22 +73,6 @@ function triggerDatepickerOnClick(datepickerDivs) {
  * @assumption: startDate has a valid value
  * @returns
  */
-function getMinDateForEndDate(startDate) {
-    return startDate;
-}
-
-/**
- * @assumption: endDate has a valid value
- * @returns
- */
-function getMaxDateForStartDate(endDate) {
-    return endDate;
-}
-
-/**
- * @assumption: startDate has a valid value
- * @returns
- */
 function getMaxDateForVisibleDate(startDate, publishDate) {
     var minDate = 0;
 


### PR DESCRIPTION
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Fixes #6693 

**Outline of Solution**

> Tell us how you solved the issue
I just remove the unused methods getMinDateForEndDate and getMaxDateForStartDate, as described in the issue.
Is ready for review
