### PR TITLE
Add contents of `FeedbackSessionState.java` to `AdminSearchPageData.java` as private enum

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionState.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionState.java
@@ -1,5 +1,0 @@
-package teammates.common.datatransfer;
-
-public enum FeedbackSessionState {
-    OPEN, CLOSED, PUBLISHED, AWAITING;
-}

--- a/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
@@ -22,6 +22,10 @@ import teammates.ui.template.AdminSearchStudentTable;
 
 public class AdminSearchPageData extends PageData {
 
+    private enum FeedbackSessionState {
+        OPEN, CLOSED, PUBLISHED, AWAITING;
+    }
+
     public String searchKey = "";
 
     /*

--- a/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
-import teammates.common.datatransfer.FeedbackSessionState;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -22,6 +21,10 @@ import teammates.ui.template.AdminSearchStudentRow;
 import teammates.ui.template.AdminSearchStudentTable;
 
 public class AdminSearchPageData extends PageData {
+
+  private enum FeedbackSessionState {
+      OPEN, CLOSED, PUBLISHED, AWAITING;
+  }
 
     public String searchKey = "";
 

--- a/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
@@ -22,10 +22,6 @@ import teammates.ui.template.AdminSearchStudentTable;
 
 public class AdminSearchPageData extends PageData {
 
-  private enum FeedbackSessionState {
-      OPEN, CLOSED, PUBLISHED, AWAITING;
-  }
-
     public String searchKey = "";
 
     /*


### PR DESCRIPTION
Issue #6640 

Fixes #

**Outline of Solution**

Basically I added the `FeedbackSessionState.java` class as an enum to the `AdminSearchPageData.java` class as asked for in the Issue tracker.

> Tell us how you solved the issue

I basically just cut the enum from `FeedbackSessionState.java` file to `AdminSearchPageData.java` and deleted the `FeedbackSessionState.java` from `/src/main/java/teammates/common/datatransfer` as it was no longer needed.
