### PR TITLE
Give an alternative link to the account request form #7202

### DIFF
--- a/src/main/webapp/request.jsp
+++ b/src/main/webapp/request.jsp
@@ -4,6 +4,7 @@
         Request for an Account
     </h1>
     <div id="contentHolder">
+	<p> Cannot see the request form below? Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ" target="_blank">here</a></p>
         <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"
                 width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
             Loading...

--- a/src/main/webapp/request.jsp
+++ b/src/main/webapp/request.jsp
@@ -1,11 +1,13 @@
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <t:staticPage>
+    <c:set var="googleDocURL" value="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"></c:set>
     <h1 class="color_orange">
         Request for an Account
     </h1>
     <div id="contentHolder">
-	<p> Cannot see the request form below? Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ" target="_blank">here.</a></p>
-        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"
+    <p> Cannot see the request form below? Click <a href="${googleDocURL}" target="_blank" rel="noopener noreferrer">here.</a></p>
+        <iframe src="${googleDocURL}"
                 width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
             Loading...
         </iframe>

--- a/src/main/webapp/request.jsp
+++ b/src/main/webapp/request.jsp
@@ -4,7 +4,7 @@
         Request for an Account
     </h1>
     <div id="contentHolder">
-        <iframe src="https://spreadsheets.google.com/embeddedform?formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"
+        <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"
                 width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
             Loading...
         </iframe>

--- a/src/main/webapp/request.jsp
+++ b/src/main/webapp/request.jsp
@@ -4,7 +4,7 @@
         Request for an Account
     </h1>
     <div id="contentHolder">
-	<p> Cannot see the request form below? Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ" target="_blank">here</a></p>
+	<p> Cannot see the request form below? Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ" target="_blank">here.</a></p>
         <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ"
                 width="760px" height="880px" frameborder="0" marginheight="0" marginwidth="0">
             Loading...


### PR DESCRIPTION
Fixes #7202 

The google doc form embedded in the request.jsp file is not loading. The google doc alone was loading fine when accessed directly. However it was redirecting to a new URL. I updated the link present in the jsp file to the new link which is working. After updating, I tested it in my local Dev and Staging server setups, it seems to load fine.

I checked the traffic for the actual link and observed that a status message of 301 - moved permanently appears followed by the redirect to new URL.

Log:
`https://spreadsheets.google.com/embeddedform?formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ`

`301 Moved Permanently`

`https://docs.google.com/forms/d/e/1FAIpQLSfmiNsVnVANdB1-cOwkfn9l8Ts8eN-CtolLQwi93Nrug0sngw/viewform?embedded=true&formkey=dDNsQmU4QXVYTVRhMjA2dEJWYW82Umc6MQ`

`200 OK`


This PR is ready for review.