### PR TITLE
Specify default jsp encoding in web.xml #7403

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,6 +5,14 @@
 http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
 
+    <!-- This jsp-config element tag must be put above other tags or else it might cause all error pages to be non-accessible -->
+    <jsp-config>
+        <jsp-property-group>
+            <url-pattern>*.jsp</url-pattern>
+            <page-encoding>UTF-8</page-encoding>
+        </jsp-property-group>
+    </jsp-config>
+
     <filter>
         <filter-name>appstats</filter-name>
         <filter-class>com.google.appengine.tools.appstats.AppstatsFilter</filter-class>
@@ -78,11 +86,20 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <servlet-name>BackDoorServlet</servlet-name>
         <url-pattern>/backdoor</url-pattern>
     </servlet-mapping>
-    
+
+    <!-- Workaround for serving index.jsp as the home page while avoiding the GAE infinite redirect issue for 404s -->
     <welcome-file-list>
-        <welcome-file>index.jsp</welcome-file>
+        <welcome-file>home</welcome-file>
     </welcome-file-list>
-    
+    <servlet>
+        <servlet-name>HomePageServlet</servlet-name>
+        <jsp-file>/index.jsp</jsp-file>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>HomePageServlet</servlet-name>
+        <url-pattern>/home</url-pattern>
+    </servlet-mapping>
+
     <servlet>
         <servlet-name>EntityModifiedLogs</servlet-name>
         <servlet-class>teammates.ui.controller.EntityModifiedLogsServlet</servlet-class>

--- a/src/main/webapp/about.jsp
+++ b/src/main/webapp/about.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:staticPage currentPage="about">
     <div class="container">

--- a/src/main/webapp/contact.jsp
+++ b/src/main/webapp/contact.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:staticPage currentPage="contact">
     <main class="container">

--- a/src/main/webapp/deadlineExceededErrorPage.jsp
+++ b/src/main/webapp/deadlineExceededErrorPage.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
 <t:errorPage>

--- a/src/main/webapp/enableJs.jsp
+++ b/src/main/webapp/enableJs.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <div>
   <h1>
     TEAMMATES works best with JavaScript enabled.<br>

--- a/src/main/webapp/entityNotFoundPage.jsp
+++ b/src/main/webapp/entityNotFoundPage.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
 <t:errorPage>

--- a/src/main/webapp/errorPage.jsp
+++ b/src/main/webapp/errorPage.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(500);%>
 <t:errorPage>

--- a/src/main/webapp/features.jsp
+++ b/src/main/webapp/features.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:staticPage currentPage="features">
     <div class="container">

--- a/src/main/webapp/feedbackSessionNotVisible.jsp
+++ b/src/main/webapp/feedbackSessionNotVisible.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page import="teammates.common.util.Const"%>

--- a/src/main/webapp/googleAccountHint.jsp
+++ b/src/main/webapp/googleAccountHint.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ page import="teammates.common.util.Const"%>
 <%

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <c:set var="jsIncludes">

--- a/src/main/webapp/instructorHelp.jsp
+++ b/src/main/webapp/instructorHelp.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:helpPage>
     <h1>Help for Instructors</h1>

--- a/src/main/webapp/invalidOrigin.jsp
+++ b/src/main/webapp/invalidOrigin.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(403);%>
 <t:errorPage>

--- a/src/main/webapp/pageNotFound.jsp
+++ b/src/main/webapp/pageNotFound.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(404);%>
 <t:errorPage>

--- a/src/main/webapp/partials/instructorHelpAddEditInstructors.jsp
+++ b/src/main/webapp/partials/instructorHelpAddEditInstructors.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="editCourse">Add/Edit instructors</a>
 </h4>

--- a/src/main/webapp/partials/instructorHelpComments.jsp
+++ b/src/main/webapp/partials/instructorHelpComments.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="editComments">Comments</a>
 </h4>

--- a/src/main/webapp/partials/instructorHelpFAQ.jsp
+++ b/src/main/webapp/partials/instructorHelpFAQ.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="faq">Frequently Asked Questions</a>
 </h4>

--- a/src/main/webapp/partials/instructorHelpGettingStarted.jsp
+++ b/src/main/webapp/partials/instructorHelpGettingStarted.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="gs">Getting Started</a>
 </h4>

--- a/src/main/webapp/partials/instructorHelpSessions.jsp
+++ b/src/main/webapp/partials/instructorHelpSessions.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="sessionTypes">Sessions</a>
 </h4>

--- a/src/main/webapp/partials/instructorHelpTips.jsp
+++ b/src/main/webapp/partials/instructorHelpTips.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <h4>
     <a name="tips">Tips for conducting 'team peer evaluation' sessions</a>
 </h4>

--- a/src/main/webapp/pulse.jsp
+++ b/src/main/webapp/pulse.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 
 <html>

--- a/src/main/webapp/request.jsp
+++ b/src/main/webapp/request.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <t:staticPage>

--- a/src/main/webapp/studentHelp.jsp
+++ b/src/main/webapp/studentHelp.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:helpPage>
     <h1>Help for Students</h1><br>

--- a/src/main/webapp/terms.jsp
+++ b/src/main/webapp/terms.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <t:staticPage currentPage="terms">
     <main>

--- a/src/main/webapp/unauthorized.jsp
+++ b/src/main/webapp/unauthorized.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <% response.setStatus(401);%>
 <t:errorPage>

--- a/src/main/webapp/usermap.jsp
+++ b/src/main/webapp/usermap.jsp
@@ -1,4 +1,3 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page import="teammates.common.util.FrontEndLibrary" %>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>


### PR DESCRIPTION
Fixes #7403

Demo:
https://teammates-whipermr5.appspot.com/ (root URL home page test)
https://teammates-whipermr5.appspot.com/abc (finite 404 test #6889)
https://teammates-whipermr5.appspot.com/instructorHelp.jsp#gs (UTF-8 test https://github.com/TEAMMATES/teammates/pull/7391#issuecomment-304433019)

**Outline of Solution**

- Use custom `welcome-file-list` implementation to serve home page without running into infinite redirect issue (#6889)
- Restore `jsp-config` with default `jsp` encoding specified, originally removed in #7221
- Remove `<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>` line from all static `jsp` files