### PR TITLE
Remove inline javascript onclicks #6961

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -192,9 +192,9 @@ public class AdminActivityLogPageAction extends Action {
         }
 
         // the "Search More" button to continue searching from the previous fromDate
-        status.append("<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax("
+        status.append("<button class=\"btn-link\" id=\"button_older\" data-next-end-time-to-search=\""
                       + nextEndTimeToSearch
-                      + ");\">Search More</button><input id=\"ifShowAll\" type=\"hidden\" value=\""
+                      + "\">Search More</button><input id=\"ifShowAll\" type=\"hidden\" value=\""
                       + data.getIfShowAll()
                       + "\"/><input id=\"ifShowTestData\" type=\"hidden\" value=\""
                       + data.getIfShowTestData() + "\"/>");

--- a/src/main/java/teammates/ui/controller/AdminEmailLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailLogPageAction.java
@@ -92,8 +92,8 @@ public class AdminEmailLogPageAction extends Action {
 
         String status = "&nbsp;&nbsp;Total Logs gone through in last search: "
                 + totalLogsSearched + "<br>"
-                + "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('"
-                + nextEndTimeToSearch + "');\">Search More</button>";
+                + "<button class=\"btn-link\" id=\"button_older\" data-next-end-time-to-search=\""
+                + nextEndTimeToSearch + "\">Search More</button>";
         data.setStatusForAjax(status);
         statusToUser.add(new StatusMessage(status, StatusMessageColor.INFO));
     }
@@ -129,8 +129,8 @@ public class AdminEmailLogPageAction extends Action {
         long nextEndTimeToSearch = query.getEndTime();
         String status = "&nbsp;&nbsp;Total Logs gone through in last search: "
                       + totalLogsSearched + "<br>"
-                      + "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('"
-                      + nextEndTimeToSearch + "');\">Search More</button>";
+                      + "<button class=\"btn-link\" id=\"button_older\" data-next-end-time-to-search=\""
+                      + nextEndTimeToSearch + "\">Search More</button>";
         data.setStatusForAjax(status);
         statusToUser.add(new StatusMessage(status, StatusMessageColor.INFO));
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
@@ -144,7 +144,6 @@ public class InstructorCourseEditPageData extends PageData {
         button.setAttribute("type", "button");
         button.setAttribute("id", "btnShowNewInstructorForm");
         button.setAttribute("class", "btn btn-primary");
-        button.setAttribute("onclick", "showNewInstructorForm()");
         if (isDisabled) {
             button.setAttribute("disabled", null);
         }

--- a/src/main/webapp/js/adminActivityLog.es6
+++ b/src/main/webapp/js/adminActivityLog.es6
@@ -4,9 +4,17 @@ setStatusMessage:false StatusType:false bindBackToTopButtons:false addLoadingInd
 
 $(document).ready(() => {
     $('#filterReference').toggle();
+    enableOnclicks();
     bindBackToTopButtons('.back-to-top-left, .back-to-top-right');
     highlightKeywordsInLogMessages();
 });
+
+function enableOnclicks() {
+    $(document).on('click', '#button_older', () => {
+        const nextEndTimeToSearch = $('#button_older').attr('data-next-end-time-to-search');
+        submitFormAjax(nextEndTimeToSearch);
+    });
+}
 
 function toggleReference() {
     $('#filterReference').toggle('slow');

--- a/src/main/webapp/js/adminEmailLog.es6
+++ b/src/main/webapp/js/adminEmailLog.es6
@@ -43,9 +43,15 @@ function highlightKeywordsInEmailLogMessages() {
 
 $(document).ready(() => {
     bindClickAction();
+    enableOnclicks();
     highlightKeywordsInEmailLogMessages();
     $('#filterReference').toggle();
 });
+
+function enableOnclicks() {
+    const nextEndTimeToSearch = $('#button_older').attr('data-next-end-time-to-search');
+    submitFormAjax(nextEndTimeToSearch);
+}
 
 function submitFormAjax(offset) {
     $('input[name=offset]').val(offset);

--- a/src/main/webapp/js/adminEmailLog.es6
+++ b/src/main/webapp/js/adminEmailLog.es6
@@ -49,8 +49,10 @@ $(document).ready(() => {
 });
 
 function enableOnclicks() {
-    const nextEndTimeToSearch = $('#button_older').attr('data-next-end-time-to-search');
-    submitFormAjax(nextEndTimeToSearch);
+    $(document).on('click', '#button_older', () => {
+        const nextEndTimeToSearch = $('#button_older').attr('data-next-end-time-to-search');
+        submitFormAjax(nextEndTimeToSearch);
+    });
 }
 
 function submitFormAjax(offset) {

--- a/src/main/webapp/js/instructorCourseEdit.es6
+++ b/src/main/webapp/js/instructorCourseEdit.es6
@@ -515,6 +515,10 @@ function editFormRequest(e) {
 $(document).ready(() => {
     prepareInstructorPages();
 
+    $(document).on('click', '#btnShowNewInstructorForm', () => {
+        showNewInstructorForm();
+    });
+
     const numOfInstr = $("form[id^='formEditInstructor']").length;
     for (let i = 0; i < numOfInstr; i += 1) {
         const instrNum = i + 1;

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -1335,7 +1335,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="9">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -779,7 +779,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="8">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -1343,7 +1343,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="9">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -1343,7 +1343,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="9">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -889,7 +889,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="9">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -1340,7 +1340,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="9">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -862,7 +862,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="8">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -779,7 +779,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="8">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -779,7 +779,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="8">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -779,7 +779,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" disabled="" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="8">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -177,7 +177,7 @@
   <br>
   <br>
   <div class="align-center">
-    <input class="btn btn-primary" id="btnShowNewInstructorForm" onclick="showNewInstructorForm()" type="button" value="Add New Instructor">
+    <input class="btn btn-primary" id="btnShowNewInstructorForm" type="button" value="Add New Instructor">
     <input id="new-instructor-index" type="hidden" value="2">
   </div>
   <div class="panel panel-primary" id="panelAddInstructor" style="display: none;">


### PR DESCRIPTION
Fixes #6961 partially. WIP. 

Gets rid of `onclicks` in the `*Action` and `*PageData` classes, **except** the `toggleSort`s.