### PR TITLE
Remove useless replacement of text in AdminActivityLogPageActionTest #6857

### DIFF
--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -450,7 +450,6 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
         assertEquals(expectedMsgs.size(), actualLogs.size());
         for (int i = 0; i < expectedMsgs.size(); i++) {
             String actualMsg = actualLogs.get(i).generateLogMessage();
-            actualMsg = actualMsg.replace("<mark>", "").replace("</mark>", "");
             assertTrue("expecte: " + expectedMsgs.get(i) + "to contain:" + actualMsg,
                     expectedMsgs.get(i).contains(actualMsg));
         }

--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -450,7 +450,7 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
         assertEquals(expectedMsgs.size(), actualLogs.size());
         for (int i = 0; i < expectedMsgs.size(); i++) {
             String actualMsg = actualLogs.get(i).generateLogMessage();
-            assertTrue("expecte: " + expectedMsgs.get(i) + "to contain:" + actualMsg,
+            assertTrue("expect: " + expectedMsgs.get(i) + "to contain:" + actualMsg,
                     expectedMsgs.get(i).contains(actualMsg));
         }
     }


### PR DESCRIPTION
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Fixes #6857

**Outline of Solution**
> Delete the line as xpdavid suggested.
actualMsg = actualMsg.replace("<mark>", "").replace("</mark>", "");
