### PR TITLE
Token validation: handle requests with old sessions #7411

### DIFF
--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -195,7 +195,12 @@ public abstract class Action {
     }
 
     private boolean isSessionTokenValid(String actualToken) {
-        String sessionId = session.getId();
+        String sessionId = request.getRequestedSessionId();
+        if (sessionId == null) {
+            // Newly-created session
+            sessionId = session.getId();
+        }
+
         String expectedToken = CryptoHelper.computeSessionToken(sessionId);
 
         return actualToken.equals(expectedToken);


### PR DESCRIPTION
Fixes #7411

**Outline of Solution**

- Compute session token from requested session ID instead of current session ID in case it has changed (if request does not have a session, use ID of new session)