### PR TITLE
Add HTTP referrer validation #7261

### DIFF
--- a/src/main/java/teammates/common/exception/InvalidOriginException.java
+++ b/src/main/java/teammates/common/exception/InvalidOriginException.java
@@ -1,0 +1,12 @@
+package teammates.common.exception;
+
+@SuppressWarnings("serial")
+public class InvalidOriginException extends RuntimeException {
+    public InvalidOriginException() {
+        super();
+    }
+
+    public InvalidOriginException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -143,6 +143,60 @@ public final class Const {
 
         public static final String DEFAULT_PROFILE_PICTURE_PATH = "/images/profile_picture_default.png";
 
+        public static final List<String> PAGES_REQUIRING_ORIGIN_VALIDATION = Collections.unmodifiableList(
+                Arrays.asList(
+                        ActionURIs.ADMIN_ACCOUNT_DELETE,
+                        ActionURIs.ADMIN_EMAIL_COMPOSE_SAVE,
+                        ActionURIs.ADMIN_EMAIL_COMPOSE_SEND,
+                        ActionURIs.ADMIN_EMAIL_CREATE_GROUP_RECEIVER_LIST_UPLOAD_URL,
+                        ActionURIs.ADMIN_EMAIL_CREATE_IMAGE_UPLOAD_URL,
+                        ActionURIs.ADMIN_EMAIL_GROUP_RECEIVER_LIST_UPLOAD,
+                        ActionURIs.ADMIN_EMAIL_IMAGE_UPLOAD,
+                        ActionURIs.ADMIN_EMAIL_MOVE_OUT_TRASH,
+                        ActionURIs.ADMIN_EMAIL_MOVE_TO_TRASH,
+                        ActionURIs.ADMIN_EMAIL_TRASH_DELETE,
+                        ActionURIs.ADMIN_INSTRUCTORACCOUNT_ADD,
+                        ActionURIs.ADMIN_STUDENT_GOOGLE_ID_RESET,
+                        ActionURIs.CREATE_IMAGE_UPLOAD_URL,
+                        ActionURIs.IMAGE_UPLOAD,
+                        ActionURIs.INSTRUCTOR_COURSE_ADD,
+                        ActionURIs.INSTRUCTOR_COURSE_ARCHIVE,
+                        ActionURIs.INSTRUCTOR_COURSE_DELETE,
+                        ActionURIs.INSTRUCTOR_COURSE_EDIT_SAVE,
+                        ActionURIs.INSTRUCTOR_COURSE_ENROLL_SAVE,
+                        ActionURIs.INSTRUCTOR_COURSE_INSTRUCTOR_ADD,
+                        ActionURIs.INSTRUCTOR_COURSE_INSTRUCTOR_DELETE,
+                        ActionURIs.INSTRUCTOR_COURSE_INSTRUCTOR_EDIT_SAVE,
+                        ActionURIs.INSTRUCTOR_COURSE_REMIND,
+                        ActionURIs.INSTRUCTOR_COURSE_STUDENT_DELETE,
+                        ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_EDIT_SAVE,
+                        ActionURIs.INSTRUCTOR_EDIT_INSTRUCTOR_FEEDBACK_SAVE,
+                        ActionURIs.INSTRUCTOR_EDIT_STUDENT_FEEDBACK_SAVE,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_ADD,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_COPY,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_DELETE,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_EDIT_COPY,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_EDIT_SAVE,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_PUBLISH,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_ADD,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_COPY,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_EDIT,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_REMIND,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_REMIND_PARTICULAR_STUDENTS,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_ADD,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_DELETE,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_EDIT,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_SUBMISSION_EDIT_SAVE,
+                        ActionURIs.INSTRUCTOR_FEEDBACK_UNPUBLISH,
+                        ActionURIs.INSTRUCTOR_STUDENT_COMMENT_ADD,
+                        ActionURIs.INSTRUCTOR_STUDENT_COMMENT_CLEAR_PENDING,
+                        ActionURIs.INSTRUCTOR_STUDENT_COMMENT_EDIT,
+                        ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_SAVE,
+                        ActionURIs.STUDENT_PROFILE_CREATEUPLOADFORMURL,
+                        ActionURIs.STUDENT_PROFILE_EDIT_SAVE,
+                        ActionURIs.STUDENT_PROFILE_PICTURE_EDIT,
+                        ActionURIs.STUDENT_PROFILE_PICTURE_UPLOAD));
+
         public static final List<String> PAGES_ACCESSIBLE_WITHOUT_GOOGLE_LOGIN = Collections.unmodifiableList(
                 Arrays.asList(
                         ActionURIs.STUDENT_COURSE_JOIN,
@@ -1122,6 +1176,7 @@ public final class Const {
 
         public static final String GOOGLE_ACCOUNT_HINT = "/googleAccountHint.jsp";
         public static final String ENABLE_JS = "/enableJs.jsp";
+        public static final String INVALID_ORIGIN = "/invalidOrigin.jsp";
         public static final String UNAUTHORIZED = "/unauthorized.jsp";
         public static final String ERROR_PAGE = "/errorPage.jsp";
         public static final String DEADLINE_EXCEEDED_ERROR_PAGE = "/deadlineExceededErrorPage.jsp";

--- a/src/main/java/teammates/common/util/Url.java
+++ b/src/main/java/teammates/common/util/Url.java
@@ -29,6 +29,21 @@ public class Url {
     }
 
     /**
+     * Returns The first part of the URL, including the protocol and
+     * authority (host name + port number if specified) but not the path.<br>
+     * Example:
+     * <ul>
+     * <li><code>new Url("http://localhost:8888/index.jsp").getBaseUrl()</code>
+     * returns <code>http://localhost:8888</code></li>
+     * <li><code>new Url("https://teammatesv4.appspot.com/index.jsp").getBaseUrl()</code>
+     * returns <code>https://teammatesv4.appspot.com</code></li>
+     * </ul>
+     */
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    /**
      * Returns The value of the {@code parameterName} parameter. Null if no such parameter.
      */
     public String get(String parameterName) {

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -12,6 +12,7 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.InvalidOriginException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.ActivityLogEntry;
 import teammates.common.util.Assumption;
@@ -22,6 +23,7 @@ import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
 import teammates.common.util.StringHelper;
+import teammates.common.util.Url;
 import teammates.logic.api.EmailSender;
 import teammates.logic.api.GateKeeper;
 import teammates.logic.api.Logic;
@@ -85,6 +87,7 @@ public abstract class Action {
      */
     public void init(HttpServletRequest req) {
         initialiseAttributes(req);
+        validateOriginIfRequired();
         authenticateUser();
     }
 
@@ -118,6 +121,67 @@ public abstract class Action {
     public void setEmailSender(EmailSender emailSender) {
         this.emailSender = emailSender;
     }
+
+    // These methods are used for Cross-Site Request Forgery (CSRF) prevention
+
+    private void validateOriginIfRequired() {
+        if (!Const.SystemParams.PAGES_REQUIRING_ORIGIN_VALIDATION.contains(request.getRequestURI())) {
+            return;
+        }
+
+        String referrer = request.getHeader("referer");
+        if (referrer == null) {
+            throw new InvalidOriginException("Missing HTTP referrer");
+        }
+
+        if (!isHttpReferrerValid(referrer)) {
+            throw new InvalidOriginException("Invalid HTTP referrer");
+        }
+    }
+
+    /**
+     * Validates the HTTP referrer against the request URL. The origin is the
+     * base URL of the HTTP referrer, which includes the protocol and authority
+     * (host name + port number if specified). Similarly, the target is the base
+     * URL of the requested action URL. For the referrer to be considered valid,
+     * origin and target must match exactly. Otherwise, the request is likely to
+     * be a CSRF attack, and is considered invalid.
+     *
+     * <p>Example of malicious request originating from embedded image in email:
+     * <pre>
+     * Request URL: https://teammatesv4.appspot.com/page/instructorCourseDelete?courseid=abcdef
+     * Referrer:    https://mail.google.com/mail/u/0/
+     *
+     * Target: https://teammatesv4.appspot.com
+     * Origin: https://mail.google.com
+     * </pre>
+     * Origin does not match target. This request is invalid.</p>
+     *
+     * <p>Example of legitimate request originating from instructor courses page:
+     * <pre>
+     * Request URL: https://teammatesv4.appspot.com/page/instructorCourseDelete?courseid=abcdef
+     * Referrer:    https://teammatesv4.appspot.com/page/instructorCoursesPage
+     *
+     * Target: https://teammatesv4.appspot.com
+     * Origin: https://teammatesv4.appspot.com
+     * </pre>
+     * Origin matches target. This request is valid.</p>
+     */
+    private boolean isHttpReferrerValid(String referrer) {
+        String origin;
+        try {
+            origin = new Url(referrer).getBaseUrl();
+        } catch (AssertionError e) { // due to MalformedURLException
+            return false;
+        }
+
+        String requestUrl = request.getRequestURL().toString();
+        String target = new Url(requestUrl).getBaseUrl();
+
+        return origin.equals(target);
+    }
+
+    // These methods are used for user authentication
 
     protected void authenticateUser() {
         UserType currentUser = gateKeeper.getCurrentUser();

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -14,6 +14,7 @@ import com.google.apphosting.api.DeadlineExceededException;
 import teammates.common.datatransfer.UserType;
 import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.FeedbackSessionNotVisibleException;
+import teammates.common.exception.InvalidOriginException;
 import teammates.common.exception.NullPostParameterException;
 import teammates.common.exception.PageNotFoundException;
 import teammates.common.exception.TeammatesException;
@@ -86,6 +87,11 @@ public class ControllerServlet extends HttpServlet {
             cleanUpStatusMessageInSession(req);
             req.getSession().setAttribute(Const.ParamsNames.FEEDBACK_SESSION_NOT_VISIBLE, e.getStartTimeString());
             resp.sendRedirect(Const.ViewURIs.FEEDBACK_SESSION_NOT_VISIBLE);
+
+        } catch (InvalidOriginException e) {
+            log.warning(ActivityLogEntry.generateServletActionFailureLogMessage(req, e, userType));
+            cleanUpStatusMessageInSession(req);
+            resp.sendRedirect(Const.ViewURIs.INVALID_ORIGIN);
 
         } catch (UnauthorizedAccessException e) {
             log.warning(ActivityLogEntry.generateServletActionFailureLogMessage(req, e, userType));

--- a/src/main/webapp/invalidOrigin.jsp
+++ b/src/main/webapp/invalidOrigin.jsp
@@ -1,0 +1,23 @@
+<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
+<% response.setStatus(403);%>
+<t:errorPage>
+    <br><br>
+    <div class="row">
+        <div class="alert alert-warning col-md-4 col-md-offset-4">
+            <img src="/images/angry.png" style="float: left; height: 90px; margin: 0 10px 10px 0;">
+            <p>
+                The request origin could not be validated. For your security, this action has been blocked.<br><br>
+                Here are a few things you can try:
+            </p>
+            <ul class="small narrow-slight">
+                <li>
+                    Click on the link from the relevant page instead of typing in the URL.
+                </li>
+                <li>
+                    Enable the HTTP referrer setting in your browser if you previously disabled it.
+                </li>
+            </ul>
+            <br>
+        </div>
+    </div>
+</t:errorPage>

--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -1,7 +1,5 @@
 package teammates.test.cases.browsertests;
 
-import java.net.MalformedURLException;
-
 import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 
@@ -12,7 +10,6 @@ import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.test.driver.BackDoor;
-import teammates.test.driver.UrlExtension;
 import teammates.test.pageobjects.InstructorCourseDetailsPage;
 import teammates.test.pageobjects.InstructorCourseEditPage;
 import teammates.test.pageobjects.InstructorCourseEnrollPage;
@@ -383,17 +380,8 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         String courseIdForCS2104 = testData.courses.get("CHomeUiT.CS2104").getId();
 
         //delete the course, then submit archive request to it
-        String archiveLinkString = homePage.getArchiveCourseLink(courseIdForCS2104);
-        AppUrl urlToArchive;
-        try {
-            // the link returned here might be absolute; make it relative first
-            urlToArchive = createUrl(UrlExtension.getRelativePath(archiveLinkString));
-        } catch (MalformedURLException e) {
-            // the link is already relative
-            urlToArchive = createUrl(archiveLinkString);
-        }
-        homePage.clickAndConfirm(homePage.getDeleteCourseLink(courseIdForCS2104));
-        browser.driver.get(urlToArchive.toAbsoluteString());
+        BackDoor.deleteCourse(courseIdForCS2104);
+        homePage.clickArchiveCourseLinkAndConfirm(courseIdForCS2104);
         assertTrue(browser.driver.getCurrentUrl().endsWith(Const.ViewURIs.UNAUTHORIZED));
 
         // recover the deleted course and its related entities

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -199,7 +199,8 @@ public class GaeSimulation {
 
     private HttpServletRequest createWebRequest(String uri, String... parameters) {
 
-        WebRequest request = new PostMethodWebRequest("http://localhost:8888" + uri);
+        WebRequest request = new PostMethodWebRequest("http://localhost" + uri);
+        request.setHeaderField("referer", "http://localhost" + uri);
 
         Map<String, List<String>> paramMultiMap = new HashMap<String, List<String>>();
         for (int i = 0; i < parameters.length; i = i + 2) {


### PR DESCRIPTION
Fixes #7261

**Outline of Solution**

- Implement simple CSRF protection using HTTP referrer validation
- Display an informative error message if validation fails:
![invalidorigin](https://cloud.githubusercontent.com/assets/6811428/25937607/f16cacc2-365e-11e7-85ff-27e6931d8f7b.png)

Developed together with @leeyimin and @thenaesh; reviewed by @chowyb @damithc @malayaleecoder; deployed to live server some time last week. Publishing to public repo after several days of no problems with the code in actual usage.