### PR TITLE
InstructorCourseDetailsPageUiTest failing on live server #6934

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseDetailsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseDetailsPageUiTest.java
@@ -194,6 +194,7 @@ public class InstructorCourseDetailsPageUiTest extends BaseUiTestCase {
         if (isEmailEnabled) {
             assertTrue(didStudentReceiveReminder(courseName, courseId, student2.email, student2Password));
         }
+        detailsPage.verifyStatus(Const.StatusMessages.COURSE_REMINDER_SENT_TO + student2.email);
 
         // Hiding of the 'Send invite' link is already covered by content test.
         //  (i.e., they contain cases of both hidden and visible 'Send invite' links.


### PR DESCRIPTION
<!--
Please follow the naming conventions in the "guidelines for contributing" link above or the pull request may be rejected.

Also, do consider outlining the solution taken as doing so will likely help in the reviewing process
(e.g., when the pull request involves non-trivial changes)
-->

Fixes #6934

**Outline of Solution**

Wait for status message to appear on same page after ajax request to remind student so it doesn't show up unexpectedly on a subsequent page.