### PR TITLE
Fix typo in header comments for searchStudentsInWholeSystem method in StudentDb #6975

### DIFF
--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -64,7 +64,7 @@ public class StudentsDb extends EntitiesDb {
 
     /**
      * This method should be used by admin only since the searching does not restrict the
-     * visibility according to the logged-in user's google ID. This is used by amdin to
+     * visibility according to the logged-in user's google ID. This is used by admin to
      * search students in the whole system.
      * @return null if no result found
      */


### PR DESCRIPTION
Fixes #6975

Typo in header comment for searchStudentInWholeSystemMethod in
StudentDb. Changed from ‘admin’ to ‘admin.’

Fixed typo in header comment for searchStudentInWholeSystemMethod in “src/main/java/teammates/storage/api/StudentsDb.java”

Changed from ‘amdin’ to ‘admin.’
