### PR TITLE
Change `File` to `Configure` in Step 2 of instructions for setting up IntelliJ  fixes #6726  

### DIFF
--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -122,9 +122,9 @@ More information can be found at [this documentation](https://help.github.com/ar
 1. If you are an existing IntelliJ user and have a project open, close the project (`File → Close Project`) before continuing.
 1. Configure IntelliJ as follows:
    * JRE: Click `Configure → Project Defaults → Project Structure`. Under `Project SDK`, click `New → JDK`. Locate the `Java` folder where you have installed `JDK 1.7`. Select `jdk1.7.*` and click `OK`.
-   * Indentation: In TEAMMATES, we use 4 spaces in place of tabs for indentation. Go to `File → Settings → Editor → Code Style` and ensure that `Use tab character` is unchecked for `Java`, `JavaScript`, `HTML`, `CSS` and `XML`.
-   * Text Encoding: Go to `File → Settings → Editor → File Encodings` and ensure that `IDE Encoding` and `Project Encoding` are set to `UTF-8`.
-   * HTML/JSP syntax: We prefer not to use the HTML/JSP Inspections provided by IntelliJ. Go to `File → Settings → Editor → Inspections` and uncheck `HTML` and `JSP Inspections`.
+   * Indentation: In TEAMMATES, we use 4 spaces in place of tabs for indentation. Go to `Configure → Settings → Editor → Code Style` and ensure that `Use tab character` is unchecked for `Java`, `JavaScript`, `HTML`, `CSS` and `XML`.
+   * Text Encoding: Go to `Configure → Settings → Editor → File Encodings` and ensure that `IDE Encoding` and `Project Encoding` are set to `UTF-8`.
+   * HTML/JSP syntax: We prefer not to use the HTML/JSP Inspections provided by IntelliJ. Go to `Configure → Settings → Editor → Inspections` and uncheck `HTML` and `JSP Inspections`.
 1. Import the project into IntelliJ.
    * Click `Import project` and select the local repository folder.
    * Click `Import project from external model → Gradle`.


### PR DESCRIPTION
fixes #6726