### PR TITLE
Setup guide: mention the Java path should use '/'    #6723

### DIFF
--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -59,7 +59,7 @@ More information can be found at [this documentation](https://help.github.com/ar
    * `gradle.properties`<br>
       If you want to use a JDK other than the one specified in your PATH variable, add the value to the variable `org.gradle.java.home`.
       This value must be a valid **JDK 1.7** directory.
-      **Windows users** should use a **forward slash**(`/`) instead of the windows default **backward slash**(`\`) while specifying the path.
+      **Windows users** should use a **forward slash**(`/`) instead of the Windows default **backward slash**(`\`) while specifying the path.
    * `src/test/resources/test.properties`<br>
       Append a **same** unique id (e.g your name) to **each** of the default accounts found at the bottom of this file,
       e.g change `test.student1.account=alice.tmms` to `test.student1.account=alice.tmms.KevinChan`.

--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -59,7 +59,7 @@ More information can be found at [this documentation](https://help.github.com/ar
    * `gradle.properties`<br>
       If you want to use a JDK other than the one specified in your PATH variable, add the value to the variable `org.gradle.java.home`.
       This value must be a valid **JDK 1.7** directory.
-      **Windows users** must be careful while entering in the address. Use a **forward slash(/)** instead of the windows default backward slash(/) while entering the path to the directory. This confusion usually occurs when users copy and paste the path from Windows explorer to gradle.properties. 
+      **Windows users** should use a **forward slash**(`/`) instead of the windows default **backward slash**(`\`) while specifying the path.
    * `src/test/resources/test.properties`<br>
       Append a **same** unique id (e.g your name) to **each** of the default accounts found at the bottom of this file,
       e.g change `test.student1.account=alice.tmms` to `test.student1.account=alice.tmms.KevinChan`.

--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -59,6 +59,7 @@ More information can be found at [this documentation](https://help.github.com/ar
    * `gradle.properties`<br>
       If you want to use a JDK other than the one specified in your PATH variable, add the value to the variable `org.gradle.java.home`.
       This value must be a valid **JDK 1.7** directory.
+      **Windows users** must be careful while entering in the address. Use a **forward slash(/)** instead of the windows default backward slash(/) while entering the path to the directory. This confusion usually occurs when users copy and paste the path from Windows explorer to gradle.properties. 
    * `src/test/resources/test.properties`<br>
       Append a **same** unique id (e.g your name) to **each** of the default accounts found at the bottom of this file,
       e.g change `test.student1.account=alice.tmms` to `test.student1.account=alice.tmms.KevinChan`.


### PR DESCRIPTION
Added warning for windows user to use forward slash instead of backward slash while entering the path to JDK.

Fixes #6723

> Added warning for windows user to use forward slash instead of backward slash while entering the path to JDK.