### PR TITLE
questionWithResponses.tag: change "moderated-question" HTML class to an id #4296

### DIFF
--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/questionWithResponses.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/questionWithResponses.tag
@@ -17,7 +17,7 @@
                      value="${questionWithResponses.numOfResponseBoxes}">
 
 <div class="form-horizontal">
-    <div class="panel panel-primary<c:if test="${questionWithResponses.question.moderatedQuestion}"> moderated-question</c:if>">
+    <div class="panel panel-primary"<c:if test="${questionWithResponses.question.moderatedQuestion}"> id="moderated-question"</c:if>>
     
         <div class="panel-heading">Question ${isShowRealQuestionNumber ? questionWithResponses.question.questionNumber 
                                                                              : questionWithResponses.question.qnIndx}:

--- a/src/main/webapp/js/feedbackSubmissionsEdit.es6
+++ b/src/main/webapp/js/feedbackSubmissionsEdit.es6
@@ -108,8 +108,8 @@ function updateMsqOtherOptionField() {
 
 // Looks for the question to be moderated (if it exists)
 function focusModeratedQuestion() {
-    if ($('.moderated-question').length > 0) {
-        scrollToElement($('.moderated-question')[0], { duration: 1000 });
+    if ($('#moderated-question').length > 0) {
+        scrollToElement($('#moderated-question')[0], { duration: 1000 });
     }
 }
 


### PR DESCRIPTION
Fixes #4296 

In `questionWithResponses.tag` previously `moderated-question` was defined as a class, changed it to an ID because it was used for scrolling purpose.

