### PR TITLE
appveyor.yml: fix warning in install firefox command #7303

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ skip_commits:
     - docs/**/*
 
 install:
-  - choco install firefox -version 46.0
+  - choco install firefox --version 46.0
   - npm install
 
 build_script:


### PR DESCRIPTION
Fixes #7303 

Solved the issue by updating the appveyor.yml [line 23] to read "- choco install firefox --version 46.0" from "- choco install firefox -version 46.0"