### PR TITLE
Refactor some duplicated methods in *action classes #6448

### DIFF
--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -2,33 +2,27 @@ package teammates.ui.controller;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import com.google.appengine.api.datastore.Text;
 import com.google.gson.reflect.TypeToken;
 
-import teammates.common.datatransfer.FeedbackSessionType;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
+import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.EmailType;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.Logger;
-import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
 import teammates.common.util.Templates;
 import teammates.common.util.Templates.FeedbackSessionTemplates;
-import teammates.common.util.TimeHelper;
 import teammates.ui.pagedata.InstructorFeedbacksPageData;
 
 public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
@@ -36,7 +30,7 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
     private static final Logger log = Logger.getLogger();
 
     @Override
-    protected ActionResult execute() {
+    protected ActionResult execute() throws EntityDoesNotExistException {
 
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
 
@@ -48,7 +42,7 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
         gateKeeper.verifyAccessible(
                 instructor, logic.getCourse(courseId), Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
-        FeedbackSessionAttributes fs = extractFeedbackSessionData();
+        FeedbackSessionAttributes fs = extractFeedbackSessionData(true);
 
         // Set creator email as instructors' email
         fs.setCreatorEmail(instructor.email);
@@ -65,7 +59,7 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
 
             try {
                 createTemplateFeedbackQuestions(fs.getCourseId(), fs.getFeedbackSessionName(),
-                                                fs.getCreatorEmail(), feedbackSessionType);
+                        fs.getCreatorEmail(), feedbackSessionType);
             } catch (InvalidParametersException e) {
                 //Failed to create feedback questions for specified template/feedback session type.
                 //TODO: let the user know an error has occurred? delete the feedback session?
@@ -75,12 +69,13 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_SESSION_ADDED, StatusMessageColor.SUCCESS));
             statusToAdmin =
                     "New Feedback Session <span class=\"bold\">(" + fs.getFeedbackSessionName() + ")</span> for Course "
-                    + "<span class=\"bold\">[" + fs.getCourseId() + "]</span> created.<br>"
-                    + "<span class=\"bold\">From:</span> " + fs.getStartTime()
-                    + "<span class=\"bold\"> to</span> " + fs.getEndTime() + "<br>"
-                    + "<span class=\"bold\">Session visible from:</span> " + fs.getSessionVisibleFromTime() + "<br>"
-                    + "<span class=\"bold\">Results visible from:</span> " + fs.getResultsVisibleFromTime() + "<br><br>"
-                    + "<span class=\"bold\">Instructions:</span> " + fs.getInstructions();
+                            + "<span class=\"bold\">[" + fs.getCourseId() + "]</span> created.<br>"
+                            + "<span class=\"bold\">From:</span> " + fs.getStartTime()
+                            + "<span class=\"bold\"> to</span> " + fs.getEndTime() + "<br>"
+                            + "<span class=\"bold\">Session visible from:</span> " + fs.getSessionVisibleFromTime() + "<br>"
+                            + "<span class=\"bold\">Results visible from:</span> "
+                            + fs.getResultsVisibleFromTime() + "<br><br>"
+                            + "<span class=\"bold\">Instructions:</span> " + fs.getInstructions();
 
             //TODO: add a condition to include the status due to inconsistency problem of database
             //      (similar to the one below)
@@ -104,17 +99,18 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
 
         if (feedbackSessions.isEmpty()) {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_SESSION_ADD_DB_INCONSISTENCY,
-                                               StatusMessageColor.WARNING));
+                    StatusMessageColor.WARNING));
         }
 
         data.initWithoutHighlightedRow(courses, courseId, feedbackSessions, instructors, fs,
-                                       feedbackSessionType);
+                feedbackSessionType);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACKS, data);
     }
 
     private void createTemplateFeedbackQuestions(String courseId, String feedbackSessionName,
-            String creatorEmail, String feedbackSessionType) throws InvalidParametersException {
+                                                 String creatorEmail, String feedbackSessionType)
+                                                    throws InvalidParametersException {
         if (feedbackSessionType == null) {
             return;
         }
@@ -148,89 +144,5 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
 
         return new ArrayList<FeedbackQuestionAttributes>();
     }
-
-    private FeedbackSessionAttributes extractFeedbackSessionData() {
-        //TODO assert parameters are not null then update test
-        //TODO make this method stateless
-
-        FeedbackSessionAttributes newSession = new FeedbackSessionAttributes();
-        newSession.setCourseId(getRequestParamValue(Const.ParamsNames.COURSE_ID));
-        newSession.setFeedbackSessionName(SanitizationHelper.sanitizeTitle(
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME)));
-
-        newSession.setCreatedTime(new Date());
-        newSession.setStartTime(TimeHelper.combineDateTime(
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE),
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME)));
-        newSession.setEndTime(TimeHelper.combineDateTime(
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE),
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME)));
-        String paramTimeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
-        if (paramTimeZone != null) {
-            newSession.setTimeZone(Double.parseDouble(paramTimeZone));
-        }
-        String paramGracePeriod = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_GRACEPERIOD);
-        if (paramGracePeriod != null) {
-            newSession.setGracePeriod(Integer.parseInt(paramGracePeriod));
-        }
-
-        newSession.setSentOpenEmail(false);
-        newSession.setSentPublishedEmail(false);
-
-        newSession.setFeedbackSessionType(FeedbackSessionType.STANDARD);
-        newSession.setInstructions(new Text(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_INSTRUCTIONS)));
-
-        String type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_RESULTSVISIBLEBUTTON);
-        switch (type) {
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_CUSTOM:
-            newSession.setResultsVisibleFromTime(TimeHelper.combineDateTime(
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHDATE),
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHTIME)));
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_ATVISIBLE:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_VISIBLE);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_LATER:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_LATER);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_NEVER:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            break;
-        default:
-            log.severe("Invalid resultsVisibleFrom setting in creating" + newSession.getIdentificationString());
-            break;
-        }
-
-        type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_SESSIONVISIBLEBUTTON);
-        switch (type) {
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_CUSTOM:
-            newSession.setSessionVisibleFromTime(TimeHelper.combineDateTime(
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLEDATE),
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLETIME)));
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_ATOPEN:
-            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_OPENING);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_NEVER:
-            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            // overwrite if private
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
-            break;
-        default:
-            log.severe("Invalid sessionVisibleFrom setting in creating " + newSession.getIdentificationString());
-            break;
-        }
-
-        String[] sendReminderEmailsArray =
-                getRequestParamValues(Const.ParamsNames.FEEDBACK_SESSION_SENDREMINDEREMAIL);
-        List<String> sendReminderEmailsList =
-                sendReminderEmailsArray == null ? new ArrayList<String>()
-                                                : Arrays.asList(sendReminderEmailsArray);
-        newSession.setClosingEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_CLOSING.toString()));
-        newSession.setPublishedEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_PUBLISHED.toString()));
-
-        return newSession;
-    }
-
 }
+

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditSaveAction.java
@@ -1,27 +1,15 @@
 package teammates.ui.controller;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import com.google.appengine.api.datastore.Text;
-
-import teammates.common.datatransfer.FeedbackSessionType;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.EmailType;
-import teammates.common.util.Logger;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
-import teammates.common.util.TimeHelper;
 import teammates.ui.pagedata.InstructorFeedbackEditPageData;
 
-public class InstructorFeedbackEditSaveAction extends Action {
-
-    private static final Logger log = Logger.getLogger();
+public class InstructorFeedbackEditSaveAction extends InstructorFeedbacksPageAction {
 
     @Override
     protected ActionResult execute() throws EntityDoesNotExistException {
@@ -39,7 +27,7 @@ public class InstructorFeedbackEditSaveAction extends Action {
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
         InstructorFeedbackEditPageData data = new InstructorFeedbackEditPageData(account);
-        FeedbackSessionAttributes feedbackSession = extractFeedbackSessionData();
+        FeedbackSessionAttributes feedbackSession = extractFeedbackSessionData(false);
 
         // A session opening reminder email is always sent as students
         // without accounts need to receive the email to be able to respond
@@ -50,13 +38,15 @@ public class InstructorFeedbackEditSaveAction extends Action {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_SESSION_EDITED, StatusMessageColor.SUCCESS));
             statusToAdmin =
                     "Updated Feedback Session "
-                    + "<span class=\"bold\">(" + feedbackSession.getFeedbackSessionName() + ")</span> for Course "
-                    + "<span class=\"bold\">[" + feedbackSession.getCourseId() + "]</span> created.<br>"
-                    + "<span class=\"bold\">From:</span> " + feedbackSession.getStartTime()
-                    + "<span class=\"bold\"> to</span> " + feedbackSession.getEndTime()
-                    + "<br><span class=\"bold\">Session visible from:</span> " + feedbackSession.getSessionVisibleFromTime()
-                    + "<br><span class=\"bold\">Results visible from:</span> " + feedbackSession.getResultsVisibleFromTime()
-                    + "<br><br><span class=\"bold\">Instructions:</span> " + feedbackSession.getInstructions();
+                            + "<span class=\"bold\">(" + feedbackSession.getFeedbackSessionName() + ")</span> for Course "
+                            + "<span class=\"bold\">[" + feedbackSession.getCourseId() + "]</span> created.<br>"
+                            + "<span class=\"bold\">From:</span> " + feedbackSession.getStartTime()
+                            + "<span class=\"bold\"> to</span> " + feedbackSession.getEndTime()
+                            + "<br><span class=\"bold\">Session visible from:</span> "
+                            + feedbackSession.getSessionVisibleFromTime()
+                            + "<br><span class=\"bold\">Results visible from:</span> "
+                            + feedbackSession.getResultsVisibleFromTime()
+                            + "<br><br><span class=\"bold\">Instructions:</span> " + feedbackSession.getInstructions();
             data.setStatusForAjax(Const.StatusMessages.FEEDBACK_SESSION_EDITED);
             data.setHasError(false);
         } catch (InvalidParametersException e) {
@@ -66,94 +56,5 @@ public class InstructorFeedbackEditSaveAction extends Action {
         }
         return createAjaxResult(data);
     }
-
-    private FeedbackSessionAttributes extractFeedbackSessionData() {
-        //TODO make this method stateless
-
-        // null checks for parameters not done as null values do not affect data integrity
-
-        FeedbackSessionAttributes newSession = new FeedbackSessionAttributes();
-        newSession.setCourseId(getRequestParamValue(Const.ParamsNames.COURSE_ID));
-        newSession.setFeedbackSessionName(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME));
-        newSession.setCreatorEmail(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_CREATOR));
-
-        newSession.setStartTime(TimeHelper.combineDateTime(
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE),
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME)));
-        newSession.setEndTime(TimeHelper.combineDateTime(
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE),
-                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME)));
-        String paramTimeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
-        if (paramTimeZone != null) {
-            try {
-                newSession.setTimeZone(Double.parseDouble(paramTimeZone));
-            } catch (NumberFormatException nfe) {
-                log.warning("Failed to parse time zone parameter: " + paramTimeZone);
-            }
-        }
-
-        String paramGracePeriod = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_GRACEPERIOD);
-        try {
-            newSession.setGracePeriod(Integer.parseInt(paramGracePeriod));
-        } catch (NumberFormatException nfe) {
-            log.warning("Failed to parse graced period parameter: " + paramGracePeriod);
-        }
-
-        newSession.setFeedbackSessionType(FeedbackSessionType.STANDARD);
-        newSession.setInstructions(new Text(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_INSTRUCTIONS)));
-
-        String type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_RESULTSVISIBLEBUTTON);
-        switch (type) {
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_CUSTOM:
-            newSession.setResultsVisibleFromTime(TimeHelper.combineDateTime(
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHDATE),
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHTIME)));
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_ATVISIBLE:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_VISIBLE);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_LATER:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_LATER);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_NEVER:
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            break;
-        default:
-            log.severe("Invalid resultsVisibleFrom setting editing " + newSession.getIdentificationString());
-            break;
-        }
-
-        // handle session visible after results visible to avoid having a
-        // results visible date when session is private (session not visible)
-        type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_SESSIONVISIBLEBUTTON);
-        switch (type) {
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_CUSTOM:
-            newSession.setSessionVisibleFromTime(TimeHelper.combineDateTime(
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLEDATE),
-                    getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLETIME)));
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_ATOPEN:
-            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_OPENING);
-            break;
-        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_NEVER:
-            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            // overwrite if private
-            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
-            newSession.setEndTime(null);
-            newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
-            break;
-        default:
-            log.severe("Invalid sessionVisibleFrom setting editing " + newSession.getIdentificationString());
-            break;
-        }
-
-        String[] sendReminderEmailsArray = getRequestParamValues(Const.ParamsNames.FEEDBACK_SESSION_SENDREMINDEREMAIL);
-        List<String> sendReminderEmailsList = sendReminderEmailsArray == null ? new ArrayList<String>()
-                                                                              : Arrays.asList(sendReminderEmailsArray);
-        newSession.setOpeningEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_OPENING.toString()));
-        newSession.setClosingEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_CLOSING.toString()));
-        newSession.setPublishedEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_PUBLISHED.toString()));
-
-        return newSession;
-    }
 }
+

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -1,24 +1,36 @@
 package teammates.ui.controller;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.appengine.api.datastore.Text;
+
+import teammates.common.datatransfer.FeedbackSessionType;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
+import teammates.common.util.EmailType;
+import teammates.common.util.Logger;
+import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
+import teammates.common.util.TimeHelper;
 import teammates.ui.pagedata.InstructorFeedbacksPageData;
 
 public class InstructorFeedbacksPageAction extends Action {
 
+    private static final Logger log = Logger.getLogger();
+
     @Override
-    protected ActionResult execute() {
+    protected ActionResult execute() throws EntityDoesNotExistException {
         // This can be null. Non-null value indicates the page is being loaded
         // to add a feedback to the specified course
         String courseIdForNewSession = getRequestParamValue(Const.ParamsNames.COURSE_ID);
@@ -57,14 +69,14 @@ public class InstructorFeedbacksPageAction extends Action {
 
         if (courses.isEmpty()) {
             statusToUser.add(new StatusMessage(Const.StatusMessages.COURSE_EMPTY_IN_INSTRUCTOR_FEEDBACKS
-                                                       .replace("${user}", "?user=" + account.googleId),
-                                               StatusMessageColor.WARNING));
+                    .replace("${user}", "?user=" + account.googleId),
+                    StatusMessageColor.WARNING));
         }
 
         statusToAdmin = "Number of feedback sessions: " + existingFeedbackSessions.size();
 
         data.initWithoutDefaultFormValues(courses, courseIdForNewSession, existingFeedbackSessions,
-                                        instructors, feedbackSessionToHighlight);
+                instructors, feedbackSessionToHighlight);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACKS, data);
     }
@@ -99,4 +111,108 @@ public class InstructorFeedbacksPageAction extends Action {
         }
         return courseInstructorMap;
     }
+
+    protected FeedbackSessionAttributes extractFeedbackSessionData(boolean isCreating) {
+        //TODO make this method stateless
+
+        // null checks for parameters not done as null values do not affect data integrity
+
+        FeedbackSessionAttributes newSession = new FeedbackSessionAttributes();
+        newSession.setCourseId(getRequestParamValue(Const.ParamsNames.COURSE_ID));
+
+        //Default title.. If the class is InstructorFeedbackAddAction then sanitze the title
+        String title = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        if (isCreating) {
+            title = SanitizationHelper.sanitizeTitle(title);
+        }
+
+        newSession.setFeedbackSessionName(title);
+        newSession.setCreatorEmail(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_CREATOR));
+
+        newSession.setStartTime(TimeHelper.combineDateTime(
+                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE),
+                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME)));
+        newSession.setEndTime(TimeHelper.combineDateTime(
+                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE),
+                getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME)));
+        String paramTimeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
+        if (paramTimeZone != null) {
+            try {
+                newSession.setTimeZone(Double.parseDouble(paramTimeZone));
+            } catch (NumberFormatException nfe) {
+                log.warning("Failed to parse time zone parameter: " + paramTimeZone);
+            }
+        }
+
+        String paramGracePeriod = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_GRACEPERIOD);
+        try {
+            newSession.setGracePeriod(Integer.parseInt(paramGracePeriod));
+        } catch (NumberFormatException nfe) {
+            log.warning("Failed to parse graced period parameter: " + paramGracePeriod);
+        }
+        //Only run if its not editing
+        if (isCreating) {
+            newSession.setCreatedTime(new Date());
+            newSession.setSentOpenEmail(false);
+            newSession.setSentPublishedEmail(false);
+        }
+
+        newSession.setFeedbackSessionType(FeedbackSessionType.STANDARD);
+        newSession.setInstructions(new Text(getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_INSTRUCTIONS)));
+
+        String type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_RESULTSVISIBLEBUTTON);
+        switch (type) {
+        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_CUSTOM:
+            newSession.setResultsVisibleFromTime(TimeHelper.combineDateTime(
+                        getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHDATE),
+                        getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHTIME)));
+            break;
+        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_ATVISIBLE:
+            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_VISIBLE);
+            break;
+        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_LATER:
+            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_LATER);
+            break;
+        case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_NEVER:
+            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
+            break;
+        default:
+            log.severe("Invalid sessionVisibleFrom setting " + newSession.getIdentificationString());
+            break;
+        }
+
+        // handle session visible after results visible to avoid having a
+        // results visible date when session is private (session not visible)
+        type = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_SESSIONVISIBLEBUTTON);
+        switch (type) {
+        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_CUSTOM:
+            newSession.setSessionVisibleFromTime(TimeHelper.combineDateTime(
+                        getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLEDATE),
+                        getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLETIME)));
+            break;
+        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_ATOPEN:
+            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_FOLLOW_OPENING);
+            break;
+        case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_NEVER:
+            newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
+            // overwrite if private
+            newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
+            newSession.setEndTime(null);
+            newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
+            break;
+        default:
+            log.severe("Invalid sessionVisibleFrom setting " + newSession.getIdentificationString());
+            break;
+        }
+
+        String[] sendReminderEmailsArray = getRequestParamValues(Const.ParamsNames.FEEDBACK_SESSION_SENDREMINDEREMAIL);
+        List<String> sendReminderEmailsList = sendReminderEmailsArray == null ? new ArrayList<String>()
+                : Arrays.asList(sendReminderEmailsArray);
+        newSession.setOpeningEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_OPENING.toString()));
+        newSession.setClosingEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_CLOSING.toString()));
+        newSession.setPublishedEmailEnabled(sendReminderEmailsList.contains(EmailType.FEEDBACK_PUBLISHED.toString()));
+
+        return newSession;
+    }
 }
+


### PR DESCRIPTION
Fixes #6448 

extractFeedbackSessionData() was redundant in InstructorFeedbackEditSaveAction.java and InstructorFeedbackAddAction.java - moved to the parent class, InstructorFeedbackPageAction.java and added a check for if the method is creating or not, so it does not overwrite the FeedbackSessionAttributes createdTime field when editing.

InstructorFeedbackEditSaveAction.java was inheriting directly from the Action class when it should inherit from InstructorFeedbackPageAction.java - since it's an InstructorFeedbackPageAction.

InstructorFeedbackAddAction.java - just removed the extractFeedbackSessionData().

For the method extractFeedbackQuestionData(String) for InstructorFeedbackQuestionAddAction and InstructorFeedbackQuestionVisibilityMessageAction, I do not believe these can be passed on to the parent class of "Action.java". It would not make sense for them to live in the parent and would break basic rules of polymorphism. 