### PR TITLE
Add one step setting configuration at IntelliJ

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -40,6 +40,7 @@ Click the "Terminate" icon on the Eclipse console.
 
 1. Go to `File → Project Structure...`.
 1. Under `Artifacts → Gradle : <your-project-name>.war (exploded)`, check `Include in project build`.
+1. Modify `Output Directory` : `{Project Home dir}/build/libs/exploded/teammates.war` to `{Project Home dir}/build/exploded-app`.
 1. Click `OK`.
 1. Got to `Run → Edit Configurations...`.
 1. Click `+ → Google AppEngine Dev Server`.


### PR DESCRIPTION

**Environment**

MAC-OSX 10.12.3
IntelliJ IDEA 2016.3.5
JRE: 1.8.0_112-release-408-b6 x86_64
JVM: OpenJDK 64-Bit Server VM by JetBrains s.r.o
JDK: 1.7.021

Local Dev Server

appengineVersion = "1.9.27"
checkstyleVersion = "6.19"
pmdVersion = "5.5.4"
findbugsVersion = "3.0.1"

'master' branch at commit 1afe02f

A DESCRIPTION OF THE PROBLEM : 
running dev server error that the working directory does not exist.

**Steps to reproduce**

follow setting guideline
`File → Project Structure...`,
 Under `Artifacts → Gradle : <your-project-name>.war (exploded)`.
In Development Guideline Documents

and no mention about modifying Default path of output directory of teammates.war (exploded)

**Expected behaviour**

Running  Dev Server well

**Actual behaviour**

Error running dev server : 
Cannot start process, the working directory '{project home directory}/build/libs/exploded/teammates.war' does not exist

Fixes #

**Outline of Solution**

I realized that IntelliJ can not find the path to the 'appengine-web.xml' file, and I fixed the default path and pointed it to another path, which solves the problem.
so I commit a modified 'development.md' file that I think will help many people who would like to contribute to the teammates project in the IntelliJ environment.

