### PR TITLE
Create a maintainer guide #7055

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Here are some documents important for TEAMMATES developers.
 * The [**workflow/process to follow**](process.md) when contributing to TEAMMATES.
 * [**Developer Troubleshooting Guide**](troubleshooting-guide.md)
 * How the [**issue tracker**](issues.md) is used - issue lifecycle, issue labels, etc.
+* [**Maintainer Guide**](maintainer-guide.md) - for core team members.
 
 ## Supplementary documents
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -48,6 +48,7 @@ Core team members are expected to:
 * Contribute (i.e. pledge at least one issue) to almost every release cycle, thereby helping to maintain the project velocity.
   They are also strongly encouraged to pick at least one high priority issue for each release cycle.
 * Respond to community members trying to reach the project team members, e.g. requesting for help or introducing themselves.
+* Cover all of [maintainer's duties](maintainer-guide.md).
 
 Core team members can progress through various ranks, with different duties involved in those ranks.
 
@@ -79,13 +80,9 @@ Project leads have the following additional privileges:
 * Have "admin" access to the main repository.
 * Can merge any approved PRs reviewed by anyone as they see fit.
 
-Project leads have the following duties, which can also be shared with other team members:
-* Assign reviewers for PRs (if nobody volunteers to be a reviewer), based on the issue label.
-* Manage issue and PR tracker, e.g. close PRs that are abandoned for long.
-* Manage weekly release (i.e. act as Release Lead).
-* Invite new committers/core team members to the relevant teams in GitHub.
-* Ensure no unnecessary branches remain in the main repository.
-* Ensure that there are sufficient beginner-level issues (`d.FirstTimers` and `d.Contributors`) to last for at least 7 days (considering the current level of activity) at any time.
+Project leads have the following duties:
+* Manage weekly release (i.e. act as Release Lead). Can also be delegated to other team members.
+* Make sure that all of maintainer's duties are covered by the team.
 
 ### Project Mentor
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -32,7 +32,7 @@ This document lines out the common terms used in the project.
 ## Development-related
 
 + **Dev site**: [Our developer web site](https://github.com/TEAMMATES/teammates).
-+ **Main repo**: The repository containing the latest stable code. Used interchangeably with "committer repo", "upstream repo", "original repo".
++ **Main repo**: The repository containing the latest stable code.
 + **Specs**: System Specification.
 
 `* server`:

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -14,6 +14,16 @@ Colors indicate which roles are involved in which states/transitions.
 
 ## Issue labels
 
+### Status (`s.*`)
+
+This label classifies the issue based on its **status**.
+
+* No `s.*` label and no other labels: issue is yet to be triaged
+* `s.NeedsInfo`: more information is needed from the issue reporter
+* `s.ToInvestigate`: the issue needs to be validated by a core team member
+* `s.OnHold`: the issue's validity has been put on hold pending some other event
+* No `s.*` label and other labels present: issue is accepted
+
 ### Category (`c.*`)
 
 This label classifies the issue based on its **type**.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -7,6 +7,9 @@ It is assumed that the team members are familiar with the [development workflow]
 * Issue tracker management
   * [Triaging an issue](#triaging-an-issue)
   * [Closing an issue](#closing-an-issue)
+* PR management
+  * [Choosing a reviewer](#choosing-a-reviewer)
+  * [Closing a PR](#closing-a-pr)
 
 ## Issue tracker management
 
@@ -43,3 +46,21 @@ An issue can be closed without a resolution if:
 * The team has decided that the issue is not suitable to be worked on, e.g. not in line with the project's interest.
 
 In any case, leave a comment to explain why the issue is closed without resolution.
+
+## PR management
+
+### Choosing a reviewer
+
+* When a new PR comes in, assign a reviewer for the PR based on the related issue's labels and team members' expertise. Try to load-balance when assigning reviewers.
+* If a reviewer does not show any activity in **2 days**, post a reminder. If the reviewer still does not show any activity for the next **1 day**, assign another reviewer.
+
+### Closing a PR
+
+A PR can be closed without merging if:
+* The PR addresses something that has been fixed.
+* The PR addresses something that needs not be fixed.
+* The PR addresses an issue labelled `d.FirstTimers` and is authored by a contributor who has committed code to the main repository before.
+* The author does not address the review comments after **7 days**.
+* The author is not acting in the project's best interest, e.g. resisting review comments, not following project guidelines.
+
+In any case, leave a comment to explain why the PR is closed without merging.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -1,0 +1,5 @@
+# Maintainer Guide
+
+This document details the tasks that need to be done by core team (afterwards "team") members (project maintainers) in order to keep the project moving.
+
+It is assumed that the team members are familiar with the [development workflow](process.md), [individual development process](development.md), and the terms used in the project as listed in those documents, [project glossary](glossary.md), [issue labels](issues.md), and beyond.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -10,6 +10,9 @@ It is assumed that the team members are familiar with the [development workflow]
 * PR management
   * [Choosing a reviewer](#choosing-a-reviewer)
   * [Closing a PR](#closing-a-pr)
+* Release management
+  * [Making a release](#making-a-release)
+  * [Making a hot patch](#making-a-hot-patch)
 
 ## Issue tracker management
 
@@ -64,3 +67,47 @@ A PR can be closed without merging if:
 * The author is not acting in the project's best interest, e.g. resisting review comments, not following project guidelines.
 
 In any case, leave a comment to explain why the PR is closed without merging.
+
+## Release management
+
+**Roles: Release Lead (RL), Project Manager (PM)**
+
+### Making a release
+
+**Role: RL**
+
+New releases are made every set period of time (typically every week), in which new set of features and bug fixes are deployed for the users.
+
+* Before release day:
+  * Create an issue for the release to announce the scheduled release time.
+  * Update `about.jsp` with the names of new contributors, if any.
+* Release day:
+  * Ensure all issues and PRs included in the release are tagged with the correct milestone, correct assignee(s), and appropriate `e.*` labels.
+  * Merge `release` branch with `master` branch and tag the release with format `V{major}.{minor}` (e.g. `V5.100`).
+  * Close the current milestone and create a new milestone for the next + 1 release.
+  * Announce the release via GitHub release feature as well as the release issue in the issue tracker. Be sure to credit all who contributed to the release in one way or another.
+  * Assign PM to the "Release" issue.
+
+**Role: PM**
+
+* Pull the latest `release` branch.
+* Deploy to the live server.
+* Get live green, or otherwise all test failures need to be accounted for.
+* Make the version default.
+* Close the "Release" issue.
+
+## Making a hot patch
+
+Hot patches are releases containing fix for critical issues that severely affect the application's functionality.
+It is released on a necessity basis, typically few days after latest release.
+
+**Role: RL**
+
+* Tag the release with format `V{major}.{minor}.{patch}` (e.g. `V5.100.1`).
+* Close the milestone for the patch release and announce via GitHub release feature only. Be sure to credit all who contributed in one way or another.
+* Inform PM the hot patch is ready for deployment.
+* After the last hot patch of the proper release, merge the `release` branch back to the current `master` branch.
+
+**Role: PM**
+
+The PM's actions are the same as when [making a release](#making-a-release), minus the "Closing the release issue" part.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -16,6 +16,7 @@ It is assumed that the team members are familiar with the [development workflow]
 * Other tasks
   * [Branch management](#branch-management)
   * [Community membership](#community-membership)
+  * [Beginner-level issues](#beginner-level-issues)
 
 ## Issue tracker management
 
@@ -144,3 +145,19 @@ When someone's tenure as committer or team member has passed:
 
 * Do NOT revoke the team membership, unless voluntarily done by the past member him/herself.
 * Move the past member's name to the appropriate section in `about.jsp`.
+
+### Beginner-level issues
+
+Ensure that there is a healthy supply of `d.FirstTimers`-labelled issues and `d.Contributors`-labelled issues to last for at least **7 days** considering the activity level at that point of time.
+
+Possible `d.FirstTimers` issues:
+
+* Documentation-only changes
+* Fixing typo
+* Removing unused methods or classes
+
+Possible `d.Contributors` issues:
+
+* Minor refactoring
+* Adding missing tests
+* Adding minor new feature or enhancement

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -13,6 +13,8 @@ It is assumed that the team members are familiar with the [development workflow]
 * Release management
   * [Making a release](#making-a-release)
   * [Making a hot patch](#making-a-hot-patch)
+* Other tasks
+  * [Branch management](#branch-management)
 
 ## Issue tracker management
 
@@ -111,3 +113,14 @@ It is released on a necessity basis, typically few days after latest release.
 **Role: PM**
 
 The PM's actions are the same as when [making a release](#making-a-release), minus the "Closing the release issue" part.
+
+## Other tasks
+
+### Branch management
+
+Ideally, only two branches should exist in the main repository:
+
+* `master` to contain the latest stable code.
+* `release` to contain the copy of the code running on the live server.
+
+The usage of any other branch should be accounted for, and the branches should be deleted as soon as they are no longer needed.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -3,3 +3,43 @@
 This document details the tasks that need to be done by core team (afterwards "team") members (project maintainers) in order to keep the project moving.
 
 It is assumed that the team members are familiar with the [development workflow](process.md), [individual development process](development.md), and the terms used in the project as listed in those documents, [project glossary](glossary.md), [issue labels](issues.md), and beyond.
+
+* Issue tracker management
+  * [Triaging an issue](#triaging-an-issue)
+  * [Closing an issue](#closing-an-issue)
+
+## Issue tracker management
+
+### Triaging an issue
+
+A new issue needs to be triaged by a team member. Here is the process:
+
+1. Is the issue a duplicate of an existing issue?
+   * Yes: close the issue and add a reference to the original issue (which the new issue is a duplicate of). Alternatively, close the older issue and add a reference to the newly opened issue.
+   * No: continue to the next step.
+1. Does the issue provide enough information?
+   * Yes: continue to the next step.
+   * No: add the `s.NeedsInfo` label and request the issue reporter to provide more information. Additionally, if the issue does not follow the given templates (which is likely the case if the information is lacking), encourage the issue reporter to make use of an appropriate template. There is no need to comment any further until the issue reporter provides more details.
+1. Is the issue valid? (e.g. if it is a bug report, is it reproducible? If it is a feature/enhancement request, is the requested feature/enhancement absent?)
+   * Yes: continue to the next step.
+   * No: add the `s.ToInvestigate` label and assign a team member (can be yourself) to the issue. This assignee will be tasked to confirm the issue's validity, not to resolve the issue. There is no need to comment any further until the assignee confirms the validity of the issue.
+     * An issue should not be left as `s.ToInvestigate` for too long without valid reason. If the assignee does not show any activity for at least **3 days**, assign it to somebody else.
+1. Is the issue suitable? Not all issues are equal; sometimes, a valid issue does not fit well into the project's best interest.
+   * Yes: continue to the next step.
+   * No: to be dealt on a case-by-case basis. Possible actions include closing the issue, applying `s.OnHold` label and revisiting the issue in the future, or simply accepting the issue with low priority. In any case, leave a comment to explain the rationale of such action.
+1. Accept the issue by categorizing:
+   * For messages directed to the team, add the label `c.Message`, and post a comment if you can respond or know someone who can. If the message is about help requests, add the label `a-DevHelp` as well.
+   * For other types of issues, add the category labels as appropriate. Do NOT add `e.*` label.
+     * Issues marked as `c.Message` and `c.Release` are exempted from all other labels.
+     * If an issue is at priority `p.High` or higher, labels `d.FirstTimers` and `d.Contributors` cannot be applied to it.
+
+### Closing an issue
+
+An issue can be closed without a resolution if:
+
+* The issue is a message and either has been resolved with no loose ends left, or has no more activity for at least **7 days** after the last post in the issue thread and not pending any response from the team.
+* The issue is a duplicate of an existing issue.
+* The issue was opened in the past and is no longer relevant in the present.
+* The team has decided that the issue is not suitable to be worked on, e.g. not in line with the project's interest.
+
+In any case, leave a comment to explain why the issue is closed without resolution.

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -15,6 +15,7 @@ It is assumed that the team members are familiar with the [development workflow]
   * [Making a hot patch](#making-a-hot-patch)
 * Other tasks
   * [Branch management](#branch-management)
+  * [Community membership](#community-membership)
 
 ## Issue tracker management
 
@@ -124,3 +125,22 @@ Ideally, only two branches should exist in the main repository:
 * `release` to contain the copy of the code running on the live server.
 
 The usage of any other branch should be accounted for, and the branches should be deleted as soon as they are no longer needed.
+
+### Community membership
+
+To welcome a new committer:
+
+* Add the GitHub user to the `Committers` team.
+* Add the committer's name and photo to `about.jsp`.
+
+Subsequent promotions are done by moving the member's name to the appropriate section in `about.jsp`.
+
+To welcome a new project lead:
+
+* Add the GitHub user to the `Team-leads` team.
+* Set the GitHub user to have the "Owner" role for the TEAMMATES organization.
+
+When someone's tenure as committer or team member has passed:
+
+* Do NOT revoke the team membership, unless voluntarily done by the past member him/herself.
+* Move the past member's name to the appropriate section in `about.jsp`.

--- a/docs/process.md
+++ b/docs/process.md
@@ -47,13 +47,13 @@ The [issue labels](issues.md#issue-labels) may help you in choosing which issue 
 
 ### Step 2: Start clean from a new branch
 
-1. Start off from your `master` branch and make sure it is up-to-date with the latest version of the committer repo's `master` branch.
+1. Start off from your `master` branch and make sure it is up-to-date with the latest version of the main repo's `master` branch.
    ```sh
    git checkout master
    git pull
    ```
 
-1. Create a new branch to push your commits into. If you have commit access and need to push into the committer repo for some reason, name it `{IssueNumber}-{some-keywords}`,
+1. Create a new branch to push your commits into. If you have commit access and need to push into the main repo for some reason, name it `{IssueNumber}-{some-keywords}`,
    where `some-keywords` are representative keywords taken from the issue title.
    ```sh
    git checkout -b 3942-remove-unnecessary-println
@@ -62,7 +62,7 @@ The [issue labels](issues.md#issue-labels) may help you in choosing which issue 
 Notes:
 
 1. **Do not** combine fixes for multiple issues in one branch, unless they are tightly related.
-1. Your `master` branch must never be ahead of the committer repo's `master` branch at all times.
+1. Your `master` branch must never be ahead of the main repo's `master` branch at all times.
 
 ### Step 3: Fix the issue
 
@@ -80,8 +80,8 @@ Make the changes to the code, tests, and documentations as needed by the issue.
    * Use meaningful commit messages (e.g. `Add tests for the truncate method`).
      [Here](http://chris.beams.io/posts/git-commit/) is a good reference.
 
-1. Sync with the committer repo frequently. While you were fixing the issue, others might have pushed new code to the committer repo.
-   * Update your repo's `master` branch with any new changes from committer repo, then switch back to your work branch.
+1. Sync with the main repo frequently. While you were fixing the issue, others might have pushed new code to the main repo.
+   * Update your repo's `master` branch with any new changes from main repo, then switch back to your work branch.
 
      ```sh
      git checkout master
@@ -117,7 +117,7 @@ Make the changes to the code, tests, and documentations as needed by the issue.
    * All new public APIs (methods, classes) are **documented with header comments**.
    * **Documentations are updated** when necessary, particularly when there are changes or additions to software design as well as user-facing features.
 
-1. Push your branch to your fork, or to the committer repo only if necessary.
+1. Push your branch to your fork, or to the main repo only if necessary.
    ```sh
    git push {remote-name} 3942-remove-unnecessary-println
    ```
@@ -126,7 +126,7 @@ Make the changes to the code, tests, and documentations as needed by the issue.
    git push -f {remote-name} 3942-remove-unnecessary-println
    ```
 
-   > Anyone working on an issue, including core team members, should use branches in his/her own fork instead unless the branch needs to be in the committer repo.
+   > Anyone working on an issue, including core team members, should use branches in his/her own fork instead unless the branch needs to be in the main repo.
    > Such cases include:
    >
    > * The branch is being worked on by multiple people.
@@ -135,7 +135,7 @@ Make the changes to the code, tests, and documentations as needed by the issue.
 ### Step 4: Submit a PR
 
 [Create a PR](https://help.github.com/articles/creating-a-pull-request/) with the following configuration:
-* The base branch is the committer repo's `master` branch (except for hot patches in which it will be the `release` branch).
+* The base branch is the main repo's `master` branch (except for hot patches in which it will be the `release` branch).
 * PR name: copy-and-paste the relevant issue name and include the issue number as well,
   e.g. `Remove unnecessary System.out.printlns from Java files #3942`.
 * PR description: mention the issue number in this format: `Fixes #3942`.
@@ -192,7 +192,7 @@ The cycle of "code review" - "updating the PR" will be repeated until your PR is
 The core team member responsible for merging your PR might contact you for reasons such as syncing your PR with the latest `master` branch or resolving merge conflicts.
 Depending on the situation, this may necessitate more changes to be made in your PR (e.g. if your PR is functionally conflicting with a recent change), however this rarely happens.
 
-Your work on the issue is done when your PR is successfully merged to the committer repo's `master` or `release` branch.
+Your work on the issue is done when your PR is successfully merged to the main repo's `master` or `release` branch.
 
 ## Reviewing a PR
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -53,7 +53,7 @@ The [issue labels](issues.md#issue-labels) may help you in choosing which issue 
    git pull
    ```
 
-1. Create a new branch to push your commits into. If you have push access, name it `{IssueNumber}-{some-keywords}`,
+1. Create a new branch to push your commits into. If you have commit access and need to push into the committer repo for some reason, name it `{IssueNumber}-{some-keywords}`,
    where `some-keywords` are representative keywords taken from the issue title.
    ```sh
    git checkout -b 3942-remove-unnecessary-println
@@ -117,7 +117,7 @@ Make the changes to the code, tests, and documentations as needed by the issue.
    * All new public APIs (methods, classes) are **documented with header comments**.
    * **Documentations are updated** when necessary, particularly when there are changes or additions to software design as well as user-facing features.
 
-1. Push your branch to your fork, or to the committer repo if you have push access.
+1. Push your branch to your fork, or to the committer repo only if necessary.
    ```sh
    git push {remote-name} 3942-remove-unnecessary-println
    ```
@@ -125,6 +125,12 @@ Make the changes to the code, tests, and documentations as needed by the issue.
    ```sh
    git push -f {remote-name} 3942-remove-unnecessary-println
    ```
+
+   > Anyone working on an issue, including core team members, should use branches in his/her own fork instead unless the branch needs to be in the committer repo.
+   > Such cases include:
+   >
+   > * The branch is being worked on by multiple people.
+   > * The branch contains changes that need to be trialled by other core team member.
 
 ### Step 4: Submit a PR
 

--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -20,7 +20,7 @@ The instructions in all parts of this document work for Linux, OS X, and Windows
 
 1. Fork our repo at https://github.com/TEAMMATES/teammates. Clone that fork to your hard disk.
 
-1. Add a remote name (e.g `upstream`) for the original repo for your repo to keep in sync with.
+1. Add a remote name (e.g `upstream`) for the main repo for your repo to keep in sync with.
    ```sh
    git remote add upstream https://github.com/TEAMMATES/teammates.git
    ```
@@ -30,7 +30,7 @@ The instructions in all parts of this document work for Linux, OS X, and Windows
     upstream        https://github.com/TEAMMATES/teammates.git (push)
     ```
 
-1. Set your `master` branch to track the original repo's `master` branch.
+1. Set your `master` branch to track the main repo's `master` branch.
    ```sh
    git checkout master
    git branch -u upstream/master


### PR DESCRIPTION
Fixes #7055 

My last contribution as project lead before I bow out. 🙇

**Outline of Solution**

- Added everything that I think is important to know to be a project maintainer
- 429ca8a: I'm proposing a rule change that no one should push branches to the main repository unless necessary (I'm leading by example here!). Let me know your thoughts on this.
- Many parts of the guides are newly formalised by yours truly, e.g. the waiting times for certain actions. They can be strict or non-strict, entirely up to your discretion. If you think some parts need tweaks, let me know as well.

Finally, let me know what else you want to be included, and I'll try to accommodate.