### PR TITLE
Extracting checking of page result destination in action tests as a method #6909

### DIFF
--- a/src/test/java/teammates/test/cases/action/BaseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/BaseActionTest.java
@@ -730,5 +730,8 @@ public abstract class BaseActionTest extends BaseComponentTestCase {
     protected void verifyNumberOfEmailsSent(Action action, int emailCount) {
         assertEquals(emailCount, action.getEmailSender().getEmailsSent().size());
     }
-
+    
+    protected String checkingOfPageResultDestination(String user){       
+       return Const.ViewURIs.INSTRUCTOR_COURSE_DETAILS+"?error=false&user="+user+""; 
+    }
 }

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDetailsPageActionTest.java
@@ -36,7 +36,7 @@ public class InstructorCourseDetailsPageActionTest extends BaseActionTest {
         InstructorCourseDetailsPageAction pageAction = getAction(submissionParams);
         ShowPageResult pageResult = getShowPageResult(pageAction);
 
-        assertEquals(Const.ViewURIs.INSTRUCTOR_COURSE_DETAILS + "?error=false&user=idOfInstructor1OfCourse1",
+        assertEquals(checkingOfPageResultDestination("idOfInstructor1OfCourse1"),
                      pageResult.getDestinationWithParams());
         assertFalse(pageResult.isError);
         assertEquals("", pageResult.getStatusMessage());
@@ -67,7 +67,7 @@ public class InstructorCourseDetailsPageActionTest extends BaseActionTest {
         pageAction = getAction(addUserIdToParams(instructor4.googleId, submissionParams));
         pageResult = getShowPageResult(pageAction);
 
-        assertEquals(Const.ViewURIs.INSTRUCTOR_COURSE_DETAILS + "?error=false&user=idOfInstructor4",
+        assertEquals(checkingOfPageResultDestination("idOfInstructor4"),
                      pageResult.getDestinationWithParams());
         assertFalse(pageResult.isError);
         assertEquals(String.format(Const.StatusMessages.INSTRUCTOR_COURSE_EMPTY,


### PR DESCRIPTION


Fixes #6909

**Outline of Solution**
Using inheritance removed code duplications in assert statements

