### PR TITLE
Fix sanitization of query string in SearchQuery #7325

### DIFF
--- a/src/main/java/teammates/storage/search/SearchQuery.java
+++ b/src/main/java/teammates/storage/search/SearchQuery.java
@@ -8,9 +8,7 @@ import com.google.appengine.api.search.QueryOptions;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.FieldValidator;
 import teammates.common.util.Logger;
-import teammates.common.util.SanitizationHelper;
 
 /**
  * Defines how we query {@link com.google.appengine.api.search.Document}.
@@ -51,19 +49,14 @@ public abstract class SearchQuery {
 
     private void setTextFilter(String textField, String queryString) {
 
-        // The sanitize process considers the '.' (dot) as a space and this
-        // returns unnecessary search results in the case if someone searches
-        // using an email. To avoid this, we check whether the input text is an
-        // email, and if yes, we skip the sanitize process.
-        String sanitizedQueryString =
-                FieldValidator.isValidEmailAddress(queryString)
-                ? queryString.toLowerCase().trim()
-                : SanitizationHelper.sanitizeForSearch(queryString).toLowerCase().trim();
+        String trimmedQueryString = queryString.toLowerCase().trim();
 
-        if (!sanitizedQueryString.isEmpty()) {
-            String preparedOrQueryString = prepareOrQueryString(sanitizedQueryString);
-            textQueryStrings.add(textField + ":" + preparedOrQueryString);
+        if (trimmedQueryString.isEmpty()) {
+            return;
         }
+
+        String preparedOrQueryString = prepareOrQueryString(trimmedQueryString);
+        textQueryStrings.add(textField + ":" + preparedOrQueryString);
     }
 
     private String prepareOrQueryString(String queryString) {


### PR DESCRIPTION
Fixes #7325 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

sanitizeForSearch is removed for queryString as each keyword/ string formed in prepareOrQueryString is properly enclosed with quotes. Each keyword/ string is also left to be tokenized and processed on Google's end in a similar manner as the text in the document. This removes the need for sanitization of the queryString which is added to prevent injection and to simulate the tokenization.

With sanitizeForSearch removed, searching for students (or non-sanitized data in general) is improved as searches using quotes-enclosed string with special html characters can be matched properly with the unsanitized data in the document. Searches without quotes-enclosed strings are also improved as the further tokenization of the tokens are left to be handled on Google's end.

However, by removing sanitizeForSearch, the search match rate for documents with sanitized data may drop. Eg. Searching "Jean O'Kelly"(without enclosing quotes) to find a instructor with name Jean O'Kelly will only match on the token "jean", while it originally matches on "jean", "o" and "kelly".