### PR TITLE
Project setup: eliminate the need to modify config file manually after `./gradlew setup` #6812

### DIFF
--- a/docs/settingUp.md
+++ b/docs/settingUp.md
@@ -58,14 +58,11 @@ More information can be found at [this documentation](https://help.github.com/ar
    ```
    **Verification:** The file named `gradle.properties` should be added to the project root directory.
 
-1. Modify the following config files:
+1. Modify the following config file:
    * `gradle.properties`<br>
       If you want to use a JDK other than the one specified in your PATH variable, add the value to the variable `org.gradle.java.home`.
       This value must be a valid **JDK 1.7** directory.
       **Windows users** should use a **forward slash**(`/`) instead of the Windows default **backward slash**(`\`) while specifying the path.
-   * `src/test/resources/test.properties`<br>
-      Append a **same** unique id (e.g your name) to **each** of the default accounts found at the bottom of this file,
-      e.g change `test.student1.account=alice.tmms` to `test.student1.account=alice.tmms.KevinChan`.
 
 If you followed every step correctly, you should have successfully set up the development environment.
 You may proceed to the development routine as lined out in [this document](development.md).

--- a/src/test/java/teammates/test/driver/StringHelperExtension.java
+++ b/src/test/java/teammates/test/driver/StringHelperExtension.java
@@ -1,11 +1,15 @@
 package teammates.test.driver;
 
+import java.util.Random;
+
 import teammates.common.util.StringHelper;
 
 /**
  * Holds additional methods for {@link StringHelper} used only in tests.
  */
 public final class StringHelperExtension {
+
+    private static final String UPPERCASE_ALPHANUMERIC_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
 
     private StringHelperExtension() {
         // utility class
@@ -18,6 +22,21 @@ public final class StringHelperExtension {
      */
     public static String generateStringOfLength(int length) {
         return StringHelper.generateStringOfLength(length, 'a');
+    }
+
+    /**
+     * Generates a salt (random alphanumeric string) of given length.
+     * @param length of salt to be be generated
+     * @return generated salt
+     */
+    public static String generateSaltOfLength(int length) {
+        StringBuilder salt = new StringBuilder();
+        Random rnd = new Random();
+        while (salt.length() < length) {
+            int index = rnd.nextInt(UPPERCASE_ALPHANUMERIC_CHARS.length());
+            salt.append(UPPERCASE_ALPHANUMERIC_CHARS.charAt(index));
+        }
+        return salt.toString();
     }
 
 }

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -86,9 +86,9 @@ public final class TestProperties {
 
             TEAMMATES_VERSION = extractVersionNumber(FileHelper.readFile("src/main/webapp/WEB-INF/appengine-web.xml"));
 
-            if (isCiEnvironment()) {
-                // For CI, we do not read the account details from the test properties file, but generate random
-                // account names. This is for detection and prevention of hard-coded account names in test files.
+            if (isCiEnvironment() || isGodModeEnabled()) {
+                // For CI and GodMode, we do not read the account details from the test properties file, but generate
+                // random account names. This is for detection and prevention of hard-coded account names in test files.
 
                 String dotSalt = "." + StringHelperExtension.generateSaltOfLength(8);
                 String dummyPassword = "anypassword";
@@ -144,6 +144,10 @@ public final class TestProperties {
 
     public static boolean isCiEnvironment() {
         return System.getenv("TRAVIS") != null || System.getenv("APPVEYOR") != null;
+    }
+
+    public static boolean isGodModeEnabled() {
+        return Boolean.parseBoolean(System.getProperty("godmode", "false"));
     }
 
     public static boolean isDevServer() {

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -86,7 +86,7 @@ public final class TestProperties {
 
             TEAMMATES_VERSION = extractVersionNumber(FileHelper.readFile("src/main/webapp/WEB-INF/appengine-web.xml"));
 
-            if (isCiEnvironment() || isGodModeEnabled()) {
+            if (isDevServer() && (isCiEnvironment() || isGodModeEnabled())) {
                 // For CI and GodMode, we do not read the account details from the test properties file, but generate
                 // random account names. This is for detection and prevention of hard-coded account names in test files.
                 // The password values are not required for login to the dev server and hence, set to null.

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -89,24 +89,24 @@ public final class TestProperties {
             if (isCiEnvironment() || isGodModeEnabled()) {
                 // For CI and GodMode, we do not read the account details from the test properties file, but generate
                 // random account names. This is for detection and prevention of hard-coded account names in test files.
+                // The password values are not required for login to the dev server and hence, set to null.
 
                 String dotSalt = "." + StringHelperExtension.generateSaltOfLength(8);
-                String dummyPassword = "anypassword";
 
                 TEST_ADMIN_ACCOUNT = "yourGoogleId" + dotSalt;
-                TEST_ADMIN_PASSWORD = dummyPassword;
+                TEST_ADMIN_PASSWORD = null;
 
                 TEST_INSTRUCTOR_ACCOUNT = "teammates.coord" + dotSalt;
-                TEST_INSTRUCTOR_PASSWORD = dummyPassword;
+                TEST_INSTRUCTOR_PASSWORD = null;
 
                 TEST_STUDENT1_ACCOUNT = "alice.tmms" + dotSalt;
-                TEST_STUDENT1_PASSWORD = dummyPassword;
+                TEST_STUDENT1_PASSWORD = null;
 
                 TEST_STUDENT2_ACCOUNT = "charlie.tmms" + dotSalt;
-                TEST_STUDENT2_PASSWORD = dummyPassword;
+                TEST_STUDENT2_PASSWORD = null;
 
                 TEST_UNREG_ACCOUNT = "teammates.unreg" + dotSalt;
-                TEST_UNREG_PASSWORD = dummyPassword;
+                TEST_UNREG_PASSWORD = null;
 
             } else {
                 TEST_ADMIN_ACCOUNT = prop.getProperty("test.admin.account");

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -29,34 +29,34 @@ public final class TestProperties {
     /** The version number of the application under test. */
     public static final String TEAMMATES_VERSION;
 
-    /** The value of "test.instructor.account" in test.properties file. */
+    /** The Google ID of the test instructor account. */
     public static final String TEST_INSTRUCTOR_ACCOUNT;
 
-    /** The value of "test.instructor.password" in test.properties file. */
+    /** The password of the test instructor account. */
     public static final String TEST_INSTRUCTOR_PASSWORD;
 
-    /** The value of "test.student1.account" in test.properties file. */
+    /** The Google ID of the first test student account. */
     public static final String TEST_STUDENT1_ACCOUNT;
 
-    /** The value of "test.student1.password" in test.properties file. */
+    /** The password of the first test student account. */
     public static final String TEST_STUDENT1_PASSWORD;
 
-    /** The value of "test.student2.account" in test.properties file. */
+    /** The Google ID of the second test student account. */
     public static final String TEST_STUDENT2_ACCOUNT;
 
-    /** The value of "test.student2.password" in test.properties file. */
+    /** The password of the second test student account. */
     public static final String TEST_STUDENT2_PASSWORD;
 
-    /** The value of "test.admin.account" in test.properties file. */
+    /** The Google ID of the test admin account. */
     public static final String TEST_ADMIN_ACCOUNT;
 
-    /** The value of "test.admin.password" in test.properties file. */
+    /** The password of the test admin account. */
     public static final String TEST_ADMIN_PASSWORD;
 
-    /** The value of "test.unreg.account" in test.properties file. */
+    /** The Google ID of the test unregistered account. */
     public static final String TEST_UNREG_ACCOUNT;
 
-    /** The value of "test.unreg.password" in test.properties file. */
+    /** The password of the test unregistered account. */
     public static final String TEST_UNREG_PASSWORD;
 
     /** The value of "test.backdoor" in test.properties file. */
@@ -86,20 +86,44 @@ public final class TestProperties {
 
             TEAMMATES_VERSION = extractVersionNumber(FileHelper.readFile("src/main/webapp/WEB-INF/appengine-web.xml"));
 
-            TEST_ADMIN_ACCOUNT = prop.getProperty("test.admin.account");
-            TEST_ADMIN_PASSWORD = prop.getProperty("test.admin.password");
+            if (isCiEnvironment()) {
+                // For CI, we do not read the account details from the test properties file, but generate random
+                // account names. This is for detection and prevention of hard-coded account names in test files.
 
-            TEST_INSTRUCTOR_ACCOUNT = prop.getProperty("test.instructor.account");
-            TEST_INSTRUCTOR_PASSWORD = prop.getProperty("test.instructor.password");
+                String dotSalt = "." + StringHelperExtension.generateSaltOfLength(8);
+                String dummyPassword = "anypassword";
 
-            TEST_STUDENT1_ACCOUNT = prop.getProperty("test.student1.account");
-            TEST_STUDENT1_PASSWORD = prop.getProperty("test.student1.password");
+                TEST_ADMIN_ACCOUNT = "yourGoogleId" + dotSalt;
+                TEST_ADMIN_PASSWORD = dummyPassword;
 
-            TEST_STUDENT2_ACCOUNT = prop.getProperty("test.student2.account");
-            TEST_STUDENT2_PASSWORD = prop.getProperty("test.student2.password");
+                TEST_INSTRUCTOR_ACCOUNT = "teammates.coord" + dotSalt;
+                TEST_INSTRUCTOR_PASSWORD = dummyPassword;
 
-            TEST_UNREG_ACCOUNT = prop.getProperty("test.unreg.account");
-            TEST_UNREG_PASSWORD = prop.getProperty("test.unreg.password");
+                TEST_STUDENT1_ACCOUNT = "alice.tmms" + dotSalt;
+                TEST_STUDENT1_PASSWORD = dummyPassword;
+
+                TEST_STUDENT2_ACCOUNT = "charlie.tmms" + dotSalt;
+                TEST_STUDENT2_PASSWORD = dummyPassword;
+
+                TEST_UNREG_ACCOUNT = "teammates.unreg" + dotSalt;
+                TEST_UNREG_PASSWORD = dummyPassword;
+
+            } else {
+                TEST_ADMIN_ACCOUNT = prop.getProperty("test.admin.account");
+                TEST_ADMIN_PASSWORD = prop.getProperty("test.admin.password");
+
+                TEST_INSTRUCTOR_ACCOUNT = prop.getProperty("test.instructor.account");
+                TEST_INSTRUCTOR_PASSWORD = prop.getProperty("test.instructor.password");
+
+                TEST_STUDENT1_ACCOUNT = prop.getProperty("test.student1.account");
+                TEST_STUDENT1_PASSWORD = prop.getProperty("test.student1.password");
+
+                TEST_STUDENT2_ACCOUNT = prop.getProperty("test.student2.account");
+                TEST_STUDENT2_PASSWORD = prop.getProperty("test.student2.password");
+
+                TEST_UNREG_ACCOUNT = prop.getProperty("test.unreg.account");
+                TEST_UNREG_PASSWORD = prop.getProperty("test.unreg.password");
+            }
 
             BACKDOOR_KEY = prop.getProperty("test.backdoor.key");
 
@@ -116,6 +140,10 @@ public final class TestProperties {
 
     private TestProperties() {
         // access static fields directly
+    }
+
+    public static boolean isCiEnvironment() {
+        return System.getenv("TRAVIS") != null || System.getenv("APPVEYOR") != null;
     }
 
     public static boolean isDevServer() {
@@ -141,30 +169,10 @@ public final class TestProperties {
         if (!isDevServer()) {
             fail("God mode regeneration works only in dev server.");
         }
-        if (!areTestAccountsReadyForGodMode()) {
-            fail("Please append a unique id (e.g your name) to each of the default account in "
-                    + "test.properties in order to use God mode, e.g change alice.tmms to "
-                    + "alice.tmms.<yourName>, charlie.tmms to charlie.tmms.<yourName>, etc.");
-        }
         if (isStudentMotdUrlEmpty()) {
             fail("Student MOTD URL defined in app.student.motd.url in build.properties "
                     + "must not be empty. It is advised to use test-student-motd.html to test it.");
         }
-    }
-
-    private static boolean areTestAccountsReadyForGodMode() {
-        if (!TEST_STUDENT1_ACCOUNT.startsWith("alice.tmms.")) {
-            return false;
-        }
-        String uniqueId = TEST_STUDENT1_ACCOUNT.substring("alice.tmms.".length());
-        if (uniqueId.isEmpty()) {
-            return false;
-        }
-
-        boolean isSecondStudentAccountReady = ("charlie.tmms." + uniqueId).equals(TEST_STUDENT2_ACCOUNT);
-        boolean isInstructorAccountReady = ("teammates.coord." + uniqueId).equals(TEST_INSTRUCTOR_ACCOUNT);
-        boolean isAdminAccountReady = ("yourGoogleId." + uniqueId).equals(TEST_ADMIN_ACCOUNT);
-        return isSecondStudentAccountReady && isInstructorAccountReady && isAdminAccountReady;
     }
 
     private static boolean isStudentMotdUrlEmpty() {

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -81,7 +81,7 @@
             </span>
             Logout (
             <span class="text-info tool-tip-decorate" data-original-title="${test.admin}" data-placement="bottom" data-toggle="tooltip" title="">
-              yourGoogleId
+              ${test.admin}
             </span>
             )
           </a>

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -81,7 +81,7 @@
             </span>
             Logout (
             <span class="text-info tool-tip-decorate" data-original-title="${test.admin}" data-placement="bottom" data-toggle="tooltip" title="">
-              ${test.admin}
+              yourGoogleId
             </span>
             )
           </a>

--- a/src/test/resources/test.template.properties
+++ b/src/test/resources/test.template.properties
@@ -40,12 +40,16 @@ test.chromedriver.path=
 test.timeout=15
 
 ###############################################################################
-# Given below are the test accounts/passwords used for testing. If you plan to
-# run the test suite against a staging server, you need to create an additional
-# four Google accounts (not including the admin account) to use as test accounts,
-# then replace the following with the actual login details for all five accounts.
+# Given below are the test accounts/passwords used for testing.
+# If you plan to run the test suite against a staging server, you need to create
+# four additional Google accounts (not including the admin account) to use as test
+# accounts, then replace the following fields with the actual login details for all
+# five accounts.
+# For the account names, omit '@gmail.com'.
 
 # The Google account of a user that has 'admin access' to the application.
+# For testing against a staging server, this should be the account that was used to
+# create the Google App Engine project.
 test.admin.account=yourGoogleId
 test.admin.password=adminpassword
 

--- a/src/test/resources/test.template.properties
+++ b/src/test/resources/test.template.properties
@@ -40,26 +40,16 @@ test.chromedriver.path=
 test.timeout=15
 
 ###############################################################################
-# Given below are the test accounts/passwords used for testing. 
-# The values given below will work for the dev server(except one test case GodModTest).
-# To pass GodModTest, change ALL the accounts below by appending to the back of it.
-# e.g. yourGoogleId    -> yourGoogleId.JohnDoe
-#      teammates.coord -> teammates.coord.JohnDoe
-#      alice.tmms      -> alice.tmms.JohnDoe
-#      charlie.tmms    -> charlie.tmms.JohnDoe
-#      teammates.unreg -> teammates.unreg.JohnDoe
-# If you plan to run the test suite against a staging server, 
-# you need to create four Google accounts (to use as test accounts) 
-# and give their details below.
+# Given below are the test accounts/passwords used for testing. If you plan to
+# run the test suite against a staging server, you need to create an additional
+# four Google accounts (not including the admin account) to use as test accounts,
+# then replace the following with the actual login details for all five accounts.
 
-# The Google account of a user that has 'admin access' to the application
-# For testing against staging server, you should use your own google account here.
-# Omit '@gmail.com'
+# The Google account of a user that has 'admin access' to the application.
 test.admin.account=yourGoogleId
 test.admin.password=adminpassword
 
 # This Google account will be given 'instructor access' to the application.
-# For testing against a production server, replace it with details of a real GMail account.
 test.instructor.account=teammates.coord
 test.instructor.password=anypassword
 
@@ -69,6 +59,6 @@ test.student1.password=anypassword
 test.student2.account=charlie.tmms
 test.student2.password=anypassword
 
-# A Google account will not be given access to the application.
+# This Google account will not be given access to the application.
 test.unreg.account=teammates.unreg
 test.unreg.password=anypassword


### PR DESCRIPTION
Fixes #6812

**Outline of Solution**

- Use random test account names (implemented through appending a random salt to default account names) when in CI to detect and prevent hard-coding
- Remove are-all-test-accounts-ready check