### PR TITLE
Fixes typo in InstructorCourseEditPageUiTest pointed in issue #6990

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
@@ -150,9 +150,9 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
 
     private void testInviteInstructorAction() {
         ______TS("success: invite an uregistered instructor");
-        int unregisteredInsturctorIndex = 4;
+        int unregisteredInstructorIndex = 4;
 
-        courseEditPage.clickInviteInstructorLink(unregisteredInsturctorIndex);
+        courseEditPage.clickInviteInstructorLink(unregisteredInstructorIndex);
         courseEditPage.verifyStatus(Const.StatusMessages.COURSE_REMINDER_SENT_TO + "InsCrsEdit.newInstr@gmail.tmt");
     }
 


### PR DESCRIPTION
Fixes #6990

Fixed typo in "src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java"

Changed from 'unregisteredInsturctorIndex' to 'unregisteredInstructorIndex' on line 153 and 155.
