### PR TITLE
Add session token validation #7384

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -607,6 +607,7 @@ public final class Const {
         public static final String IS_STUDENT_REJOINING = "isstudentrejoining";
 
         public static final String BLOB_KEY = "blob-key";
+        public static final String SESSION_TOKEN = "token";
 
         public static final String COPIED_FEEDBACK_SESSION_NAME = "copiedfsname";
         public static final String COPIED_COURSE_ID = "copiedcourseid";

--- a/src/main/java/teammates/common/util/CryptoHelper.java
+++ b/src/main/java/teammates/common/util/CryptoHelper.java
@@ -1,0 +1,37 @@
+package teammates.common.util;
+
+import java.nio.charset.Charset;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Cryptographic helper functions.
+ */
+public final class CryptoHelper {
+    private CryptoHelper() {
+        // utility class
+    }
+
+    /**
+     * Computes session token from session ID using the HMAC-MD5 algorithm.
+     * Uses {@link Config#ENCRYPTION_KEY} as the secret key for the HMAC-MD5.
+     */
+    public static String computeSessionToken(String sessionId) {
+        SecretKeySpec sks = new SecretKeySpec(StringHelper.hexStringToByteArray(Config.ENCRYPTION_KEY), "AES");
+        Mac mac = null;
+        try {
+            mac = Mac.getInstance("HmacMD5");
+            mac.init(sks);
+        } catch (NoSuchAlgorithmException e) {
+            Assumption.fail("Algorithm specified does not exist.");
+        } catch (InvalidKeyException e) {
+            Assumption.fail("Invalid encryption key encountered. Check your build.properties file.");
+        }
+        Charset charset = Charset.forName("UTF-8");
+        byte[] encryptedSessionId = mac.doFinal(sessionId.getBytes(charset));
+        return StringHelper.byteArrayToHexString(encryptedSessionId);
+    }
+}

--- a/src/main/java/teammates/common/util/HttpRequestHelper.java
+++ b/src/main/java/teammates/common/util/HttpRequestHelper.java
@@ -3,6 +3,7 @@ package teammates.common.util;
 import java.util.Enumeration;
 import java.util.Map;
 
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
 public final class HttpRequestHelper {
@@ -90,6 +91,25 @@ public final class HttpRequestHelper {
             return link + "?" + query;
         }
         return link;
+    }
+
+    /**
+     * Returns the cookie value, or null if said cookie does not exist.
+     */
+    public static String getCookieValueFromRequest(HttpServletRequest req, String cookieName) {
+        Cookie[] existingCookies = req.getCookies();
+
+        if (existingCookies == null) {
+            return null;
+        }
+
+        for (Cookie cookie : existingCookies) {
+            if (cookie.getName().equals(cookieName)) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
     }
 
 }

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -17,6 +17,7 @@ import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
+import teammates.common.util.CryptoHelper;
 import teammates.common.util.HttpRequestHelper;
 import teammates.common.util.LogMessageGenerator;
 import teammates.common.util.SanitizationHelper;
@@ -74,6 +75,9 @@ public abstract class Action {
     /** Session that contains status message information. */
     protected HttpSession session;
 
+    /** Session token used in forms/links to actions requiring origin validation. */
+    protected String sessionToken;
+
     /** This is to get the blobInfo for any file upload from prev pages. */
     protected HttpServletRequest request;
 
@@ -101,7 +105,7 @@ public abstract class Action {
         setEmailSender(new EmailSender());
         requestParameters = request.getParameterMap();
         session = request.getSession();
-
+        sessionToken = CryptoHelper.computeSessionToken(session.getId());
         // Set error status forwarded from the previous action
         isError = getRequestParamAsBoolean(Const.ParamsNames.ERROR);
     }
@@ -136,6 +140,15 @@ public abstract class Action {
 
         if (!isHttpReferrerValid(referrer)) {
             throw new InvalidOriginException("Invalid HTTP referrer");
+        }
+
+        String sessionToken = getRequestParamValue(Const.ParamsNames.SESSION_TOKEN);
+        if (sessionToken == null) {
+            throw new InvalidOriginException("Missing session token");
+        }
+
+        if (!isSessionTokenValid(sessionToken)) {
+            throw new InvalidOriginException("Invalid session token");
         }
     }
 
@@ -179,6 +192,13 @@ public abstract class Action {
         String target = new Url(requestUrl).getBaseUrl();
 
         return origin.equals(target);
+    }
+
+    private boolean isSessionTokenValid(String actualToken) {
+        String sessionId = session.getId();
+        String expectedToken = CryptoHelper.computeSessionToken(sessionId);
+
+        return actualToken.equals(expectedToken);
     }
 
     // These methods are used for user authentication

--- a/src/main/java/teammates/ui/controller/AdminAccountDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminAccountDetailsPageAction.java
@@ -37,7 +37,7 @@ public class AdminAccountDetailsPageAction extends Action {
             studentCourseList = null;
         }
 
-        AdminAccountDetailsPageData data = new AdminAccountDetailsPageData(account, accountInformation,
+        AdminAccountDetailsPageData data = new AdminAccountDetailsPageData(account, sessionToken, accountInformation,
                                                                            instructorCourseList, studentCourseList);
         statusToAdmin = "adminAccountDetails Page Load<br>"
                 + "Viewing details for " + data.getAccountInformation().name + "(" + googleId + ")";

--- a/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminAccountManagementPageAction.java
@@ -44,8 +44,8 @@ public class AdminAccountManagementPageAction extends Action {
             }
         }
 
-        AdminAccountManagementPageData data = new AdminAccountManagementPageData(account, instructorAccountsTable,
-                                                                                 instructorCoursesTable, isToShowAll);
+        AdminAccountManagementPageData data = new AdminAccountManagementPageData(account, sessionToken,
+                instructorAccountsTable, instructorCoursesTable, isToShowAll);
 
         statusToAdmin = "Admin Account Management Page Load<br>"
                         + "<span class=\"bold\">Total Instructors:</span> " + instructorAccountsTable.size();

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -44,7 +44,7 @@ public class AdminActivityLogPageAction extends Action {
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
 
-        AdminActivityLogPageData data = new AdminActivityLogPageData(account);
+        AdminActivityLogPageData data = new AdminActivityLogPageData(account, sessionToken);
 
         String searchTimeOffset = getRequestParamValue("searchTimeOffset");
         if (searchTimeOffset == null) {

--- a/src/main/java/teammates/ui/controller/AdminEmailComposePageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposePageAction.java
@@ -12,7 +12,7 @@ public class AdminEmailComposePageAction extends Action {
     protected ActionResult execute() {
 
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailComposePageData data = new AdminEmailComposePageData(account);
+        AdminEmailComposePageData data = new AdminEmailComposePageData(account, sessionToken);
 
         String idOfEmailToEdit = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_ID);
 

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSaveAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSaveAction.java
@@ -23,7 +23,7 @@ public class AdminEmailComposeSaveAction extends Action {
     protected ActionResult execute() {
 
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailComposePageData data = new AdminEmailComposePageData(account);
+        AdminEmailComposePageData data = new AdminEmailComposePageData(account, sessionToken);
 
         String emailContent = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_CONTENT);
         String subject = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_SUBJECT);

--- a/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailComposeSendAction.java
@@ -36,7 +36,7 @@ public class AdminEmailComposeSendAction extends Action {
     protected ActionResult execute() {
 
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailComposePageData data = new AdminEmailComposePageData(account);
+        AdminEmailComposePageData data = new AdminEmailComposePageData(account, sessionToken);
 
         String emailContent = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_CONTENT);
         String subject = getRequestParamValue(Const.ParamsNames.ADMIN_EMAIL_SUBJECT);

--- a/src/main/java/teammates/ui/controller/AdminEmailCreateGroupReceiverListUploadUrlAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailCreateGroupReceiverListUploadUrlAction.java
@@ -4,6 +4,7 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
+import teammates.common.util.Url;
 import teammates.ui.pagedata.AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData;
 
 public class AdminEmailCreateGroupReceiverListUploadUrlAction extends Action {
@@ -14,11 +15,14 @@ public class AdminEmailCreateGroupReceiverListUploadUrlAction extends Action {
         gateKeeper.verifyAdminPrivileges(account);
 
         AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData data =
-                new AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData(account);
+                new AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData(account, sessionToken);
 
         try {
+            String callbackUrl = Url.addParamToUrl(Const.ActionURIs.ADMIN_EMAIL_GROUP_RECEIVER_LIST_UPLOAD,
+                                                   Const.ParamsNames.SESSION_TOKEN,
+                                                   sessionToken);
             data.nextUploadUrl =
-                    GoogleCloudStorageHelper.getNewUploadUrl(Const.ActionURIs.ADMIN_EMAIL_GROUP_RECEIVER_LIST_UPLOAD);
+                    GoogleCloudStorageHelper.getNewUploadUrl(callbackUrl);
             data.ajaxStatus = "Group receiver list upload url created, proceed to uploading";
         } catch (BlobstoreFailureException | IllegalArgumentException e) {
             data.nextUploadUrl = null;

--- a/src/main/java/teammates/ui/controller/AdminEmailCreateImageUploadUrlAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailCreateImageUploadUrlAction.java
@@ -2,6 +2,7 @@ package teammates.ui.controller;
 
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
+import teammates.common.util.Url;
 
 /**
  * Action: creates a URL for uploading an image in admin email.
@@ -20,7 +21,9 @@ public class AdminEmailCreateImageUploadUrlAction extends CreateImageUploadUrlAc
 
     @Override
     protected String getUploadUrl() {
-        return GoogleCloudStorageHelper.getNewUploadUrl(Const.ActionURIs.ADMIN_EMAIL_IMAGE_UPLOAD);
+        String callbackUrl =
+                Url.addParamToUrl(Const.ActionURIs.ADMIN_EMAIL_IMAGE_UPLOAD, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+        return GoogleCloudStorageHelper.getNewUploadUrl(callbackUrl);
     }
 
 }

--- a/src/main/java/teammates/ui/controller/AdminEmailDraftPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailDraftPageAction.java
@@ -8,7 +8,7 @@ public class AdminEmailDraftPageAction extends Action {
     @Override
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailDraftPageData data = new AdminEmailDraftPageData(account);
+        AdminEmailDraftPageData data = new AdminEmailDraftPageData(account, sessionToken);
 
         data.draftEmailList = logic.getAdminEmailDrafts();
         statusToAdmin = "adminEmailDraftPage Page Load";

--- a/src/main/java/teammates/ui/controller/AdminEmailGroupReceiverListUploadAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailGroupReceiverListUploadAction.java
@@ -24,7 +24,7 @@ public class AdminEmailGroupReceiverListUploadAction extends Action {
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
 
-        data = new AdminEmailComposePageData(account);
+        data = new AdminEmailComposePageData(account, sessionToken);
         BlobInfo blobInfo = extractGroupReceiverListFileKey();
 
         if (blobInfo == null) {

--- a/src/main/java/teammates/ui/controller/AdminEmailImageUploadAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailImageUploadAction.java
@@ -16,7 +16,7 @@ public class AdminEmailImageUploadAction extends ImageUploadAction {
         gateKeeper.verifyAdminPrivileges(account);
 
         FileUploadPageData uploadPageData = prepareData();
-        AdminEmailComposePageData data = new AdminEmailComposePageData(account);
+        AdminEmailComposePageData data = new AdminEmailComposePageData(account, sessionToken);
         data.isFileUploaded = uploadPageData.isFileUploaded;
         data.fileSrcUrl = uploadPageData.fileSrcUrl;
         data.ajaxStatus = uploadPageData.ajaxStatus;

--- a/src/main/java/teammates/ui/controller/AdminEmailLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailLogPageAction.java
@@ -34,7 +34,7 @@ public class AdminEmailLogPageAction extends Action {
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
 
-        AdminEmailLogPageData data = new AdminEmailLogPageData(account, getRequestParamValue("filterQuery"),
+        AdminEmailLogPageData data = new AdminEmailLogPageData(account, sessionToken, getRequestParamValue("filterQuery"),
                                                                getRequestParamAsBoolean("all"));
 
         if (data.getFilterQuery() == null) {

--- a/src/main/java/teammates/ui/controller/AdminEmailSentPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailSentPageAction.java
@@ -8,7 +8,7 @@ public class AdminEmailSentPageAction extends Action {
     @Override
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailSentPageData data = new AdminEmailSentPageData(account);
+        AdminEmailSentPageData data = new AdminEmailSentPageData(account, sessionToken);
 
         data.adminSentEmailList = logic.getSentAdminEmails();
 

--- a/src/main/java/teammates/ui/controller/AdminEmailTrashPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminEmailTrashPageAction.java
@@ -8,7 +8,7 @@ public class AdminEmailTrashPageAction extends Action {
     @Override
     protected ActionResult execute() {
         gateKeeper.verifyAdminPrivileges(account);
-        AdminEmailTrashPageData data = new AdminEmailTrashPageData(account);
+        AdminEmailTrashPageData data = new AdminEmailTrashPageData(account, sessionToken);
 
         data.adminTrashEmailList = logic.getAdminEmailsInTrashBin();
         statusToAdmin = "adminEmailTrashPage Page Load";

--- a/src/main/java/teammates/ui/controller/AdminHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminHomePageAction.java
@@ -10,7 +10,7 @@ public class AdminHomePageAction extends Action {
 
         gateKeeper.verifyAdminPrivileges(account);
 
-        AdminHomePageData data = new AdminHomePageData(account);
+        AdminHomePageData data = new AdminHomePageData(account, sessionToken);
 
         data.instructorShortName = "";
         data.instructorName = "";

--- a/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
+++ b/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
@@ -41,7 +41,7 @@ public class AdminInstructorAccountAddAction extends Action {
 
         gateKeeper.verifyAdminPrivileges(account);
 
-        AdminHomePageData data = new AdminHomePageData(account);
+        AdminHomePageData data = new AdminHomePageData(account, sessionToken);
 
         data.instructorDetailsSingleLine = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_DETAILS_SINGLE_LINE);
         data.instructorShortName = "";
@@ -100,6 +100,7 @@ public class AdminInstructorAccountAddAction extends Action {
             retryUrl = Url.addParamToUrl(retryUrl, Const.ParamsNames.INSTRUCTOR_NAME, data.instructorName);
             retryUrl = Url.addParamToUrl(retryUrl, Const.ParamsNames.INSTRUCTOR_EMAIL, data.instructorEmail);
             retryUrl = Url.addParamToUrl(retryUrl, Const.ParamsNames.INSTRUCTOR_INSTITUTION, data.instructorInstitution);
+            retryUrl = Url.addParamToUrl(retryUrl, Const.ParamsNames.SESSION_TOKEN, data.getSessionToken());
 
             StringBuilder errorMessage = new StringBuilder(100);
             String retryLink = "<a href=" + retryUrl + ">Exception in Importing Data, Retry</a>";

--- a/src/main/java/teammates/ui/controller/AdminSearchPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSearchPageAction.java
@@ -31,7 +31,7 @@ public class AdminSearchPageAction extends Action {
         String searchKey = getRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
         String searchButtonHit = getRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_BUTTON_HIT);
 
-        AdminSearchPageData data = new AdminSearchPageData(account);
+        AdminSearchPageData data = new AdminSearchPageData(account, sessionToken);
 
         if (searchKey == null || searchKey.trim().isEmpty()) {
 

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -39,7 +39,7 @@ public class AdminSessionsPageAction extends Action {
     protected ActionResult execute() {
 
         gateKeeper.verifyAdminPrivileges(account);
-        data = new AdminSessionsPageData(account);
+        data = new AdminSessionsPageData(account, sessionToken);
 
         isShowAll = getRequestParamAsBoolean("all");
 

--- a/src/main/java/teammates/ui/controller/AdminStudentGoogleIdResetAction.java
+++ b/src/main/java/teammates/ui/controller/AdminStudentGoogleIdResetAction.java
@@ -26,7 +26,7 @@ public class AdminStudentGoogleIdResetAction extends Action {
         String studentCourseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
         String wrongGoogleId = getRequestParamValue(Const.ParamsNames.STUDENT_ID);
 
-        AdminStudentGoogleIdResetPageData data = new AdminStudentGoogleIdResetPageData(account);
+        AdminStudentGoogleIdResetPageData data = new AdminStudentGoogleIdResetPageData(account, sessionToken);
 
         if (studentEmail != null && studentCourseId != null) {
             try {

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -66,6 +66,7 @@ public class ControllerServlet extends HttpServlet {
             Action c = new ActionFactory().getAction(req);
             if (c.isValidUser()) {
                 ActionResult actionResult = c.executeAndPostProcess();
+                actionResult.writeSessionTokenToCookieIfRequired(req, resp);
                 actionResult.send(req, resp);
             } else {
                 resp.sendRedirect(c.getAuthenticationRedirectUrl());

--- a/src/main/java/teammates/ui/controller/CourseStatsPageAction.java
+++ b/src/main/java/teammates/ui/controller/CourseStatsPageAction.java
@@ -12,7 +12,7 @@ public class CourseStatsPageAction extends Action {
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
         Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, courseId);
 
-        CourseStatsPageData data = new CourseStatsPageData(account);
+        CourseStatsPageData data = new CourseStatsPageData(account, sessionToken);
 
         gateKeeper.verifyInstructorPrivileges(account);
 

--- a/src/main/java/teammates/ui/controller/CreateImageUploadUrlAction.java
+++ b/src/main/java/teammates/ui/controller/CreateImageUploadUrlAction.java
@@ -4,6 +4,7 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
+import teammates.common.util.Url;
 import teammates.ui.pagedata.CreateImageUploadUrlAjaxPageData;
 
 /**
@@ -17,7 +18,7 @@ public class CreateImageUploadUrlAction extends Action {
     }
 
     protected final CreateImageUploadUrlAjaxPageData getCreateImageUploadUrlPageData() {
-        CreateImageUploadUrlAjaxPageData data = new CreateImageUploadUrlAjaxPageData(account);
+        CreateImageUploadUrlAjaxPageData data = new CreateImageUploadUrlAjaxPageData(account, sessionToken);
 
         try {
             data.nextUploadUrl = getUploadUrl();
@@ -32,7 +33,9 @@ public class CreateImageUploadUrlAction extends Action {
     }
 
     protected String getUploadUrl() {
-        return GoogleCloudStorageHelper.getNewUploadUrl(Const.ActionURIs.IMAGE_UPLOAD);
+        String callbackUrl =
+                Url.addParamToUrl(Const.ActionURIs.IMAGE_UPLOAD, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+        return GoogleCloudStorageHelper.getNewUploadUrl(callbackUrl);
     }
 
 }

--- a/src/main/java/teammates/ui/controller/FeedbackSessionStatsPageAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSessionStatsPageAction.java
@@ -17,7 +17,7 @@ public class FeedbackSessionStatsPageAction extends Action {
         String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
 
-        FeedbackSessionStatsPageData data = new FeedbackSessionStatsPageData(account);
+        FeedbackSessionStatsPageData data = new FeedbackSessionStatsPageData(account, sessionToken);
 
         FeedbackSessionAttributes fsa = logic.getFeedbackSession(feedbackSessionName, courseId);
 

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditPageAction.java
@@ -40,7 +40,7 @@ public abstract class FeedbackSubmissionEditPageAction extends Action {
         String email = getRequestParamValue(Const.ParamsNames.STUDENT_EMAIL);
 
         String userEmailForCourse = getUserEmailForCourse();
-        data = new FeedbackSubmissionEditPageData(account, student);
+        data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
         data.bundle = getDataBundle(userEmailForCourse);
 
         data.setSessionOpenForSubmission(isSessionOpenForSpecificUser(data.bundle.feedbackSession));

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -59,7 +59,7 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
 
         String userEmailForCourse = getUserEmailForCourse();
 
-        data = new FeedbackSubmissionEditPageData(account, student);
+        data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
         data.bundle = getDataBundle(userEmailForCourse);
         Assumption.assertNotNull("Feedback session " + feedbackSessionName
                                  + " does not exist in " + courseId + ".", data.bundle);

--- a/src/main/java/teammates/ui/controller/ImageUploadAction.java
+++ b/src/main/java/teammates/ui/controller/ImageUploadAction.java
@@ -35,7 +35,7 @@ public class ImageUploadAction extends Action {
     }
 
     protected FileUploadPageData prepareData() {
-        FileUploadPageData data = new FileUploadPageData(account);
+        FileUploadPageData data = new FileUploadPageData(account, sessionToken);
         BlobInfo blobInfo = extractImageKey(getImageKeyParam());
 
         if (blobInfo == null) {

--- a/src/main/java/teammates/ui/controller/InstructorCommentsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCommentsPageAction.java
@@ -52,7 +52,7 @@ public class InstructorCommentsPageAction extends Action {
 
         List<String> coursePaginationList = new ArrayList<String>();
         String courseName = getCoursePaginationList(coursePaginationList);
-        InstructorCommentsPageData data = new InstructorCommentsPageData(account);
+        InstructorCommentsPageData data = new InstructorCommentsPageData(account, sessionToken);
 
         CourseRoster roster = null;
         Map<String, List<CommentAttributes>> giverEmailToCommentsMap = new HashMap<String, List<CommentAttributes>>();

--- a/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
@@ -36,7 +36,7 @@ public class InstructorCourseAddAction extends Action {
         gateKeeper.verifyInstructorPrivileges(account);
 
         /* Create a new course in the database */
-        data = new InstructorCoursesPageData(account);
+        data = new InstructorCoursesPageData(account, sessionToken);
         CourseAttributes newCourse = new CourseAttributes(newCourseId, newCourseName, newCourseTimeZone);
         createCourse(newCourse);
 

--- a/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
@@ -31,7 +31,7 @@ public class InstructorCourseDetailsPageAction extends Action {
         gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId));
 
         /* Setup page data for the "Course Details" page */
-        InstructorCourseDetailsPageData data = new InstructorCourseDetailsPageData(account);
+        InstructorCourseDetailsPageData data = new InstructorCourseDetailsPageData(account, sessionToken);
 
         if (isHtmlTableNeeded) {
             String courseStudentListAsCsv = logic.getCourseStudentListAsCsv(courseId, account.googleId);

--- a/src/main/java/teammates/ui/controller/InstructorCourseEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEditPageAction.java
@@ -50,7 +50,7 @@ public class InstructorCourseEditPageAction extends Action {
             feedbackNames.add(feedback.getFeedbackSessionName());
         }
 
-        InstructorCourseEditPageData data = new InstructorCourseEditPageData(account, courseToEdit,
+        InstructorCourseEditPageData data = new InstructorCourseEditPageData(account, sessionToken, courseToEdit,
                                                                              instructorList, instructor,
                                                                              instructorToShowIndex,
                                                                              sectionNames, feedbackNames);

--- a/src/main/java/teammates/ui/controller/InstructorCourseEnrollPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEnrollPageAction.java
@@ -24,7 +24,8 @@ public class InstructorCourseEnrollPageAction extends Action {
                 instructor, logic.getCourse(courseId), Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT);
 
         /* Setup page data for 'Enroll' page of a course */
-        InstructorCourseEnrollPageData pageData = new InstructorCourseEnrollPageData(account, courseId, studentsInfo);
+        InstructorCourseEnrollPageData pageData =
+                new InstructorCourseEnrollPageData(account, sessionToken, courseId, studentsInfo);
 
         statusToAdmin = String.format(Const.StatusMessages.ADMIN_LOG_INSTRUCTOR_COURSE_ENROLL_PAGE_LOAD,
                                       courseId);

--- a/src/main/java/teammates/ui/controller/InstructorCourseEnrollSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEnrollSaveAction.java
@@ -48,7 +48,7 @@ public class InstructorCourseEnrollSaveAction extends Action {
             List<StudentAttributes>[] students = enrollAndProcessResultForDisplay(studentsInfo, courseId);
             boolean hasSection = hasSections(students);
 
-            InstructorCourseEnrollResultPageData pageData = new InstructorCourseEnrollResultPageData(account,
+            InstructorCourseEnrollResultPageData pageData = new InstructorCourseEnrollResultPageData(account, sessionToken,
                                                                     courseId, students, hasSection, studentsInfo);
 
             statusToAdmin = "Students Enrolled in Course <span class=\"bold\">["
@@ -61,7 +61,8 @@ public class InstructorCourseEnrollSaveAction extends Action {
 
             statusToAdmin += "<br>Enrollment string entered by user:<br>" + sanitizedStudentsInfo.replace("\n", "<br>");
 
-            InstructorCourseEnrollPageData pageData = new InstructorCourseEnrollPageData(account, courseId, studentsInfo);
+            InstructorCourseEnrollPageData pageData =
+                    new InstructorCourseEnrollPageData(account, sessionToken, courseId, studentsInfo);
 
             return createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSE_ENROLL, pageData);
         } catch (EntityAlreadyExistsException e) {
@@ -73,7 +74,8 @@ public class InstructorCourseEnrollSaveAction extends Action {
                                       + "servers. Please try again after about 10 minutes. If the problem persists, "
                                       + "please contact TEAMMATES support", StatusMessageColor.DANGER));
 
-            InstructorCourseEnrollPageData pageData = new InstructorCourseEnrollPageData(account, courseId, studentsInfo);
+            InstructorCourseEnrollPageData pageData =
+                    new InstructorCourseEnrollPageData(account, sessionToken, courseId, studentsInfo);
 
             log.severe("Entity already exists exception occurred when updating student: " + e.getMessage());
             return createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSE_ENROLL, pageData);

--- a/src/main/java/teammates/ui/controller/InstructorCourseJoinAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseJoinAction.java
@@ -53,7 +53,7 @@ public class InstructorCourseJoinAction extends Action {
         //will be null
 
         InstructorCourseJoinConfirmationPageData pageData =
-                                        new InstructorCourseJoinConfirmationPageData(account, regkey, institute);
+                new InstructorCourseJoinConfirmationPageData(account, sessionToken, regkey, institute);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSE_JOIN_CONFIRMATION, pageData);
     }

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditPageAction.java
@@ -37,7 +37,7 @@ public class InstructorCourseStudentDetailsEditPageAction extends Action {
         boolean isOpenOrPublishedEmailSentForTheCourse = logic.isOpenOrPublishedEmailSentForTheCourse(courseId);
 
         InstructorCourseStudentDetailsEditPageData data =
-                new InstructorCourseStudentDetailsEditPageData(account, student, student.email, hasSection,
+                new InstructorCourseStudentDetailsEditPageData(account, sessionToken, student, student.email, hasSection,
                         isOpenOrPublishedEmailSentForTheCourse);
 
         statusToAdmin = "instructorCourseStudentEdit Page Load<br>"

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
@@ -106,7 +106,7 @@ public class InstructorCourseStudentDetailsEditSaveAction extends Action {
             student.email = studentEmail;
             boolean isOpenOrPublishedEmailSentForTheCourse = logic.isOpenOrPublishedEmailSentForTheCourse(courseId);
             InstructorCourseStudentDetailsEditPageData data =
-                    new InstructorCourseStudentDetailsEditPageData(account, student, newEmail, hasSection,
+                    new InstructorCourseStudentDetailsEditPageData(account, sessionToken, student, newEmail, hasSection,
                             isOpenOrPublishedEmailSentForTheCourse);
             return createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSE_STUDENT_EDIT, data);
         }

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsPageAction.java
@@ -41,7 +41,7 @@ public class InstructorCourseStudentDetailsPageAction extends Action {
         StudentProfileAttributes studentProfile = loadStudentProfile(student, instructor);
 
         InstructorCourseStudentDetailsPageData data =
-                new InstructorCourseStudentDetailsPageData(account, student, studentProfile,
+                new InstructorCourseStudentDetailsPageData(account, sessionToken, student, studentProfile,
                                                            isAbleToAddComment, hasSection, commentRecipient);
 
         statusToAdmin = "instructorCourseStudentDetails Page Load<br>"

--- a/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
@@ -31,7 +31,7 @@ public class InstructorCoursesPageAction extends Action {
         /* Explanation: This is a 'show page' type action. Therefore, we
          * prepare the matching PageData object, accessing the Logic
          * component if necessary.*/
-        InstructorCoursesPageData data = new InstructorCoursesPageData(account);
+        InstructorCoursesPageData data = new InstructorCoursesPageData(account, sessionToken);
         String isUsingAjax = getRequestParamValue(Const.ParamsNames.IS_USING_AJAX);
         data.setUsingAjax(isUsingAjax != null);
 

--- a/src/main/java/teammates/ui/controller/InstructorEditInstructorFeedbackPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorEditInstructorFeedbackPageAction.java
@@ -39,7 +39,7 @@ public class InstructorEditInstructorFeedbackPageAction extends Action {
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON,
                 instructorUnderModerationEmail);
 
-        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student);
+        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
 
         data.bundle = logic.getFeedbackSessionQuestionsBundleForInstructor(
                 feedbackSessionName,

--- a/src/main/java/teammates/ui/controller/InstructorEditStudentFeedbackPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorEditStudentFeedbackPageAction.java
@@ -50,7 +50,7 @@ public class InstructorEditStudentFeedbackPageAction extends Action {
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON, moderatedEntityIdentifier);
 
-        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student);
+        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
 
         data.bundle = logic.getFeedbackSessionQuestionsBundleForStudent(
                 feedbackSessionName, courseId, studentUnderModeration.email);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -59,7 +59,7 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
 
         String feedbackSessionType = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TYPE);
 
-        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(account);
+        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(account, sessionToken);
         try {
             logic.createFeedbackSession(fs);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
@@ -52,7 +52,7 @@ public class InstructorFeedbackCopyAction extends Action {
             //TODO: add a condition to include the status due to inconsistency problem of database
             //      (similar to the one below)
             return createRedirectResult(
-                    new PageData(account).getInstructorFeedbackEditLink(
+                    new PageData(account, sessionToken).getInstructorFeedbackEditLink(
                             fs.getCourseId(), fs.getFeedbackSessionName()));
 
         } catch (EntityAlreadyExistsException e) {

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
@@ -92,7 +92,7 @@ public class InstructorFeedbackEditCopyAction extends Action {
             // Return with redirection url (handled in javascript) to the sessions page after copying,
             // so that the instructor can see the new feedback sessions
             return createAjaxResultWithoutClearingStatusMessage(
-                       new InstructorFeedbackEditCopyData(account,
+                       new InstructorFeedbackEditCopyData(account, sessionToken,
                                                           Config.getAppUrl(nextUrl)
                                                                 .withParam(Const.ParamsNames.ERROR,
                                                                            Boolean.FALSE.toString())
@@ -133,6 +133,6 @@ public class InstructorFeedbackEditCopyAction extends Action {
 
     private AjaxResult createAjaxResultWithErrorMessage(String errorToUser) {
         isError = true;
-        return createAjaxResult(new InstructorFeedbackEditCopyData(account, errorToUser));
+        return createAjaxResult(new InstructorFeedbackEditCopyData(account, sessionToken, errorToUser));
     }
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyPageAction.java
@@ -40,8 +40,8 @@ public class InstructorFeedbackEditCopyPageAction extends Action {
 
         CourseAttributes.sortByCreatedDate(coursesToAddToData);
 
-        InstructorFeedbackEditCopyPageData data =
-                new InstructorFeedbackEditCopyPageData(account, coursesToAddToData, courseId, feedbackSessionName);
+        InstructorFeedbackEditCopyPageData data = new InstructorFeedbackEditCopyPageData(account, sessionToken,
+                coursesToAddToData, courseId, feedbackSessionName);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACK_COPY_MODAL, data);
     }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditPageAction.java
@@ -67,7 +67,7 @@ public class InstructorFeedbackEditPageAction extends Action {
                         + "<span class=\"bold\">[" + feedbackSessionName + "]</span>"
                         + "in Course: <span class=\"bold\">[" + courseId + "]</span>";
 
-        InstructorFeedbackEditPageData data = new InstructorFeedbackEditPageData(account);
+        InstructorFeedbackEditPageData data = new InstructorFeedbackEditPageData(account, sessionToken);
         data.init(feedbackSession, questions, questionHasResponses, studentList, instructorList, instructor);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACK_EDIT, data);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditSaveAction.java
@@ -38,7 +38,7 @@ public class InstructorFeedbackEditSaveAction extends Action {
                 false,
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
-        InstructorFeedbackEditPageData data = new InstructorFeedbackEditPageData(account);
+        InstructorFeedbackEditPageData data = new InstructorFeedbackEditPageData(account, sessionToken);
         FeedbackSessionAttributes feedbackSession = extractFeedbackSessionData();
 
         // A session opening reminder email is always sent as students

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackPreviewAsInstructorAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackPreviewAsInstructorAction.java
@@ -30,7 +30,7 @@ public class InstructorFeedbackPreviewAsInstructorAction extends Action {
                     "Instructor Email " + previewInstructorEmail + " does not exist in " + courseId + ".");
         }
 
-        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student);
+        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
 
         data.bundle = logic.getFeedbackSessionQuestionsBundleForInstructor(
                 feedbackSessionName,

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackPreviewAsStudentAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackPreviewAsStudentAction.java
@@ -30,7 +30,7 @@ public class InstructorFeedbackPreviewAsStudentAction extends Action {
                     "Student Email " + previewStudentEmail + " does not exist in " + courseId + ".");
         }
 
-        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student);
+        FeedbackSubmissionEditPageData data = new FeedbackSubmissionEditPageData(account, student, sessionToken);
 
         data.bundle = logic.getFeedbackSessionQuestionsBundleForStudent(
                 feedbackSessionName, courseId, previewStudent.email);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
@@ -38,8 +38,8 @@ public class InstructorFeedbackQuestionAddAction extends Action {
             questionDetailsErrorsMessages.add(new StatusMessage(error, StatusMessageColor.DANGER));
         }
 
-        RedirectResult redirectResult =
-                createRedirectResult(new PageData(account).getInstructorFeedbackEditLink(courseId, feedbackSessionName));
+        RedirectResult redirectResult = createRedirectResult(new PageData(account, sessionToken)
+                .getInstructorFeedbackEditLink(courseId, feedbackSessionName));
 
         if (!questionDetailsErrors.isEmpty()) {
             statusToUser.addAll(questionDetailsErrorsMessages);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionCopyAction.java
@@ -58,7 +58,7 @@ public class InstructorFeedbackQuestionCopyAction extends Action {
             isError = true;
         }
 
-        return createRedirectResult(new PageData(account)
-                                            .getInstructorFeedbackEditLink(courseId, feedbackSessionName));
+        return createRedirectResult(new PageData(account, sessionToken)
+                .getInstructorFeedbackEditLink(courseId, feedbackSessionName));
     }
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionCopyPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionCopyPageAction.java
@@ -30,7 +30,7 @@ public class InstructorFeedbackQuestionCopyPageAction extends Action {
         copiableQuestions = logic.getCopiableFeedbackQuestionsForInstructor(account.googleId);
 
         InstructorFeedbackQuestionCopyPageData data =
-                new InstructorFeedbackQuestionCopyPageData(account, copiableQuestions);
+                new InstructorFeedbackQuestionCopyPageData(account, sessionToken, copiableQuestions);
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACK_QUESTION_COPY_MODAL, data);
     }
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -63,7 +63,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
             setStatusForException(e);
         }
 
-        return createRedirectResult(new PageData(account)
+        return createRedirectResult(new PageData(account, sessionToken)
                                             .getInstructorFeedbackEditLink(courseId, feedbackSessionName));
     }
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
@@ -17,7 +17,7 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
         List<String> message = feedbackQuestion.getVisibilityMessage();
 
         InstructorFeedbackQuestionVisibilityMessagePageData data =
-                new InstructorFeedbackQuestionVisibilityMessagePageData(account);
+                new InstructorFeedbackQuestionVisibilityMessagePageData(account, sessionToken);
         data.visibilityMessage = message;
 
         return createAjaxResult(data);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackRemindParticularStudentsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackRemindParticularStudentsPageAction.java
@@ -26,7 +26,7 @@ public class InstructorFeedbackRemindParticularStudentsPageAction extends Action
                 logic.getFeedbackSessionResponseStatus(feedbackSessionName, courseId);
 
         InstructorFeedbackRemindParticularStudentsPageData data =
-                new InstructorFeedbackRemindParticularStudentsPageData(account, fsResponseStatus,
+                new InstructorFeedbackRemindParticularStudentsPageData(account, sessionToken, fsResponseStatus,
                                                                        courseId, feedbackSessionName);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACK_AJAX_REMIND_PARTICULAR_STUDENTS_MODAL, data);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
@@ -49,7 +49,7 @@ public class InstructorFeedbackResponseCommentAddAction extends Action {
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS);
 
         InstructorFeedbackResponseCommentAjaxPageData data =
-                new InstructorFeedbackResponseCommentAjaxPageData(account);
+                new InstructorFeedbackResponseCommentAjaxPageData(account, sessionToken);
 
         String giverEmail = response.giver;
         String recipientEmail = response.recipient;

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentDeleteAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentDeleteAction.java
@@ -43,7 +43,7 @@ public class InstructorFeedbackResponseCommentDeleteAction extends Action {
                 + "in course/feedback session: " + courseId + "/" + feedbackSessionName + "<br>";
 
         InstructorFeedbackResponseCommentAjaxPageData data =
-                new InstructorFeedbackResponseCommentAjaxPageData(account);
+                new InstructorFeedbackResponseCommentAjaxPageData(account, sessionToken);
 
         return createAjaxResult(data);
     }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentEditAction.java
@@ -41,7 +41,7 @@ public class InstructorFeedbackResponseCommentEditAction extends Action {
                                                                instructor, session, response);
 
         InstructorFeedbackResponseCommentAjaxPageData data =
-                new InstructorFeedbackResponseCommentAjaxPageData(account);
+                new InstructorFeedbackResponseCommentAjaxPageData(account, sessionToken);
 
         //Edit comment text
         String commentText = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentsLoadAction.java
@@ -52,7 +52,7 @@ public class InstructorFeedbackResponseCommentsLoadAction extends Action {
         FeedbackSessionResultsBundle bundle = getFeedbackResultBundle(courseId, fsName, roster);
         InstructorFeedbackResponseCommentsLoadPageData data =
                 new InstructorFeedbackResponseCommentsLoadPageData(
-                        account, fsIndex, numberOfPendingComments, instructor, bundle);
+                        account, sessionToken, fsIndex, numberOfPendingComments, instructor, bundle);
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENTS_LOAD, data);
     }
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResultsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResultsPageAction.java
@@ -39,7 +39,7 @@ public class InstructorFeedbackResultsPageAction extends Action {
 
         gateKeeper.verifyAccessible(instructor, session, !isCreatorOnly);
 
-        InstructorFeedbackResultsPageData data = new InstructorFeedbackResultsPageData(account);
+        InstructorFeedbackResultsPageData data = new InstructorFeedbackResultsPageData(account, sessionToken);
         String selectedSection = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESULTS_GROUPBYSECTION);
 
         if (selectedSection == null) {

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -34,7 +34,7 @@ public class InstructorFeedbacksPageAction extends Action {
                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
         }
 
-        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(account);
+        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(account, sessionToken);
         data.setUsingAjax(isUsingAjax != null);
 
         boolean omitArchived = true; // TODO: implement as a request parameter

--- a/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
@@ -22,7 +22,7 @@ public class InstructorHomePageAction extends Action {
             statusToUser.add(new StatusMessage(Const.StatusMessages.INSTRUCTOR_PERSISTENCE_ISSUE,
                                                StatusMessageColor.WARNING));
             statusToAdmin = "instructorHome " + Const.StatusMessages.INSTRUCTOR_PERSISTENCE_ISSUE;
-            return createShowPageResult(Const.ViewURIs.INSTRUCTOR_HOME, new InstructorHomePageData(account));
+            return createShowPageResult(Const.ViewURIs.INSTRUCTOR_HOME, new InstructorHomePageData(account, sessionToken));
         }
 
         gateKeeper.verifyInstructorPrivileges(account);
@@ -46,7 +46,7 @@ public class InstructorHomePageAction extends Action {
                      .size();
         int pendingCommentsCount = commentsForSendingStateCount + feedbackResponseCommentsForSendingStateCount;
 
-        InstructorHomeCourseAjaxPageData data = new InstructorHomeCourseAjaxPageData(account);
+        InstructorHomeCourseAjaxPageData data = new InstructorHomeCourseAjaxPageData(account, sessionToken);
         data.init(index, course, instructor, pendingCommentsCount);
 
         statusToAdmin = "instructorHome Course Load:<br>" + courseToLoad;
@@ -64,7 +64,7 @@ public class InstructorHomePageAction extends Action {
         String sortCriteria = getSortCriteria();
         sortCourse(courseList, sortCriteria);
 
-        InstructorHomePageData data = new InstructorHomePageData(account);
+        InstructorHomePageData data = new InstructorHomePageData(account, sessionToken);
         data.init(courseList, sortCriteria);
 
         if (logic.isNewInstructor(account.googleId)) {

--- a/src/main/java/teammates/ui/controller/InstructorSearchPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorSearchPageAction.java
@@ -92,7 +92,7 @@ public class InstructorSearchPageAction extends Action {
             }
         }
 
-        InstructorSearchPageData data = new InstructorSearchPageData(account);
+        InstructorSearchPageData data = new InstructorSearchPageData(account, sessionToken);
         data.init(commentSearchResults, frCommentSearchResults, studentSearchResults, searchKey,
                       isSearchCommentForStudents, isSearchCommentForResponses, isSearchForStudents);
 

--- a/src/main/java/teammates/ui/controller/InstructorStudentCommentAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentCommentAddAction.java
@@ -86,14 +86,15 @@ public class InstructorStudentCommentAddAction extends Action {
         //TODO: remove fromCommentsPage
         if (isFromCommentsPage) {
             return createRedirectResult(
-                           new PageData(account).getInstructorCommentsLink()
+                           new PageData(account, sessionToken).getInstructorCommentsLink()
                            + "&" + Const.ParamsNames.COURSE_ID + "=" + courseId);
         } else if (isFromStudentDetailsPage) {
             return createRedirectResult(getCourseStudentDetailsLink(courseId, studentEmail));
         } else if (isFromCourseDetailsPage) {
-            return createRedirectResult(new PageData(account).getInstructorCourseDetailsLink(courseId));
+            return createRedirectResult(new PageData(account, sessionToken).getInstructorCourseDetailsLink(courseId));
         } else { //studentRecordsPage by default
-            return createRedirectResult(new PageData(account).getInstructorStudentRecordsLink(courseId, studentEmail));
+            return createRedirectResult(new PageData(account, sessionToken)
+                    .getInstructorStudentRecordsLink(courseId, studentEmail));
         }
     }
 
@@ -208,7 +209,7 @@ public class InstructorStudentCommentAddAction extends Action {
         String link = Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE;
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_EMAIL, studentEmail);
-        link = new PageData(account).addUserIdToUrl(link);
+        link = new PageData(account, sessionToken).addUserIdToUrl(link);
         return link;
     }
 }

--- a/src/main/java/teammates/ui/controller/InstructorStudentCommentClearPendingAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentCommentClearPendingAction.java
@@ -62,7 +62,7 @@ public class InstructorStudentCommentClearPendingAction extends Action {
             statusToAdmin = "Successful: " + account.googleId + " cleared pending comments for course " + courseId;
         }
 
-        return createRedirectResult(new PageData(account).getInstructorCommentsLink() + "&"
+        return createRedirectResult(new PageData(account, sessionToken).getInstructorCommentsLink() + "&"
                                     + Const.ParamsNames.COURSE_ID + "=" + courseId);
     }
 

--- a/src/main/java/teammates/ui/controller/InstructorStudentCommentEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentCommentEditAction.java
@@ -73,9 +73,10 @@ public class InstructorStudentCommentEditAction extends Action {
         }
 
         return isFromCommentPage
-             ? createRedirectResult(new PageData(account).getInstructorCommentsLink()
+             ? createRedirectResult(new PageData(account, sessionToken).getInstructorCommentsLink()
                                     + "&" + Const.ParamsNames.COURSE_ID + "=" + courseId)
-             : createRedirectResult(new PageData(account).getInstructorStudentRecordsLink(courseId, studentEmail));
+             : createRedirectResult(new PageData(account, sessionToken)
+                                    .getInstructorStudentRecordsLink(courseId, studentEmail));
     }
 
     private void verifyAccessibleByInstructor(String courseId, String commentId) {

--- a/src/main/java/teammates/ui/controller/InstructorStudentListAjaxPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentListAjaxPageAction.java
@@ -63,10 +63,8 @@ public class InstructorStudentListAjaxPageAction extends Action {
             sectionPrivileges.put(sectionDetails.name, sectionPrivilege);
         }
 
-        InstructorStudentListAjaxPageData data = new InstructorStudentListAjaxPageData(account, courseId, courseIndex,
-                                                                                       hasSection, courseSectionDetails,
-                                                                                       sectionPrivileges,
-                                                                                       emailPhotoUrlMapping);
+        InstructorStudentListAjaxPageData data = new InstructorStudentListAjaxPageData(account, sessionToken, courseId,
+                courseIndex, hasSection, courseSectionDetails, sectionPrivileges, emailPhotoUrlMapping);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_STUDENT_LIST_AJAX, data);
     }

--- a/src/main/java/teammates/ui/controller/InstructorStudentListPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentListPageAction.java
@@ -63,7 +63,7 @@ public class InstructorStudentListPageAction extends Action {
         }
 
         InstructorStudentListPageData data =
-                new InstructorStudentListPageData(account, searchKey, displayArchive, coursesToDisplay);
+                new InstructorStudentListPageData(account, sessionToken, searchKey, displayArchive, coursesToDisplay);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_STUDENT_LIST, data);
     }

--- a/src/main/java/teammates/ui/controller/InstructorStudentRecordsAjaxPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentRecordsAjaxPageAction.java
@@ -69,7 +69,7 @@ public class InstructorStudentRecordsAjaxPageAction extends Action {
                       + "in course <span class=\"bold\">[" + courseId + "]</span>";
 
         InstructorStudentRecordsAjaxPageData data =
-                                        new InstructorStudentRecordsAjaxPageData(account, student, results);
+                                        new InstructorStudentRecordsAjaxPageData(account, student, sessionToken, results);
 
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_STUDENT_RECORDS_AJAX, data);
     }

--- a/src/main/java/teammates/ui/controller/InstructorStudentRecordsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorStudentRecordsPageAction.java
@@ -95,7 +95,7 @@ public class InstructorStudentRecordsPageAction extends Action {
 
         InstructorStudentRecordsPageData data =
                 new InstructorStudentRecordsPageData(
-                        account, student, courseId, showCommentBox, studentProfile,
+                        account, student, sessionToken, courseId, showCommentBox, studentProfile,
                         giverEmailToCommentsMap, giverEmailToGiverNameMap, sessionNames, instructor);
 
         statusToAdmin = "instructorStudentRecords Page Load<br>"

--- a/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
@@ -77,7 +77,7 @@ public class StudentCommentsPageAction extends Action {
             feedbackResultBundles = getFeedbackResultBundles(roster);
         }
 
-        StudentCommentsPageData data = new StudentCommentsPageData(account);
+        StudentCommentsPageData data = new StudentCommentsPageData(account, sessionToken);
         data.init(courseId, courseName, coursePaginationList, comments, roster,
                   studentEmail, feedbackResultBundles);
 

--- a/src/main/java/teammates/ui/controller/StudentCourseDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseDetailsPageAction.java
@@ -21,8 +21,7 @@ public class StudentCourseDetailsPageAction extends Action {
         CourseAttributes course = logic.getCourse(courseId);
         gateKeeper.verifyAccessible(logic.getStudentForGoogleId(courseId, account.googleId), course);
 
-        StudentCourseDetailsPageData data =
-                                        new StudentCourseDetailsPageData(account);
+        StudentCourseDetailsPageData data = new StudentCourseDetailsPageData(account, sessionToken);
 
         data.init(logic.getCourseDetails(courseId), logic.getInstructorsForCourse(courseId),
                       logic.getStudentForGoogleId(courseId, account.googleId),

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
@@ -54,7 +54,7 @@ public class StudentCourseJoinAction extends Action {
         String courseId = student.course;
         StudentCourseJoinConfirmationPageData data =
                 new StudentCourseJoinConfirmationPageData(
-                        account, student, confirmUrl,
+                        account, student, sessionToken, confirmUrl,
                         gateKeeper.getLogoutUrl(SanitizationHelper.sanitizeForNextUrl(confirmUrl)),
                         isRedirectResult, courseId, isNextUrlAccessibleWithoutLogin);
         excludeStudentDetailsFromResponseParams();

--- a/src/main/java/teammates/ui/controller/StudentFeedbackResultsPageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentFeedbackResultsPageAction.java
@@ -30,7 +30,7 @@ public class StudentFeedbackResultsPageAction extends Action {
         gateKeeper.verifyAccessible(getCurrentStudent(courseId),
                                     logic.getFeedbackSession(feedbackSessionName, courseId));
 
-        StudentFeedbackResultsPageData data = new StudentFeedbackResultsPageData(account, student);
+        StudentFeedbackResultsPageData data = new StudentFeedbackResultsPageData(account, student, sessionToken);
 
         data.student = getCurrentStudent(courseId);
         data.setBundle(logic.getFeedbackSessionResultsForStudent(feedbackSessionName, courseId, data.student.email));

--- a/src/main/java/teammates/ui/controller/StudentHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentHomePageAction.java
@@ -53,7 +53,7 @@ public class StudentHomePageAction extends Action {
             }
         }
 
-        StudentHomePageData data = new StudentHomePageData(account, courses, sessionSubmissionStatusMap);
+        StudentHomePageData data = new StudentHomePageData(account, sessionToken, courses, sessionSubmissionStatusMap);
 
         return createShowPageResult(Const.ViewURIs.STUDENT_HOME, data);
     }

--- a/src/main/java/teammates/ui/controller/StudentProfileCreateFormUrlAction.java
+++ b/src/main/java/teammates/ui/controller/StudentProfileCreateFormUrlAction.java
@@ -5,6 +5,7 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
 import teammates.common.util.Logger;
+import teammates.common.util.Url;
 import teammates.ui.pagedata.StudentProfileCreateFormUrlAjaxPageData;
 
 /**
@@ -19,14 +20,15 @@ public class StudentProfileCreateFormUrlAction extends Action {
     @Override
     protected ActionResult execute() {
         StudentProfileCreateFormUrlAjaxPageData data =
-                new StudentProfileCreateFormUrlAjaxPageData(account, getUploadUrl(), isError);
+                new StudentProfileCreateFormUrlAjaxPageData(account, sessionToken, getUploadUrl(), isError);
         return createAjaxResult(data);
     }
 
     private String getUploadUrl() {
+        String callbackUrl = Url.addParamToUrl(Const.ActionURIs.STUDENT_PROFILE_PICTURE_UPLOAD,
+                Const.ParamsNames.SESSION_TOKEN, sessionToken);
         try {
-            String uploadUrl =
-                    GoogleCloudStorageHelper.getNewUploadUrl(Const.ActionURIs.STUDENT_PROFILE_PICTURE_UPLOAD);
+            String uploadUrl = GoogleCloudStorageHelper.getNewUploadUrl(callbackUrl);
             statusToAdmin = "Created Url successfully: " + uploadUrl;
             return uploadUrl;
         } catch (BlobstoreFailureException e) {
@@ -35,8 +37,7 @@ public class StudentProfileCreateFormUrlAction extends Action {
         } catch (IllegalArgumentException e) {
             // This branch is not tested as this error can and should never occur
             isError = true;
-            log.severe(Const.ActionURIs.STUDENT_PROFILE_PICTURE_UPLOAD
-                       + " was found to be illegal success path. Error: " + e.getMessage());
+            log.severe(callbackUrl + " was found to be illegal success path. Error: " + e.getMessage());
             statusToAdmin = "Failed to create profile picture upload-url: " + e.getMessage();
         }
         return "";

--- a/src/main/java/teammates/ui/controller/StudentProfilePageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentProfilePageAction.java
@@ -25,7 +25,7 @@ public class StudentProfilePageAction extends Action {
             return createRedirectResult(Const.ActionURIs.STUDENT_HOME_PAGE);
         }
 
-        StudentProfilePageData data = new StudentProfilePageData(account, isEditingPhoto);
+        StudentProfilePageData data = new StudentProfilePageData(account, sessionToken, isEditingPhoto);
         statusToAdmin = "studentProfile Page Load <br> Profile: "
                 + SanitizationHelper.sanitizeForHtmlTag(account.studentProfile.toString());
 

--- a/src/main/java/teammates/ui/pagedata/AdminAccountDetailsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminAccountDetailsPageData.java
@@ -6,8 +6,6 @@ import java.util.List;
 import teammates.common.datatransfer.CourseDetailsBundle;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.common.util.Const;
-import teammates.common.util.Url;
 import teammates.ui.template.AdminAccountDetailsInstructorCourseListTableRow;
 import teammates.ui.template.AdminAccountDetailsStudentCourseListTableRow;
 
@@ -17,10 +15,10 @@ public class AdminAccountDetailsPageData extends PageData {
     private List<AdminAccountDetailsInstructorCourseListTableRow> instructorCourseListTable;
     private List<AdminAccountDetailsStudentCourseListTableRow> studentCourseListTable;
 
-    public AdminAccountDetailsPageData(AccountAttributes account, AccountAttributes accountInformation,
+    public AdminAccountDetailsPageData(AccountAttributes account, String sessionToken, AccountAttributes accountInformation,
                                        List<CourseDetailsBundle> instructorCourseList,
                                        List<CourseAttributes> studentCourseList) {
-        super(account);
+        super(account, sessionToken);
         this.accountInformation = accountInformation;
         this.instructorCourseListTable = createInstructorCourseListTable(instructorCourseList);
         this.studentCourseListTable = createStudentCourseListTable(studentCourseList);
@@ -34,8 +32,8 @@ public class AdminAccountDetailsPageData extends PageData {
         if (studentCourseList != null) {
             for (CourseAttributes courseDetails : studentCourseList) {
                 AdminAccountDetailsStudentCourseListTableRow row =
-                        new AdminAccountDetailsStudentCourseListTableRow(
-                                                        accountInformation.googleId, courseDetails);
+                        new AdminAccountDetailsStudentCourseListTableRow(accountInformation.googleId, courseDetails,
+                                getSessionToken());
                 courseListTable.add(row);
             }
         }
@@ -49,8 +47,8 @@ public class AdminAccountDetailsPageData extends PageData {
                 new ArrayList<AdminAccountDetailsInstructorCourseListTableRow>();
         if (instructorCourseList != null) {
             for (CourseDetailsBundle courseDetails : instructorCourseList) {
-                AdminAccountDetailsInstructorCourseListTableRow row =
-                        new AdminAccountDetailsInstructorCourseListTableRow(accountInformation.googleId, courseDetails);
+                AdminAccountDetailsInstructorCourseListTableRow row = new AdminAccountDetailsInstructorCourseListTableRow(
+                        accountInformation.googleId, courseDetails, getSessionToken());
                 courseListTable.add(row);
             }
         }
@@ -68,22 +66,6 @@ public class AdminAccountDetailsPageData extends PageData {
 
     public List<AdminAccountDetailsStudentCourseListTableRow> getStudentCourseListTable() {
         return studentCourseListTable;
-    }
-
-    public static String getAdminDeleteInstructorFromCourseLink(String instructorId, String courseId) {
-        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, instructorId);
-        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
-
-        return link;
-    }
-
-    public static String getAdminDeleteStudentFromCourseLink(String studentId, String courseId) {
-        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_ID, studentId);
-        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
-
-        return link;
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/AdminAccountManagementPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminAccountManagementPageData.java
@@ -6,8 +6,6 @@ import java.util.Map;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.util.Const;
-import teammates.common.util.Url;
 import teammates.ui.template.AdminAccountManagementAccountTableRow;
 
 public class AdminAccountManagementPageData extends PageData {
@@ -16,11 +14,11 @@ public class AdminAccountManagementPageData extends PageData {
     // By default the testing accounts should not be shown
     private boolean isToShowAll;
 
-    public AdminAccountManagementPageData(AccountAttributes account,
+    public AdminAccountManagementPageData(AccountAttributes account, String sessionToken,
                                           Map<String, AccountAttributes> instructorAccountsTable,
                                           Map<String, ArrayList<InstructorAttributes>> instructorCoursesTable,
                                           boolean isToShowAll) {
-        super(account);
+        super(account, sessionToken);
         this.isToShowAll = isToShowAll;
         accountTable = createAccountTable(instructorAccountsTable, instructorCoursesTable);
     }
@@ -40,7 +38,8 @@ public class AdminAccountManagementPageData extends PageData {
 
             ArrayList<InstructorAttributes> coursesList = instructorCoursesTable.get(key);
 
-            AdminAccountManagementAccountTableRow row = new AdminAccountManagementAccountTableRow(acc, coursesList);
+            AdminAccountManagementAccountTableRow row =
+                    new AdminAccountManagementAccountTableRow(acc, coursesList, getSessionToken());
             table.add(row);
         }
 
@@ -49,31 +48,6 @@ public class AdminAccountManagementPageData extends PageData {
 
     public List<AdminAccountManagementAccountTableRow> getAccountTable() {
         return accountTable;
-    }
-
-    public static String getAdminViewAccountDetailsLink(String googleId) {
-        String link = Const.ActionURIs.ADMIN_ACCOUNT_DETAILS_PAGE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, googleId);
-        return link;
-    }
-
-    public static String getAdminDeleteInstructorStatusLink(String googleId) {
-        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, googleId);
-        return link;
-    }
-
-    public static String getAdminDeleteAccountLink(String googleId) {
-        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, googleId);
-        link = Url.addParamToUrl(link, "account", "true");
-        return link;
-    }
-
-    public static String getInstructorHomePageViewLink(String googleId) {
-        String link = Const.ActionURIs.INSTRUCTOR_HOME_PAGE;
-        link = Url.addParamToUrl(link, Const.ParamsNames.USER_ID, googleId);
-        return link;
     }
 
     public boolean isTestingAccount(AccountAttributes account) {

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -54,8 +54,8 @@ public class AdminActivityLogPageData extends PageData {
     private String statusForAjax;
     private QueryParameters q;
 
-    public AdminActivityLogPageData(AccountAttributes account) {
-        super(account);
+    public AdminActivityLogPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
         setDefaultLogSearchPeriod();
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminEmailComposePageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailComposePageData.java
@@ -12,8 +12,8 @@ public class AdminEmailComposePageData extends AdminEmailPageData {
 
     public AdminEmailAttributes emailToEdit;
 
-    public AdminEmailComposePageData(AccountAttributes account) {
-        super(account);
+    public AdminEmailComposePageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
         state = AdminEmailPageState.COMPOSE;
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData.java
@@ -8,8 +8,8 @@ public class AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData extends
     public String ajaxStatus;
 
     public AdminEmailCreateGroupReceiverListUploadUrlAjaxPageData(
-            AccountAttributes account) {
-        super(account);
+            AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/AdminEmailDraftPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailDraftPageData.java
@@ -8,8 +8,8 @@ import teammates.common.datatransfer.attributes.AdminEmailAttributes;
 public class AdminEmailDraftPageData extends AdminEmailPageData {
     public List<AdminEmailAttributes> draftEmailList;
 
-    public AdminEmailDraftPageData(AccountAttributes account) {
-        super(account);
+    public AdminEmailDraftPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
         this.state = AdminEmailPageState.DRAFT;
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminEmailLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailLogPageData.java
@@ -26,8 +26,9 @@ public class AdminEmailLogPageData extends PageData {
     private String statusForAjax;
     private QueryParameters q;
 
-    public AdminEmailLogPageData(AccountAttributes account, String filterQuery, boolean shouldShowAll) {
-        super(account);
+    public AdminEmailLogPageData(AccountAttributes account, String sessionToken, String filterQuery,
+            boolean shouldShowAll) {
+        super(account, sessionToken);
         this.filterQuery = filterQuery;
         this.shouldShowAll = shouldShowAll;
     }

--- a/src/main/java/teammates/ui/pagedata/AdminEmailPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailPageData.java
@@ -24,8 +24,8 @@ public abstract class AdminEmailPageData extends PageData {
         COMPOSE, SENT, TRASH, DRAFT
     }
 
-    protected AdminEmailPageData(AccountAttributes account) {
-        super(account);
+    protected AdminEmailPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init() {
@@ -111,7 +111,7 @@ public abstract class AdminEmailPageData extends PageData {
         String addressReceiver = ae.getAddressReceiver().size() > 0 ? ae.getAddressReceiver().get(0) : "";
         String groupReceiver = ae.getGroupReceiver().size() > 0 ? ae.getGroupReceiver().get(0) : "";
 
-        return new AdminSentEmailRow(emailId, new AdminEmailActions(emailId, "sentpage"), addressReceiver,
+        return new AdminSentEmailRow(emailId, new AdminEmailActions(emailId, "sentpage", getSessionToken()), addressReceiver,
                                         groupReceiver, ae.getSubject(), ae.getSendDateForDisplay());
     }
 
@@ -144,8 +144,8 @@ public abstract class AdminEmailPageData extends PageData {
         String addressReceiver = ae.getAddressReceiver().size() > 0 ? ae.getAddressReceiver().get(0) : "";
         String groupReceiver = ae.getGroupReceiver().size() > 0 ? ae.getGroupReceiver().get(0) : "";
 
-        return new AdminDraftEmailRow(emailId, new AdminEmailActions(emailId, "draftpage"), addressReceiver,
-                                        groupReceiver, ae.getSubject(), ae.getCreateDateForDisplay());
+        return new AdminDraftEmailRow(emailId, new AdminEmailActions(emailId, "draftpage", getSessionToken()),
+                                      addressReceiver, groupReceiver, ae.getSubject(), ae.getCreateDateForDisplay());
     }
 
     // Trash email table
@@ -185,7 +185,7 @@ public abstract class AdminEmailPageData extends PageData {
         String addressReceiver = ae.getAddressReceiver().size() > 0 ? ae.getAddressReceiver().get(0) : "";
         String groupReceiver = ae.getGroupReceiver().size() > 0 ? ae.getGroupReceiver().get(0) : "";
 
-        return new AdminTrashEmailRow(emailId, new AdminTrashEmailActions(emailId), addressReceiver,
+        return new AdminTrashEmailRow(emailId, new AdminTrashEmailActions(emailId, getSessionToken()), addressReceiver,
                                         groupReceiver, ae.getSubject(), ae.getSendDateForDisplay());
     }
 }

--- a/src/main/java/teammates/ui/pagedata/AdminEmailSentPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailSentPageData.java
@@ -8,8 +8,8 @@ import teammates.common.datatransfer.attributes.AdminEmailAttributes;
 public class AdminEmailSentPageData extends AdminEmailPageData {
     public List<AdminEmailAttributes> adminSentEmailList;
 
-    public AdminEmailSentPageData(AccountAttributes account) {
-        super(account);
+    public AdminEmailSentPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
         this.state = AdminEmailPageState.SENT;
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminEmailTrashPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailTrashPageData.java
@@ -10,14 +10,15 @@ import teammates.common.util.Url;
 public class AdminEmailTrashPageData extends AdminEmailPageData {
     public List<AdminEmailAttributes> adminTrashEmailList;
 
-    public AdminEmailTrashPageData(AccountAttributes account) {
-        super(account);
+    public AdminEmailTrashPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
         this.state = AdminEmailPageState.TRASH;
     }
 
     public String getEmptyTrashBinActionUrl() {
-        return Url.addParamToUrl(Const.ActionURIs.ADMIN_EMAIL_TRASH_DELETE,
-                                 Const.ParamsNames.ADMIN_EMAIL_EMPTY_TRASH_BIN,
-                                 "true");
+        String url = Const.ActionURIs.ADMIN_EMAIL_TRASH_DELETE;
+        url = Url.addParamToUrl(url, Const.ParamsNames.ADMIN_EMAIL_EMPTY_TRASH_BIN, "true");
+        url = addSessionTokenToUrl(url);
+        return url;
     }
 }

--- a/src/main/java/teammates/ui/pagedata/AdminHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminHomePageData.java
@@ -14,8 +14,8 @@ public class AdminHomePageData extends PageData {
     // e.g: "Instructor1 \t instructor1@test.com \t NUS"
     public String instructorDetailsSingleLine;
 
-    public AdminHomePageData(AccountAttributes account) {
-        super(account);
+    public AdminHomePageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public String getInstructorShortName() {

--- a/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
@@ -59,8 +59,8 @@ public class AdminSearchPageData extends PageData {
     private AdminSearchInstructorTable instructorTable;
     private AdminSearchStudentTable studentTable;
 
-    public AdminSearchPageData(AccountAttributes account) {
-        super(account);
+    public AdminSearchPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init() {

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -28,8 +28,8 @@ public class AdminSessionsPageData extends PageData {
     private List<InstitutionPanel> institutionPanels;
     private AdminFilter filter;
 
-    public AdminSessionsPageData(AccountAttributes account) {
-        super(account);
+    public AdminSessionsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
 
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminStudentGoogleIdResetPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminStudentGoogleIdResetPageData.java
@@ -9,8 +9,8 @@ public class AdminStudentGoogleIdResetPageData extends PageData {
     public boolean isGoogleIdReset;
     public String statusForAjax;
 
-    public AdminStudentGoogleIdResetPageData(AccountAttributes account) {
-        super(account);
+    public AdminStudentGoogleIdResetPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/CourseStatsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/CourseStatsPageData.java
@@ -6,7 +6,7 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 public class CourseStatsPageData extends PageData {
     public CourseDetailsBundle courseDetails;
 
-    public CourseStatsPageData(AccountAttributes account) {
-        super(account);
+    public CourseStatsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 }

--- a/src/main/java/teammates/ui/pagedata/CreateImageUploadUrlAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/CreateImageUploadUrlAjaxPageData.java
@@ -9,7 +9,7 @@ public class CreateImageUploadUrlAjaxPageData extends PageData {
     public String nextUploadUrl;
     public String ajaxStatus;
 
-    public CreateImageUploadUrlAjaxPageData(AccountAttributes account) {
-        super(account);
+    public CreateImageUploadUrlAjaxPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 }

--- a/src/main/java/teammates/ui/pagedata/FeedbackSessionStatsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/FeedbackSessionStatsPageData.java
@@ -6,7 +6,7 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 public class FeedbackSessionStatsPageData extends PageData {
     public FeedbackSessionDetailsBundle sessionDetails;
 
-    public FeedbackSessionStatsPageData(AccountAttributes account) {
-        super(account);
+    public FeedbackSessionStatsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 }

--- a/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
@@ -32,8 +32,8 @@ public class FeedbackSubmissionEditPageData extends PageData {
     private String submitAction;
     private List<StudentFeedbackSubmissionEditQuestionsWithResponses> questionsWithResponses;
 
-    public FeedbackSubmissionEditPageData(AccountAttributes account, StudentAttributes student) {
-        super(account, student);
+    public FeedbackSubmissionEditPageData(AccountAttributes account, StudentAttributes student, String sessionToken) {
+        super(account, student, sessionToken);
         isPreview = false;
         isModeration = false;
         isShowRealQuestionNumber = false;

--- a/src/main/java/teammates/ui/pagedata/FileUploadPageData.java
+++ b/src/main/java/teammates/ui/pagedata/FileUploadPageData.java
@@ -10,8 +10,8 @@ public class FileUploadPageData extends PageData {
     public String fileSrcUrl;
     public String ajaxStatus;
 
-    public FileUploadPageData(AccountAttributes account) {
-        super(account);
+    public FileUploadPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorCommentsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCommentsPageData.java
@@ -31,8 +31,8 @@ public class InstructorCommentsPageData extends PageData {
 
     private List<CommentsForStudentsTable> commentsForStudentsTables;
 
-    public InstructorCommentsPageData(AccountAttributes account) {
-        super(account);
+    public InstructorCommentsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(boolean isViewingDraft, boolean isDisplayArchive, String courseId, String courseName,
@@ -73,6 +73,10 @@ public class InstructorCommentsPageData extends PageData {
 
     public List<CommentsForStudentsTable> getCommentsForStudentsTables() {
         return commentsForStudentsTables;
+    }
+
+    public String getStudentCommentClearPendingLink() {
+        return getInstructorStudentCommentClearPendingLink(courseId);
     }
 
     public boolean isDisplayArchive() {

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseDetailsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseDetailsPageData.java
@@ -29,8 +29,8 @@ public class InstructorCourseDetailsPageData extends PageData {
     private List<StudentListSectionData> sections;
     private boolean hasSection;
 
-    public InstructorCourseDetailsPageData(AccountAttributes account) {
-        super(account);
+    public InstructorCourseDetailsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(InstructorAttributes currentInstructor, CourseDetailsBundle courseDetails,
@@ -71,7 +71,7 @@ public class InstructorCourseDetailsPageData extends PageData {
                                             Const.ParamsNames.INSTRUCTOR_PERMISSION_GIVE_COMMENT_IN_SECTIONS);
             this.sections.add(new StudentListSectionData(section, isAllowedToViewStudentInSection,
                                                          isAllowedToModifyStudent, isAllowedToGiveCommentInSection,
-                                                         emailPhotoUrlMapping, account.googleId));
+                                                         emailPhotoUrlMapping, account.googleId, getSessionToken()));
         }
         if (sections.size() == 1) {
             StudentListSectionData section = sections.get(0);

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
@@ -19,11 +19,11 @@ public class InstructorCourseEditPageData extends PageData {
     private CourseEditInstructorPanel addInstructorPanel;
     private ElementTag addInstructorButton;
 
-    public InstructorCourseEditPageData(AccountAttributes account, CourseAttributes course,
+    public InstructorCourseEditPageData(AccountAttributes account, String sessionToken, CourseAttributes course,
                                         List<InstructorAttributes> instructorList,
                                         InstructorAttributes currentInstructor, int instructorToShowIndex,
                                         List<String> sectionNames, List<String> feedbackNames) {
-        super(account);
+        super(account, sessionToken);
         this.course = course;
         this.instructorToShowIndex = instructorToShowIndex;
 

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseEnrollPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseEnrollPageData.java
@@ -9,8 +9,9 @@ public class InstructorCourseEnrollPageData extends PageData {
     private String courseId;
     private String enrollStudents;
 
-    public InstructorCourseEnrollPageData(AccountAttributes account, String courseId, String enrollStudents) {
-        super(account);
+    public InstructorCourseEnrollPageData(AccountAttributes account, String sessionToken, String courseId,
+            String enrollStudents) {
+        super(account, sessionToken);
         this.courseId = courseId;
         this.enrollStudents = enrollStudents;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseEnrollResultPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseEnrollResultPageData.java
@@ -23,10 +23,10 @@ public class InstructorCourseEnrollResultPageData extends PageData {
     private String enrollStudents;
     private List<EnrollResultPanel> enrollResultPanelList;
 
-    public InstructorCourseEnrollResultPageData(AccountAttributes account, String courseId,
+    public InstructorCourseEnrollResultPageData(AccountAttributes account, String sessionToken, String courseId,
                                                 List<StudentAttributes>[] students, boolean hasSection,
                                                 String enrollStudents) {
-        super(account);
+        super(account, sessionToken);
         this.courseId = courseId;
         this.students = students;
         this.hasSection = hasSection;

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseJoinConfirmationPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseJoinConfirmationPageData.java
@@ -9,8 +9,9 @@ public class InstructorCourseJoinConfirmationPageData extends PageData {
     private String regkey;
     private String institute;
 
-    public InstructorCourseJoinConfirmationPageData(AccountAttributes account, String regkey, String institute) {
-        super(account);
+    public InstructorCourseJoinConfirmationPageData(AccountAttributes account, String sessionToken, String regkey,
+            String institute) {
+        super(account, sessionToken);
         this.regkey = regkey;
         this.institute = institute;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseStudentDetailsEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseStudentDetailsEditPageData.java
@@ -9,15 +9,15 @@ public class InstructorCourseStudentDetailsEditPageData extends InstructorCourse
     private boolean isOpenOrPublishedEmailSentForTheCourse;
 
     public InstructorCourseStudentDetailsEditPageData(
-            AccountAttributes account, StudentAttributes student, boolean hasSection,
+            AccountAttributes account, String sessionToken, StudentAttributes student, boolean hasSection,
             boolean isOpenOrPublishedEmailSentForTheCourse) {
-        this(account, student, student.email, hasSection, isOpenOrPublishedEmailSentForTheCourse);
+        this(account, sessionToken, student, student.email, hasSection, isOpenOrPublishedEmailSentForTheCourse);
     }
 
     public InstructorCourseStudentDetailsEditPageData(
-            AccountAttributes account, StudentAttributes student, String newEmail, boolean hasSection,
+            AccountAttributes account, String sessionToken, StudentAttributes student, String newEmail, boolean hasSection,
             boolean isOpenOrPublishedEmailSentForTheCourse) {
-        super(account, student, null, false, hasSection, null);
+        super(account, sessionToken, student, null, false, hasSection, null);
         this.newEmail = newEmail;
         this.isOpenOrPublishedEmailSentForTheCourse = isOpenOrPublishedEmailSentForTheCourse;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseStudentDetailsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseStudentDetailsPageData.java
@@ -12,10 +12,10 @@ public class InstructorCourseStudentDetailsPageData extends PageData {
     private StudentInfoTable studentInfoTable;
     private String commentRecipient;
 
-    public InstructorCourseStudentDetailsPageData(AccountAttributes account, StudentAttributes student,
+    public InstructorCourseStudentDetailsPageData(AccountAttributes account, String sessionToken, StudentAttributes student,
             StudentProfileAttributes studentProfile, boolean isAbleToAddComment, boolean hasSection,
             String commentRecipient) {
-        super(account);
+        super(account, sessionToken);
         if (studentProfile != null) {
             String pictureUrl = getPictureUrl(studentProfile.pictureKey);
             this.studentProfile = new StudentProfile(student.name, studentProfile, pictureUrl);

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -30,8 +30,8 @@ public class InstructorCoursesPageData extends PageData {
     private String courseNameToShow;
     private Map<String, InstructorAttributes> instructorsForCourses;
 
-    public InstructorCoursesPageData(AccountAttributes account) {
-        super(account);
+    public InstructorCoursesPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(List<CourseAttributes> activeCoursesParam, List<CourseAttributes> archivedCoursesParam,

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditCopyData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditCopyData.java
@@ -12,9 +12,9 @@ public class InstructorFeedbackEditCopyData extends PageData {
     public final String redirectUrl;
     public final String errorMessage;
 
-    public InstructorFeedbackEditCopyData(AccountAttributes account,
+    public InstructorFeedbackEditCopyData(AccountAttributes account, String sessionToken,
                                           Url redirectUrl, String errorMessage) {
-        super(account);
+        super(account, sessionToken);
         String redirectUrlAsString = redirectUrl == null ? ""
                                                          : redirectUrl.toString();
         this.redirectUrl = redirectUrlAsString;
@@ -25,14 +25,14 @@ public class InstructorFeedbackEditCopyData extends PageData {
     /**
      * Creates a new {@code InstructorFeedbackEditCopyData} with a redirect url, and without an errorMessage.
      */
-    public InstructorFeedbackEditCopyData(AccountAttributes account, Url redirectUrl) {
-        this(account, redirectUrl, null);
+    public InstructorFeedbackEditCopyData(AccountAttributes account, String sessionToken, Url redirectUrl) {
+        this(account, sessionToken, redirectUrl, null);
     }
 
     /**
      * Creates a new {@code InstructorFeedbackEditCopyData} with an error message, and a redirect url of "".
      */
-    public InstructorFeedbackEditCopyData(AccountAttributes account, String errorMessage) {
-        this(account, null, errorMessage);
+    public InstructorFeedbackEditCopyData(AccountAttributes account, String sessionToken, String errorMessage) {
+        this(account, sessionToken, null, errorMessage);
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditCopyPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditCopyPageData.java
@@ -10,9 +10,9 @@ public class InstructorFeedbackEditCopyPageData extends PageData {
     private String courseId;
     private String fsName;
 
-    public InstructorFeedbackEditCopyPageData(AccountAttributes account, List<CourseAttributes> courses,
-                                              String courseId, String fsName) {
-        super(account);
+    public InstructorFeedbackEditCopyPageData(AccountAttributes account, String sessionToken,
+            List<CourseAttributes> courses, String courseId, String fsName) {
+        super(account, sessionToken);
         this.courses = courses;
         this.courseId = courseId;
         this.fsName = fsName;

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackEditPageData.java
@@ -35,8 +35,8 @@ public class InstructorFeedbackEditPageData extends PageData {
     private String statusForAjax;
     private boolean hasError;
 
-    public InstructorFeedbackEditPageData(AccountAttributes account) {
-        super(account);
+    public InstructorFeedbackEditPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(FeedbackSessionAttributes feedbackSession, List<FeedbackQuestionAttributes> questions,

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackQuestionCopyPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackQuestionCopyPageData.java
@@ -14,8 +14,8 @@ public class InstructorFeedbackQuestionCopyPageData extends PageData {
     private final List<FeedbackQuestionAttributes> questions;
 
     public InstructorFeedbackQuestionCopyPageData(
-            AccountAttributes account, List<FeedbackQuestionAttributes> copiableQuestions) {
-        super(account);
+            AccountAttributes account, String sessionToken, List<FeedbackQuestionAttributes> copiableQuestions) {
+        super(account, sessionToken);
         questions = copiableQuestions;
     }
 

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackQuestionVisibilityMessagePageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackQuestionVisibilityMessagePageData.java
@@ -7,7 +7,7 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 public class InstructorFeedbackQuestionVisibilityMessagePageData extends PageData {
     public List<String> visibilityMessage;
 
-    public InstructorFeedbackQuestionVisibilityMessagePageData(AccountAttributes account) {
-        super(account);
+    public InstructorFeedbackQuestionVisibilityMessagePageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackRemindParticularStudentsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackRemindParticularStudentsPageData.java
@@ -9,9 +9,9 @@ public class InstructorFeedbackRemindParticularStudentsPageData extends PageData
     private String fsName;
 
     public InstructorFeedbackRemindParticularStudentsPageData(
-                AccountAttributes account, FeedbackSessionResponseStatus responseStatus,
+                AccountAttributes account, String sessionToken, FeedbackSessionResponseStatus responseStatus,
                 String courseId, String fsName) {
-        super(account);
+        super(account, sessionToken);
         this.responseStatus = responseStatus;
         this.courseId = courseId;
         this.fsName = fsName;

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
@@ -21,8 +21,8 @@ public class InstructorFeedbackResponseCommentAjaxPageData extends PageData {
     public String errorMessage;
     public boolean isError;
 
-    public InstructorFeedbackResponseCommentAjaxPageData(AccountAttributes account) {
-        super(account);
+    public InstructorFeedbackResponseCommentAjaxPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public FeedbackResponseCommentRow getComment() {

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentsLoadPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentsLoadPageData.java
@@ -26,9 +26,10 @@ public class InstructorFeedbackResponseCommentsLoadPageData extends PageData {
     private int feedbackSessionIndex;
     private Map<FeedbackQuestionAttributes, List<InstructorFeedbackResponseComment>> questionCommentsMap;
 
-    public InstructorFeedbackResponseCommentsLoadPageData(AccountAttributes account, int feedbackSessionIndex,
-            int numberOfPendingComments, InstructorAttributes currentInstructor, FeedbackSessionResultsBundle bundle) {
-        super(account);
+    public InstructorFeedbackResponseCommentsLoadPageData(
+            AccountAttributes account, String sessionToken, int feedbackSessionIndex, int numberOfPendingComments,
+            InstructorAttributes currentInstructor, FeedbackSessionResultsBundle bundle) {
+        super(account, sessionToken);
         this.feedbackSessionIndex = feedbackSessionIndex;
         this.numberOfPendingComments = numberOfPendingComments;
         this.instructor = currentInstructor;

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
@@ -87,8 +87,8 @@ public class InstructorFeedbackResultsPageData extends PageData {
     // rather than an enum determining behavior in many methods
     private InstructorFeedbackResultsPageViewType viewType;
 
-    public InstructorFeedbackResultsPageData(AccountAttributes account) {
-        super(account);
+    public InstructorFeedbackResultsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbacksPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbacksPageData.java
@@ -27,8 +27,8 @@ public class InstructorFeedbacksPageData extends PageData {
     private FeedbackSessionsForm newFsForm;
     private FeedbackSessionsCopyFromModal copyFromModal;
 
-    public InstructorFeedbacksPageData(AccountAttributes account) {
-        super(account);
+    public InstructorFeedbacksPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public boolean isUsingAjax() {

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -21,8 +21,8 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
     private CourseTable courseTable;
     private int index;
 
-    public InstructorHomeCourseAjaxPageData(AccountAttributes account) {
-        super(account);
+    public InstructorHomeCourseAjaxPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(int tableIndex, CourseSummaryBundle courseSummary, InstructorAttributes instructor,

--- a/src/main/java/teammates/ui/pagedata/InstructorHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomePageData.java
@@ -14,8 +14,8 @@ public class InstructorHomePageData extends PageData {
     private List<CourseTable> courseTables;
     private String sortCriteria;
 
-    public InstructorHomePageData(AccountAttributes account) {
-        super(account);
+    public InstructorHomePageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(List<CourseSummaryBundle> courseList, String sortCriteria) {

--- a/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
@@ -50,8 +50,8 @@ public class InstructorSearchPageData extends PageData {
     private List<SearchCommentsForResponsesTable> searchCommentsForResponsesTables;
     private List<SearchStudentsTable> searchStudentsTables;
 
-    public InstructorSearchPageData(AccountAttributes account) {
-        super(account);
+    public InstructorSearchPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(CommentSearchResultBundle commentSearchResultBundle,
@@ -297,7 +297,7 @@ public class InstructorSearchPageData extends PageData {
                             section.name, Const.ParamsNames.INSTRUCTOR_PERMISSION_GIVE_COMMENT_IN_SECTIONS);
             rows.add(new StudentListSectionData(section, isAllowedToViewStudentInSection,
                                                 isAllowedToModifyStudent, isAllowedToGiveCommentInSection,
-                                                emailToPhotoUrlMap, account.googleId));
+                                                emailToPhotoUrlMap, account.googleId, getSessionToken()));
         }
         return rows;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorStudentListAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorStudentListAjaxPageData.java
@@ -16,11 +16,12 @@ public class InstructorStudentListAjaxPageData extends PageData {
     private boolean hasSection;
     private List<StudentListSectionData> sections;
 
-    public InstructorStudentListAjaxPageData(AccountAttributes account, String courseId, int courseIndex,
+    public InstructorStudentListAjaxPageData(AccountAttributes account, String sessionToken,
+                                             String courseId, int courseIndex,
                                              boolean hasSection, List<SectionDetailsBundle> sections,
                                              Map<String, Map<String, Boolean>> sectionPrivileges,
                                              Map<String, String> emailPhotoUrlMapping) {
-        super(account);
+        super(account, sessionToken);
         this.courseId = courseId;
         this.courseIndex = courseIndex;
         this.hasSection = hasSection;
@@ -35,7 +36,7 @@ public class InstructorStudentListAjaxPageData extends PageData {
                                             .get(Const.ParamsNames.INSTRUCTOR_PERMISSION_GIVE_COMMENT_IN_SECTIONS);
             sectionsDetails.add(new StudentListSectionData(section, isAllowedToViewStudentInSection,
                                                            isAllowedToModifyStudent, isAllowedToGiveCommentInSection,
-                                                           emailPhotoUrlMapping, account.googleId));
+                                                           emailPhotoUrlMapping, account.googleId, getSessionToken()));
         }
         this.sections = sectionsDetails;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorStudentListPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorStudentListPageData.java
@@ -18,10 +18,10 @@ public class InstructorStudentListPageData extends PageData {
     private List<InstructorStudentListStudentsTableCourse> studentsTable;
     private int numOfCourses;
 
-    public InstructorStudentListPageData(AccountAttributes account, String searchKey,
+    public InstructorStudentListPageData(AccountAttributes account, String sessionToken, String searchKey,
                                          boolean displayArchive,
                                          List<InstructorStudentListPageCourseData> coursesToDisplay) {
-        super(account);
+        super(account, sessionToken);
         this.searchBox = new InstructorStudentListSearchBox(getInstructorSearchLink(), searchKey, account.googleId);
         List<InstructorStudentListFilterCourse> coursesForFilter =
                                         new ArrayList<InstructorStudentListFilterCourse>();

--- a/src/main/java/teammates/ui/pagedata/InstructorStudentRecordsAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorStudentRecordsAjaxPageData.java
@@ -12,9 +12,9 @@ public class InstructorStudentRecordsAjaxPageData extends PageData {
 
     private List<FeedbackResultsTable> resultsTables;
 
-    public InstructorStudentRecordsAjaxPageData(AccountAttributes account, StudentAttributes student,
+    public InstructorStudentRecordsAjaxPageData(AccountAttributes account, StudentAttributes student, String sessionToken,
                                                 List<FeedbackSessionResultsBundle> results) {
-        super(account, student);
+        super(account, student, sessionToken);
         this.resultsTables = new ArrayList<FeedbackResultsTable>();
         for (int i = 0; i < results.size(); i++) {
             FeedbackSessionResultsBundle result = results.get(i);

--- a/src/main/java/teammates/ui/pagedata/InstructorStudentRecordsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorStudentRecordsPageData.java
@@ -27,12 +27,12 @@ public class InstructorStudentRecordsPageData extends PageData {
     private List<CommentsForStudentsTable> commentsForStudentTable;
     private List<String> sessionNames;
 
-    public InstructorStudentRecordsPageData(AccountAttributes account, StudentAttributes student,
+    public InstructorStudentRecordsPageData(AccountAttributes account, StudentAttributes student, String sessionToken,
                                             String courseId, String showCommentBox, StudentProfileAttributes spa,
                                             Map<String, List<CommentAttributes>> giverEmailToCommentsMap,
                                             Map<String, String> giverEmailToGiverNameMap,
                                             List<String> sessionNames, InstructorAttributes instructor) {
-        super(account, student);
+        super(account, student, sessionToken);
         this.courseId = courseId;
         this.studentName = student.name;
         this.studentEmail = student.email;

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -39,18 +39,24 @@ public class PageData {
 
     private List<StatusMessage> statusMessagesToUser;
 
-    public PageData(AccountAttributes account) {
-        this.account = account;
-        this.student = null;
+    private String sessionToken;
+
+    public PageData(AccountAttributes account, String sessionToken) {
+        this(account, null, sessionToken);
     }
 
-    public PageData(AccountAttributes account, StudentAttributes student) {
+    public PageData(AccountAttributes account, StudentAttributes student, String sessionToken) {
         this.account = account;
         this.student = student;
+        this.sessionToken = sessionToken;
     }
 
     public AccountAttributes getAccount() {
         return account;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
     }
 
     public boolean isUnregisteredStudent() {
@@ -79,6 +85,10 @@ public class PageData {
 
     public String addUserIdToUrl(String link) {
         return Url.addParamToUrl(link, Const.ParamsNames.USER_ID, account.googleId);
+    }
+
+    public String addSessionTokenToUrl(String link) {
+        return Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
     }
 
     /**
@@ -377,6 +387,7 @@ public class PageData {
     public String getInstructorFeedbackEditCopyActionLink(String returnUrl) {
         String link = Const.ActionURIs.INSTRUCTOR_FEEDBACK_EDIT_COPY;
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -389,6 +400,7 @@ public class PageData {
                                  isHome ? Const.ActionURIs.INSTRUCTOR_HOME_PAGE
                                         : Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -401,6 +413,7 @@ public class PageData {
                                  isHome ? Const.ActionURIs.INSTRUCTOR_HOME_PAGE
                                         : Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -421,6 +434,7 @@ public class PageData {
         String link = Const.ActionURIs.INSTRUCTOR_STUDENT_COMMENT_CLEAR_PENDING;
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -437,6 +451,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -479,6 +494,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -505,6 +521,7 @@ public class PageData {
     public String getInstructorFeedbackRemindParticularStudentsLink(String returnUrl) {
         String link = Const.ActionURIs.INSTRUCTOR_FEEDBACK_REMIND_PARTICULAR_STUDENTS;
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -515,6 +532,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -525,6 +543,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
         link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, returnUrl);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
 
         return link;
     }
@@ -559,6 +578,7 @@ public class PageData {
         String link = Const.ActionURIs.INSTRUCTOR_COURSE_REMIND;
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -584,6 +604,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_EMAIL, studentEmail);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -592,6 +613,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_EMAIL, studentEmail);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -601,6 +623,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_EMAIL, studentEmail);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -609,6 +632,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_EMAIL, instructorEmail);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 
@@ -617,6 +641,7 @@ public class PageData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
         link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_EMAIL, instructorEmail);
         link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
         return link;
     }
 

--- a/src/main/java/teammates/ui/pagedata/StudentCommentsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentCommentsPageData.java
@@ -36,8 +36,8 @@ public class StudentCommentsPageData extends PageData {
 
     private List<CommentsForStudentsTable> commentsForStudentsTables;
 
-    public StudentCommentsPageData(AccountAttributes account) {
-        super(account);
+    public StudentCommentsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(String courseId, String courseName, List<String> coursePaginationList,

--- a/src/main/java/teammates/ui/pagedata/StudentCourseDetailsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentCourseDetailsPageData.java
@@ -12,8 +12,8 @@ import teammates.ui.template.StudentCourseDetailsPanel;
 public class StudentCourseDetailsPageData extends PageData {
     private StudentCourseDetailsPanel studentCourseDetailsPanel;
 
-    public StudentCourseDetailsPageData(AccountAttributes account) {
-        super(account);
+    public StudentCourseDetailsPageData(AccountAttributes account, String sessionToken) {
+        super(account, sessionToken);
     }
 
     public void init(CourseDetailsBundle courseDetails, List<InstructorAttributes> instructors,

--- a/src/main/java/teammates/ui/pagedata/StudentCourseJoinConfirmationPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentCourseJoinConfirmationPageData.java
@@ -10,10 +10,10 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
     private boolean nextUrlAccessibleWithoutLogin;
     private String courseId;
 
-    public StudentCourseJoinConfirmationPageData(AccountAttributes account, StudentAttributes student,
+    public StudentCourseJoinConfirmationPageData(AccountAttributes account, StudentAttributes student, String sessionToken,
                                                  String confirmUrl, String logoutUrl, boolean redirectResult,
                                                  String courseId, boolean nextUrlAccessibleWithoutLogin) {
-        super(account, student);
+        super(account, student, sessionToken);
         this.confirmUrl = confirmUrl;
         this.logoutUrl = logoutUrl;
         this.redirectResult = redirectResult;

--- a/src/main/java/teammates/ui/pagedata/StudentFeedbackResultsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentFeedbackResultsPageData.java
@@ -26,8 +26,8 @@ public class StudentFeedbackResultsPageData extends PageData {
     private String registerMessage;
     private List<StudentFeedbackResultsQuestionWithResponses> feedbackResultsQuestionsWithResponses;
 
-    public StudentFeedbackResultsPageData(AccountAttributes account, StudentAttributes student) {
-        super(account, student);
+    public StudentFeedbackResultsPageData(AccountAttributes account, StudentAttributes student, String sessionToken) {
+        super(account, student, sessionToken);
     }
 
     public void init(Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponses) {

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -20,10 +20,10 @@ public class StudentHomePageData extends PageData {
 
     private List<CourseTable> courseTables;
 
-    public StudentHomePageData(AccountAttributes account,
+    public StudentHomePageData(AccountAttributes account, String sessionToken,
                                List<CourseDetailsBundle> courses,
                                Map<FeedbackSessionAttributes, Boolean> sessionSubmissionStatusMap) {
-        super(account);
+        super(account, sessionToken);
         setCourseTables(courses, sessionSubmissionStatusMap);
     }
 

--- a/src/main/java/teammates/ui/pagedata/StudentProfileCreateFormUrlAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentProfileCreateFormUrlAjaxPageData.java
@@ -7,8 +7,9 @@ public class StudentProfileCreateFormUrlAjaxPageData extends PageData {
     public String formUrl;
     boolean isError;
 
-    public StudentProfileCreateFormUrlAjaxPageData(AccountAttributes account, String url, boolean hasError) {
-        super(account);
+    public StudentProfileCreateFormUrlAjaxPageData(AccountAttributes account, String sessionToken, String url,
+            boolean hasError) {
+        super(account, sessionToken);
         formUrl = url;
         isError = hasError;
     }

--- a/src/main/java/teammates/ui/pagedata/StudentProfilePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentProfilePageData.java
@@ -11,8 +11,8 @@ public class StudentProfilePageData extends PageData {
     private StudentProfileEditBox profileEditBox;
     private StudentProfileUploadPhotoModal uploadPhotoModal;
 
-    public StudentProfilePageData(AccountAttributes account, String isEditingPhoto) {
-        super(account);
+    public StudentProfilePageData(AccountAttributes account, String sessionToken, String isEditingPhoto) {
+        super(account, sessionToken);
         StudentProfileAttributes profile = account.studentProfile;
         String pictureUrl;
         if (profile.pictureKey.isEmpty()) {

--- a/src/main/java/teammates/ui/template/AdminAccountDetailsInstructorCourseListTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminAccountDetailsInstructorCourseListTableRow.java
@@ -1,16 +1,20 @@
 package teammates.ui.template;
 
 import teammates.common.datatransfer.CourseDetailsBundle;
-import teammates.ui.pagedata.AdminAccountDetailsPageData;
+import teammates.common.util.Const;
+import teammates.common.util.Url;
 
 public class AdminAccountDetailsInstructorCourseListTableRow {
     private String instructorId;
     private CourseDetailsBundle courseDetails;
     private ElementTag removeFromCourseButton;
+    private String sessionToken;
 
-    public AdminAccountDetailsInstructorCourseListTableRow(String instructorId, CourseDetailsBundle courseDetails) {
+    public AdminAccountDetailsInstructorCourseListTableRow(String instructorId, CourseDetailsBundle courseDetails,
+            String sessionToken) {
         this.instructorId = instructorId;
         this.courseDetails = courseDetails;
+        this.sessionToken = sessionToken;
         this.removeFromCourseButton = createRemoveButton();
     }
 
@@ -24,9 +28,17 @@ public class AdminAccountDetailsInstructorCourseListTableRow {
 
     private ElementTag createRemoveButton() {
         String content = "<span class=\"glyphicon glyphicon-trash\"></span>Remove From Course";
-        String href = AdminAccountDetailsPageData.getAdminDeleteInstructorFromCourseLink(instructorId,
-                                                                               courseDetails.course.getId());
+        String href = getAdminDeleteInstructorFromCourseLink();
         return new ElementTag(content, "id", "instructor_" + courseDetails.course.getId(), "class",
                               "btn btn-danger btn-sm", "href", href);
+    }
+
+    private String getAdminDeleteInstructorFromCourseLink() {
+        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, instructorId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseDetails.course.getId());
+        link = Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+
+        return link;
     }
 }

--- a/src/main/java/teammates/ui/template/AdminAccountDetailsStudentCourseListTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminAccountDetailsStudentCourseListTableRow.java
@@ -1,16 +1,20 @@
 package teammates.ui.template;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
-import teammates.ui.pagedata.AdminAccountDetailsPageData;
+import teammates.common.util.Const;
+import teammates.common.util.Url;
 
 public class AdminAccountDetailsStudentCourseListTableRow {
     private String googleId;
     private CourseAttributes courseDetails;
     private ElementTag removeFromCourseButton;
+    private String sessionToken;
 
-    public AdminAccountDetailsStudentCourseListTableRow(String googleId, CourseAttributes courseDetails) {
+    public AdminAccountDetailsStudentCourseListTableRow(String googleId, CourseAttributes courseDetails,
+            String sessionToken) {
         this.googleId = googleId;
         this.courseDetails = courseDetails;
+        this.sessionToken = sessionToken;
         this.removeFromCourseButton = createRemoveButton();
     }
 
@@ -24,8 +28,17 @@ public class AdminAccountDetailsStudentCourseListTableRow {
 
     private ElementTag createRemoveButton() {
         String content = "<span class=\"glyphicon glyphicon-trash\"></span>Remove From Course";
-        String href = AdminAccountDetailsPageData.getAdminDeleteStudentFromCourseLink(googleId, courseDetails.getId());
+        String href = getAdminDeleteStudentFromCourseLink();
         return new ElementTag(content, "id", "student_" + courseDetails.getId(), "class",
                               "btn btn-danger btn-sm", "href", href);
+    }
+
+    private String getAdminDeleteStudentFromCourseLink() {
+        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_ID, googleId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseDetails.getId());
+        link = Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+
+        return link;
     }
 }

--- a/src/main/java/teammates/ui/template/AdminAccountManagementAccountTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminAccountManagementAccountTableRow.java
@@ -4,15 +4,20 @@ import java.util.List;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.Url;
 import teammates.ui.pagedata.AdminAccountManagementPageData;
 
 public class AdminAccountManagementAccountTableRow {
     private AccountAttributes account;
     private List<InstructorAttributes> instructorList;
+    private String sessionToken;
 
-    public AdminAccountManagementAccountTableRow(AccountAttributes account, List<InstructorAttributes> instructorList) {
+    public AdminAccountManagementAccountTableRow(AccountAttributes account, List<InstructorAttributes> instructorList,
+            String sessionToken) {
         this.account = account;
         this.instructorList = instructorList;
+        this.sessionToken = sessionToken;
     }
 
     public AccountAttributes getAccount() {
@@ -24,7 +29,9 @@ public class AdminAccountManagementAccountTableRow {
     }
 
     public String getInstructorHomePageViewLink() {
-        return AdminAccountManagementPageData.getInstructorHomePageViewLink(account.googleId);
+        String link = Const.ActionURIs.INSTRUCTOR_HOME_PAGE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.USER_ID, account.googleId);
+        return link;
     }
 
     public String getCreatedAt() {
@@ -32,14 +39,23 @@ public class AdminAccountManagementAccountTableRow {
     }
 
     public String getAdminViewAccountDetailsLink() {
-        return AdminAccountManagementPageData.getAdminViewAccountDetailsLink(account.googleId);
+        String link = Const.ActionURIs.ADMIN_ACCOUNT_DETAILS_PAGE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, account.googleId);
+        return link;
     }
 
     public String getAdminDeleteInstructorStatusLink() {
-        return AdminAccountManagementPageData.getAdminDeleteInstructorStatusLink(account.googleId);
+        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, account.googleId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+        return link;
     }
 
     public String getAdminDeleteAccountLink() {
-        return AdminAccountManagementPageData.getAdminDeleteAccountLink(account.googleId);
+        String link = Const.ActionURIs.ADMIN_ACCOUNT_DELETE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.INSTRUCTOR_ID, account.googleId);
+        link = Url.addParamToUrl(link, "account", "true");
+        link = Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
+        return link;
     }
 }

--- a/src/main/java/teammates/ui/template/AdminEmailActions.java
+++ b/src/main/java/teammates/ui/template/AdminEmailActions.java
@@ -1,14 +1,15 @@
 package teammates.ui.template;
 
 import teammates.common.util.Const;
+import teammates.common.util.Url;
 
 public class AdminEmailActions {
     private ElementTag editButton;
     private ElementTag deleteButton;
 
-    public AdminEmailActions(String emailId, String currentPage) {
+    public AdminEmailActions(String emailId, String currentPage, String sessionToken) {
         this.editButton = createEditButton(emailId);
-        this.deleteButton = createDeleteButton(emailId, currentPage);
+        this.deleteButton = createDeleteButton(emailId, currentPage, sessionToken);
     }
 
     public ElementTag getEditButton() {
@@ -27,10 +28,12 @@ public class AdminEmailActions {
         return new ElementTag(content, "target", "blank", "href", href);
     }
 
-    private ElementTag createDeleteButton(String emailId, String currentPage) {
+    private ElementTag createDeleteButton(String emailId, String currentPage, String sessionToken) {
         String content = "<span class=\"glyphicon glyphicon-trash\"></span>";
-        String href = Const.ActionURIs.ADMIN_EMAIL_MOVE_TO_TRASH + "?" + Const.ParamsNames.ADMIN_EMAIL_ID
-                        + "=" + emailId + "&" + Const.ParamsNames.ADMIN_EMAIL_TRASH_ACTION_REDIRECT + "=" + currentPage;
+        String href = Const.ActionURIs.ADMIN_EMAIL_MOVE_TO_TRASH;
+        href = Url.addParamToUrl(href, Const.ParamsNames.ADMIN_EMAIL_ID, emailId);
+        href = Url.addParamToUrl(href, Const.ParamsNames.ADMIN_EMAIL_TRASH_ACTION_REDIRECT, currentPage);
+        href = Url.addParamToUrl(href, Const.ParamsNames.SESSION_TOKEN, sessionToken);
 
         return new ElementTag(content, "target", "blank", "href", href);
     }

--- a/src/main/java/teammates/ui/template/AdminTrashEmailActions.java
+++ b/src/main/java/teammates/ui/template/AdminTrashEmailActions.java
@@ -1,14 +1,15 @@
 package teammates.ui.template;
 
 import teammates.common.util.Const;
+import teammates.common.util.Url;
 
 public class AdminTrashEmailActions {
     private ElementTag editButton;
     private ElementTag moveOutOfTrashButton;
 
-    public AdminTrashEmailActions(String emailId) {
+    public AdminTrashEmailActions(String emailId, String sessionToken) {
         this.editButton = createEditButton(emailId);
-        this.moveOutOfTrashButton = createMoveOutOfTrashButton(emailId);
+        this.moveOutOfTrashButton = createMoveOutOfTrashButton(emailId, sessionToken);
     }
 
     public ElementTag getEditButton() {
@@ -27,10 +28,11 @@ public class AdminTrashEmailActions {
         return new ElementTag(content, "target", "blank", "href", href);
     }
 
-    private ElementTag createMoveOutOfTrashButton(String emailId) {
+    private ElementTag createMoveOutOfTrashButton(String emailId, String sessionToken) {
         String content = "<span class=\"glyphicon glyphicon-step-backward\"></span>";
-        String href = Const.ActionURIs.ADMIN_EMAIL_MOVE_OUT_TRASH + "?"
-                          + Const.ParamsNames.ADMIN_EMAIL_ID + "=" + emailId;
+        String href = Const.ActionURIs.ADMIN_EMAIL_MOVE_OUT_TRASH;
+        href = Url.addParamToUrl(href, Const.ParamsNames.ADMIN_EMAIL_ID, emailId);
+        href = Url.addParamToUrl(href, Const.ParamsNames.SESSION_TOKEN, sessionToken);
 
         return new ElementTag(content, "target", "blank", "href", href);
     }

--- a/src/main/java/teammates/ui/template/StudentListSectionData.java
+++ b/src/main/java/teammates/ui/template/StudentListSectionData.java
@@ -17,14 +17,14 @@ public class StudentListSectionData {
 
     public StudentListSectionData(SectionDetailsBundle section, boolean isAllowedToViewStudentInSection,
                                   boolean isAllowedToModifyStudent, boolean isAllowedToGiveCommentInSection,
-                                  Map<String, String> emailPhotoUrlMapping, String googleId) {
+                                  Map<String, String> emailPhotoUrlMapping, String googleId, String sessionToken) {
         this.sectionName = section.name;
         this.allowedToViewStudentInSection = isAllowedToViewStudentInSection;
         this.allowedToModifyStudent = isAllowedToModifyStudent;
         this.allowedToGiveCommentInSection = isAllowedToGiveCommentInSection;
         List<StudentListTeamData> teamsDetails = new ArrayList<StudentListTeamData>();
         for (TeamDetailsBundle team : section.teams) {
-            teamsDetails.add(new StudentListTeamData(team, emailPhotoUrlMapping, googleId));
+            teamsDetails.add(new StudentListTeamData(team, emailPhotoUrlMapping, googleId, sessionToken));
         }
         this.teams = teamsDetails;
     }

--- a/src/main/java/teammates/ui/template/StudentListStudentData.java
+++ b/src/main/java/teammates/ui/template/StudentListStudentData.java
@@ -17,15 +17,17 @@ public class StudentListStudentData {
     private String courseStudentRemindLink;
     private String courseStudentDeleteLink;
     private String courseStudentRecordsLink;
+    private String sessionToken;
 
     public StudentListStudentData(String googleId, String studentName, String studentEmail, String course,
-                                  String studentStatus, String photoUrl) {
+                                  String studentStatus, String photoUrl, String sessionToken) {
         this.studentName = studentName;
         this.studentEmail = studentEmail;
         this.studentStatus = studentStatus;
         this.studentNameForJs = SanitizationHelper.sanitizeForJs(studentName);
         this.courseIdForJs = SanitizationHelper.sanitizeForJs(course);
         this.photoUrl = photoUrl;
+        this.sessionToken = sessionToken;
         this.courseStudentDetailsLink =
                 furnishLinkWithCourseEmailAndUserId(Const.ActionURIs.INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE,
                                                     course, studentEmail, googleId);
@@ -46,6 +48,7 @@ public class StudentListStudentData {
         link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, course);
         link = Url.addParamToUrl(link, Const.ParamsNames.STUDENT_EMAIL, studentEmail);
         link = Url.addParamToUrl(link, Const.ParamsNames.USER_ID, googleId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.SESSION_TOKEN, sessionToken);
         return link;
     }
 

--- a/src/main/java/teammates/ui/template/StudentListTeamData.java
+++ b/src/main/java/teammates/ui/template/StudentListTeamData.java
@@ -12,14 +12,16 @@ public class StudentListTeamData {
     private String teamName;
     private List<StudentListStudentData> students;
 
-    public StudentListTeamData(TeamDetailsBundle team, Map<String, String> emailPhotoUrlMapping, String googleId) {
+    public StudentListTeamData(TeamDetailsBundle team, Map<String, String> emailPhotoUrlMapping, String googleId,
+                               String sessionToken) {
         this.teamName = team.name;
         List<StudentListStudentData> studentsDetails =
                                         new ArrayList<StudentListStudentData>();
         for (StudentAttributes student : team.students) {
             studentsDetails.add(new StudentListStudentData(googleId, student.name, student.email, student.course,
                                                            student.getStudentStatus(),
-                                                           emailPhotoUrlMapping.get(student.email)));
+                                                           emailPhotoUrlMapping.get(student.email),
+                                                           sessionToken));
         }
         this.students = studentsDetails;
     }

--- a/src/main/webapp/WEB-INF/tags/admin/email/compose.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/email/compose.tag
@@ -11,7 +11,8 @@
         <c:if test="${(not empty emailToEdit) and (not empty emailToEdit.sendDate) and (not empty emailToEdit.emailId)}">
             <input type="hidden" value="${emailToEdit.emailId}" name="<%=Const.ParamsNames.ADMIN_EMAIL_ID%>">
         </c:if>
-        
+        <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
+
         To :
         <div class="row">
             <div class="col-md-11">

--- a/src/main/webapp/WEB-INF/tags/instructor/comments/commentsNotifyPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/comments/commentsNotifyPanel.tag
@@ -1,10 +1,10 @@
 <%@ tag description="Panel to notify students of new/edited comments" %>
 <%@ tag import="teammates.common.util.Const" %>
-<%@ attribute name="courseId" required="true" %>
+<%@ attribute name="studentCommentClearPendingLink" required="true" %>
 <%@ attribute name="numberOfPendingComments" required="true" %>
 <div class="btn-group pull-right" style="${numberOfPendingComments==0 ? 'display:none' : ''}">
     <a type="button" class="btn btn-sm btn-info" data-toggle="tooltip" style="margin-right: 17px;"
-        href="<%= Const.ActionURIs.INSTRUCTOR_STUDENT_COMMENT_CLEAR_PENDING %>?<%= Const.ParamsNames.COURSE_ID %>=${courseId}&<%= Const.ParamsNames.USER_ID %>=${data.account.googleId}"
+        href="${studentCommentClearPendingLink}"
         title="Send email notification to ${numberOfPendingComments} recipient(s) of comments pending notification">
         <span class="badge" style="margin-right: 5px">${numberOfPendingComments}</span>
         <span class="glyphicon glyphicon-comment"></span>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/addCoursePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/addCoursePanel.tag
@@ -5,11 +5,13 @@
 <%@ attribute name="googleId" required="true" %>
 <%@ attribute name="courseIdToShow" required="true" %>
 <%@ attribute name="courseNameToShow" required="true" %>
+<%@ attribute name="sessionToken" required="true" %>
 
 <div class="panel panel-primary">
     <div class="panel-body fill-plain">
         <form method="get" action="<%=Const.ActionURIs.INSTRUCTOR_COURSE_ADD%>" name="form_addcourse" class="form form-horizontal">
             <input type="hidden" id="<%=Const.ParamsNames.INSTRUCTOR_ID%>" name="<%=Const.ParamsNames.INSTRUCTOR_ID%>" value="${googleId}">
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${sessionToken}">
             <input type="hidden" name="<%=Const.ParamsNames.USER_ID%>" value="${googleId}">
             <div class="form-group">
                 <label class="col-sm-3 control-label">Course ID:</label>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/commentArea.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/commentArea.tag
@@ -82,6 +82,7 @@
             <input type="hidden" name=<%=Const.ParamsNames.COMMENTS_SHOWRECIPIENTTO%> value="">
             <input type="hidden" name="<%=Const.ParamsNames.USER_ID%>" value="${data.account.googleId}">
             <input type="hidden" name="<%=Const.ParamsNames.FROM_COURSE_DETAILS_PAGE%>" value="true">
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
         </div>
     </form>
 </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
@@ -21,6 +21,7 @@
                 class="form form-horizontal" id="formAddInstructor">
             <input type="hidden" name="<%=Const.ParamsNames.COURSE_ID%>" value="${courseId}">
             <input type="hidden" name="<%=Const.ParamsNames.USER_ID%>" value="${data.account.googleId}">
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
             
             <div id="instructorAddTable">
                 <div class="form-group">

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditCourseInfo.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditCourseInfo.tag
@@ -24,6 +24,7 @@
     <div class="panel-body fill-plain">
         <form action="<%=Const.ActionURIs.INSTRUCTOR_COURSE_EDIT_SAVE%>" method="post" id="formEditcourse" class="form form-horizontal">
             <input type="hidden" name="<%=Const.ParamsNames.COURSE_ID%>" value="${course.id}">
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
             <input type="hidden" name="<%=Const.ParamsNames.INSTRUCTOR_ID%>" value="${data.account.googleId}">
             
             <div class="form-group">

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorListPanelBody.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorListPanelBody.tag
@@ -14,7 +14,8 @@
             <input type="hidden" name="<%=Const.ParamsNames.INSTRUCTOR_ID%>" value="${instructorPanel.instructor.googleId}">
         </c:if>
         <input type="hidden" name="<%=Const.ParamsNames.USER_ID%>" value="${data.account.googleId}">
-    
+        <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
+
         <div id="instructorTable${instructorPanel.index}">
             
             <div class="form-group">

--- a/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetails/studentInformationTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetails/studentInformationTable.tag
@@ -203,6 +203,7 @@
             <input type="hidden" name="<%=Const.ParamsNames.COMMENTS_SHOWRECIPIENTTO%>" value="">
             <input type="hidden" name="<%=Const.ParamsNames.USER_ID%>" value="${data.account.googleId}">
             <input type="hidden" name="<%=Const.ParamsNames.FROM_STUDENT_DETAILS_PAGE%>" value="true">
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
         </div>
     </form>
 </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetailsEdit/studentInformationTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetailsEdit/studentInformationTable.tag
@@ -5,6 +5,7 @@
 <%@ attribute name="studentInfoTable" type="teammates.ui.template.StudentInfoTable" required="true" %>
 <%@ attribute name="newEmail" required="true" %>
 <%@ attribute name="openOrPublishedEmailSentForTheCourse" required="true" %>
+<%@ attribute name="sessionToken" required="true" %>
 <%@ tag import="teammates.common.util.Const" %>
 <div class="panel panel-primary">
     <div class="panel-body fill-plain">
@@ -12,7 +13,8 @@
             <input type="hidden" name="<%=Const.ParamsNames.COURSE_ID%>" value="${studentInfoTable.course}">
             <input type="hidden" name="<%=Const.ParamsNames.SESSION_SUMMARY_EMAIL_SEND_CHECK %>" value="false">
             <input type="hidden" id="<%=Const.ParamsNames.OPEN_OR_PUBLISHED_EMAIL_SEND_CHECK %>" name="openorpublishedemailsent" value="${openOrPublishedEmailSentForTheCourse}">
-            <div class="form-group"> 
+            <input type="hidden" name="<%=Const.ParamsNames.SESSION_TOKEN%>" value="${sessionToken}">
+            <div class="form-group">
                 <label class="col-sm-1 control-label">Student Name:</label>
                 <div class="col-sm-11">
                     <input class="form-control" name="<%=Const.ParamsNames.STUDENT_NAME%>" 

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/copyQuestionModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/copyQuestionModal.tag
@@ -21,6 +21,7 @@
                     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${feedbackSessionName}">
                     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
                     <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${courseId}">
+                    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
                 </form>
                 <div id="question-copy-modal-status"></div>
             </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/newQuestionForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/newQuestionForm.tag
@@ -141,4 +141,5 @@
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_GENERATEDOPTIONS %>"
         value="<%= FeedbackParticipantType.NONE.toString() %>"
         id="<%= Const.ParamsNames.FEEDBACK_QUESTION_GENERATEDOPTIONS %>">
+    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
 </form>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbackEdit/questionEditForm.tag
@@ -128,5 +128,6 @@
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO %>" >
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO %>" >
     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
 </form>
 <br><br>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/copyFromModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/copyFromModal.tag
@@ -71,6 +71,8 @@
                         value="" id="modalCourseId">
                     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>"
                         value="${data.account.googleId }">
+                    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>"
+                        value="${data.sessionToken}">
                 </form>
             </div>
             <div class="modal-footer margin-0">

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsForm.tag
@@ -277,5 +277,6 @@
         <input type="hidden"
             name="<%= Const.ParamsNames.USER_ID %>"
             value="${data.account.googleId}">
+        <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN%>" value="${data.sessionToken}">
     </form>
 </div>

--- a/src/main/webapp/WEB-INF/tags/shared/commentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/commentRow.tag
@@ -294,6 +294,7 @@
             <input type="hidden" name="<%= Const.ParamsNames.COMMENTS_SHOWGIVERTO %>" value="${comment.showGiverNameToString}">
             <input type="hidden" name="<%= Const.ParamsNames.COMMENTS_SHOWRECIPIENTTO %>" value="${comment.showRecipientNameToString}">
             <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+            <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
         </form>
     </c:if>
 </li>

--- a/src/main/webapp/WEB-INF/tags/shared/commentsPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/commentsPanel.tag
@@ -193,6 +193,7 @@
                                     <input type="hidden" name="<%= Const.ParamsNames.COMMENTS_SHOWGIVERTO %>" value="">
                                     <input type="hidden" name="<%= Const.ParamsNames.COMMENTS_SHOWRECIPIENTTO %>" value="">
                                     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.googleId}">
+                                    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
                                 </div>
                             </form>
                         </li>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
@@ -216,4 +216,5 @@
     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
     <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWCOMMENTSTO %>" value="${frc.showCommentToString}">
     <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWGIVERTO %>" value="${frc.showGiverNameToString}">
+    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
 </form>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
@@ -74,6 +74,7 @@
                 <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
                 <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
                 <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+                <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
             </form>
             <a type="button"
                id="commentedit-${divId}"

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
@@ -9,6 +9,7 @@
 <form method="post" name="form_submit_response" action="${data.submitAction}">
     <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${data.bundle.feedbackSession.feedbackSessionName}">
     <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${data.bundle.feedbackSession.courseId}">
+    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
     
     <c:choose>
         <c:when test="${not empty data.account.googleId}">

--- a/src/main/webapp/WEB-INF/tags/student/profile/studentProfileDiv.tag
+++ b/src/main/webapp/WEB-INF/tags/student/profile/studentProfileDiv.tag
@@ -2,6 +2,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ tag import="teammates.common.util.Const" %>
 <%@ attribute name="profile" type="teammates.ui.template.StudentProfileEditBox" required="true" %>
+<%@ attribute name="sessionToken" required="true" %>
 <c:set var="MALE" value="<%= Const.GenderTypes.MALE %>" />
 <c:set var="FEMALE" value="<%= Const.GenderTypes.FEMALE %>" />
 <c:set var="OTHER" value="<%= Const.GenderTypes.OTHER %>" />
@@ -159,5 +160,6 @@
             <i>* This profile will be visible to all your Instructors and Coursemates</i>
         </p>
         <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${profile.googleId}">
+        <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
     </form>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/profile/uploadPhotoModal.tag
+++ b/src/main/webapp/WEB-INF/tags/student/profile/uploadPhotoModal.tag
@@ -2,6 +2,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ tag import="teammates.common.util.Const" %>
 <%@ attribute name="modal" type="teammates.ui.template.StudentProfileUploadPhotoModal" required="true" %>
+<%@ attribute name="sessionToken" required="true" %>
 <c:set var="DEFAULT_PROFILE_PICTURE_PATH" value="<%= Const.SystemParams.DEFAULT_PROFILE_PICTURE_PATH %>" />
 <div class="modal fade"
      id="studentPhotoUploader"
@@ -109,6 +110,7 @@
                                     <input id="rotate" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_ROTATE %>" value="">
                                     <input id="blobKey" type="hidden" name="<%= Const.ParamsNames.BLOB_KEY %>" value="${modal.pictureKey}">
                                     <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${modal.googleId}">
+                                    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
                                     <button type="button"
                                             id="profileEditPictureSubmit"
                                             class="btn btn-primary">

--- a/src/main/webapp/invalidOrigin.jsp
+++ b/src/main/webapp/invalidOrigin.jsp
@@ -16,6 +16,9 @@
                 <li>
                     Enable the HTTP referrer setting in your browser if you previously disabled it.
                 </li>
+                <li>
+                    Enable cookies in your browser.
+                </li>
             </ul>
             <br>
         </div>

--- a/src/main/webapp/js/adminEmail.es6
+++ b/src/main/webapp/js/adminEmail.es6
@@ -1,4 +1,4 @@
-/* global StatusType:false setStatusMessage:false toggleSort:false richTextEditorBuilder:false */
+/* global StatusType:false setStatusMessage:false toggleSort:false richTextEditorBuilder:false makeCsrfTokenParam:false */
 
 // Form input placeholders
 const PLACEHOLDER_IMAGE_UPLOAD_ALT_TEXT = 'Please enter an alt text for the image';
@@ -16,7 +16,7 @@ function showUploadingGif() {
 function createGroupReceiverListUploadUrl() {
     $.ajax({
         type: 'POST',
-        url: '/admin/adminEmailCreateGroupReceiverListUploadUrl',
+        url: `/admin/adminEmailCreateGroupReceiverListUploadUrl?${makeCsrfTokenParam()}`,
         beforeSend() {
             showUploadingGif();
         },
@@ -132,7 +132,7 @@ function submitImageUploadFormAjax() {
 function createImageUploadUrl() {
     $.ajax({
         type: 'POST',
-        url: '/admin/adminEmailCreateImageUploadUrl',
+        url: `/admin/adminEmailCreateImageUploadUrl?${makeCsrfTokenParam()}`,
         beforeSend() {
             showUploadingGif();
         },
@@ -181,7 +181,7 @@ $(document).ready(() => {
     });
 
     $('#composeSaveButton').on('click', () => {
-        $('#adminEmailMainForm').attr('action', '/admin/adminEmailComposeSave');
+        $('#adminEmailMainForm').attr('action', `/admin/adminEmailComposeSave?${makeCsrfTokenParam()}`);
         $('#composeSubmitButton').click();
     });
 

--- a/src/main/webapp/js/adminHome.es6
+++ b/src/main/webapp/js/adminHome.es6
@@ -1,4 +1,4 @@
-/* global encodeHtmlString:false */
+/* global encodeHtmlString:false makeCsrfTokenParam:false */
 /**
  * Functions defined and used in `/adminHome`
  */
@@ -96,7 +96,7 @@ function addInstructorAjax(isError, data) {
 function addInstructorByAjaxRecursively() {
     $.ajax({
         type: 'POST',
-        url: `/admin/adminInstructorAccountAdd?${paramsList[paramsCounter]}`,
+        url: `/admin/adminInstructorAccountAdd?${makeCsrfTokenParam()}&${paramsList[paramsCounter]}`,
         beforeSend: disableAddInstructorForm,
         error() {
             addInstructorAjax(true, null);

--- a/src/main/webapp/js/adminSearch.es6
+++ b/src/main/webapp/js/adminSearch.es6
@@ -1,4 +1,4 @@
-/* global highlightSearchResult:false StatusType:false setStatusMessage:false */
+/* global highlightSearchResult:false StatusType:false setStatusMessage:false makeCsrfTokenParam:false */
 
 $(document).ready(() => {
     $('.fslink').hide();
@@ -67,7 +67,7 @@ function submitResetGoogleIdAjaxRequest(studentCourseId, studentEmail, wrongGoog
 
     $.ajax({
         type: 'POST',
-        url: `/admin/adminStudentGoogleIdReset?${params}`,
+        url: `/admin/adminStudentGoogleIdReset?${makeCsrfTokenParam()}&${params}`,
         beforeSend() {
             $(button).html("<img src='/images/ajax-loader.gif'/>");
         },

--- a/src/main/webapp/js/common.es6
+++ b/src/main/webapp/js/common.es6
@@ -1083,3 +1083,24 @@ $(document).on('ajaxComplete ready', () => {
         }
     });
 });
+
+/**
+ * Returns the value of a cookie given its name.
+ * Returns null if the cookie is not set.
+ */
+function getCookie(cookieNameToFind) {
+    const cookies = document.cookie.split('; ').map(s => s.split('='));
+
+    for (let i = 0; i < cookies.length; i += 1) {
+        const cookieName = cookies[i][0];
+        const cookieValue = cookies[i][1];
+
+        // the cookie was found in the ith iteration
+        if (cookieName === cookieNameToFind) {
+            return cookieValue;
+        }
+    }
+
+    // the cookie was not found
+    return null;
+}

--- a/src/main/webapp/js/crypto.es6
+++ b/src/main/webapp/js/crypto.es6
@@ -1,0 +1,13 @@
+/* global getCookie:false */
+
+function makeCsrfTokenParam() {
+    const tokenParamName = 'token';
+    const tokenCookieName = 'token';
+    const tokenCookieValue = getCookie(tokenCookieName);
+
+    return `${tokenParamName}=${tokenCookieValue}`;
+}
+
+/*
+exported makeCsrfTokenParam
+*/

--- a/src/main/webapp/js/instructorFeedbackEdit.es6
+++ b/src/main/webapp/js/instructorFeedbackEdit.es6
@@ -9,6 +9,7 @@ setStatusMessage:false, clearStatusMessages:false, fixContribQnGiverRecipient:fa
 showVisibilityCheckboxesIfCustomOptionSelected:false, hasAssignedWeights:false, disallowNonNumericEntries:false
 getVisibilityMessage:false, hideConstSumOptionTable:false, setDefaultContribQnVisibilityIfNeeded:false
 hideRankOptionTable:false, matchVisibilityOptionToFeedbackPath:false prepareDatepickers:false prepareInstructorPages:false
+makeCsrfTokenParam:false
 
 FEEDBACK_SESSION_PUBLISHDATE:false, FEEDBACK_SESSION_PUBLISHTIME:false, FEEDBACK_SESSION_VISIBLEDATE:false
 FEEDBACK_SESSION_VISIBLETIME:false, FEEDBACK_QUESTION_DESCRIPTION:false, FEEDBACK_QUESTION_EDITTEXT:false
@@ -81,7 +82,7 @@ function bindFeedbackSessionEditFormSubmission() {
         const $form = $(event.target);
         // Use Ajax to submit form data
         $.ajax({
-            url: '/page/instructorFeedbackEditSave',
+            url: `/page/instructorFeedbackEditSave?${makeCsrfTokenParam()}`,
             type: 'POST',
             data: $form.serialize(),
             beforeSend() {

--- a/src/main/webapp/js/studentProfile.es6
+++ b/src/main/webapp/js/studentProfile.es6
@@ -1,4 +1,5 @@
-/* global setStatusMessage:false StatusType:false scrollToTop:false bindLinksInUnregisteredPage:false */
+/* global setStatusMessage:false StatusType:false scrollToTop:false bindLinksInUnregisteredPage:false
+   makeCsrfTokenParam:false */
 
 function finaliseEditPictureForm() {
     const picture = $('#editableProfilePicture');
@@ -23,7 +24,7 @@ function finaliseUploadPictureForm() {
 
     const initialSubmitMessage = $('#profileUploadPictureSubmit').html();
     $.ajax({
-        url: `/page/studentProfileCreateFormUrl?user=${$("input[name='user']").val()}`,
+        url: `/page/studentProfileCreateFormUrl?${makeCsrfTokenParam()}&user=${$("input[name='user']").val()}`,
         beforeSend() {
             $('#profileUploadPictureSubmit').html('<img src="/images/ajax-loader.gif">');
         },

--- a/src/main/webapp/jsp/adminEmail.jsp
+++ b/src/main/webapp/jsp/adminEmail.jsp
@@ -8,6 +8,7 @@
 <c:set var="jsIncludes">
     <script type="text/javascript" src="<%= FrontEndLibrary.TINYMCE %>"></script>
     <script type="text/javascript" src="/js/richTextEditor.js"></script>
+    <script type="text/javascript" src="/js/crypto.js"></script>
     <script type="text/javascript" src="/js/administrator.js"></script>
     <script type="text/javascript" src="/js/adminEmail.js"></script>
 </c:set>

--- a/src/main/webapp/jsp/adminHome.jsp
+++ b/src/main/webapp/jsp/adminHome.jsp
@@ -6,6 +6,7 @@
 
 <c:set var="jsIncludes">
     <script type="text/javascript" src="/js/administrator.js"></script>
+    <script type="text/javascript" src="/js/crypto.js"></script>
     <script type="text/javascript" src="/js/adminHome.js"></script>
 </c:set>
 

--- a/src/main/webapp/jsp/adminSearch.jsp
+++ b/src/main/webapp/jsp/adminSearch.jsp
@@ -7,6 +7,7 @@
 
 <c:set var="jsIncludes">
     <script type="text/javascript" src="<%= FrontEndLibrary.JQUERY_HIGHLIGHT %>"></script>
+    <script type="text/javascript" src="/js/crypto.js"></script>
     <script type="text/javascript" src="/js/administrator.js"></script>
     <script type="text/javascript" src="/js/adminSearch.js"></script>
 </c:set>

--- a/src/main/webapp/jsp/instructorComments.jsp
+++ b/src/main/webapp/jsp/instructorComments.jsp
@@ -29,7 +29,8 @@
                         ${data.viewingDraft ? "Drafts" : data.courseName}
                     </strong>
                 </h4>
-                <comments:commentsNotifyPanel courseId="${data.courseId}" numberOfPendingComments="${data.numberOfPendingComments}" />
+                <comments:commentsNotifyPanel studentCommentClearPendingLink="${data.studentCommentClearPendingLink}"
+                                              numberOfPendingComments="${data.numberOfPendingComments}" />
             </div>
             <div id="no-comment-panel" style="${empty data.commentsForStudentsTables and empty data.feedbackSessions ? '' : 'display:none;'}">
                 <br>

--- a/src/main/webapp/jsp/instructorCourseEnroll.jsp
+++ b/src/main/webapp/jsp/instructorCourseEnroll.jsp
@@ -1,4 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="teammates.common.util.Const" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
@@ -10,6 +11,9 @@
 <c:set var="jsIncludes">
     <script type="text/javascript" src="/js/instructor.js"></script>
     <script type="text/javascript" src="/js/instructorCourseEnrollPage.js"></script>
+</c:set>
+<c:set var="SESSION_TOKEN">
+    <%=Const.ParamsNames.SESSION_TOKEN%>
 </c:set>
 
 <ti:instructorPage pageTitle="TEAMMATES - Instructor" bodyTitle="Enroll Students for ${data.courseId}" cssIncludes="${cssIncludes}" jsIncludes="${jsIncludes}">
@@ -24,6 +28,7 @@
             </div>
             <br>
             <form action="${data.instructorCourseEnrollSaveLink}" method="post" class="form-horizontal" role="form">
+                <input type="hidden" name="${SESSION_TOKEN}" value="${data.sessionToken}">
                 <div class="col-md-12">
                     <div class="form-group">
                         <label for="instructions" class="col-sm-1 control-label">Student data:</label>

--- a/src/main/webapp/jsp/instructorCourseStudentEdit.jsp
+++ b/src/main/webapp/jsp/instructorCourseStudentEdit.jsp
@@ -11,6 +11,7 @@
     <csde:studentInformationTable
         studentInfoTable="${data.studentInfoTable}"
         newEmail="${data.newEmail}"
-        openOrPublishedEmailSentForTheCourse="${data.openOrPublishedEmailSentForTheCourse}" />
+        openOrPublishedEmailSentForTheCourse="${data.openOrPublishedEmailSentForTheCourse}"
+        sessionToken="${data.sessionToken}" />
     <br><br>
 </ti:instructorPage>

--- a/src/main/webapp/jsp/instructorCourses.jsp
+++ b/src/main/webapp/jsp/instructorCourses.jsp
@@ -16,7 +16,8 @@
     <c:if test="${!data.usingAjax}">
         <course:addCoursePanel courseIdToShow="${data.courseIdToShow}" 
             courseNameToShow="${data.courseNameToShow}" 
-            googleId="${data.account.googleId}"/>
+            googleId="${data.account.googleId}"
+            sessionToken="${data.sessionToken}"/>
         <course:loadCoursesTableByAjaxForm />
     </c:if>
     

--- a/src/main/webapp/jsp/instructorFeedbackEdit.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackEdit.jsp
@@ -18,6 +18,7 @@
     <script type="text/javascript" src="<%= FrontEndLibrary.TINYMCE %>"></script>
     <script type="text/javascript" src="/js/richTextEditor.js"></script>
 
+    <script type="text/javascript" src="/js/crypto.js"></script>
     <script type="text/javascript" src="/js/datepicker.js"></script>
     <script type="text/javascript" src="/js/instructor.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbacks.js"></script>

--- a/src/main/webapp/jsp/studentProfilePage.jsp
+++ b/src/main/webapp/jsp/studentProfilePage.jsp
@@ -10,11 +10,12 @@
 <c:set var="jsIncludes">
     <script type="text/javascript" src="<%= FrontEndLibrary.JQUERY_GUILLOTINE %>"></script>
     <script type="text/javascript" src="/js/student.js"></script>
+    <script type="text/javascript" src="/js/crypto.js"></script>
     <script type="text/javascript" src="/js/studentProfile.js"></script>
 </c:set>
 <ts:studentPage pageTitle="TEAMMATES - Student Profile" bodyTitle="Student Profile" cssIncludes="${cssIncludes}" jsIncludes="${jsIncludes}">
     <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
     <br>
-    <tsp:uploadPhotoModal modal="${data.uploadPhotoModal}" />
-    <tsp:studentProfileDiv profile="${data.profileEditBox}" />
+    <tsp:uploadPhotoModal modal="${data.uploadPhotoModal}" sessionToken="${data.sessionToken}" />
+    <tsp:studentProfileDiv profile="${data.profileEditBox}" sessionToken="${data.sessionToken}" />
 </ts:studentPage>

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -20,6 +20,11 @@ import teammates.test.driver.TestProperties;
 public class BaseTestCase {
 
     /**
+     * Dummy session token for use in tests that depend on, but don't use, it (e.g. page data tests).
+     */
+    protected static final String dummySessionToken = null;
+
+    /**
      * Test Segment divider. Used to divide a test case into logical sections.
      * The weird name is for easy spotting.
      *

--- a/src/test/java/teammates/test/cases/pagedata/AdminHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/AdminHomePageDataTest.java
@@ -23,7 +23,7 @@ public class AdminHomePageDataTest extends BaseTestCase {
 
     private void createData() {
         AccountAttributes admin = dataBundle.accounts.get("instructor1OfCourse1");
-        pageData = new AdminHomePageData(admin);
+        pageData = new AdminHomePageData(admin, dummySessionToken);
     }
 
     private void setHomePageAttributes() {

--- a/src/test/java/teammates/test/cases/pagedata/FeedbackSubmissionEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/FeedbackSubmissionEditPageDataTest.java
@@ -71,7 +71,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         AccountAttributes studentAccount = dataBundle.accounts.get("student1InCourse1");
         StudentAttributes student = dataBundle.students.get("student1InCourse1");
 
-        pageData = new FeedbackSubmissionEditPageData(studentAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(studentAccount, student, dummySessionToken);
         createData(student);
 
         pageData.init(student.key, student.email, student.course);
@@ -96,7 +96,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         ______TS("student in unregistered course");
         student = dataBundle.students.get("student1InUnregisteredCourse");
 
-        pageData = new FeedbackSubmissionEditPageData(studentAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(studentAccount, student, dummySessionToken);
         createData(student);
 
         pageData.init(student.key, student.email, student.course);
@@ -120,7 +120,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         ______TS("student in archived course");
         student = dataBundle.students.get("student1InArchivedCourse");
 
-        pageData = new FeedbackSubmissionEditPageData(studentAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(studentAccount, student, dummySessionToken);
         createData(student);
 
         pageData.init(student.key, student.email, student.course);
@@ -143,7 +143,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         ______TS("student submission open");
         student = dataBundle.students.get("student1InCourse1");
 
-        pageData = new FeedbackSubmissionEditPageData(studentAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(studentAccount, student, dummySessionToken);
         createData(student);
 
         pageData.setSessionOpenForSubmission(true);
@@ -169,7 +169,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
         student = dataBundle.students.get("student1InCourse1");
 
-        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student, dummySessionToken);
         createData(student);
 
         pageData.setModeration(true);
@@ -186,7 +186,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         ______TS("instructor moderating a response - open for submission");
         student = dataBundle.students.get("student1InCourse1");
 
-        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student, dummySessionToken);
         createData(student);
 
         pageData.setModeration(true);
@@ -202,7 +202,7 @@ public class FeedbackSubmissionEditPageDataTest extends BaseTestCase {
         testQuestionAttributes();
 
         ______TS("instructor previewing a response");
-        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student);
+        pageData = new FeedbackSubmissionEditPageData(instructorAccount, student, dummySessionToken);
         createData(student);
 
         pageData.setPreview(true);

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCommentsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCommentsPageDataTest.java
@@ -46,7 +46,7 @@ public class InstructorCommentsPageDataTest extends BaseTestCase {
         ______TS("typical success case");
 
         AccountAttributes account = dataBundle.accounts.get("instructor3");
-        InstructorCommentsPageData data = new InstructorCommentsPageData(account);
+        InstructorCommentsPageData data = new InstructorCommentsPageData(account, dummySessionToken);
 
         boolean isViewingDraft = false;
         boolean isDisplayArchive = false;

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseDetailsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseDetailsPageDataTest.java
@@ -24,7 +24,8 @@ public class InstructorCourseDetailsPageDataTest extends BaseTestCase {
     public void testAll() {
         ______TS("test typical case");
         AccountAttributes instructorAccount = dataBundle.accounts.get("instructor1OfCourse1");
-        InstructorCourseDetailsPageData pageData = new InstructorCourseDetailsPageData(instructorAccount);
+        InstructorCourseDetailsPageData pageData =
+                new InstructorCourseDetailsPageData(instructorAccount, dummySessionToken);
 
         InstructorAttributes curInstructor = dataBundle.instructors.get("instructor1OfCourse1");
 

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseEditPageDataTest.java
@@ -50,7 +50,7 @@ public class InstructorCourseEditPageDataTest extends BaseTestCase {
         feedbackSessionNames.add("Empty session");
         feedbackSessionNames.add("non visible session");
 
-        InstructorCourseEditPageData pageData = new InstructorCourseEditPageData(account, course,
+        InstructorCourseEditPageData pageData = new InstructorCourseEditPageData(account, dummySessionToken, course,
                                                                                  instructorList,
                                                                                  currentInstructor,
                                                                                  offset, sectionNames,
@@ -107,7 +107,7 @@ public class InstructorCourseEditPageDataTest extends BaseTestCase {
             currentInstructor.privileges.updatePrivilege(privilege, false);
         }
 
-        pageData = new InstructorCourseEditPageData(account, course, instructorList, currentInstructor,
+        pageData = new InstructorCourseEditPageData(account, dummySessionToken, course, instructorList, currentInstructor,
                                                     offset, sectionNames, feedbackSessionNames);
         assertNull(pageData.getDeleteCourseButton().getAttributes().get("disabled"));
         assertTrue(pageData.getDeleteCourseButton().getAttributes().containsKey("disabled"));
@@ -116,7 +116,7 @@ public class InstructorCourseEditPageDataTest extends BaseTestCase {
 
         ______TS("test showing only one instructor");
         offset = 1;
-        pageData = new InstructorCourseEditPageData(account, course, instructorList, currentInstructor,
+        pageData = new InstructorCourseEditPageData(account, dummySessionToken, course, instructorList, currentInstructor,
                                                     offset, sectionNames, feedbackSessionNames);
         assertNotNull(pageData.getAddInstructorPanel());
         assertTrue(pageData.getInstructorPanelList().get(0).isAccessControlDisplayed());
@@ -125,13 +125,13 @@ public class InstructorCourseEditPageDataTest extends BaseTestCase {
         InstructorAttributes instructor = instructorList.get(0);
         instructor.privileges.addSessionWithDefaultPrivileges("Section 1", "First feedback session");
 
-        pageData = new InstructorCourseEditPageData(account, course, instructorList, currentInstructor,
+        pageData = new InstructorCourseEditPageData(account, dummySessionToken, course, instructorList, currentInstructor,
                                                     offset, sectionNames, feedbackSessionNames);
         assertTrue(pageData.getInstructorPanelList().get(0).getSectionRows().get(0).isSectionSpecial());
 
         ______TS("test empty sectionNames");
         sectionNames = new ArrayList<String>();
-        pageData = new InstructorCourseEditPageData(account, course, instructorList, currentInstructor,
+        pageData = new InstructorCourseEditPageData(account, dummySessionToken, course, instructorList, currentInstructor,
                                                     offset, sectionNames, feedbackSessionNames);
         assertNotNull(pageData.getAddInstructorPanel());
         panel = pageData.getInstructorPanelList().get(0);

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseEnrollPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseEnrollPageDataTest.java
@@ -24,7 +24,8 @@ public class InstructorCourseEnrollPageDataTest extends BaseTestCase {
                       + "Tut Group 1 | Team 2 | Jack Wayne | jack@email.com\n"
                       + "Tut Group 2 | Team 3 | Thora Parker | thora@email.com";
 
-        InstructorCourseEnrollPageData pageData = new InstructorCourseEnrollPageData(account, courseId, enroll);
+        InstructorCourseEnrollPageData pageData =
+                new InstructorCourseEnrollPageData(account, dummySessionToken, courseId, enroll);
 
         assertNotNull(pageData.getCourseId());
         assertEquals(courseId, pageData.getCourseId());

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseEnrollResultPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseEnrollResultPageDataTest.java
@@ -38,7 +38,7 @@ public class InstructorCourseEnrollResultPageDataTest extends BaseTestCase {
         boolean hasSection = true;
         String enrollStudents = "enrollString";
 
-        InstructorCourseEnrollResultPageData pageData = new InstructorCourseEnrollResultPageData(account,
+        InstructorCourseEnrollResultPageData pageData = new InstructorCourseEnrollResultPageData(account, dummySessionToken,
                                                                 courseId, students, hasSection, enrollStudents);
 
         assertNotNull(pageData.getCourseId());

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseJoinConfirmationPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseJoinConfirmationPageDataTest.java
@@ -23,7 +23,7 @@ public class InstructorCourseJoinConfirmationPageDataTest extends BaseTestCase {
         String institute = "Institute Name";
 
         InstructorCourseJoinConfirmationPageData pageData =
-                new InstructorCourseJoinConfirmationPageData(account, regkey, institute);
+                new InstructorCourseJoinConfirmationPageData(account, dummySessionToken, regkey, institute);
 
         assertNotNull(pageData.getRegkey());
         assertEquals(regkey, pageData.getRegkey());
@@ -41,7 +41,7 @@ public class InstructorCourseJoinConfirmationPageDataTest extends BaseTestCase {
         account = dataBundle.accounts.get("instructor1OfCourse1");
         regkey = "someRandomKey";
 
-        pageData = new InstructorCourseJoinConfirmationPageData(account, regkey, null);
+        pageData = new InstructorCourseJoinConfirmationPageData(account, dummySessionToken, regkey, null);
 
         assertNotNull(pageData.getRegkey());
         assertEquals(regkey, pageData.getRegkey());

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseStudentDetailsEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseStudentDetailsEditPageDataTest.java
@@ -42,8 +42,8 @@ public class InstructorCourseStudentDetailsEditPageDataTest extends BaseTestCase
 
         createStudent(name, email);
 
-        return new InstructorCourseStudentDetailsEditPageData(new AccountAttributes(), inputStudent, email,
-                hasSection, isOpenOrPublishedEmailSentForTheCourse);
+        return new InstructorCourseStudentDetailsEditPageData(new AccountAttributes(), dummySessionToken, inputStudent,
+                email, hasSection, isOpenOrPublishedEmailSentForTheCourse);
     }
 
     private void createStudent(String name, String email) {

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCourseStudentDetailsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCourseStudentDetailsPageDataTest.java
@@ -138,16 +138,16 @@ public class InstructorCourseStudentDetailsPageDataTest extends BaseTestCase {
     private InstructorCourseStudentDetailsPageData createData() {
         createCommonData();
 
-        return new InstructorCourseStudentDetailsPageData(new AccountAttributes(), inputStudent, inputStudentProfile,
-                                                          isAbleToAddComment, hasSection, commentRecipient);
+        return new InstructorCourseStudentDetailsPageData(new AccountAttributes(), dummySessionToken, inputStudent,
+                inputStudentProfile, isAbleToAddComment, hasSection, commentRecipient);
     }
 
     private InstructorCourseStudentDetailsPageData createData(String commentRecipient) {
         createCommonData();
         this.commentRecipient = commentRecipient;
 
-        return new InstructorCourseStudentDetailsPageData(new AccountAttributes(), inputStudent, inputStudentProfile,
-                                                          isAbleToAddComment, hasSection, commentRecipient);
+        return new InstructorCourseStudentDetailsPageData(new AccountAttributes(), dummySessionToken, inputStudent,
+                inputStudentProfile, isAbleToAddComment, hasSection, commentRecipient);
     }
 
     private void createCommonData() {

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
@@ -24,7 +24,8 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
     public void testAll() {
         ______TS("test no course");
         AccountAttributes instructorAccountWithoutCourses = dataBundle.accounts.get("instructorWithoutCourses");
-        InstructorCoursesPageData pageData = new InstructorCoursesPageData(instructorAccountWithoutCourses);
+        InstructorCoursesPageData pageData =
+                new InstructorCoursesPageData(instructorAccountWithoutCourses, dummySessionToken);
         List<CourseAttributes> activeCourses = new ArrayList<CourseAttributes>();
         List<CourseAttributes> archivedCourses = new ArrayList<CourseAttributes>();
         Map<String, InstructorAttributes> instructorForCourses = new HashMap<String, InstructorAttributes>();
@@ -43,7 +44,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
 
         ______TS("test 1 active course");
         AccountAttributes instructorAccountWithOneActiveCourse = dataBundle.accounts.get("instructor1OfCourse1");
-        pageData = new InstructorCoursesPageData(instructorAccountWithOneActiveCourse);
+        pageData = new InstructorCoursesPageData(instructorAccountWithOneActiveCourse, dummySessionToken);
         activeCourses = new ArrayList<CourseAttributes>();
         activeCourses.add(dataBundle.courses.get("typicalCourse1"));
 
@@ -65,7 +66,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
 
         ______TS("test 2 active courses");
         AccountAttributes instructorAccountWithTwoActiveCourses = dataBundle.accounts.get("instructor3");
-        pageData = new InstructorCoursesPageData(instructorAccountWithTwoActiveCourses);
+        pageData = new InstructorCoursesPageData(instructorAccountWithTwoActiveCourses, dummySessionToken);
         activeCourses = new ArrayList<CourseAttributes>();
         activeCourses.add(dataBundle.courses.get("typicalCourse1"));
         activeCourses.add(dataBundle.courses.get("typicalCourse2"));
@@ -89,7 +90,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
 
         ______TS("test 1 archived course");
         AccountAttributes instructorAccountWithOneArchivedCourse = dataBundle.accounts.get("instructorOfArchivedCourse");
-        pageData = new InstructorCoursesPageData(instructorAccountWithOneArchivedCourse);
+        pageData = new InstructorCoursesPageData(instructorAccountWithOneArchivedCourse, dummySessionToken);
         activeCourses = new ArrayList<CourseAttributes>();
 
         archivedCourses = new ArrayList<CourseAttributes>();

--- a/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackEditPageDataTest.java
@@ -43,7 +43,7 @@ public class InstructorFeedbackEditPageDataTest extends BaseTestCase {
         ______TS("Typical case");
         // Setup
         InstructorFeedbackEditPageData data =
-                new InstructorFeedbackEditPageData(dataBundle.accounts.get("instructor1OfCourse1"));
+                new InstructorFeedbackEditPageData(dataBundle.accounts.get("instructor1OfCourse1"), dummySessionToken);
         FeedbackSessionAttributes fs = dataBundle.feedbackSessions.get("session1InCourse1");
 
         List<FeedbackQuestionAttributes> questions = new ArrayList<FeedbackQuestionAttributes>();
@@ -202,7 +202,7 @@ public class InstructorFeedbackEditPageDataTest extends BaseTestCase {
 
         ______TS("empty feedback session");
         // setup
-        data = new InstructorFeedbackEditPageData(dataBundle.accounts.get("instructor1OfCourse1"));
+        data = new InstructorFeedbackEditPageData(dataBundle.accounts.get("instructor1OfCourse1"), dummySessionToken);
 
         fs = dataBundle.feedbackSessions.get("empty.session");
         fs.setPublishedEmailEnabled(false);

--- a/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackQuestionCopyPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackQuestionCopyPageDataTest.java
@@ -26,7 +26,7 @@ public class InstructorFeedbackQuestionCopyPageDataTest extends BaseTestCase {
         copiableQuestions.addAll(dataBundle.feedbackQuestions.values());
 
         InstructorFeedbackQuestionCopyPageData data = new InstructorFeedbackQuestionCopyPageData(
-                dataBundle.accounts.get("instructor1OfCourse1"), copiableQuestions);
+                dataBundle.accounts.get("instructor1OfCourse1"), dummySessionToken, copiableQuestions);
         FeedbackQuestionCopyTable copyForm = data.getCopyQnForm();
         assertEquals(dataBundle.feedbackQuestions.size(), copyForm.getQuestionRows().size());
     }

--- a/src/test/java/teammates/test/cases/pagedata/InstructorFeedbacksPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorFeedbacksPageDataTest.java
@@ -39,7 +39,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
 
         ______TS("typical success case");
 
-        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount);
+        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount, dummySessionToken);
 
         HashMap<String, InstructorAttributes> courseInstructorMap = new HashMap<String, InstructorAttributes>();
         List<InstructorAttributes> instructors = getInstructorsForGoogleId(instructorAccount.googleId, true);
@@ -122,7 +122,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
         ______TS("case with instructor with only archived course");
         AccountAttributes instructorOfArchivedCourseAccount = dataBundle.accounts.get("instructorOfArchivedCourse");
         InstructorFeedbacksPageData instructorArchivedCourseData =
-                new InstructorFeedbacksPageData(instructorOfArchivedCourseAccount);
+                new InstructorFeedbacksPageData(instructorOfArchivedCourseAccount, dummySessionToken);
         Map<String, InstructorAttributes> archivedCourseInstructorMap = new HashMap<String, InstructorAttributes>();
 
         instructors = getInstructorsForGoogleId(instructorOfArchivedCourseAccount.googleId, true);
@@ -152,7 +152,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
         ______TS("case with instructor with restricted permissions");
         AccountAttributes helperAccount = dataBundle.accounts.get("helperOfCourse1");
 
-        InstructorFeedbacksPageData helperData = new InstructorFeedbacksPageData(helperAccount);
+        InstructorFeedbacksPageData helperData = new InstructorFeedbacksPageData(helperAccount, dummySessionToken);
 
         Map<String, InstructorAttributes> helperCourseInstructorMap = new HashMap<String, InstructorAttributes>();
         instructors = getInstructorsForGoogleId(helperAccount.googleId, true);
@@ -196,7 +196,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
 
         instructorAccount = dataBundle.accounts.get("instructor1OfCourse1");
 
-        data = new InstructorFeedbacksPageData(instructorAccount);
+        data = new InstructorFeedbacksPageData(instructorAccount, dummySessionToken);
 
         courseInstructorMap = new HashMap<String, InstructorAttributes>();
         instructors = getInstructorsForGoogleId(instructorAccount.googleId, true);
@@ -237,7 +237,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
 
         ______TS("typical success case with existing fs passed in");
 
-        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount);
+        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount, dummySessionToken);
 
         Map<String, InstructorAttributes> courseInstructorMap = new HashMap<String, InstructorAttributes>();
         List<InstructorAttributes> instructors = getInstructorsForGoogleId(instructorAccount.googleId, true);
@@ -325,7 +325,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
 
         ______TS("typical success case with existing fs passed in");
 
-        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount);
+        InstructorFeedbacksPageData data = new InstructorFeedbacksPageData(instructorAccount, dummySessionToken);
 
         Map<String, InstructorAttributes> courseInstructorMap = new HashMap<String, InstructorAttributes>();
         List<InstructorAttributes> instructors = getInstructorsForGoogleId(instructorAccount.googleId, true);

--- a/src/test/java/teammates/test/cases/pagedata/InstructorStudentListAjaxPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorStudentListAjaxPageDataTest.java
@@ -116,7 +116,7 @@ public class InstructorStudentListAjaxPageDataTest extends BaseTestCase {
         Map<String, String> emailPhotoUrlMapping = new HashMap<String, String>();
         emailPhotoUrlMapping.put(sampleStudent.email, photoUrl);
 
-        return new InstructorStudentListAjaxPageData(acct, "valid course id", 1, true, sections,
+        return new InstructorStudentListAjaxPageData(acct, dummySessionToken, "valid course id", 1, true, sections,
                                                      sectionPrivileges, emailPhotoUrlMapping);
     }
 

--- a/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
@@ -60,12 +60,12 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
         coursesToDisplay = new ArrayList<InstructorStudentListPageCourseData>();
         coursesToDisplay.add(new InstructorStudentListPageCourseData(sampleCourse, isCourseArchived,
                                                                      isInstructorAllowedToModify));
-        return new InstructorStudentListPageData(acct, searchKey, displayArchive, coursesToDisplay);
+        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, displayArchive, coursesToDisplay);
     }
 
     private InstructorStudentListPageData initializeDataWithNoSearchKey() {
         searchKey = null;
-        return new InstructorStudentListPageData(acct, searchKey, displayArchive, coursesToDisplay);
+        return new InstructorStudentListPageData(acct, dummySessionToken, searchKey, displayArchive, coursesToDisplay);
     }
 
     private void testSearchBox(InstructorStudentListSearchBox searchBox) {

--- a/src/test/java/teammates/test/cases/pagedata/StudentCommentsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentCommentsPageDataTest.java
@@ -60,7 +60,7 @@ public class StudentCommentsPageDataTest extends BaseTestCase {
         ______TS("typical success case");
 
         AccountAttributes account = dataBundle.accounts.get("student1InCourse1");
-        data = new StudentCommentsPageData(account);
+        data = new StudentCommentsPageData(account, dummySessionToken);
 
         String courseId = sampleCourse.getId();
         String courseName = sampleCourse.getName();

--- a/src/test/java/teammates/test/cases/pagedata/StudentCourseDetailsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentCourseDetailsPageDataTest.java
@@ -27,7 +27,7 @@ public class StudentCourseDetailsPageDataTest extends BaseTestCase {
         ______TS("typical success case");
 
         AccountAttributes account = dataBundle.accounts.get("student1InCourse1");
-        StudentCourseDetailsPageData pageData = new StudentCourseDetailsPageData(account);
+        StudentCourseDetailsPageData pageData = new StudentCourseDetailsPageData(account, dummySessionToken);
 
         StudentAttributes student = dataBundle.students.get("student1InCourse1");
         CourseAttributes course = dataBundle.courses.get("typicalCourse1");

--- a/src/test/java/teammates/test/cases/pagedata/StudentFeedbackResultsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentFeedbackResultsPageDataTest.java
@@ -42,7 +42,7 @@ public class StudentFeedbackResultsPageDataTest extends BaseComponentTestCase {
         student.key = dummyKey;
         Logic logic = new Logic();
 
-        StudentFeedbackResultsPageData pageData = new StudentFeedbackResultsPageData(account, student);
+        StudentFeedbackResultsPageData pageData = new StudentFeedbackResultsPageData(account, student, dummySessionToken);
 
         Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponses =
                                         new LinkedHashMap<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>();
@@ -114,7 +114,7 @@ public class StudentFeedbackResultsPageDataTest extends BaseComponentTestCase {
 
         student = dataBundle.students.get("student1InUnregisteredCourse");
 
-        pageData = new StudentFeedbackResultsPageData(account, student);
+        pageData = new StudentFeedbackResultsPageData(account, student, dummySessionToken);
         Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponsesUnregistered =
                                         new LinkedHashMap<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>();
 

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -187,7 +187,7 @@ public class StudentHomePageDataTest extends BaseTestCase {
         courses.add(newCourseBundle);
         courses.add(oldCourseBundle);
 
-        return new StudentHomePageData(new AccountAttributes(), courses, sessionSubmissionStatusMap);
+        return new StudentHomePageData(new AccountAttributes(), dummySessionToken, courses, sessionSubmissionStatusMap);
     }
 
     private FeedbackSessionAttributes createFeedbackSession(String name,

--- a/src/test/java/teammates/test/cases/pagedata/StudentProfilePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentProfilePageDataTest.java
@@ -49,14 +49,14 @@ public class StudentProfilePageDataTest extends BaseTestCase {
         pictureUrl = Const.ActionURIs.STUDENT_PROFILE_PICTURE
                    + "?" + Const.ParamsNames.BLOB_KEY + "=" + spa.pictureKey
                    + "&" + Const.ParamsNames.USER_ID + "=" + acct.googleId;
-        return new StudentProfilePageData(acct, isEditingPhoto);
+        return new StudentProfilePageData(acct, dummySessionToken, isEditingPhoto);
     }
 
     private StudentProfilePageData initializeDataWithNoPictureKeyAndNullFields() {
         spa = new StudentProfileAttributes("valid.id.2", null, null, null, null, "male", null, "");
         acct = new AccountAttributes("valid.id", "full name", false, "e@mail1.com", "inst", spa);
         pictureUrl = Const.SystemParams.DEFAULT_PROFILE_PICTURE_PATH;
-        return new StudentProfilePageData(acct, isEditingPhoto);
+        return new StudentProfilePageData(acct, dummySessionToken, isEditingPhoto);
     }
 
     private void testProfileEditBox(StudentProfileEditBox profileEditBox) {

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -25,6 +25,8 @@ import com.meterware.servletunit.InvocationContext;
 import com.meterware.servletunit.ServletRunner;
 import com.meterware.servletunit.ServletUnitClient;
 
+import teammates.common.util.Const;
+import teammates.common.util.CryptoHelper;
 import teammates.logic.api.GateKeeper;
 import teammates.ui.automated.AutomatedAction;
 import teammates.ui.automated.AutomatedActionFactory;
@@ -200,7 +202,14 @@ public class GaeSimulation {
     private HttpServletRequest createWebRequest(String uri, String... parameters) {
 
         WebRequest request = new PostMethodWebRequest("http://localhost" + uri);
-        request.setHeaderField("referer", "http://localhost" + uri);
+
+        if (Const.SystemParams.PAGES_REQUIRING_ORIGIN_VALIDATION.contains(uri)) {
+            request.setHeaderField("referer", "http://localhost");
+
+            String sessionId = sc.getSession(true).getId();
+            String token = CryptoHelper.computeSessionToken(sessionId);
+            request.setParameter(Const.ParamsNames.SESSION_TOKEN, token);
+        }
 
         Map<String, List<String>> paramMultiMap = new HashMap<String, List<String>>();
         for (int i = 0; i < parameters.length; i = i + 2) {

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -25,16 +25,20 @@ public final class HtmlHelper {
 
     private static final String INDENTATION_STEP = "  ";
 
+    private static final String REGEX_UPPERCASE_HEXADECIMAL_CHAR_32_MULTI = "[A-F0-9]{32,}";
+    private static final String REGEX_UPPERCASE_HEXADECIMAL_CHAR_32 = "[A-F0-9]{32}";
+
     private static final String REGEX_CONTINUE_URL = ".*?";
-    private static final String REGEX_ENCRYPTED_STUDENT_EMAIL = "[A-F0-9]{32,}";
-    private static final String REGEX_ENCRYPTED_COURSE_ID = "[A-F0-9]{32,}";
-    private static final String REGEX_ENCRYPTED_REGKEY = "[A-F0-9]{32,}";
+    private static final String REGEX_ENCRYPTED_STUDENT_EMAIL = REGEX_UPPERCASE_HEXADECIMAL_CHAR_32_MULTI;
+    private static final String REGEX_ENCRYPTED_COURSE_ID = REGEX_UPPERCASE_HEXADECIMAL_CHAR_32_MULTI;
+    private static final String REGEX_ENCRYPTED_REGKEY = REGEX_UPPERCASE_HEXADECIMAL_CHAR_32_MULTI;
     private static final String REGEX_ANONYMOUS_PARTICIPANT_HASH = "[0-9]{1,10}";
     private static final String REGEX_BLOB_KEY = "(encoded_gs_key:)?[a-zA-Z0-9-_]{10,}";
     private static final String REGEX_QUESTION_ID = "[a-zA-Z0-9-_]{40,}";
     private static final String REGEX_COMMENT_ID = "[0-9]{16}";
     private static final String REGEX_DISPLAY_TIME = "(0[0-9]|1[0-2]):[0-5][0-9] [AP]M( UTC)?";
     private static final String REGEX_ADMIN_INSTITUTE_FOOTER = ".*?";
+    private static final String REGEX_SESSION_TOKEN = REGEX_UPPERCASE_HEXADECIMAL_CHAR_32;
 
     private HtmlHelper() {
         // utility class
@@ -438,6 +442,15 @@ public final class HtmlHelper {
                       .replaceAll("(?s)<div( class=\"col-md-8\"| id=\"adminInstitute\"){2}>"
                                               + REGEX_ADMIN_INSTITUTE_FOOTER + "</div>",
                                   "\\${admin\\.institute}")
+                      // sessionToken in form inputs
+                      .replaceAll("( type=\"hidden\"|"
+                                   + " name=\"" + Const.ParamsNames.SESSION_TOKEN + "\"|"
+                                   + " value=\"" + REGEX_SESSION_TOKEN + "\"){3}",
+                                   " name=\"" + Const.ParamsNames.SESSION_TOKEN + "\""
+                                   + " type=\"hidden\" value=\"\\${sessionToken}\"")
+                      // sessionToken in URL parameters
+                      .replaceAll("(\\&amp;|\\?)" + Const.ParamsNames.SESSION_TOKEN + "=" + REGEX_SESSION_TOKEN,
+                                  "$1" + Const.ParamsNames.SESSION_TOKEN + "=\\${sessionToken}")
                       // top HTML tag with xmlns defined
                       // TODO check if this is necessary
                       .replace("<html xmlns=\"http://www.w3.org/1999/xhtml\">", "<html>")

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -174,7 +174,7 @@
             [AAMgtUiT.CS2103] Software Engineering
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2103" id="instructor_AAMgtUiT.CS2103">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2103&token=${sessionToken}" id="instructor_AAMgtUiT.CS2103">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course
@@ -186,7 +186,7 @@
             [AAMgtUiT.CS2104] Programming Language Concepts
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2104" id="instructor_AAMgtUiT.CS2104">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2104&token=${sessionToken}" id="instructor_AAMgtUiT.CS2104">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course
@@ -198,7 +198,7 @@
             [AAMgtUiT.CS1101] Programming Methodology
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101" id="instructor_AAMgtUiT.CS1101">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101&token=${sessionToken}" id="instructor_AAMgtUiT.CS1101">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course
@@ -237,7 +237,7 @@
             [AAMgtUiT.CS1101] Programming Methodology
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?googleid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101" id="student_AAMgtUiT.CS1101">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?googleid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101&token=${sessionToken}" id="student_AAMgtUiT.CS1101">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course

--- a/src/test/resources/pages/adminAccountDetailsRemoveStudent.html
+++ b/src/test/resources/pages/adminAccountDetailsRemoveStudent.html
@@ -87,7 +87,7 @@
             [AAMgtUiT.CS2103] Software Engineering
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2103" id="instructor_AAMgtUiT.CS2103">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS2103&token=${sessionToken}" id="instructor_AAMgtUiT.CS2103">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course
@@ -99,7 +99,7 @@
             [AAMgtUiT.CS1101] Programming Methodology
           </td>
           <td>
-            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101" id="instructor_AAMgtUiT.CS1101">
+            <a class="btn btn-danger btn-sm" href="/admin/adminAccountDelete?instructorid=AAMgtUiT.instr2&courseid=AAMgtUiT.CS1101&token=${sessionToken}" id="instructor_AAMgtUiT.CS1101">
               <span class="glyphicon glyphicon-trash">
               </span>
               Remove From Course

--- a/src/test/resources/pages/adminHomePage.html
+++ b/src/test/resources/pages/adminHomePage.html
@@ -239,6 +239,8 @@
 </script>
 <script src="/js/administrator.js" type="text/javascript">
 </script>
+<script src="/js/crypto.js" type="text/javascript">
+</script>
 <script src="/js/adminHome.js" type="text/javascript">
 </script>
 </body>

--- a/src/test/resources/pages/godmode.html
+++ b/src/test/resources/pages/godmode.html
@@ -49,6 +49,9 @@
                 <li><div id="adminInstitute" class="col-md-8">
                     Test Institute 123
                 </div></li>
+                <li><input type="hidden" value="EB3E5FE588E0E30FA51F1126F74B65F4" name="token"></li>
+                <li>/page/instructorCourseDelete?courseid=abcdef&amp;token=EB3E5FE588E0E30FA51F1126F74B65F4</li>
+                <li>/page/instructorCourseDelete?token=EB3E5FE588E0E30FA51F1126F74B65F4</li>
             </ul>
         </div>
     </body>

--- a/src/test/resources/pages/godmodeExpectedOutput.html
+++ b/src/test/resources/pages/godmodeExpectedOutput.html
@@ -43,6 +43,9 @@
                 <li>${datetime.now}</li>
                 <li>${admin.institute}</li>
                 <li>${admin.institute}</li>
+                <li><input name="token" type="hidden" value="${sessionToken}"></li>
+                <li>/page/instructorCourseDelete?courseid=abcdef&amp;token=${sessionToken}</li>
+                <li>/page/instructorCourseDelete?token=${sessionToken}</li>
             </ul>
         </div>
     </body>

--- a/src/test/resources/pages/godmodeExpectedPartOutput.html
+++ b/src/test/resources/pages/godmodeExpectedPartOutput.html
@@ -39,5 +39,8 @@
         <li>${datetime.now}</li>
         <li>${admin.institute}</li>
         <li>${admin.institute}</li>
+        <li><input name="token" type="hidden" value="${sessionToken}"></li>
+        <li>/page/instructorCourseDelete?courseid=abcdef&token=${sessionToken}</li>
+        <li>/page/instructorCourseDelete?token=${sessionToken}</li>
     </ul>
 </div>

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instr3">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instr3">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -127,10 +128,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instr3" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCommentsForTypicalCourseWithCommentsWithHelperView.html
+++ b/src/test/resources/pages/instructorCommentsForTypicalCourseWithCommentsWithHelperView.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfHelperOfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfHelperOfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -327,6 +327,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfHelperOfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>

--- a/src/test/resources/pages/instructorCommentsPageAddFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddFrc.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 1 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 1 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             1
           </span>
@@ -361,6 +361,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -525,6 +526,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -673,6 +675,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -837,6 +840,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1001,6 +1005,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1165,6 +1170,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1329,6 +1335,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1491,6 +1498,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1621,6 +1629,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1747,6 +1756,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1834,6 +1844,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -1931,6 +1942,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-2">
@@ -1949,6 +1961,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-2" onclick="showResponseCommentEditForm(1,1,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2042,6 +2055,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2128,6 +2142,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2193,6 +2208,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2325,6 +2341,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2345,6 +2362,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2477,6 +2495,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2497,6 +2516,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2629,6 +2649,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2754,6 +2775,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageAddSc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddSc.html
@@ -177,7 +177,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 1 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 1 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             1
           </span>
@@ -344,6 +344,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE, INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -492,6 +493,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -656,6 +658,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -804,6 +807,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -968,6 +972,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1132,6 +1137,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1296,6 +1302,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1460,6 +1467,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1622,6 +1630,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1748,6 +1757,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1874,6 +1884,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>

--- a/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -361,6 +361,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -525,6 +526,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -673,6 +675,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -837,6 +840,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1001,6 +1005,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1165,6 +1170,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1329,6 +1335,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1491,6 +1498,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1621,6 +1629,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1747,6 +1756,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1830,6 +1840,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -1923,6 +1934,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2009,6 +2021,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2074,6 +2087,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2206,6 +2220,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2226,6 +2241,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2358,6 +2374,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2378,6 +2395,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2510,6 +2528,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2635,6 +2654,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageEditFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageEditFrc.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -361,6 +361,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -525,6 +526,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -673,6 +675,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -837,6 +840,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1001,6 +1005,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1165,6 +1170,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1329,6 +1335,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1491,6 +1498,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1621,6 +1629,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1747,6 +1756,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1830,6 +1840,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -1931,6 +1942,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-you status_display-private" id="responseCommentRow-1-1-1-2">
@@ -1949,6 +1961,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-2" onclick="showResponseCommentEditForm(1,1,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2042,6 +2055,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2128,6 +2142,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2193,6 +2208,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2325,6 +2341,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2345,6 +2362,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2477,6 +2495,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2497,6 +2516,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2629,6 +2649,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2754,6 +2775,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
+++ b/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfUriCharsCourse&user=comments.idOfInstructorOfCourseWithUriChars" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfUriCharsCourse&user=comments.idOfInstructorOfCourseWithUriChars&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -361,6 +361,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -444,6 +445,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse">
                               <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#">
                               <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -537,6 +539,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -623,6 +626,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageForCourseWithoutComment.html
+++ b/src/test/resources/pages/instructorCommentsPageForCourseWithoutComment.html
@@ -160,7 +160,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfSampleCourse-demo&user=comments.idOfInstructorWithSampleCourse" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfSampleCourse-demo&user=comments.idOfInstructorWithSampleCourse&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>

--- a/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
+++ b/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private" style="display: block;">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: block;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: block;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: block;">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private" style="display: none;">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: block;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: block;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: none;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: none;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public" style="display: none;">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private" style="display: none;">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: none;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: none;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: block;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: block;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
@@ -172,7 +172,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=comments.idOfTypicalCourse1&user=comments.idOfInstructor1OfCourse1&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -329,6 +329,7 @@
                     <input name="showgiverto" type="hidden" value="COURSE">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -477,6 +478,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -641,6 +643,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -789,6 +792,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -953,6 +957,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1117,6 +1122,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1281,6 +1287,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -1445,6 +1452,7 @@
                     <input name="showgiverto" type="hidden" value="PERSON">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -1607,6 +1615,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1733,6 +1742,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1859,6 +1869,7 @@
                     <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                     <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>
@@ -1942,6 +1953,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-1-1-1" onclick="showResponseCommentEditForm(1,1,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2035,6 +2047,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-1-1" style="display: none;">
@@ -2121,6 +2134,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2186,6 +2200,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-1" onclick="showResponseCommentEditForm(1,2,1,1)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2318,6 +2333,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-2" style="display: none;">
@@ -2338,6 +2354,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-2" onclick="showResponseCommentEditForm(1,2,1,2)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2470,6 +2487,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning giver_display-by-others status_display-public" id="responseCommentRow-1-2-1-3" style="display: none;">
@@ -2490,6 +2508,7 @@
                               <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1">
                               <input name="fsname" type="hidden" value="comments.First feedback session">
                               <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
+                              <input name="token" type="hidden" value="${sessionToken}">
                             </form>
                             <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-1-2-1-3" onclick="showResponseCommentEditForm(1,2,1,3)" style="display: none;" title="" type="button">
                               <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -2622,6 +2641,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="INSTRUCTORS, RECEIVER_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                         <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-1-2-1" style="display: none;">
@@ -2747,6 +2767,7 @@
                             <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, RECEIVER_TEAM_MEMBERS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
@@ -254,6 +254,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCDetailsUiT.instr">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>

--- a/src/test/resources/pages/instructorCourseDetailsStudentDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCourseDetailsStudentDeleteSuccessful.html
@@ -78,7 +78,7 @@
       </div>
       <div class="form-group">
         <div class="align-center">
-          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2104" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&user=CCDetailsUiT.instr" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
+          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2104" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&user=CCDetailsUiT.instr&token=${sessionToken}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
           <form action="/page/instructorCourseStudentListDownload" method="post" style="display:inline;">
             <input class="btn btn-primary" id="button_download" name="fruploaddownloadbtn" type="submit" value=" Download Student List ">
             <input name="user" type="hidden" value="CCDetailsUiT.instr">
@@ -229,6 +229,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCDetailsUiT.instr">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>
@@ -304,16 +305,16 @@
           ${test.student1}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -322,12 +323,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Alice Betsy&lt;/option&gt;&lt;/td&gt;&lt;/div&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
@@ -367,19 +368,19 @@
           ${test.student2}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -388,12 +389,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Charlie Davis
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
@@ -433,16 +434,16 @@
           danny.e.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -451,12 +452,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Danny Engrid
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>

--- a/src/test/resources/pages/instructorCourseDetailsWithSections.html
+++ b/src/test/resources/pages/instructorCourseDetailsWithSections.html
@@ -78,7 +78,7 @@
       </div>
       <div class="form-group">
         <div class="align-center">
-          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2103" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&user=CCDetailsUiT.instr2" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
+          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2103" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&user=CCDetailsUiT.instr2&token=${sessionToken}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
           <form action="/page/instructorCourseStudentListDownload" method="post" style="display:inline;">
             <input class="btn btn-primary" id="button_download" name="fruploaddownloadbtn" type="submit" value=" Download Student List ">
             <input name="user" type="hidden" value="CCDetailsUiT.instr2">
@@ -229,6 +229,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCDetailsUiT.instr2">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>
@@ -299,16 +300,16 @@
           ${test.student1}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -317,17 +318,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Alice Betsy
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 1
                 </a>
               </li>
@@ -367,19 +368,19 @@
           ${test.student2}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -388,17 +389,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Charlie Davis
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 1
                 </a>
               </li>
@@ -438,19 +439,19 @@
           benny.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2103" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -459,17 +460,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Benny Charles
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 2
                 </a>
               </li>

--- a/src/test/resources/pages/instructorCourseDetailsWithSectionsWithHelperView.html
+++ b/src/test/resources/pages/instructorCourseDetailsWithSectionsWithHelperView.html
@@ -78,7 +78,7 @@
       </div>
       <div class="form-group">
         <div class="align-center">
-          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2103" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&user=CCDetailsUiT.instr2Helper" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
+          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2103" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2103&user=CCDetailsUiT.instr2Helper&token=${sessionToken}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
           <form action="/page/instructorCourseStudentListDownload" method="post" style="display:inline;">
             <input class="btn btn-primary" id="button_download" name="fruploaddownloadbtn" type="submit" value=" Download Student List ">
             <input name="user" type="hidden" value="CCDetailsUiT.instr2Helper">
@@ -229,6 +229,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCDetailsUiT.instr2Helper">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>
@@ -308,7 +309,7 @@
           <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="CCDetailsUiT.CS2103" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Alice Betsy" data-toggle="tooltip" disabled="" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -317,17 +318,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Alice Betsy
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 1
                 </a>
               </li>
@@ -379,7 +380,7 @@
           <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="CCDetailsUiT.CS2103" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" disabled="" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -388,17 +389,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Charlie Davis
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 1
                 </a>
               </li>
@@ -450,7 +451,7 @@
           <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="CCDetailsUiT.CS2103" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" disabled="" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -459,17 +460,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Benny Charles
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2103&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr2Helper&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tut Group 2
                 </a>
               </li>

--- a/src/test/resources/pages/instructorCourseDetailsWithoutSections.html
+++ b/src/test/resources/pages/instructorCourseDetailsWithoutSections.html
@@ -78,7 +78,7 @@
       </div>
       <div class="form-group">
         <div class="align-center">
-          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2104" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&user=CCDetailsUiT.instr" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
+          <input class="btn btn-primary" data-course-id="CCDetailsUiT.CS2104" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&user=CCDetailsUiT.instr&token=${sessionToken}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
           <form action="/page/instructorCourseStudentListDownload" method="post" style="display:inline;">
             <input class="btn btn-primary" id="button_download" name="fruploaddownloadbtn" type="submit" value=" Download Student List ">
             <input name="user" type="hidden" value="CCDetailsUiT.instr">
@@ -229,6 +229,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCDetailsUiT.instr">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>
@@ -299,16 +300,16 @@
           ${test.student1}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -317,12 +318,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Alice Betsy&lt;/option&gt;&lt;/td&gt;&lt;/div&gt;'"
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student1}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
@@ -362,19 +363,19 @@
           ${test.student2}@gmail.com
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -383,12 +384,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Charlie Davis
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=${test.student2}%40gmail.com&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1&lt;/option&gt;&lt;option value="dump"&gt;&lt;/td&gt;&lt;td&gt;'"
                 </a>
               </li>
@@ -428,19 +429,19 @@
           benny.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -449,12 +450,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Benny Charles
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=benny.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
@@ -494,16 +495,16 @@
           danny.e.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="CCDetailsUiT.CS2104" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -512,12 +513,12 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Danny Engrid
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=CCDetailsUiT.CS2104&studentemail=danny.e.tmms%40gmail.tmt&user=CCDetailsUiT.instr&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -197,7 +199,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -209,6 +211,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -281,7 +284,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink3" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -302,7 +305,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -313,6 +316,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor3" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -853,7 +857,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -865,6 +869,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -937,7 +942,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink5" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -958,7 +963,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -969,6 +974,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor5" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1058,7 +1064,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1070,6 +1076,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1158,7 +1165,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1170,6 +1177,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1258,7 +1266,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink8" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink8" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1270,6 +1278,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable8">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1348,6 +1357,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
@@ -2,6 +2,7 @@
   <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
   <input name="instructorid" type="hidden" value="InsCrsEdit.test">
   <input name="user" type="hidden" value="InsCrsEdit.test">
+  <input name="token" type="hidden" value="${sessionToken}">
   <div id="instructorTable7">
     <div class="form-group">
       <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
@@ -2,6 +2,7 @@
   <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
   <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
   <input name="user" type="hidden" value="InsCrsEdit.test">
+  <input name="token" type="hidden" value="${sessionToken}">
   <div id="instructorTable1">
     <div class="form-group">
       <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
@@ -2,6 +2,7 @@
   <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
   <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
   <input name="user" type="hidden" value="InsCrsEdit.test">
+  <input name="token" type="hidden" value="${sessionToken}">
   <div id="instructorTable1">
     <div class="form-group">
       <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -197,7 +199,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -209,6 +211,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -297,7 +300,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -309,6 +312,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -381,7 +385,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink4" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -402,7 +406,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -413,6 +417,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor4" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -502,7 +507,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -514,6 +519,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -602,7 +608,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -614,6 +620,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -702,7 +709,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -714,6 +721,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -792,6 +800,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -105,7 +106,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -117,6 +118,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -656,7 +658,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -668,6 +670,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -740,7 +743,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink3" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -761,7 +764,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -772,6 +775,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor3" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -861,7 +865,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -873,6 +877,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -945,7 +950,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink5" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -966,7 +971,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -977,6 +982,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor5" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1066,7 +1072,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1078,6 +1084,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1166,7 +1173,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1178,6 +1185,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1266,7 +1274,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink8" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink8" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1278,6 +1286,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable8">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1356,6 +1365,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -105,7 +106,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -117,6 +118,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -656,7 +658,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -668,6 +670,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -740,7 +743,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink3" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -761,7 +764,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -772,6 +775,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor3" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -861,7 +865,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -873,6 +877,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -945,7 +950,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink5" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -966,7 +971,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -977,6 +982,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor5" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1066,7 +1072,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1078,6 +1084,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1166,7 +1173,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1178,6 +1185,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1266,7 +1274,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink8" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink8" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1278,6 +1286,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable8">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1356,6 +1365,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -105,7 +106,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -117,6 +118,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -202,7 +204,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -214,6 +216,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -286,7 +289,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink3" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -307,7 +310,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -318,6 +321,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor3" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -407,7 +411,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -419,6 +423,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -491,7 +496,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink5" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -512,7 +517,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -523,6 +528,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor5" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -612,7 +618,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -624,6 +630,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -712,7 +719,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -724,6 +731,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -812,7 +820,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink8" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink8" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -824,6 +832,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable8">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -902,6 +911,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -105,7 +106,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="New name" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=new_email%40email.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -117,6 +118,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -653,7 +655,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -665,6 +667,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -737,7 +740,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink3" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -758,7 +761,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.instructor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -769,6 +772,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor3" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -858,7 +862,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -870,6 +874,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -942,7 +947,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrRemindLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrRemindLink5" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -963,7 +968,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -974,6 +979,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor5" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1063,7 +1069,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1075,6 +1081,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1163,7 +1170,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1175,6 +1182,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1263,7 +1271,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test" id="instrDeleteLink8" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.test&token=${sessionToken}" id="instrDeleteLink8" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -1275,6 +1283,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable8">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -1353,6 +1362,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.test">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -100,7 +100,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.Helper" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.Helper&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -110,6 +110,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -183,7 +184,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -195,6 +196,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -280,7 +282,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -292,6 +294,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -380,7 +383,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -392,6 +395,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -464,7 +468,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.Helper" id="instrRemindLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrRemindLink4" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -485,7 +489,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -496,6 +500,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor4" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -585,7 +590,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -597,6 +602,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -685,7 +691,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -697,6 +703,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -785,7 +792,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.Helper" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.Helper&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -797,6 +804,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -875,6 +883,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.Helper">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.manager" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.manager&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -197,7 +199,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -209,6 +211,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -297,7 +300,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -309,6 +312,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -381,7 +385,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.manager" id="instrRemindLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrRemindLink4" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -402,7 +406,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -413,6 +417,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor4" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -502,7 +507,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -514,6 +519,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -602,7 +608,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -614,6 +620,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -702,7 +709,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.manager" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.manager&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -714,6 +721,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -792,6 +800,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.manager">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.observer" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.observer&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -197,7 +199,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -209,6 +211,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -297,7 +300,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -309,6 +312,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -381,7 +385,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.observer" id="instrRemindLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrRemindLink4" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -402,7 +406,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -413,6 +417,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor4" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -502,7 +507,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -514,6 +519,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -602,7 +608,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -614,6 +620,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -702,7 +709,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.observer" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.observer&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -714,6 +721,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -792,6 +800,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.observer">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.tutor" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.tutor&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.Helper%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.Helper">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -197,7 +199,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink2" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Coord" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.coord%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink2" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -209,6 +211,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.coord">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable2">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -297,7 +300,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink3" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Manager" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.manager%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink3" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -309,6 +312,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.manager">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable3">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -381,7 +385,7 @@
       <div class="pull-right">
         <div class="display-icon" style="display:inline;">
         </div>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.tutor" id="instrRemindLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-original-title="Send invitation email to the instructor" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseRemind?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrRemindLink4" title="" type="button">
           <span class="glyphicon glyphicon-envelope">
           </span>
           Resend Invite
@@ -402,7 +406,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink4" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates New Instructor" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.newInstr%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink4" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -413,6 +417,7 @@
       <form action="/page/instructorCourseInstructorEditSave" class="form form-horizontal" id="formEditInstructor4" method="post" name="formEditInstructors">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable4">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -502,7 +507,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink5" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Observer" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.observer%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink5" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -514,6 +519,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.observer">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable5">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -602,7 +608,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink6" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Test" data-is-delete-self="false" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.test%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink6" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -614,6 +620,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.test">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable6">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -702,7 +709,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.tutor" id="instrDeleteLink7" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-instructor-name="Teammates Tutor" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseInstructorDelete?courseid=InsCrsEdit.CS2104&instructoremail=InsCrsEdit.tutor%40gmail.tmt&user=InsCrsEdit.tutor&token=${sessionToken}" id="instrDeleteLink7" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -714,6 +721,7 @@
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="instructorid" type="hidden" value="InsCrsEdit.tutor">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable7">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -792,6 +800,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="InsCrsEdit.CS2104">
         <input name="user" type="hidden" value="InsCrsEdit.tutor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCourseEnrollError.html
+++ b/src/test/resources/pages/instructorCourseEnrollError.html
@@ -26,6 +26,7 @@
       </div>
       <br>
       <form action="/page/instructorCourseEnrollSave?courseid=CCEnrollUiT.CS2104&user=CCEnrollUiT.teammates.test" class="form-horizontal" method="post" role="form">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div class="col-md-12">
           <div class="form-group">
             <label class="col-sm-1 control-label" for="instructions">

--- a/src/test/resources/pages/instructorCourseEnrollPage.html
+++ b/src/test/resources/pages/instructorCourseEnrollPage.html
@@ -110,6 +110,7 @@
       </div>
       <br>
       <form action="/page/instructorCourseEnrollSave?courseid=CCEnrollUiT.CS2104&user=CCEnrollUiT.teammates.test" class="form-horizontal" method="post" role="form">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div class="col-md-12">
           <div class="form-group">
             <label class="col-sm-1 control-label" for="instructions">

--- a/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
@@ -332,6 +332,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCSDetailsUiT.instr.veryLongGoogleId">
         <input name="studentdetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentDetailsRegisteredWithAttemptedScriptInjection.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsRegisteredWithAttemptedScriptInjection.html
@@ -276,6 +276,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCSDetailsUiT.sanitizationInstruct">
         <input name="studentdetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentDetailsRegisteredWithHelperView.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsRegisteredWithHelperView.html
@@ -247,6 +247,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCSDetailsUiT.Helper">
         <input name="studentdetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentDetailsUnregistered.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsUnregistered.html
@@ -192,6 +192,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="CCSDetailsUiT.instr.veryLongGoogleId">
         <input name="studentdetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentEditPage.html
+++ b/src/test/resources/pages/instructorCourseStudentEditPage.html
@@ -94,6 +94,7 @@
         <input name="courseid" type="hidden" value="CCSDEditUiT.CS2104">
         <input name="sessionsummarysendemail" type="hidden" value="false">
         <input id="openorpublishedemailsent" name="openorpublishedemailsent" type="hidden" value="false">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div class="form-group">
           <label class="col-sm-1 control-label">
             Student Name:

--- a/src/test/resources/pages/instructorCourseStudentEditUnregisteredPage.html
+++ b/src/test/resources/pages/instructorCourseStudentEditUnregisteredPage.html
@@ -11,6 +11,7 @@
         <input name="courseid" type="hidden" value="CCSDEditUiT.CS2104">
         <input name="sessionsummarysendemail" type="hidden" value="false">
         <input id="openorpublishedemailsent" name="openorpublishedemailsent" type="hidden" value="false">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div class="form-group">
           <label class="col-sm-1 control-label">
             Student Name:

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -177,10 +178,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -222,10 +223,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -177,10 +178,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -222,10 +223,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -177,10 +178,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -222,10 +223,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -142,10 +143,10 @@
             <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -187,10 +188,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -232,10 +233,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -176,10 +177,10 @@
             Programming Methodology
           </td>
           <td class="align-center no-print">
-            <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" id="t_course_unarchive1">
+            <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive1">
               Unarchive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" id="t_course_delete1" title="">
+            <a class="btn btn-default btn-xs course-delete-link" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_delete1" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -177,10 +178,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -127,10 +128,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -172,10 +173,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -92,6 +92,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instr2">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instr2">
         <div class="form-group">
           <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -127,10 +128,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -176,10 +177,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -127,10 +128,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -164,10 +165,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instructor">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="CCAddUiTest.instructor">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -177,10 +178,10 @@
             <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorEditStudentFeedbackSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First feedback session">
     <input name="courseid" type="hidden" value="IESFPTCourse">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IESFPTCourseinstr">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-success statusMessage">

--- a/src/test/resources/pages/instructorEditStudentFeedbackPageOpen.html
+++ b/src/test/resources/pages/instructorEditStudentFeedbackPageOpen.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorEditStudentFeedbackSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First feedback session">
     <input name="courseid" type="hidden" value="IESFPTCourse">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IESFPTCourseinstr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ##" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ##" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="New Session ##">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
       <input disabled="" name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1825,6 +1826,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1847,6 +1849,7 @@
             <input name="fsname" type="hidden" value="New Session ##">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -758,6 +758,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -820,7 +821,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -835,7 +836,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -844,7 +845,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -856,7 +857,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -885,7 +886,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -924,7 +925,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -939,7 +940,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -948,7 +949,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -960,7 +961,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -989,7 +990,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1004,7 +1005,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1013,7 +1014,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1025,7 +1026,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1054,7 +1055,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1069,7 +1070,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1078,7 +1079,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1090,7 +1091,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1107,7 +1108,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1249,6 +1250,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1265,7 +1267,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -755,6 +755,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.helper">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -817,7 +818,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.helper" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -832,7 +833,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -841,7 +842,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -853,7 +854,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -882,7 +883,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.helper" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -897,7 +898,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -906,7 +907,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -918,7 +919,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -947,7 +948,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&user=CFeedbackUiT.helper" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -962,7 +963,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -971,7 +972,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -983,7 +984,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1012,7 +1013,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&user=CFeedbackUiT.helper" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1027,7 +1028,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1036,7 +1037,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper">
+                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1048,7 +1049,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.helper&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1065,7 +1066,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1171,6 +1172,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.helper">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1187,7 +1189,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FConstSumOptionQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumOptionQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumOptionQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FConstSumOptionQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumOptionQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumOptionQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1339,6 +1340,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2371,6 +2373,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2393,6 +2396,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
             <input name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FConstSumOptionQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumOptionQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumOptionQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FConstSumOptionQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumOptionQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumOptionQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1339,6 +1340,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2371,6 +2373,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2393,6 +2396,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FConstSumOptionQnUiT.instructor">
             <input name="courseid" type="hidden" value="FConstSumOptionQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FConstSumRecipientQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumRecipientQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumRecipientQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FConstSumRecipientQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumRecipientQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumRecipientQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1306,6 +1307,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2338,6 +2340,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2360,6 +2363,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
             <input name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FConstSumRecipientQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumRecipientQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumRecipientQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FConstSumRecipientQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FConstSumRecipientQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FConstSumRecipientQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1306,6 +1307,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2338,6 +2340,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2360,6 +2363,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FConstSumRecipientQnUiT.instructor">
             <input name="courseid" type="hidden" value="FConstSumRecipientQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FContribQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FContribQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1232,6 +1233,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2264,6 +2266,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2286,6 +2289,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FContribQnUiT.instructor">
             <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FContribQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FContribQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1232,6 +1233,7 @@
     <input name="showgiverto" type="hidden" value="INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2264,6 +2266,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2286,6 +2289,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FContribQnUiT.instructor">
             <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FContribQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FContribQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FContribQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FContribQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FContribQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1232,6 +1233,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2264,6 +2266,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FContribQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2286,6 +2289,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FContribQnUiT.instructor">
             <input name="courseid" type="hidden" value="FContribQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionModal.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionModal.html
@@ -70,6 +70,7 @@
           <input name="fsname" type="hidden" value="First Session">
           <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
           <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+          <input name="token" type="hidden" value="${sessionToken}">
         </form>
         <div id="question-copy-modal-status">
         </div>

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1230,6 +1231,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -1669,6 +1671,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2704,6 +2707,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2726,6 +2730,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopySuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ## (Copied)" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23+%28Copied%29&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ## (Copied)" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23+%28Copied%29&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="New Session ## (Copied)">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
       <input disabled="" name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1825,6 +1826,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1847,6 +1849,7 @@
             <input name="fsname" type="hidden" value="New Session ## (Copied)">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackCopyTrimmedSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyTrimmedSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ## Trimmed (Copied)" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23+Trimmed+%28Copied%29&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="New Session ## Trimmed (Copied)" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23+Trimmed+%28Copied%29&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="New Session ## Trimmed (Copied)">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
       <input disabled="" name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1825,6 +1826,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1847,6 +1849,7 @@
             <input name="fsname" type="hidden" value="New Session ## Trimmed (Copied)">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -758,6 +758,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -825,7 +826,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="responses cant be seen my students 1 #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="responses cant be seen my students 1 #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -840,7 +841,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="responses cant be seen my students 1 #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="responses cant be seen my students 1 #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -849,7 +850,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="responses cant be seen my students 1 #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="responses cant be seen my students 1 #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -861,7 +862,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="responses cant be seen my students 1 #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="false" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="responses cant be seen my students 1 #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="false" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=responses+cant+be+seen+my+students+1+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -890,7 +891,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Allow Early Viewing Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Allow Early Viewing Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -905,7 +906,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Allow Early Viewing Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Allow Early Viewing Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -914,7 +915,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Allow Early Viewing Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Allow Early Viewing Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -926,7 +927,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Allow Early Viewing Session #" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="false" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Allow Early Viewing Session #" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="false" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS1101&fsname=Allow+Early+Viewing+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -955,7 +956,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="private session of characters1234567 #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="private session of characters1234567 #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -994,7 +995,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="New Session ##" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="New Session ##" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1009,7 +1010,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New Session ##" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New Session ##" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1018,7 +1019,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="New Session ##" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="New Session ##" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1030,7 +1031,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New Session ##" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New Session ##" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=New+Session+%23%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1059,7 +1060,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1074,7 +1075,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1083,7 +1084,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1095,7 +1096,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1124,7 +1125,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1163,7 +1164,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1178,7 +1179,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1187,7 +1188,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1199,7 +1200,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1228,7 +1229,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1243,7 +1244,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1252,7 +1253,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1264,7 +1265,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1293,7 +1294,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1308,7 +1309,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1317,7 +1318,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1329,7 +1330,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1346,7 +1347,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1532,6 +1533,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1548,7 +1550,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackEditCopyFail.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyFail.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FeedbackEditCopy.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FeedbackEditCopy.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
       <input disabled="" name="user" type="hidden" value="FeedbackEditCopyinstructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -760,7 +761,7 @@
   <div aria-hidden="false" aria-labelledby="fsCopyModal" class="modal fade in" id="fsCopyModal" role="dialog" style="display: block;" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1261,6 +1262,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2293,6 +2295,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2315,6 +2318,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
             <input name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopyPage.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyPage.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FeedbackEditCopy.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FeedbackEditCopy.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
       <input disabled="" name="user" type="hidden" value="FeedbackEditCopyinstructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -760,7 +761,7 @@
   <div aria-hidden="false" aria-labelledby="fsCopyModal" class="modal fade in" id="fsCopyModal" role="dialog" style="display: block;" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1260,6 +1261,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2292,6 +2294,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2314,6 +2317,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
             <input name="courseid" type="hidden" value="FeedbackEditCopy.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -761,6 +761,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -828,7 +829,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&user=FeedbackEditCopyinstructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2104" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2104" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -843,7 +844,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -852,7 +853,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -864,7 +865,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2104&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -893,7 +894,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&user=FeedbackEditCopyinstructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2105" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2105" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -908,7 +909,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -917,7 +918,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -929,7 +930,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -958,7 +959,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&user=FeedbackEditCopyinstructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2103" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2103" data-fsname="New name!" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -973,7 +974,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -982,7 +983,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                    <a class="session-remind-inner-for-test" data-fsname="New name!" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -994,7 +995,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="New name!" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1023,7 +1024,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&user=FeedbackEditCopyinstructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2104" data-fsname="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="FeedbackEditCopy.CS2104" data-fsname="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1038,7 +1039,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1047,7 +1048,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session" href="/page/instructorFeedbackRemind?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1059,7 +1060,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=FeedbackEditCopy.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FeedbackEditCopyinstructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1076,7 +1077,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1210,6 +1211,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="FeedbackEditCopyinstructor">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1226,7 +1228,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackEditEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackEditEmpty.html
@@ -106,7 +106,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -838,6 +838,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -846,7 +847,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1906,6 +1907,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1928,6 +1930,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>
@@ -2047,6 +2050,8 @@
 <script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/richTextEditor.js" type="text/javascript">
+</script>
+<script src="/js/crypto.js" type="text/javascript">
 </script>
 <script src="/js/datepicker.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
+++ b/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -760,7 +761,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1820,6 +1821,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1842,6 +1844,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -760,7 +761,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1820,6 +1821,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -1842,6 +1844,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -848,6 +848,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.nocourses">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -925,7 +926,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1007,6 +1008,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.nocourses">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1023,7 +1025,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -755,6 +755,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.nosessions">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -823,7 +824,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -905,6 +906,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.nosessions">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -921,7 +923,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FMcqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMcqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMcqQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FMcqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMcqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMcqQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FMcqQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1303,6 +1304,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMcqQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2335,6 +2337,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMcqQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2357,6 +2360,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FMcqQnUiT.instructor">
             <input name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FMcqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMcqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMcqQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FMcqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMcqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMcqQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FMcqQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1289,6 +1290,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMcqQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2321,6 +2323,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMcqQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2343,6 +2346,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FMcqQnUiT.instructor">
             <input name="courseid" type="hidden" value="FMcqQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FMsqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMsqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMsqQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FMsqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMsqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMsqQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FMsqQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1303,6 +1304,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMsqQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2335,6 +2337,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMsqQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2357,6 +2360,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FMsqQnUiT.instructor">
             <input name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FMsqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMsqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMsqQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FMsqQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FMsqQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FMsqQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FMsqQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1289,6 +1290,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMsqQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2321,6 +2323,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FMsqQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2343,6 +2346,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FMsqQnUiT.instructor">
             <input name="courseid" type="hidden" value="FMsqQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FNumScaleQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FNumScaleQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FNumScaleQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FNumScaleQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FNumScaleQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FNumScaleQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FNumScaleQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1242,6 +1243,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2274,6 +2276,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2296,6 +2299,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
             <input name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FNumScaleQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FNumScaleQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FNumScaleQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FNumScaleQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FNumScaleQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FNumScaleQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FNumScaleQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1242,6 +1243,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2274,6 +2276,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2296,6 +2299,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FNumScaleQnUiT.instructor">
             <input name="courseid" type="hidden" value="FNumScaleQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -758,6 +758,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -825,7 +826,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -840,7 +841,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -849,7 +850,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -861,7 +862,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -890,7 +891,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -929,7 +930,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -944,7 +945,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -953,7 +954,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -965,7 +966,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -994,7 +995,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1009,7 +1010,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1018,7 +1019,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1030,7 +1031,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1059,7 +1060,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1074,7 +1075,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1083,7 +1084,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1095,7 +1096,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Manual Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Manual Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1112,7 +1113,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1254,6 +1255,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1270,7 +1272,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1227,6 +1228,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2259,6 +2261,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2281,6 +2284,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1227,6 +1228,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2259,6 +2261,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2281,6 +2284,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1227,6 +1228,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2259,6 +2261,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2281,6 +2284,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackEditUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackEditUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackEditUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1227,6 +1228,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2259,6 +2261,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2281,6 +2284,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRankUiT.CS4221" data-feedback-session-name="Edit Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRankUiT.CS4221&fsname=Edit+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRankUiT.CS4221" data-feedback-session-name="Edit Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRankUiT.CS4221&fsname=Edit+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="Edit Session">
       <input disabled="" name="courseid" type="hidden" value="FRankUiT.CS4221">
       <input disabled="" name="user" type="hidden" value="FRankUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1264,6 +1265,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -1699,6 +1701,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2734,6 +2737,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2756,6 +2760,7 @@
             <input name="fsname" type="hidden" value="Edit Session">
             <input name="user" type="hidden" value="FRankUiT.instructor">
             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRankUiT.CS4221" data-feedback-session-name="Edit Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRankUiT.CS4221&fsname=Edit+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRankUiT.CS4221" data-feedback-session-name="Edit Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRankUiT.CS4221&fsname=Edit+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="Edit Session">
       <input disabled="" name="courseid" type="hidden" value="FRankUiT.CS4221">
       <input disabled="" name="user" type="hidden" value="FRankUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1275,6 +1276,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -1710,6 +1712,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2745,6 +2748,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRankUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2767,6 +2771,7 @@
             <input name="fsname" type="hidden" value="Edit Session">
             <input name="user" type="hidden" value="FRankUiT.instructor">
             <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackResultDefaultSort.html
+++ b/src/test/resources/pages/instructorFeedbackResultDefaultSort.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -388,6 +388,7 @@
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                    <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
                                   <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-1-0-1-1" onclick="showResponseCommentEditForm(1,0,1,1, { sectionIndex: 0 })" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -537,6 +538,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-1-0-1-2">
@@ -555,6 +557,7 @@
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                    <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
                                   <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-1-0-1-2" onclick="showResponseCommentEditForm(1,0,1,2, { sectionIndex: 0 })" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -704,6 +707,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-0-0-1-1" style="display: none;">
@@ -780,6 +784,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -508,6 +508,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -664,6 +665,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -827,6 +829,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -971,6 +974,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1115,6 +1119,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1284,6 +1289,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1453,6 +1459,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1622,6 +1629,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1831,6 +1839,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2000,6 +2009,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2169,6 +2179,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2369,6 +2380,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2538,6 +2550,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2701,6 +2714,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2901,6 +2915,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3101,6 +3116,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3301,6 +3317,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3470,6 +3487,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3639,6 +3657,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3818,6 +3837,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3962,6 +3982,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -74,7 +74,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper1" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper1&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -74,7 +74,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper2" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper2&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -510,6 +510,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -666,6 +667,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -829,6 +831,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -973,6 +976,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1117,6 +1121,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1294,6 +1299,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1471,6 +1477,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1673,6 +1680,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1859,6 +1867,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2036,6 +2045,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2238,6 +2248,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2415,6 +2426,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2617,6 +2629,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2794,6 +2807,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2996,6 +3010,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3173,6 +3188,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3375,6 +3391,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3562,6 +3579,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3706,6 +3724,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3871,6 +3890,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -388,6 +388,7 @@
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                    <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
                                   <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-0-1-1-1" onclick="showResponseCommentEditForm(0,1,1,1, { sectionIndex: 0 })" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -472,6 +473,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-0-1-1-2">
@@ -490,6 +492,7 @@
                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
                                     <input name="fsname" type="hidden" value="First Session">
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                    <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
                                   <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-0-1-1-2" onclick="showResponseCommentEditForm(0,1,1,2, { sectionIndex: 0 })" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
@@ -574,6 +577,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="showResponseCommentAddForm-0-0-1-1" style="display: none;">
@@ -647,6 +651,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Third Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=Third+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Third Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=Third+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -160,7 +160,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
@@ -74,7 +74,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper1" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper1&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -74,7 +74,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper2" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.helper2&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -557,6 +557,7 @@
                             <input name="user" type="hidden" value="FRankUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -687,6 +688,7 @@
                             <input name="user" type="hidden" value="FRankUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -885,6 +887,7 @@
                             <input name="user" type="hidden" value="FRankUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1071,6 +1074,7 @@
                             <input name="user" type="hidden" value="FRankUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Instructor Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRankUiT.CS4221&fsname=Instructor+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRankUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankSubmission.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Instructor Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="FRankUiT.instructor">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -462,6 +462,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -633,6 +634,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -835,6 +837,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1006,6 +1009,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1208,6 +1212,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -464,6 +464,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -643,6 +644,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -847,6 +849,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1026,6 +1029,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1230,6 +1234,7 @@
                             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, STUDENTS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Sanitized Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.SanitizedTeam&fsname=Sanitized+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Sanitized Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.SanitizedTeam&fsname=Sanitized+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -508,6 +508,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -664,6 +665,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -827,6 +829,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -971,6 +974,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1115,6 +1119,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1284,6 +1289,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1453,6 +1459,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1622,6 +1629,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1831,6 +1839,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2000,6 +2009,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2169,6 +2179,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2369,6 +2380,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2538,6 +2550,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2701,6 +2714,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2901,6 +2915,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3101,6 +3116,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3301,6 +3317,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3470,6 +3487,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3639,6 +3657,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3818,6 +3837,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3962,6 +3982,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -526,6 +526,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -682,6 +683,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -845,6 +847,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -989,6 +992,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1133,6 +1137,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1302,6 +1307,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1471,6 +1477,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1640,6 +1647,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1849,6 +1857,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2018,6 +2027,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2187,6 +2197,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2387,6 +2398,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2556,6 +2568,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2719,6 +2732,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2940,6 +2954,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3140,6 +3155,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3340,6 +3356,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3509,6 +3526,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3678,6 +3696,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3857,6 +3876,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -4001,6 +4021,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRGQSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRGQSearch.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -443,6 +443,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -691,6 +692,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -847,6 +849,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1010,6 +1013,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1154,6 +1158,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1298,6 +1303,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1475,6 +1481,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1652,6 +1659,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1854,6 +1862,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2040,6 +2049,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2217,6 +2227,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2419,6 +2430,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2596,6 +2608,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2819,6 +2832,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2996,6 +3010,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3198,6 +3213,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3375,6 +3391,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3577,6 +3594,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3764,6 +3782,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3908,6 +3927,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -4073,6 +4093,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -4362,6 +4383,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -510,6 +510,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -666,6 +667,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -829,6 +831,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -973,6 +976,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1117,6 +1121,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1294,6 +1299,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1471,6 +1477,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1673,6 +1680,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1859,6 +1867,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2036,6 +2045,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2238,6 +2248,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2415,6 +2426,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2617,6 +2629,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2794,6 +2807,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2996,6 +3010,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3173,6 +3188,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3375,6 +3391,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3562,6 +3579,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3706,6 +3724,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -3871,6 +3890,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>
@@ -528,6 +528,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -684,6 +685,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -847,6 +849,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -991,6 +994,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1135,6 +1139,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1312,6 +1317,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1489,6 +1495,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1691,6 +1698,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1877,6 +1885,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2054,6 +2063,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2256,6 +2266,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2433,6 +2444,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2656,6 +2668,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2833,6 +2846,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3035,6 +3049,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3212,6 +3227,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3414,6 +3430,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS, RECEIVER, STUDENTS, OWN_TEAM_MEMBERS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3601,6 +3618,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3745,6 +3763,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -3910,6 +3929,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="First Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>
@@ -523,6 +523,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -674,6 +675,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -792,6 +794,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -924,6 +927,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1055,6 +1059,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1219,6 +1224,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1373,6 +1379,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1530,6 +1537,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1684,6 +1692,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1838,6 +1847,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1976,6 +1986,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2133,6 +2144,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2271,6 +2283,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2428,6 +2441,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2602,6 +2616,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2725,6 +2740,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2880,6 +2896,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>
@@ -541,6 +541,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -692,6 +693,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -810,6 +812,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -942,6 +945,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1073,6 +1077,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1237,6 +1242,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1391,6 +1397,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1548,6 +1555,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1702,6 +1710,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1856,6 +1865,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1994,6 +2004,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2151,6 +2162,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2289,6 +2301,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2446,6 +2459,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2620,6 +2634,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2743,6 +2758,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2987,6 +3003,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>
@@ -525,6 +525,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -676,6 +677,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -794,6 +796,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -926,6 +929,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1057,6 +1061,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1221,6 +1226,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1408,6 +1414,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1565,6 +1572,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1717,6 +1725,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -1904,6 +1913,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2091,6 +2101,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2257,6 +2268,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2414,6 +2426,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2580,6 +2593,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>
@@ -2737,6 +2751,7 @@
                             <input name="user" type="hidden" value="CFResultsUiT.instr">
                             <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                             <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                            <input name="token" type="hidden" value="${sessionToken}">
                           </form>
                         </li>
                       </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>
@@ -543,6 +543,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -694,6 +695,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, STUDENTS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -812,6 +814,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -944,6 +947,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1075,6 +1079,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1239,6 +1244,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1426,6 +1432,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1583,6 +1590,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1735,6 +1743,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -1971,6 +1980,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2158,6 +2168,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2401,6 +2412,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2558,6 +2570,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2745,6 +2758,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>
@@ -2902,6 +2916,7 @@
                                   <input name="user" type="hidden" value="CFResultsUiT.instr">
                                   <input name="showresponsecommentsto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
                                   <input name="showresponsegiverto" type="hidden" value="GIVER, RECEIVER, OWN_TEAM_MEMBERS, RECEIVER_TEAM_MEMBERS, INSTRUCTORS">
+                                  <input name="token" type="hidden" value="${sessionToken}">
                                 </form>
                               </li>
                             </ul>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-publish-for-test" data-fsname="Second Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFResultsUiT.CS2104&fsname=Second+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFResultsUiT.instr&token=${sessionToken}" title="">
                     Publish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1373,6 +1374,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2405,6 +2407,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2427,6 +2430,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1373,6 +1374,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2405,6 +2407,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2427,6 +2430,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1336,6 +1337,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2368,6 +2370,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2390,6 +2393,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1370,6 +1371,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2402,6 +2404,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2424,6 +2427,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1336,6 +1337,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2368,6 +2370,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2390,6 +2393,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1373,6 +1374,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2405,6 +2407,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2427,6 +2430,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="FRubricQnUiT.CS2104" data-feedback-session-name="First Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=FRubricQnUiT.CS2104&fsname=First+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=FRubricQnUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="First Session">
       <input disabled="" name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
       <input disabled="" name="user" type="hidden" value="FRubricQnUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1339,6 +1340,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2371,6 +2373,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -2393,6 +2396,7 @@
             <input name="fsname" type="hidden" value="First Session">
             <input name="user" type="hidden" value="FRubricQnUiT.instructor">
             <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -93,6 +93,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Fourth Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Second Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageEmpty.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Third Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Grace Period Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr2">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePreview.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Private Session">
     <input name="courseid" type="hidden" value="IFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageRankHelper.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Instructor Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="FRankUiT.helper">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="Team Peer Evaluation Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Team+Peer+Evaluation+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="CFeedbackUiT.CS1101" data-feedback-session-name="Team Peer Evaluation Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Team+Peer+Evaluation+Session&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="Team Peer Evaluation Session">
       <input disabled="" name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
       <input disabled="" name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -765,7 +766,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1244,6 +1245,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -1700,6 +1702,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2147,6 +2150,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2591,6 +2595,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -3041,6 +3046,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -4085,6 +4091,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="CFeedbackUiT.instructor">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -4107,6 +4114,7 @@
             <input name="fsname" type="hidden" value="Team Peer Evaluation Session">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
             <input name="courseid" type="hidden" value="CFeedbackUiT.CS1101">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -758,6 +758,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -825,7 +826,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Awaiting Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -840,7 +841,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -849,7 +850,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Awaiting Session #" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -861,7 +862,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Awaiting Session #" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -890,7 +891,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="Private Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -929,7 +930,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Open Session #" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -944,7 +945,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -953,7 +954,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Open Session #" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -965,7 +966,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Open Session #" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -994,7 +995,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS2104" data-fsname="First Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1009,7 +1010,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -1018,7 +1019,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="First Session #1" disabled="" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1030,7 +1031,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First Session #1" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CFeedbackUiT.CS2104&fsname=First+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1059,7 +1060,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&user=CFeedbackUiT.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CFeedbackUiT.CS1101" data-fsname="Manual Session #1" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -1074,7 +1075,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -1083,7 +1084,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor">
+                    <a class="session-remind-inner-for-test" data-fsname="Manual Session #1" href="/page/instructorFeedbackRemind?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -1095,7 +1096,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Manual Session #1" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS1101&fsname=Manual+Session+%231&next=%2Fpage%2FinstructorFeedbacksPage&user=CFeedbackUiT.instructor&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -1112,7 +1113,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1254,6 +1255,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="CFeedbackUiT.instructor">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1270,7 +1272,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -38,7 +38,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -161,12 +161,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -239,7 +239,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -254,7 +254,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -263,7 +263,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -275,7 +275,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -311,7 +311,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -326,7 +326,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -335,7 +335,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -347,7 +347,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -383,7 +383,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -398,7 +398,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -407,7 +407,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -419,7 +419,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -455,7 +455,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -470,7 +470,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -479,7 +479,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -491,7 +491,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -502,7 +502,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
@@ -36,7 +36,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -97,7 +97,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLEmpty.html
+++ b/src/test/resources/pages/instructorHomeHTMLEmpty.html
@@ -46,7 +46,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -107,7 +107,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -119,7 +119,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -581,7 +581,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -596,7 +596,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -605,7 +605,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -617,7 +617,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -628,7 +628,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -578,7 +578,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -593,7 +593,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -602,7 +602,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -614,7 +614,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -625,7 +625,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -232,7 +232,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -247,7 +247,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -256,7 +256,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -268,7 +268,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -304,7 +304,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -319,7 +319,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -328,7 +328,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -340,7 +340,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -376,7 +376,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -391,7 +391,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -400,7 +400,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -412,7 +412,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -448,7 +448,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -463,7 +463,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -472,7 +472,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -484,7 +484,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -557,12 +557,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS1101" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS1101&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="CHomeUiT.CS2104" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CHomeUiT.CS2104&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -364,7 +364,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="First Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -379,7 +379,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -388,7 +388,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="First Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -400,7 +400,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="First Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=First+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -436,7 +436,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Second Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -451,7 +451,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -460,7 +460,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Second Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -472,7 +472,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second Feedback Session" data-original-title="This session is not yet opened" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" disabled="" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -508,7 +508,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Third Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -523,7 +523,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -532,7 +532,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Third Feedback Session" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -544,7 +544,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Third Feedback Session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -580,7 +580,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&user=CHomeUiT.instructor.tmms" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="CHomeUiT.CS2104" data-fsname="Fourth Feedback Session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -595,7 +595,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -604,7 +604,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms">
+                    <a class="session-remind-inner-for-test" data-fsname="Fourth Feedback Session" disabled="" href="/page/instructorFeedbackRemind?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -616,7 +616,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Fourth Feedback Session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=CHomeUiT.CS2104&fsname=Fourth+Feedback+Session&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -627,7 +627,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -31,7 +31,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -154,12 +154,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo1&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo1&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo1&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo1&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -286,12 +286,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo2&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo2&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo2" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo2&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo2" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo2&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -418,12 +418,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo3" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo3&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="ins.wit-demo3" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=ins.wit-demo3&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo3" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo3&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo3" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo3&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -510,7 +510,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -46,7 +46,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -169,12 +169,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="newIns.wit-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=newIns.wit-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="newIns.wit-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=newIns.wit-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="newIns.wit-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=newIns.wit-demo&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="newIns.wit-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=newIns.wit-demo&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -239,7 +239,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
@@ -46,7 +46,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -107,7 +107,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent1.html
+++ b/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent1.html
@@ -155,16 +155,16 @@
                   @gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student1 In Course1</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student1 In Course1</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -173,7 +173,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             student1
@@ -188,12 +188,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -250,16 +250,16 @@
                   @gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -268,7 +268,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student: student2 2
                           <span class="highlight">
                             In
@@ -279,12 +279,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -341,16 +341,16 @@
                   @gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -359,7 +359,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student: student2
                           <span class="highlight">
                             In
@@ -370,12 +370,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -432,16 +432,16 @@
                   @gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student3 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student3 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -450,7 +450,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student: student3
                           <span class="highlight">
                             In
@@ -461,12 +461,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.2
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>

--- a/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent2.html
+++ b/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent2.html
@@ -140,16 +140,16 @@
                   Course1@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student1 In Course1</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student1 In Course1</option></td></div>\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -158,7 +158,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student: student1
                           <span class="highlight">
                             In
@@ -167,12 +167,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student1InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -228,16 +228,16 @@
                   Course1@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -246,7 +246,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             student2
@@ -259,12 +259,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -321,16 +321,16 @@
                   Course1@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +339,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             student2
@@ -351,12 +351,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>
@@ -408,16 +408,16 @@
                   Course1@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student3 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student3 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -426,7 +426,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student: student3
                           <span class="highlight">
                             In
@@ -435,12 +435,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.2
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student3InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>

--- a/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent2WithExactString.html
+++ b/src/test/resources/pages/instructorSearchPageSearchStudentsForStudent2WithExactString.html
@@ -130,16 +130,16 @@
                   searchUI.student2.2InCourse1@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="searchUI.idOfTypicalCourse1" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="student2 2 In Course1" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -148,7 +148,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             student2 2 In Course1
@@ -156,12 +156,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1.1&lt;/td&gt;&lt;/div&gt;'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=searchUI.idOfTypicalCourse1&studentemail=searchUI.student2.2InCourse1%40gmail.tmt&user=searchUI.idOfInstructor1OfCourse1&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section 1
                         </a>
                       </li>

--- a/src/test/resources/pages/instructorStudentList.html
+++ b/src/test/resources/pages/instructorStudentList.html
@@ -307,16 +307,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -325,17 +325,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -375,16 +375,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -393,17 +393,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -443,16 +443,16 @@
                 hugh.i.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -461,17 +461,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Hugh Ivanov
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -511,16 +511,16 @@
                 ivan.j.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ivan James" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ivan James" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -529,17 +529,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Ivan James
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -579,16 +579,16 @@
                 jack.k.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Jack Khan" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Jack Khan" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -597,17 +597,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Jack Khan
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -710,16 +710,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -728,12 +728,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -773,16 +773,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -791,12 +791,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -836,16 +836,16 @@
                 CCSDetailsUiT.charlie.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -854,12 +854,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Charlie D
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -899,16 +899,16 @@
                 denny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -917,12 +917,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Denny Charlés
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>

--- a/src/test/resources/pages/instructorStudentListPageDisplayArchivedCourses.html
+++ b/src/test/resources/pages/instructorStudentListPageDisplayArchivedCourses.html
@@ -316,16 +316,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -334,12 +334,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -379,16 +379,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -397,12 +397,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -442,16 +442,16 @@
                 CCSDetailsUiT.charlie.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -460,12 +460,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Charlie D
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -505,16 +505,16 @@
                 denny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -523,12 +523,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Denny Charlés
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -631,16 +631,16 @@
                 ann.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course4" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ann" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course4" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ann" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -649,12 +649,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Ann
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course4&studentemail=ann.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>

--- a/src/test/resources/pages/instructorStudentListPageHideArchivedCourses.html
+++ b/src/test/resources/pages/instructorStudentListPageHideArchivedCourses.html
@@ -295,16 +295,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -313,12 +313,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -358,16 +358,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -376,12 +376,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -421,16 +421,16 @@
                 CCSDetailsUiT.charlie.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -439,12 +439,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Charlie D
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -484,16 +484,16 @@
                 denny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -502,12 +502,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Denny Charlés
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorOfCourse4&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>

--- a/src/test/resources/pages/instructorStudentListPageSearchStudent.html
+++ b/src/test/resources/pages/instructorStudentListPageSearchStudent.html
@@ -135,16 +135,16 @@
                   .tmms@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -153,7 +153,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             Charlie
@@ -162,7 +162,7 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 2
                         </a>
                       </li>

--- a/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
+++ b/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
@@ -135,16 +135,16 @@
                   .tmms@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -153,7 +153,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             Alice
@@ -162,12 +162,12 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on section: Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                         </a>
                       </li>
@@ -262,16 +262,16 @@
                   .tmms@gmail.tmt
                 </td>
                 <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     View
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     Edit
                   </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                  <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                     Delete
                   </a>
-                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                  <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                     All Records
                   </a>
                   <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -280,7 +280,7 @@
                     </a>
                     <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on student:
                           <span class="highlight">
                             Alice
@@ -289,7 +289,7 @@
                         </a>
                       </li>
                       <li role="presentation">
-                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                        <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                           Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                         </a>
                       </li>

--- a/src/test/resources/pages/instructorStudentListPageWithPicture.html
+++ b/src/test/resources/pages/instructorStudentListPageWithPicture.html
@@ -301,16 +301,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -319,17 +319,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -369,16 +369,16 @@
                 hugh.i.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -387,17 +387,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Hugh Ivanov
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -437,16 +437,16 @@
                 ivan.j.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ivan James" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Ivan James" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -455,17 +455,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Ivan James
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -505,16 +505,16 @@
                 jack.k.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Jack Khan" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Jack Khan" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -523,17 +523,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Jack Khan
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -636,16 +636,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -654,12 +654,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -699,16 +699,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -717,12 +717,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -759,16 +759,16 @@
                 CCSDetailsUiT.charlie.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -777,12 +777,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Charlie D
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -822,16 +822,16 @@
                 denny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -840,12 +840,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Denny Charlés
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>

--- a/src/test/resources/pages/instructorStudentListWithHelperView.html
+++ b/src/test/resources/pages/instructorStudentListWithHelperView.html
@@ -399,7 +399,7 @@
                 <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="course2" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" disabled="" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -408,17 +408,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -467,7 +467,7 @@
                 <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="course2" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" disabled="" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -476,17 +476,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -535,7 +535,7 @@
                 <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="course2" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" disabled="" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -544,17 +544,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Hugh Ivanov
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=hugh.i.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -603,7 +603,7 @@
                 <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="course2" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Ivan James" data-toggle="tooltip" disabled="" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -612,17 +612,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Ivan James
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=ivan.j.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -671,7 +671,7 @@
                 <a class="course-student-delete-link btn btn-default btn-xs disabled mouse-hover-only" data-course-id="course2" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-student-name="Jack Khan" data-toggle="tooltip" disabled="" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="You do not have the permissions to access this feature" data-placement="top" data-toggle="tooltip" title="">
@@ -680,17 +680,17 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Jack Khan
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 3
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=jack.k.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on section: Section B
                       </a>
                     </li>
@@ -793,16 +793,16 @@
                 CCSDetailsUiT.alice.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -811,12 +811,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Alice&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -856,16 +856,16 @@
                 benny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -874,12 +874,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Benny Charles
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=benny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                       </a>
                     </li>
@@ -919,16 +919,16 @@
                 CCSDetailsUiT.charlie.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie D" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -937,12 +937,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Charlie D
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=CCSDetailsUiT.charlie.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>
@@ -982,16 +982,16 @@
                 denny.c.tmms@gmail.tmt
               </td>
               <td class="no-print align-center">
-                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   View
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   Edit
                 </a>
-                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" title="">
+                <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="course3" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Denny Charlés" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
                   Delete
                 </a>
-                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses" rel="noopener noreferrer" target="_blank" title="">
+                <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
                   All Records
                 </a>
                 <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -1000,12 +1000,12 @@
                   </a>
                   <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on student: Denny Charlés
                       </a>
                     </li>
                     <li role="presentation">
-                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                      <a href="/page/instructorCourseStudentDetailsPage?courseid=course3&studentemail=denny.c.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                         Comment on team: Team 2
                       </a>
                     </li>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -385,6 +385,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -550,6 +551,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -687,6 +689,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>
@@ -865,6 +868,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -1002,6 +1006,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>
@@ -1180,6 +1185,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -1317,6 +1323,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsPageAddComment.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageAddComment.html
@@ -313,6 +313,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -482,6 +483,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -647,6 +649,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -812,6 +815,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -949,6 +953,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>
@@ -1127,6 +1132,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -1264,6 +1270,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>
@@ -1442,6 +1449,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -1579,6 +1587,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsPageMixedQuestionType.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageMixedQuestionType.html
@@ -292,6 +292,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="FSQTT.idOfInstructor1OfCourse1">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsPageNoRecords.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageNoRecords.html
@@ -186,6 +186,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.no.eval">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsPageWithPrivateFeedback.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageWithPrivateFeedback.html
@@ -292,6 +292,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>
@@ -470,6 +471,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -607,6 +609,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsPageWithScriptInjectionProfile.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageWithScriptInjectionProfile.html
@@ -304,6 +304,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.instr">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -441,6 +442,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.instr">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/instructorStudentRecordsWithHelperView.html
+++ b/src/test/resources/pages/instructorStudentRecordsWithHelperView.html
@@ -206,6 +206,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test.Helper">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -373,6 +374,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test.Helper">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -540,6 +542,7 @@
                       <input name="showgiverto" type="hidden" value="">
                       <input name="showrecipientto" type="hidden" value="INSTRUCTOR">
                       <input name="user" type="hidden" value="ISR.teammates.test.Helper">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning">
@@ -707,6 +710,7 @@
                       <input name="showgiverto" type="hidden" value="INSTRUCTOR">
                       <input name="showrecipientto" type="hidden" value="">
                       <input name="user" type="hidden" value="ISR.teammates.test.Helper">
+                      <input name="token" type="hidden" value="${sessionToken}">
                     </form>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="comment_box" style="display: none;">
@@ -844,6 +848,7 @@
                         <input name="showgiverto" type="hidden" value="">
                         <input name="showrecipientto" type="hidden" value="">
                         <input name="user" type="hidden" value="ISR.teammates.test.Helper">
+                        <input name="token" type="hidden" value="${sessionToken}">
                       </div>
                     </form>
                   </li>

--- a/src/test/resources/pages/newlyJoinedInstructorCommentsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCommentsPage.html
@@ -184,7 +184,7 @@
         </strong>
       </h4>
       <div class="btn-group pull-right" style="display:none">
-        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}" style="margin-right: 17px;" title="" type="button">
+        <a class="btn btn-sm btn-info" data-original-title="Send email notification to 0 recipient(s) of comments pending notification" data-toggle="tooltip" href="/page/instructorStudentCommentClearPending?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}&token=${sessionToken}" style="margin-right: 17px;" title="" type="button">
           <span class="badge" style="margin-right: 5px">
             0
           </span>
@@ -389,6 +389,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM, COURSE">
                     <input name="showrecipientto" type="hidden" value="TEAM, COURSE">
                     <input name="user" type="hidden" value="${test.instructor}">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-public">
@@ -553,6 +554,7 @@
                     <input name="showgiverto" type="hidden" value="TEAM">
                     <input name="showrecipientto" type="hidden" value="TEAM">
                     <input name="user" type="hidden" value="${test.instructor}">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
                 <li class="list-group-item list-group-item-warning status_display-private">
@@ -715,6 +717,7 @@
                     <input name="showgiverto" type="hidden" value="">
                     <input name="showrecipientto" type="hidden" value="">
                     <input name="user" type="hidden" value="${test.instructor}">
+                    <input name="token" type="hidden" value="${sessionToken}">
                   </form>
                 </li>
               </ul>

--- a/src/test/resources/pages/newlyJoinedInstructorCourseDetailsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseDetailsPage.html
@@ -75,7 +75,7 @@
       </div>
       <div class="form-group">
         <div class="align-center">
-          <input class="btn btn-primary" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
+          <input class="btn btn-primary" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Email an invitation to all students yet to join requesting them to join the course using their Google Accounts. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}&token=${sessionToken}" id="button_remind" tabindex="1" title="" type="button" value="Remind Students to Join">
           <form action="/page/instructorCourseStudentListDownload" method="post" style="display:inline;">
             <input class="btn btn-primary" id="button_download" name="fruploaddownloadbtn" type="submit" value=" Download Student List ">
             <input name="user" type="hidden" value="${test.instructor}">
@@ -226,6 +226,7 @@
         <input name="showrecipientto" type="hidden" value="">
         <input name="user" type="hidden" value="${test.instructor}">
         <input name="coursedetailspage" type="hidden" value="true">
+        <input name="token" type="hidden" value="${sessionToken}">
       </div>
     </form>
   </div>
@@ -296,16 +297,16 @@
           alice.b.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice Betsy" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -314,17 +315,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Alice Betsy
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=alice.b.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 1
                 </a>
               </li>
@@ -364,16 +365,16 @@
           benny.c.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Benny Charles" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -382,17 +383,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Benny Charles
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=benny.c.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 1
                 </a>
               </li>
@@ -432,16 +433,16 @@
           danny.e.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Danny Engrid" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -450,17 +451,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Danny Engrid
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=danny.e.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 1
                 </a>
               </li>
@@ -500,16 +501,16 @@
           emma.f.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Emma Farrell" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Emma Farrell" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -518,17 +519,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Emma Farrell
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 1
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=emma.f.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 1
                 </a>
               </li>
@@ -568,16 +569,16 @@
           AHPUiT+++_.instr1!@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="AHPUiT Instrúctör WithPlusInEmail" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="AHPUiT Instrúctör WithPlusInEmail" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -586,17 +587,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: AHPUiT Instrúctör WithPlusInEmail
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 2
                 </a>
               </li>
@@ -636,16 +637,16 @@
           charlie.d.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Charlie Davis" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -654,17 +655,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Charlie Davis
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=charlie.d.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 2
                 </a>
               </li>
@@ -704,16 +705,16 @@
           francis.g.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Francis Gabriel" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Francis Gabriel" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -722,17 +723,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Francis Gabriel
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=francis.g.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 2
                 </a>
               </li>
@@ -772,16 +773,16 @@
           gene.h.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Gene Hudson" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Gene Hudson" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -790,17 +791,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Gene Hudson
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 2
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=gene.h.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 2
                 </a>
               </li>
@@ -840,19 +841,19 @@
           hugh.i.tmms@gmail.tmt
         </td>
         <td class="no-print align-center">
-          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             View
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             Edit
           </a>
-          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-remind-link btn btn-default btn-xs" data-original-title="Email an invitation to the student requesting him/her to join the course using his/her Google Account. Note: Students can use TEAMMATES without ‘joining’, but a joined student can access extra features e.g. set up a user profile" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseRemind?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Send Invite
           </a>
-          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}" title="">
+          <a class="course-student-delete-link btn btn-default btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Hugh Ivanov" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" title="">
             Delete
           </a>
-          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}" rel="noopener noreferrer" target="_blank" title="">
+          <a class="btn btn-default btn-xs" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
             All Records
           </a>
           <div class="btn-group" data-original-title="Give a comment for this student, his/her team/section" data-placement="top" data-toggle="tooltip" title="">
@@ -861,17 +862,17 @@
             </a>
             <ul aria-labelledby="dLabel" class="dropdown-menu align-left" role="menu">
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=student" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on student: Hugh Ivanov
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=team" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on team: Team 3
                 </a>
               </li>
               <li role="presentation">
-                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
+                <a href="/page/instructorCourseStudentDetailsPage?courseid=AHPUiT____.instr1_.gma-demo&studentemail=hugh.i.tmms%40gmail.tmt&user=${test.instructor}&token=${sessionToken}&addComment=section" rel="noopener noreferrer" role="menuitem" tabindex="-1" target="_blank">
                   Comment on section: Tutorial Group 2
                 </a>
               </li>

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -27,6 +27,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseEditSave" class="form form-horizontal" id="formEditcourse" method="post">
         <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="instructorid" type="hidden" value="${test.instructor}">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -100,7 +101,7 @@
           </span>
           Cancel
         </a>
-        <a class="btn btn-primary btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-instructor-name="AHPUiT Instrúctör WithPlusInEmail" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=AHPUiT____.instr1_.gma-demo&instructoremail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}" id="instrDeleteLink1" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-instructor-name="AHPUiT Instrúctör WithPlusInEmail" data-is-delete-self="true" data-original-title="Delete the instructor from the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseInstructorDelete?courseid=AHPUiT____.instr1_.gma-demo&instructoremail=AHPUiT%2B%2B%2B_.instr1%21%40gmail.tmt&user=${test.instructor}&token=${sessionToken}" id="instrDeleteLink1" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete
@@ -112,6 +113,7 @@
         <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
         <input name="instructorid" type="hidden" value="${test.instructor}">
         <input name="user" type="hidden" value="${test.instructor}">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorTable1">
           <div class="form-group">
             <label class="col-sm-3 control-label">
@@ -190,6 +192,7 @@
       <form action="/page/instructorCourseInstructorAdd" class="form form-horizontal" id="formAddInstructor" method="post" name="formAddInstructor">
         <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
         <input name="user" type="hidden" value="${test.instructor}">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div id="instructorAddTable">
           <div class="form-group">
             <label class="col-sm-3 control-label">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEnrollPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEnrollPage.html
@@ -26,6 +26,7 @@
       </div>
       <br>
       <form action="/page/instructorCourseEnrollSave?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}" class="form-horizontal" method="post" role="form">
+        <input name="token" type="hidden" value="${sessionToken}">
         <div class="col-md-12">
           <div class="form-group">
             <label class="col-sm-1 control-label" for="instructions">

--- a/src/test/resources/pages/newlyJoinedInstructorCoursesPageSampleCourseUnarhived.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCoursesPageSampleCourseUnarhived.html
@@ -9,6 +9,7 @@
     <div class="panel-body fill-plain">
       <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
         <input id="instructorid" name="instructorid" type="hidden" value="${test.instructor}">
+        <input name="token" type="hidden" value="${sessionToken}">
         <input name="user" type="hidden" value="${test.instructor}">
         <div class="form-group">
           <label class="col-sm-3 control-label">
@@ -132,10 +133,10 @@
             <a class="btn btn-default btn-xs t_course_edit0" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=AHPUiT____.instr1_.gma-demo&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
@@ -77,7 +77,7 @@
                 </form>
                 <br>
                 <div>
-                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+                  <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
                     Unpublish Results
                   </a>
                 </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionPublished.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionPublished.html
@@ -49,7 +49,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -172,12 +172,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -250,7 +250,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -265,7 +265,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -274,7 +274,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -286,7 +286,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -322,7 +322,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -337,7 +337,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -346,7 +346,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -358,7 +358,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -394,7 +394,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -409,7 +409,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -418,7 +418,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -430,7 +430,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -441,7 +441,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionRemind.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionRemind.html
@@ -49,7 +49,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -172,12 +172,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -250,7 +250,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -265,7 +265,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -274,7 +274,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -286,7 +286,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -322,7 +322,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -337,7 +337,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -346,7 +346,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -358,7 +358,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -394,7 +394,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -409,7 +409,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -418,7 +418,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -430,7 +430,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -441,7 +441,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
@@ -20,7 +20,7 @@
               </span>
               Save
             </button>
-            <a class="btn btn-primary btn-sm" data-course-id="AHPUiT____.instr1_.gma-demo" data-feedback-session-name="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" id="fsDeleteLink" title="">
+            <a class="btn btn-primary btn-sm" data-course-id="AHPUiT____.instr1_.gma-demo" data-feedback-session-name="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" id="fsDeleteLink" title="">
               <span class="glyphicon glyphicon-trash">
               </span>
               Delete
@@ -752,6 +752,7 @@
       <input disabled="" name="fsname" type="hidden" value="Second team feedback session">
       <input disabled="" name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
       <input disabled="" name="user" type="hidden" value="${test.instructor}">
+      <input disabled="" name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <br>
@@ -760,7 +761,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1239,6 +1240,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -1695,6 +1697,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2142,6 +2145,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -2586,6 +2590,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -3036,6 +3041,7 @@
     <input name="showgiverto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <br>
   <br>
@@ -4080,6 +4086,7 @@
     <input name="showrecipientto" type="hidden" value="RECEIVER,INSTRUCTORS">
     <input name="user" type="hidden" value="${test.instructor}">
     <input id="generatedOptions" name="generatedOptions" type="hidden" value="NONE">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
   <div aria-hidden="true" aria-labelledby="copyModalTitle" class="modal fade" id="copyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog modal-lg">
@@ -4102,6 +4109,7 @@
             <input name="fsname" type="hidden" value="Second team feedback session">
             <input name="user" type="hidden" value="${test.instructor}">
             <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
           <div id="question-copy-modal-status">
           </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionUnpublished.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionUnpublished.html
@@ -49,7 +49,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -172,12 +172,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -250,7 +250,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -265,7 +265,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -274,7 +274,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -286,7 +286,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second team feedback session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-publish-for-test" data-fsname="Second team feedback session" data-original-title="Make session responses available for viewing" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackPublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Publish Results
             </a>
           </td>
@@ -322,7 +322,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -337,7 +337,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -346,7 +346,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -358,7 +358,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -394,7 +394,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -409,7 +409,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -418,7 +418,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -430,7 +430,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -441,7 +441,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSubmissionEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSubmissionEditPage.html
@@ -8,6 +8,7 @@
   <form action="/page/instructorFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Second team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="${test.instructor}">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbacksPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbacksPage.html
@@ -755,6 +755,7 @@
         </div>
       </div>
       <input name="user" type="hidden" value="${test.instructor}">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
   <form action="/page/instructorFeedbacksPage" class="ajaxForSessionsForm" id="ajaxForSessions" style="display:none;">
@@ -817,7 +818,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -832,7 +833,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -841,7 +842,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -853,7 +854,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -882,7 +883,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -897,7 +898,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -906,7 +907,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -918,7 +919,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -947,7 +948,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -962,7 +963,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -971,7 +972,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -983,7 +984,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorFeedbacksPage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -1000,7 +1001,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -1117,6 +1118,7 @@
             <input id="modalSessionName" name="fsname" type="hidden" value="">
             <input id="modalCourseId" name="courseid" type="hidden" value="">
             <input name="user" type="hidden" value="${test.instructor}">
+            <input name="token" type="hidden" value="${sessionToken}">
           </form>
         </div>
         <div class="modal-footer margin-0">
@@ -1133,7 +1135,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorFeedbacksPage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -46,7 +46,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -169,12 +169,12 @@
               </button>
               <ul class="dropdown-menu">
                 <li>
-                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-archive-for-test" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=AHPUiT____.instr1_.gma-demo&archive=true&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Archive
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -247,7 +247,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Second team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -262,7 +262,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" type="button">
@@ -271,7 +271,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Second team feedback session" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -283,7 +283,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Second team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Second+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -319,7 +319,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="First team feedback session" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -334,7 +334,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -343,7 +343,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="First team feedback session" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -355,7 +355,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="First team feedback session" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=First+team+feedback+session&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -391,7 +391,7 @@
             <a class="btn btn-default btn-xs btn-tm-actions session-edit-for-test margin-bottom-7px" data-original-title="Edit feedback session details" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackEditPage?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&user=${test.instructor}" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs btn-tm-actions session-delete-for-test margin-bottom-7px" data-courseid="AHPUiT____.instr1_.gma-demo" data-fsname="Session with different question types" data-original-title="Delete the feedback session" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackDelete?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Delete
             </a>
             <div data-original-title="Copy feedback session details" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
@@ -406,7 +406,7 @@
             </div>
             <div data-original-title="Send e-mails to remind students and instructors who have not submitted their feedbacks to do so" data-placement="top" data-toggle="tooltip" style="display: inline-block; padding-right: 5px;" title="">
               <div class="btn-group margin-bottom-7px">
-                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                <a class="btn btn-default btn-xs btn-tm-actions session-remind-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                   Remind
                 </a>
                 <button aria-expanded="false" class="btn btn-default btn-xs btn-tm-actions dropdown-toggle session-remind-options-for-test" data-toggle="dropdown" disabled="" type="button">
@@ -415,7 +415,7 @@
                 </button>
                 <ul class="dropdown-menu" role="menu">
                   <li>
-                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}">
+                    <a class="session-remind-inner-for-test" data-fsname="Session with different question types" disabled="" href="/page/instructorFeedbackRemind?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}">
                       Remind all students
                     </a>
                   </li>
@@ -427,7 +427,7 @@
                 </ul>
               </div>
             </div>
-            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}" title="">
+            <a class="btn btn-default btn-xs margin-bottom-7px btn-tm-actions session-unpublish-for-test" data-fsname="Session with different question types" data-original-title="Make responses no longer visible" data-placement="top" data-sending-published-email="true" data-toggle="tooltip" href="/page/instructorFeedbackUnpublish?courseid=AHPUiT____.instr1_.gma-demo&fsname=Session+with+different+question+types&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
               Unpublish Results
             </a>
           </td>
@@ -438,7 +438,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorHomePageSampleCourseArchived.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePageSampleCourseArchived.html
@@ -51,7 +51,7 @@
   <div aria-hidden="true" aria-labelledby="remindModal" class="modal fade" id="remindModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage" method="post" name="form_remind_list" role="form">
+        <form action="/page/instructorFeedbackRemindParticularStudents?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" method="post" name="form_remind_list" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×
@@ -112,7 +112,7 @@
   <div aria-hidden="true" aria-labelledby="fsCopyModal" class="modal fade" id="fsCopyModal" role="dialog" tabindex="-1">
     <div class="modal-dialog">
       <div class="modal-content">
-        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage" id="instructorCopyModalForm" method="post" role="form">
+        <form action="/page/instructorFeedbackEditCopy?next=%2Fpage%2FinstructorHomePage&token=${sessionToken}" id="instructorCopyModalForm" method="post" role="form">
           <div class="modal-header">
             <button aria-hidden="true" class="close" data-dismiss="modal" type="button">
               ×

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First team feedback session">
     <input name="courseid" type="hidden" value="AHPUiT____.instr1_.gma-demo">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="${test.instructor}">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -78,6 +78,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Fourth Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Second Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/studentFeedbackSubmitPageEmpty.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageEmpty.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Third Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Grace Period Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
       <div class="overflow-auto alert alert-warning statusMessage">

--- a/src/test/resources/pages/studentFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageModified.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePreview.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="CFeedbackEditUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="CFeedbackEditUiT.instructor">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRank.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Student Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="FRankUiT.alice.tmms">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Second Session">
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="CFeedbackEditUiT.alice.tmms">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageSuccessRank.html
@@ -8,6 +8,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="Student Session">
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="FRankUiT.alice.tmms">
     <div id="statusMessagesToUser" style="display: none;">
     </div>

--- a/src/test/resources/pages/studentProfileEditDivExistingValues.html
+++ b/src/test/resources/pages/studentProfileEditDivExistingValues.html
@@ -683,5 +683,6 @@
       </i>
     </p>
     <input name="user" type="hidden" value="${test.student2}">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
 </div>

--- a/src/test/resources/pages/studentProfilePageDefault.html
+++ b/src/test/resources/pages/studentProfilePageDefault.html
@@ -805,6 +805,7 @@
         </i>
       </p>
       <input name="user" type="hidden" value="SHomeUiT.benny.c">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
 </div>
@@ -858,6 +859,8 @@
 <script src="https://unpkg.com/guillotine@1.3.1/js/jquery.guillotine.min.js" type="text/javascript">
 </script>
 <script src="/js/student.js" type="text/javascript">
+</script>
+<script src="/js/crypto.js" type="text/javascript">
 </script>
 <script src="/js/studentProfile.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentProfilePageFilled.html
+++ b/src/test/resources/pages/studentProfilePageFilled.html
@@ -112,6 +112,7 @@
                 <input id="rotate" name="picturerotate" type="hidden" value="">
                 <input id="blobKey" name="blob-key" type="hidden" value="${blobkey}">
                 <input name="user" type="hidden" value="${test.student2}">
+                <input name="token" type="hidden" value="${sessionToken}">
                 <button class="btn btn-primary" id="profileEditPictureSubmit" type="button">
                   Save Edited Photo
                 </button>
@@ -809,6 +810,7 @@
         </i>
       </p>
       <input name="user" type="hidden" value="${test.student2}">
+      <input name="token" type="hidden" value="${sessionToken}">
     </form>
   </div>
 </div>

--- a/src/test/resources/pages/studentProfilePageWithAttemptedScriptInjection.html
+++ b/src/test/resources/pages/studentProfilePageWithAttemptedScriptInjection.html
@@ -683,5 +683,6 @@
       </i>
     </p>
     <input name="user" type="hidden" value="SHomeUiT.sanitizationStud">
+    <input name="token" type="hidden" value="${sessionToken}">
   </form>
 </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -78,6 +78,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="key" type="hidden" value="${regkey.enc}">
     <input name="studentemail" type="hidden" value="drop.out@gmail.tmt">
     <div id="statusMessagesToUser" style="display: none;">

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -19,6 +19,7 @@
   <form action="/page/studentFeedbackSubmissionEditSave" method="post" name="form_submit_response">
     <input name="fsname" type="hidden" value="First Session">
     <input name="courseid" type="hidden" value="SFSubmitUiT.CS2104">
+    <input name="token" type="hidden" value="${sessionToken}">
     <input name="key" type="hidden" value="${regkey.enc}">
     <input name="studentemail" type="hidden" value="drop.out@gmail.tmt">
     <div id="statusMessagesToUser">

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -114,7 +114,7 @@
       <property name="tokens" value="PARAMETER_DEF,VARIABLE_DEF,METHOD_DEF"/>
     </module>
     <module name="ConstantName">
-      <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|log|logic|.*(Db|Logic)|dataBundle|gaeSimulation)$"/>
+      <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|log|logic|.*(Db|Logic)|dataBundle|gaeSimulation|dummySessionToken)$"/>
     </module>
     <module name="RegexpSinglelineJava">
       <property name="format" value="\s+$"/>


### PR DESCRIPTION
Fixes #7384

Developed together with @leeyimin and @thenaesh

**Outline of Solution**

- Implement session token validation for actions requiring origin validation
  - Inject session token parameter for all actions requiring origin validation in `GaeSimulation` so `*ActionTest`s pass
- Implement session token generation for links to actions requiring origin validation
  - Update `PageData` to include session token field
    - Include session token in all form actions and links generated by the backend by reading from `PageData`
  - Write session token to cookie
    - Include session token in all form actions and links generated by the frontend by reading from the cookie
  - Update GodMode/ HTML verification to replace unpredictable session tokens with string literal
  - Update all test HTML files used in UI tests

Reviewed by @chowyb; deployed to live server several days ago. Publishing to public repo after several days of no problems with the code in actual usage.