### PR TITLE
InstructorFeedbackResultsPageUiTest unstable on local dev server #7064

### DIFF
--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -305,9 +305,9 @@ public abstract class AppPage {
     /**
      * Waits for the element to appear in the page, up to the timeout specified.
      */
-    public void waitForElementPresence(By by) {
+    public WebElement waitForElementPresence(By by) {
         WebDriverWait wait = new WebDriverWait(browser.driver, TestProperties.TEST_TIMEOUT);
-        wait.until(ExpectedConditions.presenceOfElementLocated(by));
+        return wait.until(ExpectedConditions.presenceOfElementLocated(by));
     }
 
     /**

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -309,19 +309,16 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     public void verifyCommentRowContent(String commentRowIdSuffix, String commentText, String giverName) {
         By commentRowSelector = By.id("responseCommentRow" + commentRowIdSuffix);
-        waitForElementPresence(commentRowSelector);
+        WebElement commentRow = waitForElementPresence(commentRowSelector);
         waitForTextContainedInElementPresence(By.id("plainCommentText" + commentRowIdSuffix), commentText);
-        WebElement commentRow = browser.driver.findElement(commentRowSelector);
         assertTrue(commentRow.findElement(By.className("text-muted")).getText().contains(giverName)
                    || commentRow.findElement(By.className("text-muted")).getText().contains("you"));
     }
 
     public void verifyCommentFormErrorMessage(String commentTableIdSuffix, String errorMessage) {
-        WebElement commentRow = browser.driver.findElement(By.id("responseCommentTable" + commentTableIdSuffix));
-        waitForElementPresence(
+        WebElement errorMessageSpan = waitForElementPresence(
                 By.cssSelector("#responseCommentTable" + commentTableIdSuffix + " .col-sm-offset-5 #errorMessage"));
-        assertEquals(errorMessage, commentRow.findElement(By.className("col-sm-offset-5"))
-                                             .findElement(By.tagName("span")).getText());
+        assertEquals(errorMessage, errorMessageSpan.getText());
     }
 
     public void verifyRowMissing(String rowIdSuffix) {
@@ -348,38 +345,32 @@ public class InstructorFeedbackResultsPage extends AppPage {
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String idOfPanelBody = "panelBodyCollapse-" + panelBodyIndex;
         WebElement photoCell = browser.driver.findElement(By.id(idOfPanelBody))
-                                             .findElements(By.cssSelector(".profile-pic-icon-click"))
-                                             .get(0);
+                                             .findElement(By.cssSelector(".profile-pic-icon-click"));
         executeScript("document.getElementById('" + idOfPanelBody + "')"
                       + ".getElementsByClassName('profile-pic-icon-click')[0]"
                       + ".getElementsByTagName('a')[0].click();");
         Actions actions = new Actions(browser.driver);
 
         actions.moveToElement(photoCell).perform();
-        waitForElementPresence(By.cssSelector(".popover-content > img"));
 
-        List<WebElement> photos = browser.driver.findElements(By.cssSelector(".popover-content > img"));
-        AssertHelper.assertContainsRegex(urlRegex, photos.get(photos.size() - 1).getAttribute("src"));
+        AssertHelper.assertContainsRegex(urlRegex,
+                waitForElementPresence(By.cssSelector(".popover-content > img")).getAttribute("src"));
     }
 
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex) {
         String idOfPanelHeading = "panelHeading-" + panelHeadingIndex;
-        WebElement photoDiv = browser.driver.findElement(By.id(idOfPanelHeading))
-                                            .findElement(By.className("profile-pic-icon-hover"));
-        executeScript("arguments[0].scrollIntoView(true);", photoDiv);
-        Actions actions = new Actions(browser.driver);
-        actions.moveToElement(photoDiv).perform();
-        waitForElementPresence(By.cssSelector(".popover-content"));
 
-        executeScript("document.getElementsByClassName('popover-content')[0]"
-                      + ".getElementsByTagName('a')[0].click();");
+        /*
+         * Execute JavaScript instead of using Selenium selectors to bypass bug
+         * regarding unix systems and current testing version of Selenium and Firefox
+         */
+        executeScript("$(document.getElementById('" + idOfPanelHeading + "')"
+                      + ".getElementsByClassName('profile-pic-icon-hover')).mouseenter()");
 
-        waitForElementPresence(By.cssSelector(".popover-content > img"));
+        waitForElementPresence(By.cssSelector(".popover-content > a")).click();
 
-        AssertHelper.assertContainsRegex(urlRegex,
-                                         browser.driver.findElements(By.cssSelector(".popover-content > img"))
-                                                       .get(0)
-                                                       .getAttribute("src"));
+        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
+                                                  .getAttribute("src"));
 
         executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
                       + "document.getElementsByClassName('popover')[0])");
@@ -387,18 +378,13 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     public void hoverAndViewStudentPhotoOnBody(String panelBodyIndex, String urlRegex) {
         String idOfPanelBody = "panelBodyCollapse-" + panelBodyIndex;
-        WebElement photoLink = browser.driver.findElements(By.cssSelector('#' + idOfPanelBody + "> .panel-body > .row"))
-                                             .get(0)
-                                             .findElements(By.className("profile-pic-icon-hover"))
-                                             .get(0);
+        WebElement photoLink = browser.driver.findElement(By.cssSelector('#' + idOfPanelBody + "> .panel-body > .row"))
+                                             .findElement(By.className("profile-pic-icon-hover"));
         Actions actions = new Actions(browser.driver);
         actions.moveToElement(photoLink).perform();
 
-        waitForElementPresence(By.cssSelector(".popover-content > img"));
-
-        AssertHelper.assertContainsRegex(urlRegex, browser.driver.findElements(By.cssSelector(".popover-content > img"))
-                                                                 .get(0)
-                                                                 .getAttribute("src"));
+        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
+                                                  .getAttribute("src"));
 
         executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
                       + "document.getElementsByClassName('popover')[0])");
@@ -417,16 +403,10 @@ public class InstructorFeedbackResultsPage extends AppPage {
                       + ".querySelectorAll('td')['" + tableCol + "']"
                       + ".getElementsByClassName('profile-pic-icon-hover')).mouseenter()");
 
-        waitForElementPresence(By.cssSelector(".popover-content"));
+        waitForElementPresence(By.cssSelector(".popover-content > a")).click();
 
-        executeScript("document.getElementsByClassName('popover-content')[0]"
-                      + ".getElementsByTagName('a')[0].click();");
-
-        waitForElementPresence(By.cssSelector(".popover-content > img"));
-
-        AssertHelper.assertContainsRegex(urlRegex, browser.driver.findElements(By.cssSelector(".popover-content > img"))
-                                                                 .get(0)
-                                                                 .getAttribute("src"));
+        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
+                                                  .getAttribute("src"));
 
         executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
                       + "document.getElementsByClassName('popover')[0])");

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -316,8 +316,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     public void verifyCommentFormErrorMessage(String commentTableIdSuffix, String errorMessage) {
-        WebElement errorMessageSpan = waitForElementPresence(
-                By.cssSelector("#responseCommentTable" + commentTableIdSuffix + " .col-sm-offset-5 #errorMessage"));
+        WebElement errorMessageSpan = waitForElementPresence(By.cssSelector("#errorMessage"));
         assertEquals(errorMessage, errorMessageSpan.getText());
     }
 
@@ -344,14 +343,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String idOfPanelBody = "panelBodyCollapse-" + panelBodyIndex;
-        WebElement photoCell = browser.driver.findElement(By.id(idOfPanelBody))
-                                             .findElement(By.cssSelector(".profile-pic-icon-click"));
-        executeScript("document.getElementById('" + idOfPanelBody + "')"
-                      + ".getElementsByClassName('profile-pic-icon-click')[0]"
-                      + ".getElementsByTagName('a')[0].click();");
-        Actions actions = new Actions(browser.driver);
-
-        actions.moveToElement(photoCell).perform();
+        browser.driver.findElement(By.id(idOfPanelBody))
+                      .findElement(By.cssSelector(".profile-pic-icon-click"))
+                      .findElement(By.tagName("a")).click();
 
         AssertHelper.assertContainsRegex(urlRegex,
                 waitForElementPresence(By.cssSelector(".popover-content > img")).getAttribute("src"));
@@ -359,13 +353,10 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex) {
         String idOfPanelHeading = "panelHeading-" + panelHeadingIndex;
-
-        /*
-         * Execute JavaScript instead of using Selenium selectors to bypass bug
-         * regarding unix systems and current testing version of Selenium and Firefox
-         */
-        executeScript("$(document.getElementById('" + idOfPanelHeading + "')"
-                      + ".getElementsByClassName('profile-pic-icon-hover')).mouseenter()");
+        WebElement photoDiv = browser.driver.findElement(By.id(idOfPanelHeading))
+                                            .findElement(By.className("profile-pic-icon-hover"));
+        Actions actions = new Actions(browser.driver);
+        actions.moveToElement(photoDiv).perform();
 
         waitForElementPresence(By.cssSelector(".popover-content > a")).click();
 


### PR DESCRIPTION
Fixes #7064 and the recent heightened failure CI rate that delayed #7033.

**Outline of Solution**

The recent build failures are mostly due to timing issues - popovers seem to disappear faster after 972a10f, leading to an error when trying to validate the popover's content. This solution optimises the `InstructorFeedbackResultsPage` page object to remove unnecessary waiting.

**Details**

Ideally, the popover's content should be validated as soon as it appears. However, in many places, the element is grabbed in a separate call to `findElement` after `waitForElementPresence` returns. This is unnecessary as the underlying Selenium methods in `waitForElementPresence` already return the element once it appears and can be used to do validation. This solution makes use of this to eliminate unnecessary calls to `findElement`, increasing the likelihood of validation without errors.

**Other improvements**

- replace `findElements(...).get(0)` with `findElement(...)`
- favour Selenium WebElement methods over executing JavaScript