### PR TITLE
Fix some bad practices in FeedbackConstantSumQuestionDetails.java #7134

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -65,49 +65,40 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             Map<String, String[]> requestParameters,
             FeedbackQuestionType questionType) {
 
-        String distributeToRecipientsString = null;
-        String pointsPerOptionString = null;
-        String pointsString = null;
-        String pointsForEachOptionString = null;
-        String pointsForEachRecipientString = null;
-        String forceUnevenDistributionString = null;
-        boolean distributeToRecipients = false;
-        boolean pointsPerOption = false;
-        boolean forceUnevenDistribution = false;
-        int points = 0;
-
-        distributeToRecipientsString =
+        String distributeToRecipientsString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS);
-        pointsPerOptionString =
+        String pointsPerOptionString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSPEROPTION);
-        pointsString =
+        String pointsString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTS);
-        pointsForEachOptionString =
+        String pointsForEachOptionString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSFOREACHOPTION);
-        pointsForEachRecipientString =
+        String pointsForEachRecipientString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMPOINTSFOREACHRECIPIENT);
 
         Assumption.assertNotNull("Null points in total", pointsString);
         Assumption.assertNotNull("Null points for each option", pointsForEachOptionString);
         Assumption.assertNotNull("Null points for each recipient", pointsForEachRecipientString);
-        forceUnevenDistributionString =
+        String forceUnevenDistributionString =
                 HttpRequestHelper.getValueFromParamMap(requestParameters,
                                                        Const.ParamsNames.FEEDBACK_QUESTION_CONSTSUMDISTRIBUTEUNEVENLY);
 
-        distributeToRecipients = "true".equals(distributeToRecipientsString);
-        pointsPerOption = "true".equals(pointsPerOptionString);
+        boolean distributeToRecipients = "true".equals(distributeToRecipientsString);
+        boolean pointsPerOption = "true".equals(pointsPerOptionString);
+
+        int points = Integer.parseInt(pointsString);
+
         if (pointsPerOption) {
             points = distributeToRecipients ? Integer.parseInt(pointsForEachRecipientString)
                                             : Integer.parseInt(pointsForEachOptionString);
-        } else {
-            points = Integer.parseInt(pointsString);
         }
-        forceUnevenDistribution = "on".equals(forceUnevenDistributionString);
+
+        boolean forceUnevenDistribution = "on".equals(forceUnevenDistributionString);
 
         if (distributeToRecipients) {
             this.setConstantSumQuestionDetails(pointsPerOption, points, forceUnevenDistribution);

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -91,11 +91,12 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         boolean distributeToRecipients = "true".equals(distributeToRecipientsString);
         boolean pointsPerOption = "true".equals(pointsPerOptionString);
 
-        int points = Integer.parseInt(pointsString);
-
+        int points = 0;
         if (pointsPerOption) {
             points = distributeToRecipients ? Integer.parseInt(pointsForEachRecipientString)
                                             : Integer.parseInt(pointsForEachOptionString);
+        } else {
+            points = Integer.parseInt(pointsString);
         }
 
         boolean forceUnevenDistribution = "on".equals(forceUnevenDistributionString);


### PR DESCRIPTION
Fixes #7134 

Just a code cleanup - the existing implementation unnecessarily instantiates local variables (to null/false/zero) - this can be done as part of the assignment operation in the String and Boolean cases.

I've also changed the 'points' integer assignment so rather than setting to 0 and then having an if/else conditional, we just assign to the value of pointsString and then override if it's a 'pointsPerOption' case. Much cleaner!

All tests / lints run cleanly. Thoughts and feedback welcome. 