### PR TITLE
Whitelist tags that can be created by the rich text editor in the sanitization policy #7256

### DIFF
--- a/src/main/java/teammates/common/util/SanitizationHelper.java
+++ b/src/main/java/teammates/common/util/SanitizationHelper.java
@@ -32,9 +32,13 @@ public final class SanitizationHelper {
                 .allowAttributes("align")
                     .matching(true, "center", "left", "right", "justify", "char")
                     .onElements("p")
+                .allowAttributes("colspan", "rowspan").onElements("td", "th")
+                .allowAttributes("cellspacing").onElements("table")
                 .allowElements(
                     "a", "p", "div", "i", "b", "em", "blockquote", "tt", "strong", "hr",
-                    "br", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6", "img", "span")
+                    "br", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6", "img", "span",
+                    "table", "tr", "td", "th", "tbody", "tfoot", "thead", "caption", "colgroup",
+                    "sup", "sub", "code")
                 .allowElements("quote", "ecode")
                 .allowStyling()
                 .toFactory();

--- a/src/test/java/teammates/test/cases/util/SanitizationHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/SanitizationHelperTest.java
@@ -165,6 +165,29 @@ public class SanitizationHelperTest extends BaseTestCase {
         Text actualRichTextObj = new Text(actualRichText);
         Text sanitizedTextObj = SanitizationHelper.sanitizeForRichText(actualRichTextObj);
         assertEquals(expectedRichText, sanitizedTextObj.getValue());
+
+        actualRichText = "<table cellspacing = \"5\" onmouseover=\"alert('onmouseover');\">"
+                + "<thead><tr><td>No.</td><td colspan = \"2\">People</td></tr></thead>"
+                + "<caption> Table with caption</caption>"
+                + "<tbody><tr><td>1</td><td>Amy</td><td><strong>Smith</strong></td></tr>"
+                + "<tr><td>2</td><td>Bob</td><td><strong>Tan</strong></td></tr>"
+                + "</tbody></table>"
+                + "<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>"
+                + "</td></option></div> invalid closing tags"
+                + "f(x) = x<sup>2</sup>"
+                + "<code>System.out.println(\"Hello World\");</code>";
+        expectedRichText = "<table cellspacing=\"5\">"
+                + "<thead><tr><td>No.</td><td colspan=\"2\">People</td></tr></thead>"
+                + "<caption> Table with caption</caption>"
+                + "<tbody><tr><td>1</td><td>Amy</td><td><strong>Smith</strong></td></tr>"
+                + "<tr><td>2</td><td>Bob</td><td><strong>Tan</strong></td></tr>"
+                + "</tbody></table>"
+                + "<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>"
+                + " invalid closing tags"
+                + "f(x) &#61; x<sup>2</sup>"
+                + "<code>System.out.println(&#34;Hello World&#34;);</code>";
+        sanitized = SanitizationHelper.sanitizeForRichText(actualRichText);
+        assertEquals(expectedRichText, sanitized);
     }
 
     @Test


### PR DESCRIPTION
Fixes #7256 

**Outline of Solution**

Allowed tags and attributes are based on manual testing with the frontend rich text editor and [a google group discussion on owasp java html sanitizer support](https://groups.google.com/forum/#!searchin/owasp-java-html-sanitizer-support/table%7Csort:relevance/owasp-java-html-sanitizer-support/4025rlufu-U/9isDp4FE8HgJ).
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
