### PR TITLE
gradlew.bat staticAnalysis does not run on Windows #7020

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Ensure that you have:
 - [ ] Gone through all the changes in this PR and ensured that:
   - [ ] They addressed one (and only one) issue
   - [ ] No unintended changes were made
-- [ ] Run and passed static analysis: `./gradlew staticAnalysis` and `npm run lint`
+- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
 - [ ] Added/updated tests, if changes in functionality were involved
 - [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Ensure that you have:
 - [ ] Gone through all the changes in this PR and ensured that:
   - [ ] They addressed one (and only one) issue
   - [ ] No unintended changes were made
-- [ ] Run and passed static analysis: `./gradlew staticAnalysis`
+- [ ] Run and passed static analysis: `./gradlew staticAnalysis` and `npm run lint`
 - [ ] Added/updated tests, if changes in functionality were involved
 - [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ before_script:
   - export PATH="./node_modules/.bin":$PATH
   - ./gradlew createConfigs testClasses
   - ./gradlew downloadStaticAnalysisTools
-  - npm install
   - ./gradlew staticAnalysis --continue
+  - npm install
+  - npm run lint
 
 install: true
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - export PATH="./node_modules/.bin":$PATH
   - ./gradlew createConfigs testClasses
   - ./gradlew downloadStaticAnalysisTools
-  - ./gradlew staticAnalysis --continue
+  - ./gradlew lint --continue
   - npm install
   - npm run lint
 

--- a/build.gradle
+++ b/build.gradle
@@ -293,10 +293,6 @@ war.dependsOn enhancerRun
 
 def isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
 
-task lint(type: Exec) {
-    commandLine "npm", "run", "lint"
-}
-
 checkstyle {
     toolVersion = checkstyleVersion
     configFile = file("static-analysis/teammates-checkstyle.xml")
@@ -354,9 +350,9 @@ macker.dependsOn testClasses
 macker.shouldRunAfter staticAnalysisMain, staticAnalysisTest
 
 task staticAnalysis {
-    description "Runs the entire static analysis tasks."
+    description "Runs the entire static analysis tasks for back-end."
     group "Static analysis"
-    dependsOn lint, staticAnalysisMain, staticAnalysisTest, macker
+    dependsOn staticAnalysisMain, staticAnalysisTest, macker
 }
 
 // TEST TASKS

--- a/build.gradle
+++ b/build.gradle
@@ -327,11 +327,11 @@ task downloadStaticAnalysisTools {
     }
 }
 
-task staticAnalysisMain {
+task lintMain {
     dependsOn checkstyleMain, pmdMain, findbugsMain
 }
 
-task staticAnalysisTest {
+task lintTest {
     dependsOn checkstyleTest, pmdTest, findbugsTest
 }
 
@@ -347,12 +347,12 @@ task macker << {
 }
 
 macker.dependsOn testClasses
-macker.shouldRunAfter staticAnalysisMain, staticAnalysisTest
+macker.shouldRunAfter lintMain, lintTest
 
-task staticAnalysis {
+task lint {
     description "Runs the entire static analysis tasks for back-end."
     group "Static analysis"
-    dependsOn staticAnalysisMain, staticAnalysisTest, macker
+    dependsOn lintMain, lintTest, macker
 }
 
 // TEST TASKS

--- a/docs/staticAnalysis.md
+++ b/docs/staticAnalysis.md
@@ -195,7 +195,7 @@ npm run lint
 
 To run all static analysis tasks in one sitting, run the following two commands:
 ```
-./gradlew staticAnalysis --continue
+./gradlew lint --continue
 npm run lint
 ```
 

--- a/docs/staticAnalysis.md
+++ b/docs/staticAnalysis.md
@@ -193,9 +193,10 @@ To run ESLint and Stylelint analysis on all JavaScript, JSON, and CSS source fil
 npm run lint
 ```
 
-To run all static analysis tasks in one sitting, run the following command:
+To run all static analysis tasks in one sitting, run the following two commands:
 ```
 ./gradlew staticAnalysis --continue
+npm run lint
 ```
 
 ## Running code coverage session

--- a/static-analysis/teammates-eslint-es6.yml
+++ b/static-analysis/teammates-eslint-es6.yml
@@ -14,8 +14,14 @@ parserOptions:
 
 rules:
 
+    # enforce named function expressions
+    func-names: "off"
+
     # enforce consistent indentation
     indent: ["error", 4]
+
+    # enforce consistent linebreak style
+    linebreak-style: "off"
 
     # enforce a maximum line length
     max-len: ["error", 125]


### PR DESCRIPTION
Fixes #7020 

**Outline of Solution**

- Suppressed rules that caused error on Windows: `linebreak-style` and `func-names` (the latter did not really cause error, but made a lot of noise in the build log).
- Separated NPM scripts from Gradle. We could alternatively try [Gradle Node plugin](https://github.com/srs/gradle-node-plugin), but this needs more research and trial/error.
- Renamed `staticAnalysis` to `lint` in Gradle tasks to standardize with NPM's.