### PR TITLE
Avoid throwing raw exception types in production code #7085

### DIFF
--- a/src/main/java/teammates/common/datatransfer/TeamEvalResult.java
+++ b/src/main/java/teammates/common/datatransfer/TeamEvalResult.java
@@ -3,6 +3,7 @@ package teammates.common.datatransfer;
 import java.util.Arrays;
 import java.util.List;
 
+import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
 import teammates.common.util.StringHelper;
@@ -443,8 +444,7 @@ public class TeamEvalResult {
     private static void verify(String message, boolean condition) {
         // TODO: replace with Assumption.assert*
         if (!condition) {
-            throw new RuntimeException("Internal assertion failuer : "
-                    + message);
+        	Assumption.assertTrue("Internal assertion failure : ", condition);
         }
     }
 

--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -20,10 +20,16 @@ public final class Assumption {
         // Intentional private constructor to prevent instantiation.
     }
 
+    /**
+     * Asserts the detail message of exception and class. 
+     */
     public static void assertEception(String message, Exception e) {
     	throw new AssertionError(message, e);
     }
 
+    /**
+     * Asserts the detail message of the exception.
+     */
     public static void assertEception(String message) {
     	throw new AssertionError(message);
     }

--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -20,6 +20,14 @@ public final class Assumption {
         // Intentional private constructor to prevent instantiation.
     }
 
+    public static void assertEception(String message, Exception e) {
+    	throw new AssertionError(message, e);
+    }
+
+    public static void assertEception(String message) {
+    	throw new AssertionError(message);
+    }
+
     /**
      * Asserts that a condition is true. If it isn't it throws an
      * AssertionFailedError with the given message.

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -64,7 +64,7 @@ public final class Config {
         try {
             properties.load(FileHelper.getResourceAsStream("build.properties"));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+        	 Assumption.assertEception("IOException", e);
         }
         APP_URL = Url.trimTrailingSlash(properties.getProperty("app.url"));
         BACKDOOR_KEY = properties.getProperty("app.backdoor.key");

--- a/src/main/java/teammates/common/util/HttpRequestHelper.java
+++ b/src/main/java/teammates/common/util/HttpRequestHelper.java
@@ -52,7 +52,7 @@ public final class HttpRequestHelper {
 
                 hashMap.put(name, decodedValue);
             } catch (Exception e) {
-                throw new RuntimeException(e);
+            	Assumption.assertEception("Exception", e);
             }
         }
 

--- a/src/main/java/teammates/ui/automated/InstructorCourseJoinEmailWorkerAction.java
+++ b/src/main/java/teammates/ui/automated/InstructorCourseJoinEmailWorkerAction.java
@@ -46,7 +46,7 @@ public class InstructorCourseJoinEmailWorkerAction extends AutomatedAction {
         try {
             emailSender.sendEmail(email);
         } catch (Exception e) {
-            throw new RuntimeException("Unexpected error while sending email", e);
+        	Assumption.assertEception("Unexpected error while sending email", e);
         }
     }
 

--- a/static-analysis/teammates-pmdMain.xml
+++ b/static-analysis/teammates-pmdMain.xml
@@ -13,6 +13,7 @@
     </rule>
 
     <rule ref="rulesets/java/strictexception.xml/SignatureDeclareThrowsException"/>
+    <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes"/>
 
     <exclude-pattern>.*/test/java/.*</exclude-pattern>
     <exclude-pattern>.*/client/java/.*</exclude-pattern>


### PR DESCRIPTION
Fixes #7085 

**Outline of Solution**
- I have created two methods in Assumption class to handle the below two types of exceptions
     - RunTimeExcepetion(String)

     - RunTimeExcepetion(String, Throwable)

