### PR TITLE
Instructor edit rubric question: ignore empty rows #7039

### DIFF
--- a/src/main/webapp/js/common.es6
+++ b/src/main/webapp/js/common.es6
@@ -60,6 +60,7 @@ const FEEDBACK_QUESTION_NUMBEROFCHOICECREATED = 'noofchoicecreated';
 const FEEDBACK_QUESTION_NUMSCALE_MIN = 'numscalemin';
 const FEEDBACK_QUESTION_NUMSCALE_MAX = 'numscalemax';
 const FEEDBACK_QUESTION_NUMSCALE_STEP = 'numscalestep';
+const FEEDBACK_QUESTION_RUBRIC_SUBQUESTION = 'rubricSubQn';
 const FEEDBACK_QUESTION_NUMBER = 'questionnum';
 const FEEDBACK_QUESTION_TEXT = 'questiontext';
 const FEEDBACK_QUESTION_DESCRIPTION = 'questiondescription';
@@ -147,6 +148,8 @@ const DISPLAY_FEEDBACK_QUESTION_TEXTINVALID = 'Please enter a valid question. Th
 const DISPLAY_FEEDBACK_QUESTION_NUMSCALE_OPTIONSINVALID = 'Please enter valid options. The min/max/step cannot be empty.';
 const DISPLAY_FEEDBACK_QUESTION_NUMSCALE_INTERVALINVALID =
         'Please enter valid options. The interval is not divisible by the specified increment.';
+const DISPLAY_FEEDBACK_QUESTION_RUBRIC_INVALIDSUBQUESTION =
+        'Sub-questions for Rubric question cannot be empty.';
 
 const DISPLAY_FEEDBACK_SESSION_VISIBLE_DATEINVALID = 'Feedback session visible date must not be empty';
 const DISPLAY_FEEDBACK_SESSION_PUBLISH_DATEINVALID = 'Feedback session publish date must not be empty';

--- a/src/main/webapp/js/instructorFeedbacks.es6
+++ b/src/main/webapp/js/instructorFeedbacks.es6
@@ -9,6 +9,7 @@ DISPLAY_FEEDBACK_QUESTION_NUMBEROFENTITIESINVALID:false, DISPLAY_FEEDBACK_QUESTI
 FEEDBACK_QUESTION_TYPE:false, FEEDBACK_SESSION_STARTDATE:false, FEEDBACK_SESSION_STARTTIME:false
 FEEDBACK_QUESTION_NUMSCALE_MIN:false, FEEDBACK_QUESTION_NUMSCALE_MAX:false, FEEDBACK_QUESTION_NUMSCALE_STEP:false
 DISPLAY_FEEDBACK_QUESTION_NUMSCALE_OPTIONSINVALID:false, DISPLAY_FEEDBACK_QUESTION_NUMSCALE_INTERVALINVALID:false
+FEEDBACK_QUESTION_RUBRIC_SUBQUESTION:false, DISPLAY_FEEDBACK_QUESTION_RUBRIC_INVALIDSUBQUESTION:false
 DISPLAY_FEEDBACK_SESSION_VISIBLE_DATEINVALID:false, DISPLAY_FEEDBACK_SESSION_PUBLISH_DATEINVALID:false
 FEEDBACK_SESSION_TIMEZONE:false, COURSE_ID:false, FEEDBACK_SESSION_NAME:false, FEEDBACK_SESSION_COPY_INVALID:false
 DISPLAY_FEEDBACK_SESSION_NAME_DUPLICATE:false, FEEDBACK_SESSION_SESSIONVISIBLEBUTTON:false
@@ -63,6 +64,18 @@ function checkFeedbackQuestion(form) {
         }
         setStatusMessageToForm(DISPLAY_FEEDBACK_QUESTION_NUMSCALE_INTERVALINVALID, StatusType.DANGER, form);
         return false;
+    }
+    if ($(form).find(`[name=${FEEDBACK_QUESTION_TYPE}]`).val() === 'RUBRIC') {
+        const questionNum = getQuestionNumFromEditForm(form);
+        const questionId = `#rubricNumRows-${questionNum}`;
+        const numberOfRows = parseInt($(questionId).val(), 10);
+        for (let row = 0; row < numberOfRows; row += 1) {
+            if ($.trim($(form).find(`[name=${FEEDBACK_QUESTION_RUBRIC_SUBQUESTION}-${row}]`).val()) === '' &&
+                $(form).find(`[name=${FEEDBACK_QUESTION_RUBRIC_SUBQUESTION}-${row}]`).get(0) !== undefined) {
+                setStatusMessageToForm(DISPLAY_FEEDBACK_QUESTION_RUBRIC_INVALIDSUBQUESTION, StatusType.DANGER, form);
+                return false;
+            }
+        }
     }
     return true;
 }

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
@@ -274,6 +274,22 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.clickSaveExistingQuestionButton(1);
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html");
 
+        ______TS("empty row test");
+        feedbackEditPage.clickEditQuestionButton(1);
+
+        // Add an empty row
+        feedbackEditPage.clickAddRubricRowLink(1);
+        feedbackEditPage.fillRubricSubQuestionBox("", 1, 1);
+
+        feedbackEditPage.clickSaveExistingQuestionButton(1);
+        feedbackEditPage.verifyStatus(Const.FeedbackQuestion.RUBRIC_ERROR_EMPTY_SUB_QUESTION);
+
+        // Remove the empty row
+        feedbackEditPage.clickRemoveRubricRowLinkAndConfirm(1, 1);
+
+        feedbackEditPage.clickSaveExistingQuestionButton(1);
+        feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html");
+
         ______TS("RUBRIC: edit choices success");
         feedbackEditPage.clickEditQuestionButton(1);
 


### PR DESCRIPTION
Fixes #7039 

**Outline of Solution**

Disallowing empty rubric sub-questions in the front-end. Also, added their test cases.


![normal](https://cloud.githubusercontent.com/assets/20799404/25065958/f611db9e-2236-11e7-9092-0c7c604ce7ba.gif)


These GIF's show that even after deleting rows we get the same result:


![anim](https://cloud.githubusercontent.com/assets/20799404/24954936/0723fd44-1f9f-11e7-9df1-cb2a54291fcf.gif)


![deleted](https://cloud.githubusercontent.com/assets/20799404/25065959/f92d2496-2236-11e7-91c0-3d1e5dccf05e.gif)

