### PR TITLE
InstructorFeedbackEditPageUiTest: fix failure against live server #6575

### DIFF
--- a/src/test/java/teammates/test/cases/BaseTestCaseWithBackDoorApiAccess.java
+++ b/src/test/java/teammates/test/cases/BaseTestCaseWithBackDoorApiAccess.java
@@ -55,9 +55,23 @@ public abstract class BaseTestCaseWithBackDoorApiAccess extends BaseTestCaseWith
         });
     }
 
+    protected FeedbackQuestionAttributes getFeedbackQuestion(String courseId, String feedbackSessionName, int qnNumber) {
+        return BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, qnNumber);
+    }
+
     @Override
     protected FeedbackQuestionAttributes getFeedbackQuestion(FeedbackQuestionAttributes fq) {
-        return BackDoor.getFeedbackQuestion(fq.courseId, fq.feedbackSessionName, fq.questionNumber);
+        return getFeedbackQuestion(fq.courseId, fq.feedbackSessionName, fq.questionNumber);
+    }
+
+    protected FeedbackQuestionAttributes getFeedbackQuestionWithRetry(
+            final String courseId, final String feedbackSessionName, final int qnNumber) {
+        return RetryManager.runUntilNotNull(new RetryableTaskReturns<FeedbackQuestionAttributes>("getFeedbackQuestion") {
+            @Override
+            public FeedbackQuestionAttributes run() {
+                return getFeedbackQuestion(courseId, feedbackSessionName, qnNumber);
+            }
+        });
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -226,11 +226,9 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickNewQuestionButton();
         feedbackEditPage.selectNewQuestionType("TEXT");
         assertTrue(feedbackEditPage.verifyNewEssayQuestionFormIsDisplayed());
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage--1"),
+        feedbackEditPage.verifyVisibilityMessageContainsForNewQuestion(
                 "You can see your own feedback in the results page later on.");
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage--1"),
+        feedbackEditPage.verifyVisibilityMessageContainsForNewQuestion(
                 "Instructors in this course can see your response, the name of the recipient, and your name.");
         assertTrue("Visibility preview for new question should be displayed",
                    feedbackEditPage.verifyVisibilityMessageIsDisplayedForNewQuestion());
@@ -333,14 +331,12 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.enableOtherVisibilityOptionsForNewQuestion();
         feedbackEditPage.clickResponseVisibilityCheckBoxForNewQuestion("RECEIVER_TEAM_MEMBERS");
 
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage--1"),
+        feedbackEditPage.verifyVisibilityMessageContainsForNewQuestion(
                 "The recipient's team members can see your response, but not the name of the recipient, or your name.");
         feedbackEditPage.enableOtherFeedbackPathOptionsForNewQuestion();
         feedbackEditPage.selectRecipientTypeForNewQuestion("Instructors in the course");
 
-        feedbackEditPage.waitForTextContainedInElementAbsence(
-                By.id("visibilityMessage--1"),
+        feedbackEditPage.verifyVisibilityMessageDoesNotContainForNewQuestion(
                 "The recipient's team members can see your response, but not the name of the recipient, or your name.");
 
         feedbackEditPage.clickDiscardChangesLinkForNewQuestion();
@@ -368,15 +364,9 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         assertFalse(feedbackEditPage.getVisibilityOptionTableRow(2, 4).isDisplayed());
 
         ______TS("test visibility preview of question 2");
-        WebElement visibilityMessage2 = browser.driver.findElement(By.id("visibilityMessage-2"));
-        feedbackEditPage.waitForElementVisibility(visibilityMessage2);
+        feedbackEditPage.verifyVisibilityMessageContains(2, "The receiving student can see your response, and your name.");
 
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage-2"),
-                "The receiving student can see your response, and your name.");
-
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage-2"),
+        feedbackEditPage.verifyVisibilityMessageContains(2,
                 "Instructors in this course can see your response, the name of the recipient, and your name.");
 
         feedbackEditPage.clickDeleteQuestionLink(2);
@@ -810,10 +800,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.selectRecipientToBe(FeedbackParticipantType.STUDENTS, 1);
         feedbackEditPage.enableOtherVisibilityOptions(1);
         feedbackEditPage.clickGiverNameVisibilityCheckBox("STUDENTS", 1);
-        WebElement visibilityMessage1 = browser.driver.findElement(By.id("visibilityMessage-1"));
-        feedbackEditPage.waitForElementVisibility(visibilityMessage1);
-        feedbackEditPage.waitForTextContainedInElementPresence(
-                By.id("visibilityMessage-1"),
+        feedbackEditPage.verifyVisibilityMessageContains(1,
                 "Other students in the course can see your response, and your name, but not the name of the recipient");
 
         ______TS("Test visibility message corresponds to visibility options: going from Others to a predefined option");
@@ -824,10 +811,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickGiverNameVisibilityCheckBox("OWN_TEAM_MEMBERS", 1);
         feedbackEditPage.clickGiverNameVisibilityCheckBox("STUDENTS", 1);
         feedbackEditPage.clickVisibilityDropdown("VISIBLE_TO_INSTRUCTORS_ONLY", 1);
-        WebElement visibilityMessage2 = browser.driver.findElement(By.id("visibilityMessage-1"));
-        feedbackEditPage.waitForElementVisibility(visibilityMessage2);
-        feedbackEditPage.waitForTextContainedInElementAbsence(
-                By.id("visibilityMessage-1"), "The receiving student");
+        feedbackEditPage.verifyVisibilityMessageContains(1, "The receiving student");
 
         ______TS("Failure case: ajax on clicking visibility message button");
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -139,7 +139,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_EDITED);
         assertTrue(feedbackEditPage.isElementInViewport(Const.ParamsNames.STATUS_MESSAGES_LIST));
 
-        FeedbackSessionAttributes savedSession = BackDoor.getFeedbackSession(
+        FeedbackSessionAttributes savedSession = getFeedbackSessionWithRetry(
                 editedSession.getCourseId(), editedSession.getFeedbackSessionName());
         editedSession.setInstructions(new Text("<p>" + editedSession.getInstructionsString() + "</p>"));
         assertEquals(editedSession.toString(), savedSession.toString());
@@ -266,7 +266,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickAddQuestionButton();
 
         feedbackEditPage.verifyStatus(Const.StatusMessages.FEEDBACK_QUESTION_ADDED);
-        assertNotNull(BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 1));
+        assertNotNull(getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 1));
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackQuestionAddSuccess.html");
     }
 
@@ -470,16 +470,10 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
 
         ______TS("questions still editable even if questions numbers became inconsistent");
 
-        FeedbackQuestionAttributes firstQuestion =
-                                        BackDoor.getFeedbackQuestion(courseId,
-                                                                     feedbackSessionName,
-                                                                     1);
+        FeedbackQuestionAttributes firstQuestion = getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 1);
         assertEquals(1, firstQuestion.questionNumber);
 
-        FeedbackQuestionAttributes secondQuestion =
-                                        BackDoor.getFeedbackQuestion(courseId,
-                                                                     feedbackSessionName,
-                                                                     2);
+        FeedbackQuestionAttributes secondQuestion = getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 2);
         assertEquals(2, secondQuestion.questionNumber);
         int originalSecondQuestionNumber = secondQuestion.questionNumber;
 
@@ -557,9 +551,9 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
                     feedbackEditPage.isCopySubmitButtonEnabled());
 
         // revert back to state expected by tests after this by deleting new copied questions
-        String questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 4).getId();
+        String questionId = getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 4).getId();
         BackDoor.deleteFeedbackQuestion(questionId);
-        questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 3).getId();
+        questionId = getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 3).getId();
         BackDoor.deleteFeedbackQuestion(questionId);
 
     }
@@ -849,14 +843,14 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
 
         feedbackEditPage.clickDeleteQuestionLink(qnNumber);
         feedbackEditPage.waitForConfirmationModalAndClickCancel();
-        assertNotNull(BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, qnNumber));
+        assertNotNull(getFeedbackQuestionWithRetry(courseId, feedbackSessionName, qnNumber));
 
         ______TS("qn " + qnNumber + " delete then accept");
 
         feedbackEditPage.clickDeleteQuestionLink(qnNumber);
         feedbackEditPage.waitForConfirmationModalAndClickOk();
         feedbackEditPage.verifyStatus(Const.StatusMessages.FEEDBACK_QUESTION_DELETED);
-        assertNull(BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, qnNumber));
+        assertNull(getFeedbackQuestion(courseId, feedbackSessionName, qnNumber));
 
     }
 
@@ -872,7 +866,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickAddQuestionButton();
 
         // Delete the new question through the backdoor so that it still appears in the browser
-        String questionId = BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 1).getId();
+        String questionId = getFeedbackQuestionWithRetry(courseId, feedbackSessionName, 1).getId();
         String status = BackDoor.deleteFeedbackQuestion(questionId);
         assertEquals(Const.StatusCodes.BACKDOOR_STATUS_SUCCESS, status);
 
@@ -1037,7 +1031,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         ______TS("session delete then cancel");
 
         feedbackEditPage.clickAndCancel(feedbackEditPage.getDeleteSessionLink());
-        assertNotNull(BackDoor.getFeedbackSession(courseId, feedbackSessionName));
+        assertNotNull(getFeedbackSessionWithRetry(courseId, feedbackSessionName));
 
         ______TS("session delete then accept");
 
@@ -1045,7 +1039,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         InstructorFeedbacksPage feedbackPage = feedbackEditPage.deleteSession();
         AssertHelper.assertContains(Const.StatusMessages.FEEDBACK_SESSION_DELETED,
                                     feedbackPage.getStatus());
-        assertNull(BackDoor.getFeedbackSession(courseId, feedbackSessionName));
+        assertNull(getFeedbackSession(courseId, feedbackSessionName));
     }
 
     private InstructorFeedbackEditPage getFeedbackEditPage() {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1178,12 +1178,9 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public boolean verifyVisibilityMessageIsDisplayed(int questionNumber) {
-        WebElement visibilityMessageDiv = getVisibilityMessageDiv(questionNumber);
-        waitForElementVisibility(visibilityMessageDiv);
-        List<WebElement> visibilityMessages = visibilityMessageDiv.findElements(By.cssSelector("ul > li"));
-        boolean isLoadVisibilityMessageAjaxError =
-                visibilityMessages.get(0).getText().equals("Error loading visibility hint. Click here to retry.");
-        return !visibilityMessages.isEmpty() && !isLoadVisibilityMessageAjaxError;
+        By firstMessageBy = By.cssSelector("#visibilityMessage-" + questionNumber + " ul > li");
+        WebElement firstMessage = waitForElementPresence(firstMessageBy);
+        return !firstMessage.getText().equals("Error loading visibility hint. Click here to retry.");
     }
 
     public boolean verifyVisibilityMessageIsDisplayedForNewQuestion() {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1177,12 +1177,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         return isVisibilityDropdownSeparatorHidden(NEW_QUESTION_NUM);
     }
 
-    private String getFirstVisibilityMessage(int questionNumber) {
-        By firstMessageBy = By.cssSelector("#visibilityMessage-" + questionNumber + " ul > li");
-        WebElement firstMessage = waitForElementPresence(firstMessageBy);
-        return firstMessage.getText();
-    }
-
     public void verifyVisibilityMessageContains(int questionNumber, String message) {
         waitForTextContainedInElementPresence(By.id("visibilityMessage-" + questionNumber), message);
     }
@@ -1200,7 +1194,9 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public boolean verifyVisibilityMessageIsDisplayed(int questionNumber) {
-        return !getFirstVisibilityMessage(questionNumber).equals("Error loading visibility hint. Click here to retry.");
+        By firstMessageBy = By.cssSelector("#visibilityMessage-" + questionNumber + " ul > li");
+        WebElement firstMessage = waitForElementPresence(firstMessageBy);
+        return !firstMessage.getText().equals("Error loading visibility hint. Click here to retry.");
     }
 
     public boolean verifyVisibilityMessageIsDisplayedForNewQuestion() {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1177,10 +1177,30 @@ public class InstructorFeedbackEditPage extends AppPage {
         return isVisibilityDropdownSeparatorHidden(NEW_QUESTION_NUM);
     }
 
-    public boolean verifyVisibilityMessageIsDisplayed(int questionNumber) {
+    private String getFirstVisibilityMessage(int questionNumber) {
         By firstMessageBy = By.cssSelector("#visibilityMessage-" + questionNumber + " ul > li");
         WebElement firstMessage = waitForElementPresence(firstMessageBy);
-        return !firstMessage.getText().equals("Error loading visibility hint. Click here to retry.");
+        return firstMessage.getText();
+    }
+
+    public void verifyVisibilityMessageContains(int questionNumber, String message) {
+        waitForTextContainedInElementPresence(By.id("visibilityMessage-" + questionNumber), message);
+    }
+
+    public void verifyVisibilityMessageContainsForNewQuestion(String message) {
+        verifyVisibilityMessageContains(NEW_QUESTION_NUM, message);
+    }
+
+    public void verifyVisibilityMessageDoesNotContain(int questionNumber, String message) {
+        waitForTextContainedInElementAbsence(By.id("visibilityMessage-" + questionNumber), message);
+    }
+
+    public void verifyVisibilityMessageDoesNotContainForNewQuestion(String message) {
+        verifyVisibilityMessageDoesNotContain(NEW_QUESTION_NUM, message);
+    }
+
+    public boolean verifyVisibilityMessageIsDisplayed(int questionNumber) {
+        return !getFirstVisibilityMessage(questionNumber).equals("Error loading visibility hint. Click here to retry.");
     }
 
     public boolean verifyVisibilityMessageIsDisplayedForNewQuestion() {
@@ -1194,15 +1214,6 @@ public class InstructorFeedbackEditPage extends AppPage {
     public WebElement getVisibilityOptionTableRow(int questionNumber, int optionRowNumber) {
         return getVisibilityOptions(questionNumber).findElement(
                 By.xpath("(table/tbody/tr|table/tbody/hide)[" + optionRowNumber + "]"));
-    }
-
-    public WebElement getVisibilityMessageDiv(int questionNumber) {
-        return browser.driver.findElement(By.id("visibilityMessage-" + questionNumber));
-    }
-
-    public String getVisibilityMessage(int questionNumber) {
-        WebElement visibilityMessageDiv = getVisibilityMessageDiv(questionNumber);
-        return visibilityMessageDiv.getText();
     }
 
     public String getVisibilityParamShowResponsesTo(int questionNumber) {


### PR DESCRIPTION
Fixes #6575

**Outline of Solution**

- Wait for presence of first message to avoid empty messages array in `verifyVisibilityMessageIsDisplayed` (fixes `IndexOutOfBoundsException`)
- Use retries in place of various `BackDoor.get*` calls (fixes various `AssertionError`s)