### PR TITLE
InstructorHomePageUiTest: remove redundant reloading of previous page #7165

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -261,7 +261,6 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.submitRemindParticularUsersForm();
         homePage.waitForPageToLoad();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_REMINDERSEMPTYRECIPIENT);
-        
 
         homePage.clickRemindOptionsLink(feedbackSessionOpen.getCourseId(), feedbackSessionOpen.getFeedbackSessionName());
         homePage.clickRemindParticularUsersLink(feedbackSessionOpen.getCourseId(),
@@ -272,7 +271,6 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.waitForPageToLoad();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_REMINDERSSENT);
         
-
         ______TS("remind action: CLOSED feedback session");
 
         homePage.verifyUnclickable(homePage.getRemindLink(feedbackSessionClosed.getCourseId(),

--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -261,7 +261,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.submitRemindParticularUsersForm();
         homePage.waitForPageToLoad();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_REMINDERSEMPTYRECIPIENT);
-        homePage.goToPreviousPage(InstructorHomePage.class);
+        
 
         homePage.clickRemindOptionsLink(feedbackSessionOpen.getCourseId(), feedbackSessionOpen.getFeedbackSessionName());
         homePage.clickRemindParticularUsersLink(feedbackSessionOpen.getCourseId(),
@@ -271,7 +271,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.submitRemindParticularUsersForm();
         homePage.waitForPageToLoad();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_REMINDERSSENT);
-        homePage.goToPreviousPage(InstructorHomePage.class);
+        
 
         ______TS("remind action: CLOSED feedback session");
 
@@ -433,7 +433,6 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.waitForPageToLoad();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPIED);
 
-        homePage.goToPreviousPage(InstructorHomePage.class);
 
         ______TS("Failure case: Ajax error");
 


### PR DESCRIPTION
No need of redirection ( homePage.goToPreviousPage(InstructorHomePage.class); ) while testing remind button as the browser remains in the home page after sending a reminder
s.ToReview

Fixes #7165 