### PR TITLE
AdminEmailComposeSendAction-has-no-log-message-on-success #6699

### DIFF
--- a/.settings/com.google.appengine.eclipse.core.prefs
+++ b/.settings/com.google.appengine.eclipse.core.prefs
@@ -1,5 +1,5 @@
 eclipse.preferences.version=1
-filesCopiedToWebInfLib=appengine-api-1.0-sdk-1.9.27.jar|appengine-api-labs.jar|appengine-endpoints-deps.jar|appengine-endpoints.jar|appengine-jsr107cache-1.9.27.jar|datanucleus-appengine-1.0.10.final.jar|datanucleus-core-1.1.5.jar|datanucleus-jpa-1.1.5.jar|geronimo-jpa_3.0_spec-1.1.1.jar|geronimo-jta_1.1_spec-1.1.1.jar|jdo2-api-2.3-eb.jar|jsr107cache-1.1.jar
+filesCopiedToWebInfLib=appengine-api-1.0-sdk-1.9.50.jar|appengine-api-labs.jar|appengine-endpoints-deps.jar|appengine-endpoints.jar|appengine-jsr107cache-1.9.50.jar|datanucleus-appengine-1.0.10.final.jar|datanucleus-core-1.1.5.jar|datanucleus-jpa-1.1.5.jar|geronimo-jpa_3.0_spec-1.1.1.jar|geronimo-jta_1.1_spec-1.1.1.jar|jdo2-api-2.3-eb.jar|jsr107cache-1.1.jar
 gaeDatanucleusVersion=v1
 gaeDeployDialogSettings=
 gaeIsEclipseDefaultInstPath=true

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
@@ -51,6 +51,8 @@ public class AdminEmailComposeSendAction extends Action {
             try {
                 groupReceiver.add(groupReceiverListFileKey);
                 GoogleCloudStorageHelper.getGroupReceiverList(new BlobKey(groupReceiverListFileKey));
+                statusToAdmin = "Email sent to " + groupReceiverListFileKey;
+                statusToUser.add(new StatusMessage("Email sent to " + groupReceiverListFileKey, StatusMessageColor.SUCCESS));
             } catch (Exception e) {
                 isError = true;
                 setStatusForException(e, "An error occurred when retrieving receiver list, please try again");
@@ -59,6 +61,8 @@ public class AdminEmailComposeSendAction extends Action {
 
         if (addressModeOn) {
             addressReceiver.add(addressReceiverListString);
+            statusToAdmin = "Email sent to " + addressReceiverListString;
+            statusToUser.add(new StatusMessage("Email sent to " + addressReceiverListString, StatusMessageColor.SUCCESS));
             try {
                 checkAddressReceiverString(addressReceiverListString);
             } catch (InvalidParametersException e) {
@@ -99,7 +103,7 @@ public class AdminEmailComposeSendAction extends Action {
                                                         null);
             data.emailToEdit.emailId = emailId;
         }
-
+        
         return createShowPageResult(Const.ViewURIs.ADMIN_EMAIL, data);
     }
 

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
@@ -103,7 +103,6 @@ public class AdminEmailComposeSendAction extends Action {
                                                         null);
             data.emailToEdit.emailId = emailId;
         }
-        
         return createShowPageResult(Const.ViewURIs.ADMIN_EMAIL, data);
     }
 

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
@@ -51,8 +51,6 @@ public class AdminEmailComposeSendAction extends Action {
             try {
                 groupReceiver.add(groupReceiverListFileKey);
                 GoogleCloudStorageHelper.getGroupReceiverList(new BlobKey(groupReceiverListFileKey));
-                statusToAdmin = "Email sent to " + groupReceiverListFileKey;
-                statusToUser.add(new StatusMessage("Email sent to " + groupReceiverListFileKey, StatusMessageColor.SUCCESS));
             } catch (Exception e) {
                 isError = true;
                 setStatusForException(e, "An error occurred when retrieving receiver list, please try again");
@@ -61,8 +59,6 @@ public class AdminEmailComposeSendAction extends Action {
 
         if (addressModeOn) {
             addressReceiver.add(addressReceiverListString);
-            statusToAdmin = "Email sent to " + addressReceiverListString;
-            statusToUser.add(new StatusMessage("Email sent to " + addressReceiverListString, StatusMessageColor.SUCCESS));
             try {
                 checkAddressReceiverString(addressReceiverListString);
             } catch (InvalidParametersException e) {
@@ -102,6 +98,16 @@ public class AdminEmailComposeSendAction extends Action {
                                                         new Text(emailContent),
                                                         null);
             data.emailToEdit.emailId = emailId;
+        } else {
+            if (addressModeOn) {
+                statusToAdmin = "Email sent to " + addressReceiverListString;
+                statusToUser.add(new StatusMessage("Email sent to "
+                        + addressReceiverListString, StatusMessageColor.SUCCESS));
+            }
+            if (groupModeOn) {
+                statusToAdmin = "Email sent to " + groupReceiverListFileKey;
+                statusToUser.add(new StatusMessage("Email sent to " + groupReceiverListFileKey, StatusMessageColor.SUCCESS));
+            }
         }
         return createShowPageResult(Const.ViewURIs.ADMIN_EMAIL, data);
     }


### PR DESCRIPTION
Fixes #6699 

**Outline of Solution**

Displays a message, after successfully sending the email in the page and also logs the info 
as "Email sent to receiver" in activityLog page.