### PR TITLE
InstructorFeedbackResultsPageUiTest view photo test unstable #7082

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #14
+    // Build #15
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -342,65 +342,48 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
-        String idOfPanelBody = "panelBodyCollapse-" + panelBodyIndex;
-        browser.driver.findElement(By.id(idOfPanelBody))
-                      .findElement(By.cssSelector(".profile-pic-icon-click"))
-                      .findElement(By.tagName("a")).click();
+        String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;
+        String popoverSelector = panelBodySelector + " .popover-content";
 
-        AssertHelper.assertContainsRegex(urlRegex,
-                waitForElementPresence(By.cssSelector(".popover-content > img")).getAttribute("src"));
+        browser.driver.findElement(By.cssSelector(panelBodySelector + " .profile-pic-icon-click a")).click();
+
+        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
+        AssertHelper.assertContainsRegex(urlRegex, imgSrc);
     }
 
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex) {
-        String idOfPanelHeading = "panelHeading-" + panelHeadingIndex;
-        WebElement photoDiv = browser.driver.findElement(By.id(idOfPanelHeading))
-                                            .findElement(By.className("profile-pic-icon-hover"));
-        Actions actions = new Actions(browser.driver);
-        actions.moveToElement(photoDiv).perform();
+        String headingSelector = "#panelHeading-" + panelHeadingIndex;
+        String popoverSelector = headingSelector + " .popover-content";
 
-        waitForElementPresence(By.cssSelector(".popover-content > a")).click();
+        moveToElement(By.cssSelector(headingSelector + " .profile-pic-icon-hover"));
+        waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
-        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
-                                                  .getAttribute("src"));
-
-        executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
-                      + "document.getElementsByClassName('popover')[0])");
+        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
+        AssertHelper.assertContainsRegex(urlRegex, imgSrc);
     }
 
     public void hoverAndViewStudentPhotoOnBody(String panelBodyIndex, String urlRegex) {
-        String idOfPanelBody = "panelBodyCollapse-" + panelBodyIndex;
-        WebElement photoLink = browser.driver.findElement(By.cssSelector('#' + idOfPanelBody + "> .panel-body > .row"))
-                                             .findElement(By.className("profile-pic-icon-hover"));
-        Actions actions = new Actions(browser.driver);
-        actions.moveToElement(photoLink).perform();
+        String bodyRowSelector = "#panelBodyCollapse-" + panelBodyIndex + " > .panel-body > .row";
+        String popoverSelector = bodyRowSelector + " .popover-content";
 
-        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
-                                                  .getAttribute("src"));
+        moveToElement(By.cssSelector(bodyRowSelector + " .profile-pic-icon-hover"));
 
-        executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
-                      + "document.getElementsByClassName('popover')[0])");
+        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
+        AssertHelper.assertContainsRegex(urlRegex, imgSrc);
     }
 
     public void hoverClickAndViewPhotoOnTableCell(int questionBodyIndex, int tableRow,
                                                   int tableCol, String urlRegex) {
-        String idOfQuestionBody = "questionBody-" + questionBodyIndex;
+        String cellSelector = "#questionBody-" + questionBodyIndex + " .dataTable tbody"
+                              + " tr:nth-child(" + (tableRow + 1) + ")"
+                              + " td:nth-child(" + (tableCol + 1) + ")";
+        String popoverSelector = cellSelector + " .popover-content";
 
-        /*
-         * Execute JavaScript instead of using Selenium selectors to bypass bug
-         * regarding unix systems and current testing version of Selenium and Firefox
-         */
-        executeScript("$(document.getElementById('" + idOfQuestionBody + "')"
-                      + ".querySelectorAll('.dataTable tbody tr')['" + tableRow + "']"
-                      + ".querySelectorAll('td')['" + tableCol + "']"
-                      + ".getElementsByClassName('profile-pic-icon-hover')).mouseenter()");
+        moveToElement(By.cssSelector(cellSelector + " .profile-pic-icon-hover"));
+        waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
-        waitForElementPresence(By.cssSelector(".popover-content > a")).click();
-
-        AssertHelper.assertContainsRegex(urlRegex, waitForElementPresence(By.cssSelector(".popover-content > img"))
-                                                  .getAttribute("src"));
-
-        executeScript("document.getElementsByClassName('popover')[0].parentNode.removeChild("
-                      + "document.getElementsByClassName('popover')[0])");
+        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
+        AssertHelper.assertContainsRegex(urlRegex, imgSrc);
     }
 
     public void hoverClickAndViewGiverPhotoOnTableCell(int questionBodyIndex, int tableRow,
@@ -494,6 +477,20 @@ public class InstructorFeedbackResultsPage extends AppPage {
         waitForElementPresence(ajaxErrorSelector);
 
         waitForTextContainedInElementPresence(ajaxErrorSelector, "[ Failed to load. Click here to retry. ]");
+    }
+
+    private void moveToElement(By by) {
+        WebElement element = browser.driver.findElement(by);
+        new Actions(browser.driver).moveToElement(element).perform();
+    }
+
+    private String getElementSrcWithRetryAfterWaitForPresence(By by) {
+        try {
+            return waitForElementPresence(by).getAttribute("src");
+        } catch (StaleElementReferenceException e) {
+            // Element changed (e.g. loading gif changed to actual image)
+            return waitForElementPresence(by).getAttribute("src");
+        }
     }
 
 }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #7
+    // Build #8
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #10
+    // Build #11
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #2
+    // Build #3
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #13
+    // Build #14
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #8
+    // Build #9
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,8 +341,6 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #15
-
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;
         String popoverSelector = panelBodySelector + " .popover-content";

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #11
+    // Build #12
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #9
+    // Build #10
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,6 +341,8 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
+    // Build #2
+
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;
         String popoverSelector = panelBodySelector + " .popover-content";

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #5
+    // Build #6
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #3
+    // Build #4
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #12
+    // Build #13
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #4
+    // Build #5
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,7 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         click(ajaxPanels);
     }
 
-    // Build #6
+    // Build #7
 
     public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;


### PR DESCRIPTION
Fixes #7082

Pending stability measure (basically running the Travis build multiple times and counting successes and failures). Will update below.

**Outline of Solution**

- Use specific selectors for popovers (avoids validating the wrong popover)
- Don’t dismiss popovers (unnecessary due to usage of more specific selectors; can help prevent stale element exceptions)
- Retry once upon stale element exception (handles loading gif transforming into actual image)