### PR TITLE
Sanitize admin email content with sanitizeForRichText #7248

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/AdminEmailAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/AdminEmailAttributes.java
@@ -89,6 +89,7 @@ public class AdminEmailAttributes extends EntityAttributes {
     @Override
     public void sanitizeForSaving() {
         this.subject = SanitizationHelper.sanitizeTextField(subject);
+        this.content = SanitizationHelper.sanitizeForRichText(content);
     }
 
     public String getEmailId() {


### PR DESCRIPTION
Fixes #7248

**Outline of Solution**
- [x] Update sanitizeforSaving
- [x] Update tests
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Rich text sanitizer does not sanitize all characters blindly and most input entered through the frontend editor will still be the same after sanitization so there is no need to update current AdminEmailAttributes in the datastore.