### PR TITLE
Add instructions for restoring IntelliJ run configurations #6818

### DIFF
--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -134,9 +134,9 @@ More information can be found at [this documentation](https://help.github.com/ar
    * Check `Use auto-import`. Ensure that `1.7` is used for the `Gradle JVM`.
    * Click `Finish`.
 1. During your import, the run configurations for the project were deleted locally. In order to restore these, open git shell and run the command
-  ```sh
-     git checkout -- .idea/runConfigurations
-  ```
+   ```sh
+      git checkout -- .idea/runConfigurations
+   ```
 1. In your `Event Log`, you should see this line: `Frameworks detected: Google App Engine, Web, JPA frameworks are detected in the project`. Click `Configure` and `OK` in the dialog box that appears.
 
 If you followed every step correctly, you should have successfully set up the development environment.

--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -133,7 +133,7 @@ More information can be found at [this documentation](https://help.github.com/ar
    * Click `Next`.
    * Check `Use auto-import`. Ensure that `1.7` is used for the `Gradle JVM`.
    * Click `Finish`.
-1. During your import, the run configurations for the project have been deleted locally. In order to restore these, open git shell and run the command
+1. During your import, the run configurations for the project were deleted locally. In order to restore these, open git shell and run the command
   ```sh
      git checkout -- .idea/runConfigurations
   ```

--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -133,6 +133,10 @@ More information can be found at [this documentation](https://help.github.com/ar
    * Click `Next`.
    * Check `Use auto-import`. Ensure that `1.7` is used for the `Gradle JVM`.
    * Click `Finish`.
+1. During your import, the run configurations for the project have been deleted locally. In order to restore these, open git shell and run the command
+  ```sh
+     git checkout -- .idea/runConfigurations
+  ```
 1. In your `Event Log`, you should see this line: `Frameworks detected: Google App Engine, Web, JPA frameworks are detected in the project`. Click `Configure` and `OK` in the dialog box that appears.
 
 If you followed every step correctly, you should have successfully set up the development environment.


### PR DESCRIPTION
Fixes #6818 

Added instructions to the file docs/settingUp.md

The following lines were added after line 135
"
1. During your import, the run configurations for the project were deleted locally. In order to restore these, open git shell and run the command
  ```sh
     git checkout -- .idea/runConfigurations
  ```
"