### PR TITLE
Fix some violations to boolean variable naming convention #7131

### DIFF
--- a/src/client/java/teammates/client/scripts/AdminEmailListGenerator.java
+++ b/src/client/java/teammates/client/scripts/AdminEmailListGenerator.java
@@ -44,11 +44,11 @@ public class AdminEmailListGenerator extends RemoteApiClient {
     private int iterationCounter;
 
     //handle test data
-    private boolean includeTestData = true;
+    private boolean shouldIncludeTestData = true;
 
     //admin email configuration
-    private boolean student;
-    private boolean instructor = true;
+    private boolean shouldIncludeStudent;
+    private boolean shouldIncludeInstructor = true;
     private StudentStatus studentStatus = StudentStatus.ALL;
     private InstructorStatus instructorStatus = InstructorStatus.ALL;
     private String studentCreatedDateRangeStart = "02/03/2013";
@@ -76,9 +76,9 @@ public class AdminEmailListGenerator extends RemoteApiClient {
             System.out.print(e.getMessage() + "\n");
         }
 
-        System.out.print("\n\nstudent : " + emailListConfig.student + "\n");
+        System.out.print("\n\nstudent : " + emailListConfig.shouldIncludeStudent + "\n");
 
-        if (emailListConfig.student) {
+        if (emailListConfig.shouldIncludeStudent) {
             System.out.print("Student Status: ");
             switch (emailListConfig.studentStatus) {
             case REG:
@@ -102,9 +102,9 @@ public class AdminEmailListGenerator extends RemoteApiClient {
             System.out.print("student end : " + emailListConfig.studentCreatedDateRangeEnd + "\n");
         }
 
-        System.out.print("instructor : " + emailListConfig.instructor + "\n");
+        System.out.print("instructor : " + emailListConfig.shouldIncludeInstructor + "\n");
 
-        if (emailListConfig.instructor) {
+        if (emailListConfig.shouldIncludeInstructor) {
             System.out.print("Instructor Status: ");
             switch (emailListConfig.studentStatus) {
             case REG:
@@ -131,8 +131,8 @@ public class AdminEmailListGenerator extends RemoteApiClient {
     }
 
     private void getInstructorEmailConfiguration() throws InvalidParametersException {
-        emailListConfig.instructor = this.instructor;
-        if (!emailListConfig.instructor) {
+        emailListConfig.shouldIncludeInstructor = this.shouldIncludeInstructor;
+        if (!emailListConfig.shouldIncludeInstructor) {
             return;
         }
         emailListConfig.instructorStatus = this.instructorStatus;
@@ -141,8 +141,8 @@ public class AdminEmailListGenerator extends RemoteApiClient {
     }
 
     private void getStudentEmailConfiguration() throws InvalidParametersException {
-        emailListConfig.student = this.student;
-        if (!emailListConfig.student) {
+        emailListConfig.shouldIncludeStudent = this.shouldIncludeStudent;
+        if (!emailListConfig.shouldIncludeStudent) {
             return;
         }
         emailListConfig.studentStatus = this.studentStatus;
@@ -169,7 +169,7 @@ public class AdminEmailListGenerator extends RemoteApiClient {
 
     private void printToFile() {
 
-        if (!emailListConfig.student && !emailListConfig.instructor) {
+        if (!emailListConfig.shouldIncludeStudent && !emailListConfig.shouldIncludeInstructor) {
             System.out.print("No email list to be generated. Exiting now..\n\n");
             return;
         }
@@ -177,11 +177,11 @@ public class AdminEmailListGenerator extends RemoteApiClient {
         HashSet<String> studentEmailSet = new HashSet<String>();
         HashSet<String> instructorEmailSet = new HashSet<String>();
 
-        if (emailListConfig.student) {
+        if (emailListConfig.shouldIncludeStudent) {
             studentEmailSet = addStudentEmailIntoSet(studentEmailSet);
         }
 
-        if (emailListConfig.instructor) {
+        if (emailListConfig.shouldIncludeInstructor) {
             instructorEmailSet = addInstructorEmailIntoSet(instructorEmailSet);
         }
 
@@ -240,7 +240,7 @@ public class AdminEmailListGenerator extends RemoteApiClient {
             int studentEmailCount = 0;
             if (!studentEmailSet.isEmpty()) {
                 for (String email : studentEmailSet) {
-                    if (!includeTestData && email.endsWith(".tmt")) {
+                    if (!shouldIncludeTestData && email.endsWith(".tmt")) {
                         continue;
                     }
                     w.write(email + ",");
@@ -251,7 +251,7 @@ public class AdminEmailListGenerator extends RemoteApiClient {
             int instructorEmailCount = 0;
             if (!instructorEmailSet.isEmpty()) {
                 for (String email : instructorEmailSet) {
-                    if (!includeTestData && email.endsWith(".tmt")) {
+                    if (!shouldIncludeTestData && email.endsWith(".tmt")) {
                         continue;
                     }
                     w.write(email + ",");
@@ -478,8 +478,8 @@ public class AdminEmailListGenerator extends RemoteApiClient {
     }
 
     private static class EmailListConfig {
-        public boolean student;
-        public boolean instructor;
+        public boolean shouldIncludeStudent;
+        public boolean shouldIncludeInstructor;
         public StudentStatus studentStatus = StudentStatus.ALL;
         public InstructorStatus instructorStatus = InstructorStatus.ALL;
         public Date studentCreatedDateRangeStart;

--- a/src/client/java/teammates/client/scripts/DataRepairForCorruptedResponses.java
+++ b/src/client/java/teammates/client/scripts/DataRepairForCorruptedResponses.java
@@ -35,10 +35,10 @@ public class DataRepairForCorruptedResponses extends RemoteApiClient {
             throws EntityDoesNotExistException, InvalidParametersException, EntityAlreadyExistsException {
         List<FeedbackQuestionAttributes> questions = logic.getFeedbackQuestionsForSession(sessionName, courseId);
         for (FeedbackQuestionAttributes question : questions) {
-            boolean needRepairGiverSection = isGiverContainingSection(question.giverType);
-            boolean needRepairRecipientSection = isRecipientContaningSection(question.giverType, question.recipientType);
-            if (needRepairGiverSection || needRepairRecipientSection) {
-                repairResponsesForQuestion(question, needRepairGiverSection, needRepairRecipientSection);
+            boolean shouldRepairGiverSection = isGiverContainingSection(question.giverType);
+            boolean shouldRepairRecipientSection = isRecipientContaningSection(question.giverType, question.recipientType);
+            if (shouldRepairGiverSection || shouldRepairRecipientSection) {
+                repairResponsesForQuestion(question, shouldRepairGiverSection, shouldRepairRecipientSection);
             }
         }
     }
@@ -48,7 +48,7 @@ public class DataRepairForCorruptedResponses extends RemoteApiClient {
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         List<FeedbackResponseAttributes> responses = logic.getFeedbackResponsesForQuestion(question.getId());
         for (FeedbackResponseAttributes response : responses) {
-            boolean needUpdateResponse = false;
+            boolean shouldUpdateResponse = false;
             String originalGiverSection = "";
             String originalRecipientSection = "";
             if (needRepairGiverSection) {
@@ -56,7 +56,7 @@ public class DataRepairForCorruptedResponses extends RemoteApiClient {
                 if (!response.giverSection.equals(student.section)) {
                     originalGiverSection = response.giverSection;
                     response.giverSection = student.section;
-                    needUpdateResponse = true;
+                    shouldUpdateResponse = true;
                 }
             }
 
@@ -67,19 +67,19 @@ public class DataRepairForCorruptedResponses extends RemoteApiClient {
                     if (!recipientSection.equals(response.recipientSection)) {
                         originalRecipientSection = response.recipientSection;
                         response.recipientSection = recipientSection;
-                        needUpdateResponse = true;
+                        shouldUpdateResponse = true;
                     }
                 } else {
                     StudentAttributes student = logic.getStudentForEmail(question.courseId, response.recipient);
                     if (!response.recipientSection.equals(student.section)) {
                         originalRecipientSection = response.recipientSection;
                         response.recipientSection = student.section;
-                        needUpdateResponse = true;
+                        shouldUpdateResponse = true;
                     }
                 }
             }
 
-            if (needUpdateResponse) {
+            if (shouldUpdateResponse) {
                 System.out.println("Repairing giver section:"
                         + originalGiverSection + "-->" + response.giverSection
                         + " receiver section:"

--- a/src/main/java/teammates/common/util/ActivityLogEntry.java
+++ b/src/main/java/teammates/common/util/ActivityLogEntry.java
@@ -52,7 +52,7 @@ public final class ActivityLogEntry {
     private long actionTimeTaken;
 
     // this field will always be true in log message for history reason
-    private boolean logToShow = true;
+    private boolean shouldShowLog = true;
 
     private ActivityLogEntry() {
         // private constructor to prevent instantiation
@@ -65,7 +65,7 @@ public final class ActivityLogEntry {
         // TEAMMATESLOG|||SERVLET_NAME|||ACTION|||TO_SHOW|||ROLE|||NAME|||GOOGLE_ID|||EMAIL|||MESSAGE(IN HTML)|||URL|||ID
         String userRoleSuffix = isMasqueradeUserRole ? Const.ActivityLog.ROLE_MASQUERADE_POSTFIX : "";
         return StringHelper.join(Const.ActivityLog.FIELD_SEPARATOR, Const.ActivityLog.TEAMMATESLOG,
-                actionName, actionResponse, Boolean.toString(logToShow), userRole + userRoleSuffix,
+                actionName, actionResponse, Boolean.toString(shouldShowLog), userRole + userRoleSuffix,
                 userName, userGoogleId, userEmail, logMessage, actionUrl, logId);
     }
 
@@ -73,8 +73,8 @@ public final class ActivityLogEntry {
         return logId;
     }
 
-    public boolean getLogToShow() {
-        return logToShow;
+    public boolean getShouldShowLog() {
+        return shouldShowLog;
     }
 
     public String getActionUrl() {

--- a/src/main/java/teammates/common/util/AdminLogQuery.java
+++ b/src/main/java/teammates/common/util/AdminLogQuery.java
@@ -12,7 +12,7 @@ public class AdminLogQuery {
     /**
      * A flag to decide whether to include application logs in result or not.
      */
-    private static final boolean INCLUDE_APP_LOG = true;
+    private static final boolean SHOULD_INCLUDE_APP_LOG = true;
 
     /**
      * Affects the internal strategy to get logs. It doesn't affect the result.
@@ -35,7 +35,7 @@ public class AdminLogQuery {
         Assumption.assertNotNull(versionsToQuery);
 
         query = LogQuery.Builder.withDefaults();
-        query.includeAppLogs(INCLUDE_APP_LOG);
+        query.includeAppLogs(SHOULD_INCLUDE_APP_LOG);
         query.batchSize(BATCH_SIZE);
         query.minLogLevel(MIN_LOG_LEVEL);
         setTimePeriod(startTime, endTime);

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -516,8 +516,8 @@ public class FieldValidator {
                                             fieldName, REASON_TOO_LONG, maxLength);
         }
         if (!Character.isLetterOrDigit(value.codePointAt(0))) {
-            boolean startsWithBraces = value.charAt(0) == '{' && value.contains("}");
-            if (!startsWithBraces) {
+            boolean hasStartingBrace = value.charAt(0) == '{' && value.contains("}");
+            if (!hasStartingBrace) {
                 return getPopulatedErrorMessage(INVALID_NAME_ERROR_MESSAGE, sanitizedValue,
                                                 fieldName, REASON_START_WITH_NON_ALPHANUMERIC_CHAR);
             }

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -207,17 +207,17 @@ public final class StringHelper {
     //From: http://stackoverflow.com/questions/5864159/count-words-in-a-string-method
     public static int countWords(String s) {
         int wordCount = 0;
-        boolean word = false;
+        boolean isWord = false;
         int endOfLine = s.length() - 1;
         for (int i = 0; i < s.length(); i++) {
             // if the char is a letter, word = true.
             if (Character.isLetter(s.charAt(i)) && i != endOfLine) {
-                word = true;
+                isWord = true;
                 // if char isn't a letter and there have been letters before,
                 // counter goes up.
-            } else if (!Character.isLetter(s.charAt(i)) && word) {
+            } else if (!Character.isLetter(s.charAt(i)) && isWord) {
                 wordCount++;
-                word = false;
+                isWord = false;
                 // last word of String; if it doesn't end with a non letter, it
                 // wouldn't count without this.
             } else if (Character.isLetter(s.charAt(i)) && i == endOfLine) {
@@ -391,14 +391,14 @@ public final class StringHelper {
         StringBuilder buffer = new StringBuilder();
         char[] chars = str.toCharArray();
 
-        boolean inquote = false;
+        boolean isInQuote = false;
 
         for (char c : chars) {
             if (c == '"') {
-                inquote = !inquote;
+                isInQuote = !isInQuote;
             }
 
-            if (c == '\n' && inquote) {
+            if (c == '\n' && isInQuote) {
                 buffer.append("<br>");
             } else {
                 buffer.append(c);

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -283,55 +283,55 @@ public final class FeedbackResponseCommentsLogic {
             FeedbackResponseAttributes response, FeedbackQuestionAttributes relatedQuestion,
             FeedbackResponseCommentAttributes relatedComment, boolean isUserStudent) {
 
-        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients =
+        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipients =
                 isUserStudent
                 && relatedQuestion.recipientType == FeedbackParticipantType.TEAMS
                 && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               FeedbackParticipantType.RECEIVER)
                 && response.recipient.equals(student.team);
 
-        boolean isUserInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers =
+        boolean isUserInResponseGiverTeamAndRelatedResponseCommentVisibleToGiversTeamMembers =
                 (relatedQuestion.giverType == FeedbackParticipantType.TEAMS
                 || isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               FeedbackParticipantType.OWN_TEAM_MEMBERS))
                 && studentsEmailInTeam.contains(response.giver);
 
-        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers =
+        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers =
                 isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                            FeedbackParticipantType.RECEIVER_TEAM_MEMBERS)
                 && studentsEmailInTeam.contains(response.recipient);
 
-        return isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients
-                || isUserInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers
-                || isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers;
+        return isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipients
+                || isUserInResponseGiverTeamAndRelatedResponseCommentVisibleToGiversTeamMembers
+                || isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers;
     }
 
     private boolean isVisibleToUser(String userEmail, FeedbackResponseAttributes response,
             FeedbackQuestionAttributes relatedQuestion, FeedbackResponseCommentAttributes relatedComment,
-            boolean isVisibleToGiver, boolean userIsInstructor, boolean isUserStudent) {
+            boolean isVisibleToGiver, boolean isUserInstructor, boolean isUserStudent) {
 
-        boolean isUserInstructorAndRelatedResponseCommentIsVisibleToInstructors =
-                userIsInstructor && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
+        boolean isUserInstructorAndRelatedResponseCommentVisibleToInstructors =
+                isUserInstructor && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                                                FeedbackParticipantType.INSTRUCTORS);
 
-        boolean isUserResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients =
+        boolean isUserResponseRecipientAndRelatedResponseCommentVisibleToRecipients =
                 response.recipient.equals(userEmail) && isResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, FeedbackParticipantType.RECEIVER);
 
-        boolean isUserResponseGiverAndRelatedResponseCommentIsVisibleToGivers =
+        boolean isUserResponseGiverAndRelatedResponseCommentVisibleToGivers =
                 response.giver.equals(userEmail) && isVisibleToGiver;
 
         boolean isUserRelatedResponseCommentGiver = relatedComment.giverEmail.equals(userEmail);
 
-        boolean isUserStudentAndRelatedResponseCommentIsVisibleToStudents =
+        boolean isUserStudentAndRelatedResponseCommentVisibleToStudents =
                 isUserStudent && isResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, FeedbackParticipantType.STUDENTS);
 
-        return isUserInstructorAndRelatedResponseCommentIsVisibleToInstructors
-                || isUserResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients
-                || isUserResponseGiverAndRelatedResponseCommentIsVisibleToGivers
+        return isUserInstructorAndRelatedResponseCommentVisibleToInstructors
+                || isUserResponseRecipientAndRelatedResponseCommentVisibleToRecipients
+                || isUserResponseGiverAndRelatedResponseCommentVisibleToGivers
                 || isUserRelatedResponseCommentGiver
-                || isUserStudentAndRelatedResponseCommentIsVisibleToStudents;
+                || isUserStudentAndRelatedResponseCommentVisibleToStudents;
     }
 
     private boolean isResponseCommentVisibleTo(FeedbackQuestionAttributes relatedQuestion,

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -267,71 +267,71 @@ public final class FeedbackResponseCommentsLogic {
         boolean isVisibleToGiver = isVisibilityFollowingFeedbackQuestion
                                  || relatedComment.isVisibleTo(FeedbackParticipantType.GIVER);
 
-        boolean userIsInstructor = role == UserRole.INSTRUCTOR;
-        boolean userIsStudent = role == UserRole.STUDENT;
+        boolean isUserInstructor = role == UserRole.INSTRUCTOR;
+        boolean isUserStudent = role == UserRole.STUDENT;
 
         boolean isVisibleToUser = isVisibleToUser(userEmail, response, relatedQuestion, relatedComment,
-                isVisibleToGiver, userIsInstructor, userIsStudent);
+                isVisibleToGiver, isUserInstructor, isUserStudent);
 
         boolean isVisibleToUserTeam = isVisibleToUserTeam(student, studentsEmailInTeam, response,
-                relatedQuestion, relatedComment, userIsStudent);
+                relatedQuestion, relatedComment, isUserStudent);
 
         return isVisibleToUser || isVisibleToUserTeam;
     }
 
     private boolean isVisibleToUserTeam(StudentAttributes student, Set<String> studentsEmailInTeam,
             FeedbackResponseAttributes response, FeedbackQuestionAttributes relatedQuestion,
-            FeedbackResponseCommentAttributes relatedComment, boolean userIsStudent) {
+            FeedbackResponseCommentAttributes relatedComment, boolean isUserStudent) {
 
-        boolean userIsInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients =
-                userIsStudent
+        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients =
+                isUserStudent
                 && relatedQuestion.recipientType == FeedbackParticipantType.TEAMS
                 && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               FeedbackParticipantType.RECEIVER)
                 && response.recipient.equals(student.team);
 
-        boolean userIsInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers =
+        boolean isUserInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers =
                 (relatedQuestion.giverType == FeedbackParticipantType.TEAMS
                 || isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               FeedbackParticipantType.OWN_TEAM_MEMBERS))
                 && studentsEmailInTeam.contains(response.giver);
 
-        boolean userIsInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers =
+        boolean isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers =
                 isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                            FeedbackParticipantType.RECEIVER_TEAM_MEMBERS)
                 && studentsEmailInTeam.contains(response.recipient);
 
-        return userIsInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients
-                || userIsInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers
-                || userIsInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers;
+        return isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipients
+                || isUserInResponseGiverTeamAndRelatedResponseCommentIsVisibleToGiversTeamMembers
+                || isUserInResponseRecipientTeamAndRelatedResponseCommentIsVisibleToRecipientsTeamMembers;
     }
 
     private boolean isVisibleToUser(String userEmail, FeedbackResponseAttributes response,
             FeedbackQuestionAttributes relatedQuestion, FeedbackResponseCommentAttributes relatedComment,
-            boolean isVisibleToGiver, boolean userIsInstructor, boolean userIsStudent) {
+            boolean isVisibleToGiver, boolean userIsInstructor, boolean isUserStudent) {
 
-        boolean userIsInstructorAndRelatedResponseCommentIsVisibleToInstructors =
+        boolean isUserInstructorAndRelatedResponseCommentIsVisibleToInstructors =
                 userIsInstructor && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                                                FeedbackParticipantType.INSTRUCTORS);
 
-        boolean userIsResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients =
+        boolean isUserResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients =
                 response.recipient.equals(userEmail) && isResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, FeedbackParticipantType.RECEIVER);
 
-        boolean userIsResponseGiverAndRelatedResponseCommentIsVisibleToGivers =
+        boolean isUserResponseGiverAndRelatedResponseCommentIsVisibleToGivers =
                 response.giver.equals(userEmail) && isVisibleToGiver;
 
-        boolean userIsRelatedResponseCommentGiver = relatedComment.giverEmail.equals(userEmail);
+        boolean isUserRelatedResponseCommentGiver = relatedComment.giverEmail.equals(userEmail);
 
-        boolean userIsStudentAndRelatedResponseCommentIsVisibleToStudents =
-                userIsStudent && isResponseCommentVisibleTo(relatedQuestion,
+        boolean isUserStudentAndRelatedResponseCommentIsVisibleToStudents =
+                isUserStudent && isResponseCommentVisibleTo(relatedQuestion,
                         relatedComment, FeedbackParticipantType.STUDENTS);
 
-        return userIsInstructorAndRelatedResponseCommentIsVisibleToInstructors
-                || userIsResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients
-                || userIsResponseGiverAndRelatedResponseCommentIsVisibleToGivers
-                || userIsRelatedResponseCommentGiver
-                || userIsStudentAndRelatedResponseCommentIsVisibleToStudents;
+        return isUserInstructorAndRelatedResponseCommentIsVisibleToInstructors
+                || isUserResponseRecipientAndRelatedResponseCommentIsVisibleToRecipients
+                || isUserResponseGiverAndRelatedResponseCommentIsVisibleToGivers
+                || isUserRelatedResponseCommentGiver
+                || isUserStudentAndRelatedResponseCommentIsVisibleToStudents;
     }
 
     private boolean isResponseCommentVisibleTo(FeedbackQuestionAttributes relatedQuestion,

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1661,8 +1661,8 @@ public final class FeedbackSessionsLogic {
                                 question, userEmail, role, section);
             }
 
-            boolean hasResponsesForThisQuestion = !responsesForThisQn.isEmpty();
-            if (hasResponsesForThisQuestion) {
+            boolean hasResponses = !responsesForThisQn.isEmpty();
+            if (hasResponses) {
                 relevantQuestions.put(question.getId(), question);
                 responses.addAll(responsesForThisQn);
                 for (FeedbackResponseAttributes response : responsesForThisQn) {
@@ -1926,8 +1926,8 @@ public final class FeedbackSessionsLogic {
                                                     question, userEmail, UserRole.INSTRUCTOR, section);
                 }
 
-                boolean isThisQuestionHasResponses = !responsesForThisQn.isEmpty();
-                if (isThisQuestionHasResponses) {
+                boolean hasResponses = !responsesForThisQn.isEmpty();
+                if (hasResponses) {
                     for (FeedbackResponseAttributes response : responsesForThisQn) {
                         InstructorAttributes instructor = getInstructor(courseId, userEmail, role);
                         boolean isVisibleResponse = isResponseVisibleForUser(userEmail, role, null, null, response,

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1661,8 +1661,8 @@ public final class FeedbackSessionsLogic {
                                 question, userEmail, role, section);
             }
 
-            boolean thisQuestionHasResponses = !responsesForThisQn.isEmpty();
-            if (thisQuestionHasResponses) {
+            boolean hasResponsesForThisQuestion = !responsesForThisQn.isEmpty();
+            if (hasResponsesForThisQuestion) {
                 relevantQuestions.put(question.getId(), question);
                 responses.addAll(responsesForThisQn);
                 for (FeedbackResponseAttributes response : responsesForThisQn) {
@@ -1926,8 +1926,8 @@ public final class FeedbackSessionsLogic {
                                                     question, userEmail, UserRole.INSTRUCTOR, section);
                 }
 
-                boolean thisQuestionHasResponses = !responsesForThisQn.isEmpty();
-                if (thisQuestionHasResponses) {
+                boolean isThisQuestionHasResponses = !responsesForThisQn.isEmpty();
+                if (isThisQuestionHasResponses) {
                     for (FeedbackResponseAttributes response : responsesForThisQn) {
                         InstructorAttributes instructor = getInstructor(courseId, userEmail, role);
                         boolean isVisibleResponse = isResponseVisibleForUser(userEmail, role, null, null, response,

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -338,12 +338,12 @@ public abstract class Action {
     }
 
     private boolean doesUserNeedToLogin(UserType currentUser) {
-        boolean userNeedsGoogleAccountForPage =
+        boolean shouldUserNeedGoogleAccountForPage =
                 !Const.SystemParams.PAGES_ACCESSIBLE_WITHOUT_GOOGLE_LOGIN.contains(request.getRequestURI());
-        boolean userIsNotLoggedIn = currentUser == null;
-        boolean noRegkeyGiven = regkey == null;
+        boolean isUserNotLoggedIn = currentUser == null;
+        boolean hasNoRegkey = getRegkeyFromRequest() == null;
 
-        if (userIsNotLoggedIn && (userNeedsGoogleAccountForPage || noRegkeyGiven)) {
+        if (isUserNotLoggedIn && (shouldUserNeedGoogleAccountForPage || hasNoRegkey)) {
             setRedirectPage(gateKeeper.getLoginUrl(requestUrl));
             return true;
         }

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -338,12 +338,12 @@ public abstract class Action {
     }
 
     private boolean doesUserNeedToLogin(UserType currentUser) {
-        boolean shouldUserNeedGoogleAccountForPage =
+        boolean isGoogleLoginRequired =
                 !Const.SystemParams.PAGES_ACCESSIBLE_WITHOUT_GOOGLE_LOGIN.contains(request.getRequestURI());
-        boolean isUserNotLoggedIn = currentUser == null;
-        boolean hasNoRegkey = getRegkeyFromRequest() == null;
+        boolean isUserLoggedIn = currentUser != null;
+        boolean hasRegkey = getRegkeyFromRequest() != null;
 
-        if (isUserNotLoggedIn && (shouldUserNeedGoogleAccountForPage || hasNoRegkey)) {
+        if (!isUserLoggedIn && (isGoogleLoginRequired || !hasRegkey)) {
             setRedirectPage(gateKeeper.getLoginUrl(requestUrl));
             return true;
         }

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -70,15 +70,15 @@ public class AdminActivityLogPageAction extends Action {
         // in AdminActivityLogPageData should be shown. Use "?all=true" in URL to show all logs.
         // This will keep showing all logs despite any action or change in the page unless
         // the page is reloaded with "?all=false" or simply reloaded with this parameter omitted.
-        boolean ifShowAll = getRequestParamAsBoolean("all");
-        data.setIfShowAll(ifShowAll);
+        boolean shouldShowAllLogs = getRequestParamAsBoolean("all");
+        data.setShowAllLogs(shouldShowAllLogs);
 
         // This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
         // to show all testing logs. This will keep showing all logs from testing data despite any action
         // or change in the page unless the page is reloaded with "?testdata=false"
         // or simply reloaded with this parameter omitted.
-        boolean ifShowTestData = getRequestParamAsBoolean("testdata");
-        data.setIfShowTestData(ifShowTestData);
+        boolean shouldShowTestData = getRequestParamAsBoolean("testdata");
+        data.setShowTestData(shouldShowTestData);
 
         String filterQuery = getRequestParamValue("filterQuery");
         if (filterQuery == null) {
@@ -195,9 +195,9 @@ public class AdminActivityLogPageAction extends Action {
         status.append("<button class=\"btn-link\" id=\"button_older\" data-next-end-time-to-search=\""
                       + nextEndTimeToSearch
                       + "\">Search More</button><input id=\"ifShowAll\" type=\"hidden\" value=\""
-                      + data.getIfShowAll()
+                      + data.getShouldShowAllLogs()
                       + "\"/><input id=\"ifShowTestData\" type=\"hidden\" value=\""
-                      + data.getIfShowTestData() + "\"/>");
+                      + data.getShouldShowTestData() + "\"/>");
 
         String statusString = status.toString();
         data.setStatusForAjax(statusString);
@@ -259,7 +259,7 @@ public class AdminActivityLogPageAction extends Action {
 
             ActivityLogEntry activityLogEntry = ActivityLogEntry.buildFromAppLog(appLog);
             boolean isToShow = data.filterLog(activityLogEntry)
-                    && (!activityLogEntry.isTestingData() || data.getIfShowTestData());
+                    && (!activityLogEntry.isTestingData() || data.getShouldShowTestData());
 
             if (!isToShow) {
                 continue;

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
@@ -22,8 +22,8 @@ public class AdminEmailComposeSendAction extends Action {
     private List<String> addressReceiver = new ArrayList<String>();
     private List<String> groupReceiver = new ArrayList<String>();
 
-    private boolean addressModeOn;
-    private boolean groupModeOn;
+    private boolean isAddressModeOn;
+    private boolean isGroupModeOn;
 
     //params needed to move heavy jobs into a address mode task
     private String addressReceiverListString;
@@ -42,12 +42,12 @@ public class AdminEmailComposeSendAction extends Action {
         String subject = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_SUBJECT);
 
         addressReceiverListString = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_ADDRESS_RECEIVERS);
-        addressModeOn = addressReceiverListString != null && !addressReceiverListString.isEmpty();
+        isAddressModeOn = addressReceiverListString != null && !addressReceiverListString.isEmpty();
         emailId = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_ID);
         groupReceiverListFileKey = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_GROUP_RECEIVER_LIST_FILE_KEY);
-        groupModeOn = groupReceiverListFileKey != null && !groupReceiverListFileKey.isEmpty();
+        isGroupModeOn = groupReceiverListFileKey != null && !groupReceiverListFileKey.isEmpty();
 
-        if (groupModeOn) {
+        if (isGroupModeOn) {
             try {
                 groupReceiver.add(groupReceiverListFileKey);
                 GoogleCloudStorageHelper.getGroupReceiverList(new BlobKey(groupReceiverListFileKey));
@@ -57,7 +57,7 @@ public class AdminEmailComposeSendAction extends Action {
             }
         }
 
-        if (addressModeOn) {
+        if (isAddressModeOn) {
             addressReceiver.add(addressReceiverListString);
             try {
                 checkAddressReceiverString(addressReceiverListString);
@@ -67,7 +67,7 @@ public class AdminEmailComposeSendAction extends Action {
             }
         }
 
-        if (!addressModeOn && !groupModeOn) {
+        if (!isAddressModeOn && !isGroupModeOn) {
             isError = true;
             statusToAdmin = "Error : No receiver address or file given";
             statusToUser.add(new StatusMessage("Error : No receiver address or file given", StatusMessageColor.DANGER));
@@ -119,7 +119,7 @@ public class AdminEmailComposeSendAction extends Action {
     }
 
     private void moveJobToGroupModeTaskQueue() {
-        if (!groupModeOn) {
+        if (!isGroupModeOn) {
             return;
         }
         taskQueuer.scheduleAdminEmailPreparationInGroupMode(emailId, groupReceiverListFileKey, 0, 0);
@@ -130,7 +130,7 @@ public class AdminEmailComposeSendAction extends Action {
     }
 
     private void moveJobToAddressModeTaskQueue() {
-        if (!addressModeOn) {
+        if (!isAddressModeOn) {
             return;
         }
         taskQueuer.scheduleAdminEmailPreparationInAddressMode(emailId, addressReceiverListString);

--- a/src/main/java/teammates/ui/controller/AdminEmailTrashDeleteAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailTrashDeleteAction.java
@@ -13,9 +13,9 @@ public class AdminEmailTrashDeleteAction extends Action {
 
         gateKeeper.verifyAdminPrivileges(account);
 
-        boolean emptyTrashBin = getRequestParamAsBoolean(Const.ParamsNames.ADMIN_EMAIL_EMPTY_TRASH_BIN);
+        boolean shouldEmptyTrashBin = getRequestParamAsBoolean(Const.ParamsNames.ADMIN_EMAIL_EMPTY_TRASH_BIN);
 
-        if (emptyTrashBin) {
+        if (shouldEmptyTrashBin) {
             try {
                 logic.deleteAllEmailsInTrashBin();
                 statusToAdmin = "All emails in trash bin has been deleted";

--- a/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
+++ b/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
@@ -47,7 +47,7 @@ public class AdminInstructorAccountAddAction extends Action {
         data.instructorName = "";
         data.instructorEmail = "";
         data.instructorInstitution = "";
-        data.instructorAddingResultForAjax = true;
+        data.isInstructorAddingResultForAjax = true;
         data.statusForAjax = "";
 
         // If there is input from the instructorDetailsSingleLine form,
@@ -67,7 +67,7 @@ public class AdminInstructorAccountAddAction extends Action {
                 data.instructorInstitution = instructorInfo[2];
             } catch (InvalidParametersException e) {
                 data.statusForAjax = e.getMessage().replace(Const.EOL, Const.HTML_BR_TAG);
-                data.instructorAddingResultForAjax = false;
+                data.isInstructorAddingResultForAjax = false;
                 statusToUser.add(new StatusMessage(data.statusForAjax, StatusMessageColor.DANGER));
                 return createAjaxResult(data);
             }
@@ -83,7 +83,7 @@ public class AdminInstructorAccountAddAction extends Action {
                                               data.instructorInstitution, data.instructorEmail);
         } catch (InvalidParametersException e) {
             data.statusForAjax = e.getMessage().replace(Const.EOL, Const.HTML_BR_TAG);
-            data.instructorAddingResultForAjax = false;
+            data.isInstructorAddingResultForAjax = false;
             statusToUser.add(new StatusMessage(data.statusForAjax, StatusMessageColor.DANGER));
             return createAjaxResult(data);
         }
@@ -114,7 +114,7 @@ public class AdminInstructorAccountAddAction extends Action {
             statusToUser.add(new StatusMessage("<br>" + message, StatusMessageColor.DANGER));
             statusToAdmin = message;
 
-            data.instructorAddingResultForAjax = false;
+            data.isInstructorAddingResultForAjax = false;
             data.statusForAjax = errorMessage.toString();
             return createAjaxResult(data);
         }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -95,8 +95,8 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
         }
         // isError == true if an exception occurred above
 
-        boolean omitArchived = true;
-        Map<String, InstructorAttributes> instructors = loadCourseInstructorMap(omitArchived);
+        boolean shouldOmitArchived = true;
+        Map<String, InstructorAttributes> instructors = loadCourseInstructorMap(shouldOmitArchived);
         List<InstructorAttributes> instructorList = new ArrayList<InstructorAttributes>(instructors.values());
         List<CourseAttributes> courses = loadCoursesList(instructorList);
         List<FeedbackSessionAttributes> feedbackSessions = loadFeedbackSessionsList(instructorList);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
@@ -121,9 +121,9 @@ public class InstructorFeedbackEditCopyAction extends Action {
         for (String courseIdToCopy : coursesIdToCopyTo) {
             FeedbackSessionAttributes existingFs =
                     logic.getFeedbackSession(feedbackSessionName, courseIdToCopy);
-            boolean fsAlreadyExists = existingFs != null;
+            boolean hasExistingFs = existingFs != null;
 
-            if (fsAlreadyExists) {
+            if (hasExistingFs) {
                 courses.add(existingFs.getCourseId());
             }
         }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
@@ -74,9 +74,9 @@ public class InstructorFeedbackResponseCommentsLoadAction extends Action {
                     instructor.isAllowedForPrivilege(fdr.recipientSection, fdr.feedbackSessionName,
                                        Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS);
 
-            boolean instructorHasSessionViewingPrivileges = canInstructorViewSessionInGiverSection
+            boolean shouldInstructorHaveSessionViewingPrivileges = canInstructorViewSessionInGiverSection
                                                             && canInstructorViewSessionInRecipientSection;
-            if (!instructorHasSessionViewingPrivileges) {
+            if (!shouldInstructorHaveSessionViewingPrivileges) {
                 iter.remove();
             }
         }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
@@ -74,9 +74,9 @@ public class InstructorFeedbackResponseCommentsLoadAction extends Action {
                     instructor.isAllowedForPrivilege(fdr.recipientSection, fdr.feedbackSessionName,
                                        Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS);
 
-            boolean shouldInstructorHaveSessionViewingPrivileges = canInstructorViewSessionInGiverSection
+            boolean hasSessionViewingPrivileges = canInstructorViewSessionInGiverSection
                                                             && canInstructorViewSessionInRecipientSection;
-            if (!shouldInstructorHaveSessionViewingPrivileges) {
+            if (!hasSessionViewingPrivileges) {
                 iter.remove();
             }
         }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditPageAction.java
@@ -18,8 +18,8 @@ public class InstructorFeedbackSubmissionEditPageAction extends FeedbackSubmissi
     @Override
     protected void verifyAccesibleForSpecificUser(FeedbackSessionAttributes session) {
         InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, account.googleId);
-        boolean isEnabledForCreatorOnly = false;
-        gateKeeper.verifyAccessible(instructor, session, isEnabledForCreatorOnly);
+        boolean isCreatorOnly = false;
+        gateKeeper.verifyAccessible(instructor, session, isCreatorOnly);
         boolean shouldEnableSubmit =
                     instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditPageAction.java
@@ -18,8 +18,8 @@ public class InstructorFeedbackSubmissionEditPageAction extends FeedbackSubmissi
     @Override
     protected void verifyAccesibleForSpecificUser(FeedbackSessionAttributes session) {
         InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, account.googleId);
-        boolean creatorOnly = false;
-        gateKeeper.verifyAccessible(instructor, session, creatorOnly);
+        boolean isEnabledForCreatorOnly = false;
+        gateKeeper.verifyAccessible(instructor, session, isEnabledForCreatorOnly);
         boolean shouldEnableSubmit =
                     instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditSaveAction.java
@@ -17,8 +17,8 @@ public class InstructorFeedbackSubmissionEditSaveAction extends FeedbackSubmissi
     protected void verifyAccesibleForSpecificUser() {
         InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, account.googleId);
         FeedbackSessionAttributes session = logic.getFeedbackSession(feedbackSessionName, courseId);
-        boolean creatorOnly = false;
-        gateKeeper.verifyAccessible(instructor, session, creatorOnly);
+        boolean isEnabledForCreatorOnly = false;
+        gateKeeper.verifyAccessible(instructor, session, isEnabledForCreatorOnly);
         boolean shouldEnableSubmit =
                     instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackSubmissionEditSaveAction.java
@@ -17,8 +17,8 @@ public class InstructorFeedbackSubmissionEditSaveAction extends FeedbackSubmissi
     protected void verifyAccesibleForSpecificUser() {
         InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, account.googleId);
         FeedbackSessionAttributes session = logic.getFeedbackSession(feedbackSessionName, courseId);
-        boolean isEnabledForCreatorOnly = false;
-        gateKeeper.verifyAccessible(instructor, session, isEnabledForCreatorOnly);
+        boolean isCreatorOnly = false;
+        gateKeeper.verifyAccessible(instructor, session, isCreatorOnly);
         boolean shouldEnableSubmit =
                     instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -37,9 +37,9 @@ public class InstructorFeedbacksPageAction extends Action {
         InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(account, sessionToken);
         data.setUsingAjax(isUsingAjax != null);
 
-        boolean omitArchived = true; // TODO: implement as a request parameter
+        boolean shouldOmitArchived = true; // TODO: implement as a request parameter
         // HashMap with courseId as key and InstructorAttributes as value
-        Map<String, InstructorAttributes> instructors = loadCourseInstructorMap(omitArchived);
+        Map<String, InstructorAttributes> instructors = loadCourseInstructorMap(shouldOmitArchived);
 
         List<InstructorAttributes> instructorList =
                 new ArrayList<InstructorAttributes>(instructors.values());

--- a/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
@@ -48,9 +48,9 @@ public class InstructorHomePageAction extends Action {
     }
 
     private ActionResult loadPage() {
-        boolean omitArchived = true;
+        boolean shouldOmitArchived = true;
         Map<String, CourseSummaryBundle> courses = logic.getCourseSummariesWithoutStatsForInstructor(
-                                                                 account.googleId, omitArchived);
+                                                                 account.googleId, shouldOmitArchived);
 
         ArrayList<CourseSummaryBundle> courseList = new ArrayList<CourseSummaryBundle>(courses.values());
 

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -42,14 +42,14 @@ public class AdminActivityLogPageData extends PageData {
      * logs despite any action or change in the page unless the page is reloaded with "?all=false"
      * or simply reloaded with this parameter omitted.
      */
-    private boolean ifShowAll;
+    private boolean shouldShowAllLogs;
 
     /**
      * This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
      * to show all testing logs. This will keep showing all logs from testing data despite any action or change in the page
      * unless the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted.
      */
-    private boolean ifShowTestData;
+    private boolean shouldShowTestData;
 
     private String statusForAjax;
     private QueryParameters q;
@@ -87,20 +87,20 @@ public class AdminActivityLogPageData extends PageData {
         }
     }
 
-    public void setIfShowAll(boolean val) {
-        ifShowAll = val;
+    public void setShowAllLogs(boolean val) {
+        shouldShowAllLogs = val;
     }
 
-    public void setIfShowTestData(boolean val) {
-        ifShowTestData = val;
+    public void setShowTestData(boolean val) {
+        shouldShowTestData = val;
     }
 
-    public boolean getIfShowAll() {
-        return ifShowAll;
+    public boolean getShouldShowAllLogs() {
+        return shouldShowAllLogs;
     }
 
-    public boolean getIfShowTestData() {
-        return ifShowTestData;
+    public boolean getShouldShowTestData() {
+        return shouldShowTestData;
     }
 
     public String getFilterQuery() {
@@ -165,7 +165,7 @@ public class AdminActivityLogPageData extends PageData {
      * Returns true if the current log entry should be included.
      */
     private boolean shouldIncludeLogEntry(ActivityLogEntry logEntry) {
-        if (ifShowAll) {
+        if (shouldShowAllLogs) {
             return true;
         }
 

--- a/src/main/java/teammates/ui/pagedata/AdminHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminHomePageData.java
@@ -8,7 +8,7 @@ public class AdminHomePageData extends PageData {
     public String instructorName;
     public String instructorEmail;
     public String instructorInstitution;
-    public boolean instructorAddingResultForAjax;
+    public boolean isInstructorAddingResultForAjax;
     public String statusForAjax;
     // this field will contain the name, email address and institution of the instructor separated by \t or |
     // e.g: "Instructor1 \t instructor1@test.com \t NUS"

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditPageData.java
@@ -172,62 +172,62 @@ public class InstructorFeedbackEditPageData extends PageData {
     }
 
     private boolean isVisibilitySetToAnonymousToRecipientAndInstructors(FeedbackQuestionAttributes question) {
-        boolean responsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
+        boolean isResponsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
                 && question.showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS)
                 && question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER);
-        boolean giverNameVisibleToNoOne = question.showGiverNameTo.isEmpty();
+        boolean isGiverNameVisibleToNoOne = question.showGiverNameTo.isEmpty();
 
-        return responsesVisibleOnlyToRecipientAndInstructors && giverNameVisibleToNoOne;
+        return isResponsesVisibleOnlyToRecipientAndInstructors && isGiverNameVisibleToNoOne;
     }
 
     private boolean isVisibilitySetToAnonymousToRecipientVisibleToInstructors(FeedbackQuestionAttributes question) {
-        boolean responsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
+        boolean isResponsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
                 && question.showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS)
                 && question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER);
-        boolean giverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
+        boolean isGiverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
                 && question.showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS);
 
-        return responsesVisibleOnlyToRecipientAndInstructors && giverNameVisibleOnlyToInstructors;
+        return isResponsesVisibleOnlyToRecipientAndInstructors && isGiverNameVisibleOnlyToInstructors;
     }
 
     private boolean isVisibilitySetToAnonymousToRecipientAndTeamVisibleToInstructors(FeedbackQuestionAttributes question) {
-        boolean responsesVisibleOnlyToRecipientTeamAndInstructors = question.showResponsesTo.size() == 4
+        boolean isResponsesVisibleOnlyToRecipientTeamAndInstructors = question.showResponsesTo.size() == 4
                 && question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER)
                 && question.showResponsesTo.contains(FeedbackParticipantType.OWN_TEAM_MEMBERS)
                 && question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS)
                 && question.showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS);
-        boolean giverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
+        boolean isGiverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
                 && question.showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS);
 
-        return responsesVisibleOnlyToRecipientTeamAndInstructors && giverNameVisibleOnlyToInstructors;
+        return isResponsesVisibleOnlyToRecipientTeamAndInstructors && isGiverNameVisibleOnlyToInstructors;
     }
 
     private boolean isVisibilitySetToVisibleToInstructorsOnly(FeedbackQuestionAttributes question) {
-        boolean responsesVisibleOnlyToInstructors = question.showResponsesTo.size() == 1
+        boolean isResponsesVisibleOnlyToInstructors = question.showResponsesTo.size() == 1
                 && question.showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS);
-        boolean giverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
+        boolean isGiverNameVisibleOnlyToInstructors = question.showGiverNameTo.size() == 1
                 && question.showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS);
-        boolean recipientNameVisibleOnlyToInstructors = question.showRecipientNameTo.size() == 1
+        boolean isRecipientNameVisibleOnlyToInstructors = question.showRecipientNameTo.size() == 1
                 && question.showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS);
 
-        return responsesVisibleOnlyToInstructors && giverNameVisibleOnlyToInstructors
-                && recipientNameVisibleOnlyToInstructors;
+        return isResponsesVisibleOnlyToInstructors && isGiverNameVisibleOnlyToInstructors
+                && isRecipientNameVisibleOnlyToInstructors;
     }
 
     private boolean isVisibilitySetToVisibleToRecipientAndInstructors(FeedbackQuestionAttributes question) {
-        boolean responsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
+        boolean isResponsesVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
                 && question.showResponsesTo.contains(FeedbackParticipantType.INSTRUCTORS)
                 && question.showResponsesTo.contains(FeedbackParticipantType.RECEIVER);
-        boolean giverNameVisibleOnlyToRecipientAndInstructors = question.showGiverNameTo.size() == 2
+        boolean isGiverNameVisibleOnlyToRecipientAndInstructors = question.showGiverNameTo.size() == 2
                 && question.showGiverNameTo.contains(FeedbackParticipantType.INSTRUCTORS)
                 && question.showGiverNameTo.contains(FeedbackParticipantType.RECEIVER);
-        boolean recipientNameVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
+        boolean isRecipientNameVisibleOnlyToRecipientAndInstructors = question.showResponsesTo.size() == 2
                 && question.showRecipientNameTo.size() == 2
                 && question.showRecipientNameTo.contains(FeedbackParticipantType.INSTRUCTORS)
                 && question.showRecipientNameTo.contains(FeedbackParticipantType.RECEIVER);
 
-        return responsesVisibleOnlyToRecipientAndInstructors && giverNameVisibleOnlyToRecipientAndInstructors
-                && recipientNameVisibleOnlyToRecipientAndInstructors;
+        return isResponsesVisibleOnlyToRecipientAndInstructors && isGiverNameVisibleOnlyToRecipientAndInstructors
+                && isRecipientNameVisibleOnlyToRecipientAndInstructors;
     }
 
     private FeedbackQuestionFeedbackPathSettings configureFeedbackPathSettings(

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentsLoadPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentsLoadPageData.java
@@ -69,7 +69,7 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
             String responseAnswerHtml =
                     response.getResponseDetails().getAnswerHtml(question.getQuestionDetails());
 
-            boolean instructorAllowedToAddComment = isInstructorAllowedForSectionalPrivilege(
+            boolean isInstructorAllowedToAddComment = isInstructorAllowedForSectionalPrivilege(
                     response.giverSection, response.recipientSection, response.feedbackSessionName,
                     Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 
@@ -85,7 +85,7 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
 
             responseCommentList.add(new InstructorFeedbackResponseComment(
                     giverName, recipientName, frcList, responseAnswerHtml,
-                    instructorAllowedToAddComment, feedbackResponseCommentAdd));
+                    isInstructorAllowedToAddComment, feedbackResponseCommentAdd));
         }
 
         return responseCommentList;
@@ -103,7 +103,7 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
             boolean isInstructorAllowedToModify = isInstructorAllowedForSectionalPrivilege(
                     response.giverSection, response.recipientSection, response.feedbackSessionName,
                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION_COMMENT_IN_SECTIONS);
-            boolean allowedToEditAndDeleteComment = isInstructorGiver || isInstructorAllowedToModify;
+            boolean isAllowedToEditAndDeleteComment = isInstructorGiver || isInstructorAllowedToModify;
 
             String showCommentToString = getResponseCommentVisibilityString(frca, question);
             String showGiverNameToString = getResponseCommentGiverNameVisibilityString(frca, question);
@@ -111,8 +111,8 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
             String whoCanSeeComment = null;
             boolean isVisibilityIconShown = false;
             if (feedbackSession.isPublished()) {
-                boolean responseCommentPublicToRecipient = !frca.showCommentTo.isEmpty();
-                isVisibilityIconShown = responseCommentPublicToRecipient;
+                boolean isResponseCommentPublicToRecipient = !frca.showCommentTo.isEmpty();
+                isVisibilityIconShown = isResponseCommentPublicToRecipient;
 
                 if (isVisibilityIconShown) {
                     whoCanSeeComment = getTypeOfPeopleCanViewComment(frca, question);
@@ -125,7 +125,7 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
 
             frc.setExtraClass(getExtraClass(frca.giverEmail, instructor.email, isVisibilityIconShown));
 
-            if (allowedToEditAndDeleteComment) {
+            if (isAllowedToEditAndDeleteComment) {
                 frc.enableEdit();
                 frc.enableDelete();
                 frc.enableEditDeleteOnHover();

--- a/src/main/java/teammates/ui/pagedata/StudentCourseJoinConfirmationPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentCourseJoinConfirmationPageData.java
@@ -6,8 +6,8 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 public class StudentCourseJoinConfirmationPageData extends PageData {
     private String confirmUrl;
     private String logoutUrl;
-    private boolean redirectResult;
-    private boolean nextUrlAccessibleWithoutLogin;
+    private boolean isRedirectResult;
+    private boolean isNextUrlAccessibleWithoutLogin;
     private String courseId;
 
     public StudentCourseJoinConfirmationPageData(AccountAttributes account, StudentAttributes student, String sessionToken,
@@ -16,9 +16,9 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
         super(account, student, sessionToken);
         this.confirmUrl = confirmUrl;
         this.logoutUrl = logoutUrl;
-        this.redirectResult = redirectResult;
+        this.isRedirectResult = redirectResult;
         this.courseId = courseId;
-        this.nextUrlAccessibleWithoutLogin = nextUrlAccessibleWithoutLogin;
+        this.isNextUrlAccessibleWithoutLogin = nextUrlAccessibleWithoutLogin;
     }
 
     public String getConfirmUrl() {
@@ -30,7 +30,7 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
     }
 
     public boolean isRedirectResult() {
-        return redirectResult;
+        return isRedirectResult;
     }
 
     public String getCourseId() {
@@ -38,7 +38,7 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
     }
 
     public boolean isNextUrlAccessibleWithoutLogin() {
-        return nextUrlAccessibleWithoutLogin;
+        return isNextUrlAccessibleWithoutLogin;
     }
 
 }

--- a/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
@@ -29,7 +29,7 @@ public class FeedbackResponseCommentRow {
 
     private String whoCanSeeComment;
 
-    private boolean isWithVisibilityIcon;
+    private boolean hasVisibilityIcon;
 
     private boolean isEditDeleteEnabled;
     private boolean isEditDeleteEnabledOnlyOnHover;
@@ -146,7 +146,7 @@ public class FeedbackResponseCommentRow {
     }
 
     public boolean isWithVisibilityIcon() {
-        return isWithVisibilityIcon;
+        return hasVisibilityIcon;
     }
 
     public boolean isEditDeleteEnabled() {
@@ -268,7 +268,7 @@ public class FeedbackResponseCommentRow {
     }
 
     public void enableVisibilityIcon(String whoCanSeeComment) {
-        this.isWithVisibilityIcon = true;
+        this.hasVisibilityIcon = true;
         this.whoCanSeeComment = whoCanSeeComment;
     }
 }

--- a/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
@@ -28,12 +28,13 @@ public class FeedbackResponseCommentRow {
     private Map<FeedbackParticipantType, Boolean> responseVisibilities;
 
     private String whoCanSeeComment;
-    private boolean withVisibilityIcon;
 
-    private boolean editDeleteEnabled;
-    private boolean editDeleteEnabledOnlyOnHover;
-    private boolean instructorAllowedToDelete;
-    private boolean instructorAllowedToEdit;
+    private boolean isWithVisibilityIcon;
+
+    private boolean isEditDeleteEnabled;
+    private boolean isEditDeleteEnabledOnlyOnHover;
+    private boolean isInstructorAllowedToDelete;
+    private boolean isInstructorAllowedToEdit;
 
     public FeedbackResponseCommentRow(FeedbackResponseCommentAttributes frc, String giverDisplay) {
         this.commentId = frc.getId();
@@ -145,23 +146,23 @@ public class FeedbackResponseCommentRow {
     }
 
     public boolean isWithVisibilityIcon() {
-        return withVisibilityIcon;
+        return isWithVisibilityIcon;
     }
 
     public boolean isEditDeleteEnabled() {
-        return editDeleteEnabled;
+        return isEditDeleteEnabled;
     }
 
     public boolean isEditDeleteEnabledOnlyOnHover() {
-        return editDeleteEnabledOnlyOnHover;
+        return isEditDeleteEnabledOnlyOnHover;
     }
 
     public boolean isInstructorAllowedToDelete() {
-        return instructorAllowedToDelete;
+        return isInstructorAllowedToDelete;
     }
 
     public boolean isInstructorAllowedToEdit() {
-        return instructorAllowedToEdit;
+        return isInstructorAllowedToEdit;
     }
 
     private boolean isResponseVisibleTo(FeedbackParticipantType type) {
@@ -249,25 +250,25 @@ public class FeedbackResponseCommentRow {
     }
 
     private void enableEditDelete() {
-        this.editDeleteEnabled = true;
+        this.isEditDeleteEnabled = true;
     }
 
     public void enableEdit() {
         enableEditDelete();
-        this.instructorAllowedToEdit = true;
+        this.isInstructorAllowedToEdit = true;
     }
 
     public void enableDelete() {
         enableEditDelete();
-        this.instructorAllowedToDelete = true;
+        this.isInstructorAllowedToDelete = true;
     }
 
     public void enableEditDeleteOnHover() {
-        this.editDeleteEnabledOnlyOnHover = true;
+        this.isEditDeleteEnabledOnlyOnHover = true;
     }
 
     public void enableVisibilityIcon(String whoCanSeeComment) {
-        this.withVisibilityIcon = true;
+        this.isWithVisibilityIcon = true;
         this.whoCanSeeComment = whoCanSeeComment;
     }
 }

--- a/src/main/java/teammates/ui/template/FeedbackSessionPublishButton.java
+++ b/src/main/java/teammates/ui/template/FeedbackSessionPublishButton.java
@@ -14,7 +14,7 @@ public class FeedbackSessionPublishButton {
 
     private String actionName;
     private String actionLink;
-    private boolean actionAllowed;
+    private boolean isActionAllowed;
 
     private String buttonType;
 
@@ -25,7 +25,7 @@ public class FeedbackSessionPublishButton {
         this.isSendingPublishedEmail = session.isPublishedEmailEnabled();
 
         boolean isUnpublishing = !session.isWaitingToOpen() && session.isPublished();
-        this.actionAllowed = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
+        this.isActionAllowed = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
         if (isUnpublishing) {
 
@@ -40,7 +40,7 @@ public class FeedbackSessionPublishButton {
                                                 : Const.Tooltips.FEEDBACK_SESSION_AWAITING;
             this.actionName = "Publish";
             this.actionLink = data.getInstructorFeedbackPublishLink(courseId, feedbackSessionName, returnUrl);
-            this.actionAllowed &= isReadyToPublish;
+            this.isActionAllowed &= isReadyToPublish;
         }
 
         this.buttonType = buttonType;
@@ -71,7 +71,7 @@ public class FeedbackSessionPublishButton {
     }
 
     public boolean isActionAllowed() {
-        return actionAllowed;
+        return isActionAllowed;
     }
 
     public String getButtonType() {

--- a/src/main/java/teammates/ui/template/InstructorFeedbackSessionActions.java
+++ b/src/main/java/teammates/ui/template/InstructorFeedbackSessionActions.java
@@ -9,7 +9,7 @@ public class InstructorFeedbackSessionActions {
 
     private static final String PUBLISH_BUTTON_TYPE = "btn-default btn-xs";
 
-    private boolean privateSession;
+    private boolean isPrivateSession;
 
     private String courseId;
     private String fsName;
@@ -22,10 +22,10 @@ public class InstructorFeedbackSessionActions {
     private String remindParticularStudentsPageLink;
     private String editCopyLink;
 
-    private boolean allowedToEdit;
-    private boolean allowedToDelete;
-    private boolean allowedToSubmit;
-    private boolean allowedToRemind;
+    private boolean isAllowedToEdit;
+    private boolean isAllowedToDelete;
+    private boolean isAllowedToSubmit;
+    private boolean isAllowedToRemind;
 
     private FeedbackSessionPublishButton publishButton;
 
@@ -34,7 +34,7 @@ public class InstructorFeedbackSessionActions {
         String courseId = session.getCourseId();
         String feedbackSessionName = session.getFeedbackSessionName();
 
-        this.privateSession = session.isPrivateSession();
+        this.isPrivateSession = session.isPrivateSession();
 
         this.courseId = courseId;
         this.fsName = feedbackSessionName;
@@ -48,8 +48,8 @@ public class InstructorFeedbackSessionActions {
                 data.getInstructorFeedbackRemindParticularStudentsPageLink(courseId, feedbackSessionName);
         this.editCopyLink = data.getInstructorFeedbackEditCopyLink();
 
-        this.allowedToEdit = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
-        this.allowedToDelete = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
+        this.isAllowedToEdit = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
+        this.isAllowedToDelete = instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
         boolean shouldEnableSubmitLink =
                 instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
         if (!shouldEnableSubmitLink) {
@@ -58,8 +58,8 @@ public class InstructorFeedbackSessionActions {
                             Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
         }
 
-        this.allowedToSubmit = (session.isVisible() || session.isPrivateSession()) && shouldEnableSubmitLink;
-        this.allowedToRemind =
+        this.isAllowedToSubmit = (session.isVisible() || session.isPrivateSession()) && shouldEnableSubmitLink;
+        this.isAllowedToRemind =
                 (session.isOpened() || session.isClosed() && !session.isPublished())
                 && instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
@@ -68,7 +68,7 @@ public class InstructorFeedbackSessionActions {
     }
 
     public boolean isPrivateSession() {
-        return privateSession;
+        return isPrivateSession;
     }
 
     public String getCourseId() {
@@ -108,19 +108,19 @@ public class InstructorFeedbackSessionActions {
     }
 
     public boolean isAllowedToEdit() {
-        return allowedToEdit;
+        return isAllowedToEdit;
     }
 
     public boolean isAllowedToDelete() {
-        return allowedToDelete;
+        return isAllowedToDelete;
     }
 
     public boolean isAllowedToSubmit() {
-        return allowedToSubmit;
+        return isAllowedToSubmit;
     }
 
     public boolean isAllowedToRemind() {
-        return allowedToRemind;
+        return isAllowedToRemind;
     }
 
     public FeedbackSessionPublishButton getPublishButton() {

--- a/src/main/java/teammates/ui/template/InstructorStudentListFilterBox.java
+++ b/src/main/java/teammates/ui/template/InstructorStudentListFilterBox.java
@@ -5,12 +5,12 @@ import java.util.List;
 public class InstructorStudentListFilterBox {
 
     private List<InstructorStudentListFilterCourse> courses;
-    private boolean displayArchive;
+    private boolean shouldDisplayArchive;
 
     public InstructorStudentListFilterBox(List<InstructorStudentListFilterCourse> courses,
                                           boolean displayArchive) {
         this.courses = courses;
-        this.displayArchive = displayArchive;
+        this.shouldDisplayArchive = displayArchive;
     }
 
     public List<InstructorStudentListFilterCourse> getCourses() {
@@ -18,7 +18,7 @@ public class InstructorStudentListFilterBox {
     }
 
     public boolean isDisplayArchive() {
-        return displayArchive;
+        return shouldDisplayArchive;
     }
 
 }

--- a/src/main/java/teammates/ui/template/InstructorStudentListStudentsTableCourse.java
+++ b/src/main/java/teammates/ui/template/InstructorStudentListStudentsTableCourse.java
@@ -4,27 +4,27 @@ import teammates.common.util.SanitizationHelper;
 
 public class InstructorStudentListStudentsTableCourse {
 
-    private boolean courseArchived;
+    private boolean isCourseArchived;
     private String courseId;
     private String courseName;
     private String googleId;
     private String instructorCourseEnrollLink;
-    private boolean instructorAllowedToModify;
+    private boolean isInstructorAllowedToModify;
 
     public InstructorStudentListStudentsTableCourse(boolean isCourseArchived, String courseId, String courseName,
                                                     String googleId,
                                                     String instructorCourseEnrollLink,
                                                     boolean isInstructorAllowedToModify) {
-        this.courseArchived = isCourseArchived;
+        this.isCourseArchived = isCourseArchived;
         this.courseId = courseId;
         this.courseName = SanitizationHelper.sanitizeForHtml(courseName);
         this.googleId = googleId;
         this.instructorCourseEnrollLink = instructorCourseEnrollLink;
-        this.instructorAllowedToModify = isInstructorAllowedToModify;
+        this.isInstructorAllowedToModify = isInstructorAllowedToModify;
     }
 
     public boolean isCourseArchived() {
-        return courseArchived;
+        return isCourseArchived;
     }
 
     public String getCourseId() {
@@ -44,7 +44,7 @@ public class InstructorStudentListStudentsTableCourse {
     }
 
     public boolean isInstructorAllowedToModify() {
-        return instructorAllowedToModify;
+        return isInstructorAllowedToModify;
     }
 
 }

--- a/src/main/java/teammates/ui/template/StudentListSectionData.java
+++ b/src/main/java/teammates/ui/template/StudentListSectionData.java
@@ -10,16 +10,17 @@ import teammates.common.datatransfer.TeamDetailsBundle;
 public class StudentListSectionData {
 
     private String sectionName;
-    private boolean allowedToViewStudentInSection;
-    private boolean allowedToModifyStudent;
+    private boolean isAllowedToViewStudentInSection;
+    private boolean isAllowedToModifyStudent;
+
     private List<StudentListTeamData> teams;
 
     public StudentListSectionData(SectionDetailsBundle section, boolean isAllowedToViewStudentInSection,
                                   boolean isAllowedToModifyStudent,
                                   Map<String, String> emailPhotoUrlMapping, String googleId, String sessionToken) {
         this.sectionName = section.name;
-        this.allowedToViewStudentInSection = isAllowedToViewStudentInSection;
-        this.allowedToModifyStudent = isAllowedToModifyStudent;
+        this.isAllowedToViewStudentInSection = isAllowedToViewStudentInSection;
+        this.isAllowedToModifyStudent = isAllowedToModifyStudent;
         List<StudentListTeamData> teamsDetails = new ArrayList<StudentListTeamData>();
         for (TeamDetailsBundle team : section.teams) {
             teamsDetails.add(new StudentListTeamData(team, emailPhotoUrlMapping, googleId, sessionToken));
@@ -32,11 +33,11 @@ public class StudentListSectionData {
     }
 
     public boolean isAllowedToViewStudentInSection() {
-        return allowedToViewStudentInSection;
+        return isAllowedToViewStudentInSection;
     }
 
     public boolean isAllowedToModifyStudent() {
-        return allowedToModifyStudent;
+        return isAllowedToModifyStudent;
     }
 
     public List<StudentListTeamData> getTeams() {

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -200,7 +200,7 @@
         <%-- This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
         to show all testing logs. This will keep showing all logs from testing data despite any action or change in the page
         unless the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted. --%>
-        <input type="hidden" name="testdata" value="${shouldShowTestData}"> 
+        <input type="hidden" name="testdata" value="${shouldShowTestData}">
     </form>
 
     <%-- This form is used to store parameters for ajaxloader only --%>

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -3,8 +3,8 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ attribute name="excludedLogRequestURIs" required="true" %>
 <%@ attribute name="actionListAsHtml" required="true" %>
-<%@ attribute name="ifShowAll" required="true" %>
-<%@ attribute name="ifShowTestData" required="true" %>
+<%@ attribute name="shouldShowAllLogs" required="true" %>
+<%@ attribute name="shouldShowTestData" required="true" %>
 <%@ attribute name="filterQuery" required="true" %>
 <%@ attribute name="queryKeywordsForInfo" required="true"%>
 
@@ -195,12 +195,12 @@
         in AdminActivityLogPageData should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
         logs despite any action or change in the page unless the page is reloaded with "?all=false"
         or simply reloaded with this parameter omitted. --%>
-        <input type="hidden" name="all" value="${ifShowAll}">
+        <input type="hidden" name="all" value="${shouldShowAllLogs}">
 
         <%-- This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
         to show all testing logs. This will keep showing all logs from testing data despite any action or change in the page
         unless the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted. --%>
-        <input type="hidden" name="testdata" value="${ifShowTestData}">
+        <input type="hidden" name="testdata" value="${shouldShowTestData}"> 
     </form>
 
     <%-- This form is used to store parameters for ajaxloader only --%>
@@ -211,12 +211,12 @@
         in AdminActivityLogPageData should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
         logs despite any action or change in the page unless the page is reloaded with "?all=false"
         or simply reloaded with this parameter omitted. --%>
-        <input type="hidden" name="all" value="${ifShowAll}">
+        <input type="hidden" name="all" value="${shouldShowAllLogs}">
 
         <%-- This determines whether the logs related to testing data should be shown. Use "testdata=true" in URL
         to show all testing logs. This will keep showing all logs from testing data despite any action or change in the page
         unless the page is reloaded with "?testdata=false"  or simply reloaded with this parameter omitted. --%>
-        <input type="hidden" name="testdata" value="${ifShowTestData}">
+        <input type="hidden" name="testdata" value="${shouldShowTestData}">
 
         <input type="hidden" id="filterQuery" name="filterQuery" value="${filterQuery}">
     </form>

--- a/src/main/webapp/jsp/adminActivityLog.jsp
+++ b/src/main/webapp/jsp/adminActivityLog.jsp
@@ -13,7 +13,7 @@
 
 <ta:adminPage bodyTitle="Admin Activity Log" pageTitle="TEAMMATES - Administrator" jsIncludes="${jsIncludes}">
     <activity:filterPanel excludedLogRequestURIs="${data.excludedLogRequestUris}" actionListAsHtml="${data.actionListAsHtml}"
-                            ifShowAll="${data.ifShowAll}" ifShowTestData="${data.ifShowTestData}" filterQuery="${data.filterQuery}"
+                            shouldShowAllLogs="${data.shouldShowAllLogs}" shouldShowTestData="${data.shouldShowTestData}" filterQuery="${data.filterQuery}"
                             queryKeywordsForInfo="${data.queryKeywordsForInfo}"/>
 
     <c:if test="${not empty data.queryMessage}">

--- a/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
@@ -56,7 +56,7 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId
         };
 
-        boolean hasThrowUnauthorizedAccessException = false;
+        boolean hasThrownUnauthorizedAccessException = false;
         String exceptionMessage = "";
 
         a = getAction(addUserIdToParams(instructorId, submissionParams));
@@ -64,11 +64,11 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
         try {
             r = getAjaxResult(a);
         } catch (UnauthorizedAccessException e) {
-            hasThrowUnauthorizedAccessException = true;
+            hasThrownUnauthorizedAccessException = true;
             exceptionMessage = e.getMessage();
         }
 
-        assertTrue(hasThrowUnauthorizedAccessException);
+        assertTrue(hasThrownUnauthorizedAccessException);
         assertEquals("Trying to access system using a non-existent feedback session entity", exceptionMessage);
         assertEquals("", r.getStatusMessage());
     }

--- a/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
@@ -56,7 +56,7 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId
         };
 
-        boolean doesThrowUnauthorizedAccessException = false;
+        boolean hasThrowUnauthorizedAccessException = false;
         String exceptionMessage = "";
 
         a = getAction(addUserIdToParams(instructorId, submissionParams));
@@ -64,11 +64,11 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
         try {
             r = getAjaxResult(a);
         } catch (UnauthorizedAccessException e) {
-            doesThrowUnauthorizedAccessException = true;
+            hasThrowUnauthorizedAccessException = true;
             exceptionMessage = e.getMessage();
         }
 
-        assertTrue(doesThrowUnauthorizedAccessException);
+        assertTrue(hasThrowUnauthorizedAccessException);
         assertEquals("Trying to access system using a non-existent feedback session entity", exceptionMessage);
         assertEquals("", r.getStatusMessage());
     }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackResponseDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackResponseDetailsTest.java
@@ -199,12 +199,12 @@ public class FeedbackResponseDetailsTest extends BaseTestCase {
         constSumOptions.add("Option 1");
         constSumOptions.add("Option 2");
 
-        boolean pointsPerOption = false;
+        boolean isPointsPerOption = false;
         int points = 100;
-        boolean forceUnevenDistribution = false;
+        boolean shouldForceUnevenDistribution = false;
         FeedbackConstantSumQuestionDetails constantSumQuestionDetails =
                 new FeedbackConstantSumQuestionDetails(questionText, constSumOptions,
-                                                       pointsPerOption, points, forceUnevenDistribution);
+                                                       isPointsPerOption, points, shouldForceUnevenDistribution);
 
         requestParameters.put("questiontype-7", new String[] { "CONSTSUM" });
         requestParameters.put("responsetext-7-0", new String[] { "20", "80" });

--- a/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
@@ -25,7 +25,7 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
 
     private AccountAttributes acct;
     private String searchKey;
-    private boolean displayArchive;
+    private boolean shouldDisplayArchive;
     private List<InstructorStudentListPageCourseData> coursesToDisplay;
 
     private CourseAttributes sampleCourse;
@@ -49,7 +49,7 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
         acct.googleId = "valid.id"; // only googleId is used
 
         searchKey = "<script>alert(\"A search key\");</script>";
-        displayArchive = false;
+        shouldDisplayArchive = false;
 
         // only course ID and name are used
         sampleCourse = new CourseAttributes("validCourseId", "Sample course name", "UTC");
@@ -60,12 +60,14 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
         coursesToDisplay = new ArrayList<InstructorStudentListPageCourseData>();
         coursesToDisplay.add(new InstructorStudentListPageCourseData(sampleCourse, isCourseArchived,
                                                                      isInstructorAllowedToModify));
-        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, displayArchive, coursesToDisplay);
+
+        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, shouldDisplayArchive, coursesToDisplay);
     }
 
     private InstructorStudentListPageData initializeDataWithNoSearchKey() {
         searchKey = null;
-        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, displayArchive, coursesToDisplay);
+
+        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, shouldDisplayArchive, coursesToDisplay);
     }
 
     private void testSearchBox(InstructorStudentListSearchBox searchBox) {
@@ -75,7 +77,7 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
     }
 
     private void testFilterBox(InstructorStudentListFilterBox filterBox) {
-        assertEquals(displayArchive, filterBox.isDisplayArchive());
+        assertEquals(shouldDisplayArchive, filterBox.isDisplayArchive());
 
         // sample data has only one course
         InstructorStudentListFilterCourse course = filterBox.getCourses().get(0);

--- a/src/test/java/teammates/test/cases/util/ActivityLogEntryTest.java
+++ b/src/test/java/teammates/test/cases/util/ActivityLogEntryTest.java
@@ -78,7 +78,7 @@ public class ActivityLogEntryTest extends BaseTestCase {
         assertEquals(20, entry.getActionTimeTaken());
         assertEquals(statusToAdmin, entry.getLogMessage());
         assertTrue(entry.isTestingData());
-        assertTrue(entry.getLogToShow());
+        assertTrue(entry.getShouldShowLog());
     }
 
     @Test


### PR DESCRIPTION
Fixes #7131

**Outline of Solution**
Fix violations based on report
[Main](http://htmlpreview.github.io/?https://github.com/xpdavid/CS2103R-Report/blob/master/codingStandard/booleanNaming/main.html)
[Test](http://htmlpreview.github.io/?https://github.com/xpdavid/CS2103R-Report/blob/master/codingStandard/booleanNaming/test.html)

[Discussion](https://xpdavid.github.io/CS2103R-Report/#boolean-variable-naming-convention) on boolean variable naming convention.

The fixing on `datatransfer` and `entity` would require more efforts as they are related to how data is stored in GAE, typically JSON format. I suspect the side effects may be outweigh their benefits (need a lot data migration etc.).
