### PR TITLE
Student: view responses for rubric questions: include the criteria as well #4283

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -96,12 +96,18 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
                 chosenChoice = SanitizationHelper.sanitizeForHtml(fqd.getRubricChoices().get(answer.get(i)));
                 html.append(StringHelper.integerToLowerCaseAlphabeticalIndex(i + 1) + ") " + chosenChoice
                             + " <span class=\"color_neutral\"><i>(Choice " + (chosenIndex + 1)
-                            + ")</i></span><br>");
+                            + ")</i></span>");
+                html.append(getAddtionalInfoHtml(fqd.getRubricSubQuestions().get(i)) + "<br>");
             }
 
         }
 
         return html.toString();
+    }
+
+    private String getAddtionalInfoHtml(String subQuestion) {
+        return "&nbsp;<span data-toggle=\"tooltip\" data-placement=\"right\" title=\"" + subQuestion + "\""
+                + " class=\"glyphicon glyphicon-exclamation-sign text-info\"></span>";
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -83,10 +83,12 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
     @Override
     public String getAnswerHtml(FeedbackQuestionDetails questionDetails) {
         FeedbackRubricQuestionDetails fqd = (FeedbackRubricQuestionDetails) questionDetails;
-        StringBuilder html = new StringBuilder(100);
+        StringBuilder html = new StringBuilder(500);
         for (int i = 0; i < answer.size(); i++) {
             int chosenIndex = answer.get(i);
             String chosenChoice = "";
+            String additionalInfo = getAddtionalInfoHtml(fqd.getRubricSubQuestions().get(i));
+
             if (chosenIndex == -1) {
                 chosenChoice = "<span class=\"color_neutral\"><i>"
                              + Const.INSTRUCTOR_FEEDBACK_RESULTS_MISSING_RESPONSE
@@ -97,7 +99,8 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
                 html.append(StringHelper.integerToLowerCaseAlphabeticalIndex(i + 1) + ") " + chosenChoice
                             + " <span class=\"color_neutral\"><i>(Choice " + (chosenIndex + 1)
                             + ")</i></span>");
-                html.append(getAddtionalInfoHtml(fqd.getRubricSubQuestions().get(i)) + "<br>");
+                html.append(additionalInfo);
+                html.append("<br>");
             }
 
         }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricResponseDetails.java
@@ -109,7 +109,7 @@ public class FeedbackRubricResponseDetails extends FeedbackResponseDetails {
     }
 
     private String getAddtionalInfoHtml(String subQuestion) {
-        return "&nbsp;<span data-toggle=\"tooltip\" data-placement=\"right\" title=\"" + subQuestion + "\""
+        return " <span data-toggle=\"tooltip\" data-placement=\"right\" title=\"" + subQuestion + "\""
                 + " class=\"glyphicon glyphicon-exclamation-sign text-info\"></span>";
     }
 

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -449,6 +449,8 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b)
                               <span class="color_neutral">
@@ -481,12 +483,16 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -679,12 +685,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) No
                               <span class="color_neutral">
                                 <i>
                                   (Choice 2)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -711,12 +721,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -909,12 +923,16 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -350,6 +350,8 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b)
                           <span class="color_neutral">
@@ -522,12 +524,16 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -725,12 +731,16 @@
                               (Choice 1)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) No
                           <span class="color_neutral">
                             <i>
                               (Choice 2)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -897,12 +907,16 @@
                               (Choice 1)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -1100,12 +1114,16 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -430,6 +430,8 @@
                       (Choice 2)
                     </i>
                   </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                  </span>
                   <br>
                   b)
                   <span class="color_neutral">
@@ -475,12 +477,16 @@
                       (Choice 2)
                     </i>
                   </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                  </span>
                   <br>
                   b) Yes
                   <span class="color_neutral">
                     <i>
                       (Choice 1)
                     </i>
+                  </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                   </span>
                   <br>
                 </td>
@@ -520,12 +526,16 @@
                       (Choice 1)
                     </i>
                   </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                  </span>
                   <br>
                   b) No
                   <span class="color_neutral">
                     <i>
                       (Choice 2)
                     </i>
+                  </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                   </span>
                   <br>
                 </td>
@@ -565,12 +575,16 @@
                       (Choice 1)
                     </i>
                   </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                  </span>
                   <br>
                   b) Yes
                   <span class="color_neutral">
                     <i>
                       (Choice 1)
                     </i>
+                  </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                   </span>
                   <br>
                 </td>
@@ -610,12 +624,16 @@
                       (Choice 2)
                     </i>
                   </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                  </span>
                   <br>
                   b) Yes
                   <span class="color_neutral">
                     <i>
                       (Choice 1)
                     </i>
+                  </span>
+                  <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                   </span>
                   <br>
                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -352,6 +352,8 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b)
                           <span class="color_neutral">
@@ -532,12 +534,16 @@
                               (Choice 1)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) No
                           <span class="color_neutral">
                             <i>
                               (Choice 2)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -737,12 +743,16 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -917,12 +927,16 @@
                               (Choice 1)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>
@@ -1122,12 +1136,16 @@
                               (Choice 2)
                             </i>
                           </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                          </span>
                           <br>
                           b) Yes
                           <span class="color_neutral">
                             <i>
                               (Choice 1)
                             </i>
+                          </span>
+                          <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                           </span>
                           <br>
                         </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -446,6 +446,8 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b)
                               <span class="color_neutral">
@@ -487,12 +489,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) No
                               <span class="color_neutral">
                                 <i>
                                   (Choice 2)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -691,12 +697,16 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -732,12 +742,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>
@@ -936,12 +950,16 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </td>

--- a/src/test/resources/pages/instructorStudentRecordsPageMixedQuestionType.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageMixedQuestionType.html
@@ -1523,12 +1523,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) No
                               <span class="color_neutral">
                                 <i>
                                   (Choice 2)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </div>
@@ -1588,12 +1592,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) No
                               <span class="color_neutral">
                                 <i>
                                   (Choice 2)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </div>
@@ -1642,12 +1650,16 @@
                                   (Choice 2)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </div>
@@ -1684,6 +1696,8 @@
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                               b)
@@ -1739,12 +1753,16 @@
                                   (Choice 1)
                                 </i>
                               </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                              </span>
                               <br>
                               b) Yes
                               <span class="color_neutral">
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </div>
@@ -1799,6 +1817,8 @@
                                 <i>
                                   (Choice 1)
                                 </i>
+                              </span>
+                              <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                               </span>
                               <br>
                             </div>

--- a/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
@@ -171,12 +171,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have tried your best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -199,12 +203,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) No
                 <span class="color_neutral">
                   <i>
                     (Choice 2)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have tried your best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -227,12 +235,16 @@
                     (Choice 2)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) No
                 <span class="color_neutral">
                   <i>
                     (Choice 2)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="You have tried your best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -369,12 +381,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -397,12 +413,16 @@
                     (Choice 2)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) No
                 <span class="color_neutral">
                   <i>
                     (Choice 2)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -437,12 +457,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -579,12 +603,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) No
                 <span class="color_neutral">
                   <i>
                     (Choice 2)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -619,12 +647,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -761,12 +793,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>

--- a/src/test/resources/pages/studentFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageRubric.html
@@ -188,6 +188,8 @@
                     (Choice 2)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b)
                 <span class="color_neutral">
@@ -216,12 +218,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) No
                 <span class="color_neutral">
                   <i>
                     (Choice 2)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -256,12 +262,16 @@
                     (Choice 2)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -284,12 +294,16 @@
                     (Choice 1)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>
@@ -324,12 +338,16 @@
                     (Choice 2)
                   </i>
                 </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has done a good job." data-placement="right" data-toggle="tooltip" title="">
+                </span>
                 <br>
                 b) Yes
                 <span class="color_neutral">
                   <i>
                     (Choice 1)
                   </i>
+                </span>
+                <span class="glyphicon glyphicon-exclamation-sign text-info" data-original-title="This student has tried his/her best." data-placement="right" data-toggle="tooltip" title="">
                 </span>
                 <br>
               </td>


### PR DESCRIPTION
Fixes #4283 

**Outline of Solution**

Added a tooltip beside the result which shows the rubric sub-question. Current state of UI as seen by an instructor, student, and student (with a few `No response` entries) -

![5j1gmcjwrp](https://cloud.githubusercontent.com/assets/11662001/26673508/c3d2dd9a-46da-11e7-8ea8-466574d6cdda.gif)
