### PR TITLE
AllJsTests failing on the live server #6935

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1124,7 +1124,7 @@ public final class Const {
         public static final String ACTION_NOT_FOUND_PAGE = "/pageNotFound.jsp";
         public static final String FEEDBACK_SESSION_NOT_VISIBLE = "/feedbackSessionNotVisible.jsp";
 
-        public static final String JS_UNIT_TEST = "/dev/allJsUnitTests.jsp?coverage";
+        public static final String JS_UNIT_TEST = "/dev/allJsUnitTests.jsp";
         public static final String MASHUP = "/dev/mashup.jsp";
         public static final String TABLE_SORT = "/dev/tableSort.jsp";
         public static final String TIMEZONE = "/dev/timezone.jsp";

--- a/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
+++ b/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
@@ -29,8 +29,8 @@ public class AllJsTests extends BaseUiTestCase {
     public void classSetup() {
         loginAdmin();
         page = AppPage.getNewPageInstance(browser)
-                      .navigateTo(createUrl(Const.ViewURIs.JS_UNIT_TEST))
-                      .changePageType(QUnitPage.class);
+                .navigateTo(createUrl(Const.ViewURIs.JS_UNIT_TEST + (TestProperties.isDevServer() ? "?coverage" : "")))
+                .changePageType(QUnitPage.class);
         page.waitForPageToLoad();
     }
 
@@ -67,6 +67,10 @@ public class AllJsTests extends BaseUiTestCase {
         assertTrue(totalCases != 0);
 
         print("As expected, " + expectedFailedCases + " failed tests out of " + totalCases + " tests.");
+
+        if (!TestProperties.isDevServer()) {
+            return;
+        }
 
         float coverage = page.getCoverage();
 

--- a/src/test/java/teammates/test/pageobjects/QUnitPage.java
+++ b/src/test/java/teammates/test/pageobjects/QUnitPage.java
@@ -3,6 +3,8 @@ package teammates.test.pageobjects;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import teammates.test.driver.TestProperties;
+
 /**
  * The page object for QUnit test result page.
  */
@@ -25,7 +27,11 @@ public class QUnitPage extends AppPage {
     public void waitForPageToLoad() {
         // This is not a web page and thus document.readyState is not relevant here.
         // Instead, wait for the coverage percentage to appear.
-        waitForElementVisibility(coverage);
+        if (TestProperties.isDevServer()) {
+            waitForElementVisibility(coverage);
+        } else {
+            waitForElementVisibility(totalCase);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #6935 

**Outline of Solution**

Removed the check for coverage in staging server; that is, testing against staging server will only check that all the unit tests pass.

Coverage check is still done in dev server during CI run which is sufficient.