### PR TITLE
development.md: Timezone needs to be specified in IntelliJ dev server run configuration during testing #6780

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -131,9 +131,13 @@ It is recommended to use Firefox 46.0 as this is the browser used in CI build (T
 Before running the test suite, both the server and the test environment should be using the UTC time zone. If this has not been done yet, here is the procedure:
 * Stop the dev server if it is running.
 * Specify timezone as a VM argument:
-  * Go to the run configuration Eclipse created when you started the dev server (`Run → Run configurations ...` and select the appropriate one).
-  * Click on the `Arguments` tab and add `-Duser.timezone=UTC` to the `VM arguments` text box.
-  * Save the configuration for future use: Go to the `Common` tab (the last one) and make sure you have selected `Save as → Local file` and `Display in favorites menu → Run, Debug`.
+  * Eclipse
+    * Go to the run configuration Eclipse created when you started the dev server (`Run → Run configurations ...` and select the appropriate one).
+    * Click on the `Arguments` tab and add `-Duser.timezone=UTC` to the `VM arguments` text box.
+    * Save the configuration for future use: Go to the `Common` tab (the last one) and make sure you have selected `Save as → Local file` and `Display in favorites menu → Run, Debug`.
+  * IntelliJ
+    * Go to `Run → Edit Configurations...` and select `Dev Server`.
+    * Add `-Duser.timezone=UTC` to the `VM options` text box. Click `OK`.
 * Start the server again using the run configuration you created in the previous step.
 
 ### Using Firefox


### PR DESCRIPTION
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Fixes #6780