### PR TITLE
Random test fail in *LogicTest.java recently #6777

### DIFF
--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -380,6 +380,8 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
                 today.getTime(), LOG_MESSAGE_INTERVAL_MANY_LOGS);
     }
 
+    // The two test groups should have different 'priority' so that they can run separately
+    // as they depend on different sets of log messages
     @Test(groups = "manyLogs", priority = 2)
     public void statusMessageAndContinueSearch_withManyLogs_searchCorrectly() {
         Date today = TimeHelper.getDateOffsetToCurrentTime(0);

--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -380,7 +380,7 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
                 today.getTime(), LOG_MESSAGE_INTERVAL_MANY_LOGS);
     }
 
-    @Test(groups = "manyLogs", dependsOnGroups = "typicalLogs")
+    @Test(groups = "manyLogs", priority = 2)
     public void statusMessageAndContinueSearch_withManyLogs_searchCorrectly() {
         Date today = TimeHelper.getDateOffsetToCurrentTime(0);
 


### PR DESCRIPTION
Fixes #6777

**Possible Reason**
I guess maybe testNG takes too much time to figure out the dependency (`dependsOnGroups = "..."`) and thus result in test case failures?

**Outline of Solution**

> 1. AdminActivityLogPageActionTest: change `dependsOnGroups` to `priority`
> 1. In testNG, `priority` starts from `0`, which is the highest priority. Note that I use `priority=2` instead of `priority=1` for better understanding as some developers may think it start from `1`. And actually, as long as the `manyLogs` group run separately from `typicalLogs` group. You can set any priority that bigger or equal to 1.
