### PR TITLE
Remove inline javascript onclicks in FRC-related pages #6961

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/results/responsePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/responsePanel.tag
@@ -18,8 +18,9 @@
             <!--Note: When an element has class text-preserve-space, do not insert and HTML spaces-->
             <div class="pull-left text-preserve-space">${responsePanel.displayableResponse}</div>
 
-            <button type="button" class="btn btn-default btn-xs icon-button pull-right" id="button_add_comment"
-                onclick="showResponseCommentAddForm(${responsePanel.recipientIndex},${responsePanel.giverIndex},${responsePanel.qnIndex}, { sectionIndex: ${responsePanel.sectionId} })"
+            <button type="button" class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" id="button_add_comment"
+                data-recipientindex="${responsePanel.recipientIndex}" data-giverindex="${responsePanel.giverIndex}"
+                data-qnindex="${responsePanel.qnIndex}" data-sectionindex="${responsePanel.sectionId}"
                 data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.COMMENT_ADD%>"
                 <c:if test="${!responsePanel.allowedToAddComment}">
                         disabled

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentAdd.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentAdd.tag
@@ -12,11 +12,9 @@
 <c:choose>
     <c:when test="${not empty fourthIndex}">
         <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}" />
-        <c:set var="divIdAsJsParams" value="${firstIndex},${secondIndex},${thirdIndex}, { sectionIndex: ${fourthIndex} }" />
     </c:when>
     <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex}">
         <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}" />
-        <c:set var="divIdAsJsParams" value="${firstIndex},${secondIndex},${thirdIndex}" />
     </c:when>
 </c:choose>
 
@@ -24,9 +22,11 @@
 <li class="list-group-item list-group-item-warning"
     id="showResponseCommentAddForm-${divId}" style="display: none;">
     <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
+                                        secondIndex="${secondIndex}"
+                                        thirdIndex="${thirdIndex}"
+                                        fourthIndex="${fourthIndex}"
                                         frc="${frc}"
                                         divId="${divId}"
-                                        divIdAsJsParams="${divIdAsJsParams}"
                                         formType="Add"
                                         textAreaId="responseCommentAddForm"
                                         submitLink="${submitLink}"

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
@@ -4,9 +4,12 @@
 <%@ tag import="teammates.common.util.Const" %>
 <%@ tag import="teammates.common.datatransfer.FeedbackParticipantType" %>
 <%@ attribute name="fsIndex" required="true" %>
+<%@ attribute name="secondIndex" required="true" %>
+<%@ attribute name="thirdIndex" required="true" %>
+<%@ attribute name="fourthIndex" %>
+<%@ attribute name="frcIndex" %>
 <%@ attribute name="frc" type="teammates.ui.template.FeedbackResponseCommentRow" required="true" %>
 <%@ attribute name="divId" required="true" %>
-<%@ attribute name="divIdAsJsParams" required="true" %>
 <%@ attribute name="formType" required="true" %>
 <%@ attribute name="textAreaId" required="true" %>
 <%@ attribute name="submitLink" required="true" %>
@@ -24,14 +27,10 @@
             You may change comment's visibility using the visibility options on the right hand side.
         </div>
         <a id="frComment-visibility-options-trigger-${divId}"
-           class="btn btn-sm btn-info pull-right"
-            <c:if test="${isEditForm}">
-                onclick="toggleVisibilityEditForm(${divIdAsJsParams})"
-            </c:if>
-            <c:if test="${isAddForm}">
-                onclick="toggleVisibilityAddForm(${divIdAsJsParams})"
-            </c:if>
-        >
+           class="btn btn-sm btn-info pull-right toggle-visib-${fn:toLowerCase(formType)}-form"
+           data-sessionindex="${fsIndex}" data-qnindex="${secondIndex}"
+           data-responseindex="${thirdIndex}" data-frcindex="${frcIndex}"
+           <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>>
             <span class="glyphicon glyphicon-eye-close"></span>
             Show Visibility Options
         </a>
@@ -202,9 +201,11 @@
             ${buttonText}
         </a>
         <input type="button"
-               class="btn btn-default"
+               class="btn btn-default hide-frc-${fn:toLowerCase(formType)}-form"
                value="Cancel"
-               onclick="return hideResponseComment${formType}Form(${divIdAsJsParams});">
+               data-recipientindex="${fsIndex}" data-giverindex="${secondIndex}"
+               data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+               <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>>
     </div>
     <c:if test="${isEditForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}"></c:if>
     <c:if test="${isAddForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${frc.questionId}"></c:if>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
@@ -13,15 +13,12 @@
 <c:choose>
     <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty fourthIndex && not empty frcIndex}">
         <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
-        <c:set var="divIdAsJsParams" value="${firstIndex},${secondIndex},${thirdIndex},${frcIndex}, { sectionIndex: ${fourthIndex} }" />
     </c:when>
     <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
         <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
-        <c:set var="divIdAsJsParams" value="${firstIndex},${secondIndex},${thirdIndex},${frcIndex}" />
     </c:when>
     <c:otherwise>
         <c:set var="divId" value="${frc.commentId}" />
-        <c:set var="divIdAsJsParams" value="" />
     </c:otherwise>
 </c:choose>
 
@@ -86,9 +83,12 @@
         <c:set var="textAreaId"><%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT %></c:set>
         <c:set var="submitLink"><%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_EDIT %></c:set>
         <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
+                                            secondIndex="${secondIndex}"
+                                            thirdIndex="${thirdIndex}"
+                                            fourthIndex="${fourthIndex}"
+                                            frcIndex="${frcIndex}"
                                             frc="${frc}"
                                             divId="${divId}"
-                                            divIdAsJsParams="${divIdAsJsParams}"
                                             formType="Edit"
                                             textAreaId="${textAreaId}"
                                             submitLink="${submitLink}"

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
@@ -60,8 +60,17 @@
             </form>
             <a type="button"
                id="commentedit-${divId}"
-               class="btn btn-default btn-xs icon-button pull-right"
-               onclick="showResponseCommentEditForm(${divIdAsJsParams})"
+               <c:choose>
+                   <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
+                       class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form"
+                       data-recipientindex="${firstIndex}" data-giverindex="${secondIndex}"
+                       data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+                       <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
+                   </c:when>
+                   <c:otherwise>
+                       class="btn btn-default btn-xs icon-button pull-right"
+                   </c:otherwise>
+               </c:choose>
                data-toggle="tooltip"
                data-placement="top"
                title="<%= Const.Tooltips.COMMENT_EDIT %>"

--- a/src/main/webapp/js/feedbackResponseComments.es6
+++ b/src/main/webapp/js/feedbackResponseComments.es6
@@ -344,6 +344,33 @@ function registerResponseCommentsEvent() {
     $('body').on('click', 'form[class*="responseCommentEditForm"] > div > a[id^="button_save_comment_for_edit"]',
                  editCommentHandler);
     $('body').on('click', 'form[class*="responseCommentDeleteForm"] > a[id^="commentdelete"]', deleteCommentHandler);
+
+    $(document).on('click', '.show-frc-add-form', (e) => {
+        const ev = $(e.target).closest('button');
+        const recipientIndex = ev.data('recipientindex');
+        const giverIndex = ev.data('giverindex');
+        const qnIndex = ev.data('qnindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex);
+        } else {
+            showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex);
+        }
+    });
+
+    $(document).on('click', '.show-frc-edit-form', (e) => {
+        const ev = $(e.target).closest('a');
+        const recipientIndex = ev.data('recipientindex');
+        const giverIndex = ev.data('giverindex');
+        const qnIndex = ev.data('qnindex');
+        const frcIndex = ev.data('frcindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex, sectionIndex);
+        } else {
+            showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex);
+        }
+    });
 }
 
 function registerResponseCommentCheckboxEvent() {
@@ -387,15 +414,8 @@ function enableHoverToDisplayEditOptions() {
     });
 }
 
-function showResponseCommentAddForm(recipientIndex, giverIndex, qnIndx, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${recipientIndex}-${giverIndex}-${qnIndx}`;
-    } else {
-        id = `-${recipientIndex}-${giverIndex}-${qnIndx}`;
-    }
+function showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex) {
+    const id = `${sectionIndex !== undefined ? `-${sectionIndex}` : ''}-${recipientIndex}-${giverIndex}-${qnIndex}`;
 
     $(`#responseCommentTable${id}`).show();
     if ($(`#responseCommentTable${id} > li`).length <= 1) {
@@ -434,21 +454,9 @@ function hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndx, opts) {
     removeFormErrorMessage($(`#button_save_comment_for_add${id}`));
 }
 
-function showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, commentIndex, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (giverIndex || qnIndex || commentIndex) {
-        if (isIncludeSection) {
-            id = `-${opts.sectionIndex}-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
-        } else {
-            id = `-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
-        }
-    } else if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${recipientIndex}`;
-    } else {
-        id = `-${recipientIndex}`;
-    }
+function showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, commentIndex, sectionIndex) {
+    const id = `${sectionIndex !== undefined ? `-${sectionIndex}` : ''
+            }-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
 
     const commentBar = $(`#plainCommentText${id}`).parent().find(`#commentBar${id}`);
     commentBar.hide();

--- a/src/main/webapp/js/feedbackResponseComments.es6
+++ b/src/main/webapp/js/feedbackResponseComments.es6
@@ -371,6 +371,60 @@ function registerResponseCommentsEvent() {
             showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex);
         }
     });
+
+    $(document).on('click', '.hide-frc-add-form', (e) => {
+        const ev = $(e.target);
+        const recipientIndex = ev.data('recipientindex');
+        const giverIndex = ev.data('giverindex');
+        const qnIndex = ev.data('qnindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex);
+        } else {
+            hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndex);
+        }
+    });
+
+    $(document).on('click', '.hide-frc-edit-form', (e) => {
+        const ev = $(e.target);
+        const recipientIndex = ev.data('recipientindex');
+        const giverIndex = ev.data('giverindex');
+        const qnIndex = ev.data('qnindex');
+        const frcIndex = ev.data('frcindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex, sectionIndex);
+        } else {
+            hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex);
+        }
+    });
+
+    $(document).on('click', '.toggle-visib-add-form', (e) => {
+        const ev = $(e.target).closest('a');
+        const sessionIndex = ev.data('sessionindex');
+        const qnIndex = ev.data('qnindex');
+        const responseIndex = ev.data('responseindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            toggleVisibilityAddForm(sessionIndex, qnIndex, responseIndex, sectionIndex);
+        } else {
+            toggleVisibilityAddForm(sessionIndex, qnIndex, responseIndex);
+        }
+    });
+
+    $(document).on('click', '.toggle-visib-edit-form', (e) => {
+        const ev = $(e.target).closest('a');
+        const sessionIndex = ev.data('sessionindex');
+        const qnIndex = ev.data('qnindex');
+        const responseIndex = ev.data('responseindex');
+        const frcIndex = ev.data('frcindex');
+        if (ev.data('sectionindex') !== undefined) {
+            const sectionIndex = ev.data('sectionindex');
+            toggleVisibilityEditForm(sessionIndex, qnIndex, responseIndex, frcIndex, sectionIndex);
+        } else {
+            toggleVisibilityEditForm(sessionIndex, qnIndex, responseIndex, frcIndex);
+        }
+    });
 }
 
 function registerResponseCommentCheckboxEvent() {
@@ -436,15 +490,8 @@ function showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, section
     $(`#responseCommentAddForm${id}`).focus();
 }
 
-function hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndx, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${recipientIndex}-${giverIndex}-${qnIndx}`;
-    } else {
-        id = `-${recipientIndex}-${giverIndex}-${qnIndx}`;
-    }
+function hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex) {
+    const id = `${sectionIndex !== undefined ? `-${sectionIndex}` : ''}-${recipientIndex}-${giverIndex}-${qnIndex}`;
 
     if ($(`#responseCommentTable${id} > li`).length <= 1) {
         $(`#responseCommentTable${id}`).css('margin-top', '0');
@@ -477,21 +524,8 @@ function showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, commen
     }
 }
 
-function toggleVisibilityAddForm(sessionIdx, questionIdx, responseIdx, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (questionIdx || responseIdx) {
-        if (isIncludeSection) {
-            id = `-${opts.sectionIndex}-${sessionIdx}-${questionIdx}-${responseIdx}`;
-        } else {
-            id = `-${sessionIdx}-${questionIdx}-${responseIdx}`;
-        }
-    } else if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${sessionIdx}`;
-    } else {
-        id = `-${sessionIdx}`;
-    }
+function toggleVisibilityAddForm(sessionIdx, questionIdx, responseIdx, sectionIdx) {
+    const id = `${sectionIdx !== undefined ? `-${sectionIdx}` : ''}-${sessionIdx}-${questionIdx}-${responseIdx}`;
 
     const visibilityEditForm = $(`#visibility-options${id}`);
     if (visibilityEditForm.is(':visible')) {
@@ -505,27 +539,9 @@ function toggleVisibilityAddForm(sessionIdx, questionIdx, responseIdx, opts) {
     }
 }
 
-function toggleVisibilityEditForm(sessionIdx, questionIdx, responseIdx, commentIndex, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (questionIdx || responseIdx || commentIndex) {
-        if (commentIndex) {
-            if (isIncludeSection) {
-                id = `-${opts.sectionIndex}-${sessionIdx}-${questionIdx}-${responseIdx}-${commentIndex}`;
-            } else {
-                id = `-${sessionIdx}-${questionIdx}-${responseIdx}-${commentIndex}`;
-            }
-        } else if (isIncludeSection) {
-            id = `-${opts.sectionIndex}-${sessionIdx}-${questionIdx}-${responseIdx}`;
-        } else {
-            id = `-${sessionIdx}-${questionIdx}-${responseIdx}`;
-        }
-    } else if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${sessionIdx}`;
-    } else {
-        id = `-${sessionIdx}`;
-    }
+function toggleVisibilityEditForm(sessionIdx, questionIdx, responseIdx, commentIdx, sectionIdx) {
+    const id = `${sectionIdx !== undefined ? `-${sectionIdx}` : ''
+            }-${sessionIdx}-${questionIdx}-${responseIdx}-${commentIdx}`;
 
     const visibilityEditForm = $(`#visibility-options${id}`);
     if (visibilityEditForm.is(':visible')) {
@@ -539,21 +555,9 @@ function toggleVisibilityEditForm(sessionIdx, questionIdx, responseIdx, commentI
     }
 }
 
-function hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, commentIndex, opts) {
-    let id;
-    const isIncludeSection = opts && typeof opts.sectionIndex !== 'undefined';
-
-    if (giverIndex || qnIndex || commentIndex) {
-        if (isIncludeSection) {
-            id = `-${opts.sectionIndex}-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
-        } else {
-            id = `-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
-        }
-    } else if (isIncludeSection) {
-        id = `-${opts.sectionIndex}-${recipientIndex}`;
-    } else {
-        id = `-${recipientIndex}`;
-    }
+function hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, commentIndex, sectionIndex) {
+    const id = `${sectionIndex !== undefined ? `-${sectionIndex}` : ''
+            }-${recipientIndex}-${giverIndex}-${qnIndex}-${commentIndex}`;
 
     const commentBar = $(`#plainCommentText${id}`).parent().find(`#commentBar${id}`);
     commentBar.show();

--- a/src/main/webapp/js/feedbackResponseComments.es6
+++ b/src/main/webapp/js/feedbackResponseComments.es6
@@ -345,86 +345,30 @@ function registerResponseCommentsEvent() {
                  editCommentHandler);
     $('body').on('click', 'form[class*="responseCommentDeleteForm"] > a[id^="commentdelete"]', deleteCommentHandler);
 
-    $(document).on('click', '.show-frc-add-form', (e) => {
-        const ev = $(e.target).closest('button');
-        const recipientIndex = ev.data('recipientindex');
-        const giverIndex = ev.data('giverindex');
-        const qnIndex = ev.data('qnindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex);
-        } else {
-            showResponseCommentAddForm(recipientIndex, giverIndex, qnIndex);
-        }
-    });
+    const clickHandlerMap = new Map();
+    clickHandlerMap.set('.show-frc-add-form',
+            [showResponseCommentAddForm, ['recipientindex', 'giverindex', 'qnindex', 'sectionindex']]);
+    clickHandlerMap.set('.show-frc-edit-form',
+            [showResponseCommentEditForm, ['recipientindex', 'giverindex', 'qnindex', 'frcindex', 'sectionindex']]);
+    clickHandlerMap.set('.hide-frc-add-form',
+            [hideResponseCommentAddForm, ['recipientindex', 'giverindex', 'qnindex', 'sectionindex']]);
+    clickHandlerMap.set('.hide-frc-edit-form',
+            [hideResponseCommentEditForm, ['recipientindex', 'giverindex', 'qnindex', 'frcindex', 'sectionindex']]);
+    clickHandlerMap.set('.toggle-visib-add-form',
+            [toggleVisibilityAddForm, ['sessionindex', 'qnindex', 'responseindex', 'sectionindex']]);
+    clickHandlerMap.set('.toggle-visib-edit-form',
+            [toggleVisibilityEditForm, ['sessionindex', 'qnindex', 'responseindex', 'frcindex', 'sectionindex']]);
 
-    $(document).on('click', '.show-frc-edit-form', (e) => {
-        const ev = $(e.target).closest('a');
-        const recipientIndex = ev.data('recipientindex');
-        const giverIndex = ev.data('giverindex');
-        const qnIndex = ev.data('qnindex');
-        const frcIndex = ev.data('frcindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex, sectionIndex);
-        } else {
-            showResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex);
-        }
-    });
-
-    $(document).on('click', '.hide-frc-add-form', (e) => {
-        const ev = $(e.target);
-        const recipientIndex = ev.data('recipientindex');
-        const giverIndex = ev.data('giverindex');
-        const qnIndex = ev.data('qnindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndex, sectionIndex);
-        } else {
-            hideResponseCommentAddForm(recipientIndex, giverIndex, qnIndex);
-        }
-    });
-
-    $(document).on('click', '.hide-frc-edit-form', (e) => {
-        const ev = $(e.target);
-        const recipientIndex = ev.data('recipientindex');
-        const giverIndex = ev.data('giverindex');
-        const qnIndex = ev.data('qnindex');
-        const frcIndex = ev.data('frcindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex, sectionIndex);
-        } else {
-            hideResponseCommentEditForm(recipientIndex, giverIndex, qnIndex, frcIndex);
-        }
-    });
-
-    $(document).on('click', '.toggle-visib-add-form', (e) => {
-        const ev = $(e.target).closest('a');
-        const sessionIndex = ev.data('sessionindex');
-        const qnIndex = ev.data('qnindex');
-        const responseIndex = ev.data('responseindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            toggleVisibilityAddForm(sessionIndex, qnIndex, responseIndex, sectionIndex);
-        } else {
-            toggleVisibilityAddForm(sessionIndex, qnIndex, responseIndex);
-        }
-    });
-
-    $(document).on('click', '.toggle-visib-edit-form', (e) => {
-        const ev = $(e.target).closest('a');
-        const sessionIndex = ev.data('sessionindex');
-        const qnIndex = ev.data('qnindex');
-        const responseIndex = ev.data('responseindex');
-        const frcIndex = ev.data('frcindex');
-        if (ev.data('sectionindex') !== undefined) {
-            const sectionIndex = ev.data('sectionindex');
-            toggleVisibilityEditForm(sessionIndex, qnIndex, responseIndex, frcIndex, sectionIndex);
-        } else {
-            toggleVisibilityEditForm(sessionIndex, qnIndex, responseIndex, frcIndex);
-        }
-    });
+    /* eslint-disable no-restricted-syntax */
+    for (const [className, clickHandlerAndParams] of clickHandlerMap) {
+        $(document).on('click', className, (e) => {
+            const ev = $(e.currentTarget);
+            const clickHandler = clickHandlerAndParams[0];
+            const params = clickHandlerAndParams[1].map(paramName => ev.data(paramName));
+            clickHandler(params[0], params[1], params[2], params[3], params[4]);
+        });
+    }
+    /* eslint-enable no-restricted-syntax */
 }
 
 function registerResponseCommentCheckboxEvent() {

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -40,9 +40,10 @@
                             <tr class="active table-row-${fsIndex}-${responseEntriesStatus.count}-${responseStatus.count}">
                                 <td>Comment(s):
                                     <button type="button"
-                                            class="btn btn-default btn-xs icon-button pull-right"
+                                            class="btn btn-default btn-xs icon-button pull-right show-frc-add-form"
                                             id="button_add_comment-${fsIndex}-${responseEntriesStatus.count}-${responseStatus.count}"
-                                            onclick="showResponseCommentAddForm(${fsIndex},${responseEntriesStatus.count},${responseStatus.count})"
+                                            data-recipientindex="${fsIndex}" data-giverindex="${responseEntriesStatus.count}"
+                                            data-qnindex="${responseStatus.count}"
                                             data-toggle="tooltip" data-placement="top"
                                             title="<%= Const.Tooltips.COMMENT_ADD %>"
                                             <c:if test="${not response.instructorAllowedToSubmit}">disabled</c:if>>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -349,7 +349,7 @@
                               <div class="pull-left text-preserve-space">
                                 This is for nobody specific.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 0 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -373,7 +373,7 @@
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
                                     <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-1-0-1-1" onclick="showResponseCommentEditForm(1,0,1,1, { sectionIndex: 0 })" title="" type="button">
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-1" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
@@ -393,7 +393,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-0-1-1" onclick="toggleVisibilityEditForm(1,0,1,1, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-edit-form" data-frcindex="1" data-qnindex="0" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-0-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -509,7 +509,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentEdit" id="button_save_comment_for_edit-0-1-0-1-1" type="button">
                                       Save
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-edit-form" data-frcindex="1" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -540,7 +540,7 @@
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
                                     <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-1-0-1-2" onclick="showResponseCommentEditForm(1,0,1,2, { sectionIndex: 0 })" title="" type="button">
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-2" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
@@ -560,7 +560,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-0-1-2" onclick="toggleVisibilityEditForm(1,0,1,2, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-edit-form" data-frcindex="2" data-qnindex="0" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-0-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -676,7 +676,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentEdit" id="button_save_comment_for_edit-0-1-0-1-2" type="button">
                                       Save
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,0,1,2, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-edit-form" data-frcindex="2" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -700,7 +700,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -751,7 +751,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-0-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -375,7 +375,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice self feedback.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -392,7 +392,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -479,7 +479,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -530,7 +530,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -547,7 +547,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-2" onclick="toggleVisibilityAddForm(1,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -634,7 +634,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -692,7 +692,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -709,7 +709,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-3" onclick="toggleVisibilityAddForm(1,0,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="3" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -796,7 +796,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -835,7 +835,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -852,7 +852,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-4" onclick="toggleVisibilityAddForm(1,0,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="4" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -939,7 +939,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -978,7 +978,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 1
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -995,7 +995,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-5" onclick="toggleVisibilityAddForm(1,0,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="5" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1082,7 +1082,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1133,7 +1133,7 @@
                         <div class="pull-left text-preserve-space">
                           2 Response to Benny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1150,7 +1150,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1250,7 +1250,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1301,7 +1301,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1318,7 +1318,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-0-1" onclick="toggleVisibilityAddForm(3,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1418,7 +1418,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -1469,7 +1469,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1486,7 +1486,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-0-1" onclick="toggleVisibilityAddForm(4,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1586,7 +1586,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -1690,7 +1690,7 @@
                       <div style="clear:both; overflow: hidden">
                         <div class="pull-left text-preserve-space">
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1707,7 +1707,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1794,7 +1794,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1845,7 +1845,7 @@
                         <div class="pull-left text-preserve-space">
                           4 Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1862,7 +1862,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1962,7 +1962,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2013,7 +2013,7 @@
                         <div class="pull-left text-preserve-space">
                           1 Response to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2030,7 +2030,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2130,7 +2130,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2212,7 +2212,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny to Alice.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2229,7 +2229,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2329,7 +2329,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2380,7 +2380,7 @@
                         <div class="pull-left text-preserve-space">
                           Fred's Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2397,7 +2397,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2497,7 +2497,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2568,7 +2568,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from team 1 (by alice) to team 2.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2585,7 +2585,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2659,7 +2659,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2741,7 +2741,7 @@
                         <div class="pull-left text-preserve-space">
                           3 Response to Emily.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,4,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="4" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2758,7 +2758,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-4-1" onclick="toggleVisibilityAddForm(1,4,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="4" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-4-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2858,7 +2858,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-4-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="4" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2940,7 +2940,7 @@
                         <div class="pull-left text-preserve-space">
                           Benny to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,5,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="5" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2957,7 +2957,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-5-1" onclick="toggleVisibilityAddForm(1,5,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="5" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-5-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3057,7 +3057,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-5-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="5" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -3139,7 +3139,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Alice from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3156,7 +3156,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-6-1" onclick="toggleVisibilityAddForm(1,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3256,7 +3256,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -3307,7 +3307,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Benny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3324,7 +3324,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-6-1" onclick="toggleVisibilityAddForm(2,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3424,7 +3424,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -3475,7 +3475,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Danny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3492,7 +3492,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-6-1" onclick="toggleVisibilityAddForm(3,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3592,7 +3592,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -3666,7 +3666,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3683,7 +3683,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-1" onclick="toggleVisibilityAddForm(4,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3770,7 +3770,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3809,7 +3809,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 2
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3826,7 +3826,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-2" onclick="toggleVisibilityAddForm(4,6,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="2" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3913,7 +3913,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -377,7 +377,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice self feedback.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -394,7 +394,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -481,7 +481,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -532,7 +532,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -549,7 +549,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -636,7 +636,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -694,7 +694,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -711,7 +711,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-3" onclick="toggleVisibilityAddForm(0,1,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="3" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -798,7 +798,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -837,7 +837,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -854,7 +854,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-4" onclick="toggleVisibilityAddForm(0,1,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="4" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -941,7 +941,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -980,7 +980,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 1
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -997,7 +997,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-5" onclick="toggleVisibilityAddForm(0,1,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="5" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1084,7 +1084,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1143,7 +1143,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Alice from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1160,7 +1160,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-2-1" onclick="toggleVisibilityAddForm(0,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1260,7 +1260,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1319,7 +1319,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny to Alice.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1336,7 +1336,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-3-1" onclick="toggleVisibilityAddForm(0,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1436,7 +1436,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1520,7 +1520,7 @@
                         <div class="pull-left text-preserve-space">
                           2 Response to Benny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1537,7 +1537,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1637,7 +1637,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1718,7 +1718,7 @@
                       <div style="clear:both; overflow: hidden">
                         <div class="pull-left text-preserve-space">
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1735,7 +1735,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1822,7 +1822,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1881,7 +1881,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Benny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1898,7 +1898,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1998,7 +1998,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2082,7 +2082,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2099,7 +2099,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2199,7 +2199,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2258,7 +2258,7 @@
                         <div class="pull-left text-preserve-space">
                           Benny to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2275,7 +2275,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2375,7 +2375,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2459,7 +2459,7 @@
                         <div class="pull-left text-preserve-space">
                           4 Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2476,7 +2476,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2576,7 +2576,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2635,7 +2635,7 @@
                         <div class="pull-left text-preserve-space">
                           Fred's Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2652,7 +2652,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-2-1" onclick="toggleVisibilityAddForm(3,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2752,7 +2752,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2836,7 +2836,7 @@
                         <div class="pull-left text-preserve-space">
                           1 Response to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2853,7 +2853,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-1-1" onclick="toggleVisibilityAddForm(4,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2953,7 +2953,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3012,7 +3012,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Danny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3029,7 +3029,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-2-1" onclick="toggleVisibilityAddForm(4,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3129,7 +3129,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3213,7 +3213,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3230,7 +3230,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-1" onclick="toggleVisibilityAddForm(5,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3330,7 +3330,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3412,7 +3412,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3429,7 +3429,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-1" onclick="toggleVisibilityAddForm(5,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3516,7 +3516,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3555,7 +3555,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 2
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3572,7 +3572,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-2" onclick="toggleVisibilityAddForm(5,2,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3659,7 +3659,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3732,7 +3732,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from team 1 (by alice) to team 2.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3749,7 +3749,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-1" onclick="toggleVisibilityAddForm(6,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3823,7 +3823,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -349,7 +349,7 @@
                               <div class="pull-left text-preserve-space">
                                 This is for nobody specific.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 0 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -373,7 +373,7 @@
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
                                     <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-0-1-1-1" onclick="showResponseCommentEditForm(0,1,1,1, { sectionIndex: 0 })" title="" type="button">
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-1" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
@@ -393,7 +393,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-1-1-1" onclick="toggleVisibilityEditForm(0,1,1,1, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-edit-form" data-frcindex="1" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-1-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -444,7 +444,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentEdit" id="button_save_comment_for_edit-0-0-1-1-1" type="button">
                                       Save
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentEditForm(0,1,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-edit-form" data-frcindex="1" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -475,7 +475,7 @@
                                     <input name="user" type="hidden" value="CFResultsUiT.instr">
                                     <input name="token" type="hidden" value="${sessionToken}">
                                   </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right" data-original-title="Edit this comment" data-placement="top" data-toggle="tooltip" id="commentedit-0-0-1-1-2" onclick="showResponseCommentEditForm(0,1,1,2, { sectionIndex: 0 })" title="" type="button">
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-2" title="" type="button">
                                     <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
@@ -495,7 +495,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-1-1-2" onclick="toggleVisibilityEditForm(0,1,1,2, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-edit-form" data-frcindex="2" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-1-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -546,7 +546,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentEdit" id="button_save_comment_for_edit-0-0-1-1-2" type="button">
                                       Save
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentEditForm(0,1,1,2, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-edit-form" data-frcindex="2" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="responsecommentid" type="hidden" value="${comment.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -570,7 +570,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 0 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -618,7 +618,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-0-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -437,7 +437,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -454,7 +454,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -528,7 +528,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -566,7 +566,7 @@
                         <div class="pull-left text-preserve-space">
                           1
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -583,7 +583,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -657,7 +657,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -763,7 +763,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -780,7 +780,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -854,7 +854,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -948,7 +948,7 @@
                         <div class="pull-left text-preserve-space">
                           2
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -965,7 +965,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1039,7 +1039,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -342,7 +342,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -359,7 +359,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -433,7 +433,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-1-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -512,7 +512,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -529,7 +529,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="0" data-sessionindex="2" id="frComment-visibility-options-trigger-0-2-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -603,7 +603,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-2-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -713,7 +713,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -730,7 +730,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -804,7 +804,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -883,7 +883,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -900,7 +900,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="2" id="frComment-visibility-options-trigger-0-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -974,7 +974,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1084,7 +1084,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1101,7 +1101,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1175,7 +1175,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -344,7 +344,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -361,7 +361,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -435,7 +435,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-0-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -522,7 +522,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,2,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -539,7 +539,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-0-2-1" onclick="toggleVisibilityAddForm(0,2,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="0" data-sessionindex="0" id="frComment-visibility-options-trigger-0-0-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -613,7 +613,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-0-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -725,7 +725,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -742,7 +742,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -816,7 +816,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -903,7 +903,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -920,7 +920,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="0" data-sessionindex="1" id="frComment-visibility-options-trigger-0-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -994,7 +994,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1106,7 +1106,7 @@
                           </span>
                           <br>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 0 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1123,7 +1123,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-0-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 0 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="0" data-sessionindex="2" id="frComment-visibility-options-trigger-0-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1197,7 +1197,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-0-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 0 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="0" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -375,7 +375,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice self feedback.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -392,7 +392,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -479,7 +479,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -530,7 +530,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -547,7 +547,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-2" onclick="toggleVisibilityAddForm(1,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -634,7 +634,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -692,7 +692,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -709,7 +709,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-3" onclick="toggleVisibilityAddForm(1,0,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="3" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -796,7 +796,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -835,7 +835,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -852,7 +852,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-4" onclick="toggleVisibilityAddForm(1,0,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="4" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -939,7 +939,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -978,7 +978,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 1
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -995,7 +995,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-5" onclick="toggleVisibilityAddForm(1,0,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="5" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1082,7 +1082,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1133,7 +1133,7 @@
                         <div class="pull-left text-preserve-space">
                           2 Response to Benny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1150,7 +1150,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1250,7 +1250,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1301,7 +1301,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1318,7 +1318,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-0-1" onclick="toggleVisibilityAddForm(3,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1418,7 +1418,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -1469,7 +1469,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1486,7 +1486,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-0-1" onclick="toggleVisibilityAddForm(4,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1586,7 +1586,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -1690,7 +1690,7 @@
                       <div style="clear:both; overflow: hidden">
                         <div class="pull-left text-preserve-space">
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1707,7 +1707,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1794,7 +1794,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1845,7 +1845,7 @@
                         <div class="pull-left text-preserve-space">
                           4 Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1862,7 +1862,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1962,7 +1962,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2013,7 +2013,7 @@
                         <div class="pull-left text-preserve-space">
                           1 Response to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2030,7 +2030,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2130,7 +2130,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2212,7 +2212,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny to Alice.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2229,7 +2229,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2329,7 +2329,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2380,7 +2380,7 @@
                         <div class="pull-left text-preserve-space">
                           Fred's Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2397,7 +2397,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2497,7 +2497,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2568,7 +2568,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from team 1 (by alice) to team 2.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2585,7 +2585,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2659,7 +2659,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2741,7 +2741,7 @@
                         <div class="pull-left text-preserve-space">
                           3 Response to Emily.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,4,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="4" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2758,7 +2758,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-4-1" onclick="toggleVisibilityAddForm(1,4,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="4" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-4-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2858,7 +2858,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-4-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="4" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2940,7 +2940,7 @@
                         <div class="pull-left text-preserve-space">
                           Benny to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,5,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="5" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2957,7 +2957,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-5-1" onclick="toggleVisibilityAddForm(1,5,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="5" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-5-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3057,7 +3057,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-5-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="5" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -3139,7 +3139,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Alice from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3156,7 +3156,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-6-1" onclick="toggleVisibilityAddForm(1,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3256,7 +3256,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -3307,7 +3307,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Benny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3324,7 +3324,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-6-1" onclick="toggleVisibilityAddForm(2,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3424,7 +3424,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -3475,7 +3475,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Danny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3492,7 +3492,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-6-1" onclick="toggleVisibilityAddForm(3,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3592,7 +3592,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -3666,7 +3666,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3683,7 +3683,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-1" onclick="toggleVisibilityAddForm(4,6,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3770,7 +3770,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3809,7 +3809,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 2
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3826,7 +3826,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-2" onclick="toggleVisibilityAddForm(4,6,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="2" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3913,7 +3913,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -393,7 +393,7 @@
                               <div class="pull-left text-preserve-space">
                                 Alice self feedback.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -410,7 +410,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -497,7 +497,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -548,7 +548,7 @@
                               <div class="pull-left text-preserve-space">
                                 PowerSearch
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -565,7 +565,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-2" onclick="toggleVisibilityAddForm(1,0,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -652,7 +652,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -710,7 +710,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,3, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -727,7 +727,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-3" onclick="toggleVisibilityAddForm(1,0,3, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="3" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-3">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -814,7 +814,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-3" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -853,7 +853,7 @@
                               <div class="pull-left text-preserve-space">
                                 Danny
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,4, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -870,7 +870,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-4" onclick="toggleVisibilityAddForm(1,0,4, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="4" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-4">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -957,7 +957,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-4" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -996,7 +996,7 @@
                               <div class="pull-left text-preserve-space">
                                 Team 1
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,5, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1013,7 +1013,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-5" onclick="toggleVisibilityAddForm(1,0,5, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="5" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-5">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1100,7 +1100,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-5" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1151,7 +1151,7 @@
                               <div class="pull-left text-preserve-space">
                                 2 Response to Benny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1168,7 +1168,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1268,7 +1268,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -1319,7 +1319,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1336,7 +1336,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-0-1" onclick="toggleVisibilityAddForm(3,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1436,7 +1436,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -1487,7 +1487,7 @@
                               <div class="pull-left text-preserve-space">
                                 Alice to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1504,7 +1504,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-0-1" onclick="toggleVisibilityAddForm(4,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1604,7 +1604,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -1708,7 +1708,7 @@
                             <div style="clear:both; overflow: hidden">
                               <div class="pull-left text-preserve-space">
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1725,7 +1725,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1812,7 +1812,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1863,7 +1863,7 @@
                               <div class="pull-left text-preserve-space">
                                 4 Response to Charlie.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1880,7 +1880,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1980,7 +1980,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -2031,7 +2031,7 @@
                               <div class="pull-left text-preserve-space">
                                 1 Response to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2048,7 +2048,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2148,7 +2148,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -2230,7 +2230,7 @@
                               <div class="pull-left text-preserve-space">
                                 Danny to Alice.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2247,7 +2247,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2347,7 +2347,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -2398,7 +2398,7 @@
                               <div class="pull-left text-preserve-space">
                                 Fred's Response to Charlie.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2415,7 +2415,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2515,7 +2515,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -2586,7 +2586,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response from team 1 (by alice) to team 2.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2603,7 +2603,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2677,7 +2677,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -2780,7 +2780,7 @@
                               <div class="pull-left text-preserve-space">
                                 3 Response to Emily.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,4,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="4" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2797,7 +2797,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-4-1" onclick="toggleVisibilityAddForm(1,4,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="4" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-4-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2897,7 +2897,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-4-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="4" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -2979,7 +2979,7 @@
                               <div class="pull-left text-preserve-space">
                                 Benny to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,5,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="5" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2996,7 +2996,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-5-1" onclick="toggleVisibilityAddForm(1,5,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="5" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-5-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3096,7 +3096,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-5-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="5" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -3178,7 +3178,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Alice from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,6,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3195,7 +3195,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-6-1" onclick="toggleVisibilityAddForm(1,6,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-6-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3295,7 +3295,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-6-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -3346,7 +3346,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Benny from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,6,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3363,7 +3363,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-6-1" onclick="toggleVisibilityAddForm(2,6,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-6-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3463,7 +3463,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-6-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -3514,7 +3514,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Danny from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,6,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3531,7 +3531,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-6-1" onclick="toggleVisibilityAddForm(3,6,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-6-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3631,7 +3631,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-6-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -3705,7 +3705,7 @@
                               <div class="pull-left text-preserve-space">
                                 PowerSearch
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3722,7 +3722,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-1" onclick="toggleVisibilityAddForm(4,6,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3809,7 +3809,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -3848,7 +3848,7 @@
                               <div class="pull-left text-preserve-space">
                                 Team 2
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,6,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="6" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3865,7 +3865,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-6-2" onclick="toggleVisibilityAddForm(4,6,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="6" data-responseindex="2" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-6-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3952,7 +3952,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-6-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,6,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="6" data-qnindex="2" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -377,7 +377,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice self feedback.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -394,7 +394,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -481,7 +481,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -532,7 +532,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -549,7 +549,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -636,7 +636,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -694,7 +694,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -711,7 +711,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-3" onclick="toggleVisibilityAddForm(0,1,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="3" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -798,7 +798,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -837,7 +837,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -854,7 +854,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-4" onclick="toggleVisibilityAddForm(0,1,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="4" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -941,7 +941,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -980,7 +980,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 1
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -997,7 +997,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-5" onclick="toggleVisibilityAddForm(0,1,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="5" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1084,7 +1084,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1143,7 +1143,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Alice from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1160,7 +1160,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-2-1" onclick="toggleVisibilityAddForm(0,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1260,7 +1260,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1319,7 +1319,7 @@
                         <div class="pull-left text-preserve-space">
                           Danny to Alice.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1336,7 +1336,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-3-1" onclick="toggleVisibilityAddForm(0,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1436,7 +1436,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1520,7 +1520,7 @@
                         <div class="pull-left text-preserve-space">
                           2 Response to Benny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1537,7 +1537,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1637,7 +1637,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1718,7 +1718,7 @@
                       <div style="clear:both; overflow: hidden">
                         <div class="pull-left text-preserve-space">
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1735,7 +1735,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1822,7 +1822,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1881,7 +1881,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Benny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1898,7 +1898,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1998,7 +1998,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2082,7 +2082,7 @@
                         <div class="pull-left text-preserve-space">
                           Alice to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2099,7 +2099,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2199,7 +2199,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2258,7 +2258,7 @@
                         <div class="pull-left text-preserve-space">
                           Benny to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2275,7 +2275,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2375,7 +2375,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2459,7 +2459,7 @@
                         <div class="pull-left text-preserve-space">
                           4 Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2476,7 +2476,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2576,7 +2576,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2635,7 +2635,7 @@
                         <div class="pull-left text-preserve-space">
                           Fred's Response to Charlie.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2652,7 +2652,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-2-1" onclick="toggleVisibilityAddForm(3,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2752,7 +2752,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -2836,7 +2836,7 @@
                         <div class="pull-left text-preserve-space">
                           1 Response to Danny.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2853,7 +2853,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-1-1" onclick="toggleVisibilityAddForm(4,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2953,7 +2953,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3012,7 +3012,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Danny from Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3029,7 +3029,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-2-1" onclick="toggleVisibilityAddForm(4,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3129,7 +3129,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -3213,7 +3213,7 @@
                         <div class="pull-left text-preserve-space">
                           Response to Dropout.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3230,7 +3230,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-1" onclick="toggleVisibilityAddForm(5,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3330,7 +3330,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3412,7 +3412,7 @@
                         <div class="pull-left text-preserve-space">
                           PowerSearch
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3429,7 +3429,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-1" onclick="toggleVisibilityAddForm(5,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3516,7 +3516,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3555,7 +3555,7 @@
                         <div class="pull-left text-preserve-space">
                           Team 2
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3572,7 +3572,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-2" onclick="toggleVisibilityAddForm(5,2,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3659,7 +3659,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -3732,7 +3732,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from team 1 (by alice) to team 2.
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -3749,7 +3749,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-1" onclick="toggleVisibilityAddForm(6,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -3823,7 +3823,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -395,7 +395,7 @@
                               <div class="pull-left text-preserve-space">
                                 Alice self feedback.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -412,7 +412,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -499,7 +499,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -550,7 +550,7 @@
                               <div class="pull-left text-preserve-space">
                                 PowerSearch
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -567,7 +567,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -654,7 +654,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -712,7 +712,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,3, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -729,7 +729,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-3" onclick="toggleVisibilityAddForm(0,1,3, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="3" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-3">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -816,7 +816,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-3" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -855,7 +855,7 @@
                               <div class="pull-left text-preserve-space">
                                 Danny
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,4, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -872,7 +872,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-4" onclick="toggleVisibilityAddForm(0,1,4, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="4" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-4">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -959,7 +959,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-4" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -998,7 +998,7 @@
                               <div class="pull-left text-preserve-space">
                                 Team 1
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,5, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1015,7 +1015,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-5" onclick="toggleVisibilityAddForm(0,1,5, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="5" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-5">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1102,7 +1102,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-5" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -1161,7 +1161,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Alice from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1178,7 +1178,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-2-1" onclick="toggleVisibilityAddForm(0,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1278,7 +1278,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -1337,7 +1337,7 @@
                               <div class="pull-left text-preserve-space">
                                 Danny to Alice.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,3,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1354,7 +1354,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-3-1" onclick="toggleVisibilityAddForm(0,3,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-3-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1454,7 +1454,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-3-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -1538,7 +1538,7 @@
                               <div class="pull-left text-preserve-space">
                                 2 Response to Benny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1555,7 +1555,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1655,7 +1655,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1736,7 +1736,7 @@
                             <div style="clear:both; overflow: hidden">
                               <div class="pull-left text-preserve-space">
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1753,7 +1753,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1840,7 +1840,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1899,7 +1899,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Benny from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,3,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="3" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1916,7 +1916,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-3-1" onclick="toggleVisibilityAddForm(1,3,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="3" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-3-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2016,7 +2016,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-3-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="3" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -2100,7 +2100,7 @@
                               <div class="pull-left text-preserve-space">
                                 Alice to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2117,7 +2117,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2217,7 +2217,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -2276,7 +2276,7 @@
                               <div class="pull-left text-preserve-space">
                                 Benny to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2293,7 +2293,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-2-1" onclick="toggleVisibilityAddForm(2,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2393,7 +2393,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -2498,7 +2498,7 @@
                               <div class="pull-left text-preserve-space">
                                 4 Response to Charlie.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2515,7 +2515,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2615,7 +2615,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -2674,7 +2674,7 @@
                               <div class="pull-left text-preserve-space">
                                 Fred's Response to Charlie.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2691,7 +2691,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-2-1" onclick="toggleVisibilityAddForm(3,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2791,7 +2791,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -2875,7 +2875,7 @@
                               <div class="pull-left text-preserve-space">
                                 1 Response to Danny.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2892,7 +2892,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-1-1" onclick="toggleVisibilityAddForm(4,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2992,7 +2992,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -3051,7 +3051,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Danny from Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3068,7 +3068,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-2-1" onclick="toggleVisibilityAddForm(4,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3168,7 +3168,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -3252,7 +3252,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response to Dropout.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3269,7 +3269,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-1" onclick="toggleVisibilityAddForm(5,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3369,7 +3369,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -3451,7 +3451,7 @@
                               <div class="pull-left text-preserve-space">
                                 PowerSearch
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3468,7 +3468,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-1" onclick="toggleVisibilityAddForm(5,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3555,7 +3555,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -3594,7 +3594,7 @@
                               <div class="pull-left text-preserve-space">
                                 Team 2
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,2,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3611,7 +3611,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-2-2" onclick="toggleVisibilityAddForm(5,2,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-2-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3698,7 +3698,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-2-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -3771,7 +3771,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response from team 1 (by alice) to team 2.
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -3788,7 +3788,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-1" onclick="toggleVisibilityAddForm(6,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -3862,7 +3862,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="6">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -390,7 +390,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -407,7 +407,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -494,7 +494,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -540,7 +540,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -557,7 +557,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-2" onclick="toggleVisibilityAddForm(1,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -644,7 +644,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -683,7 +683,7 @@
                         <div class="pull-left text-preserve-space">
                           3.5
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -700,7 +700,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-3" onclick="toggleVisibilityAddForm(1,0,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="3" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -761,7 +761,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -814,7 +814,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -831,7 +831,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-4" onclick="toggleVisibilityAddForm(1,0,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="4" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -892,7 +892,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -931,7 +931,7 @@
                         <div class="pull-left text-preserve-space">
                           110
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -948,7 +948,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-5" onclick="toggleVisibilityAddForm(1,0,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="5" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1022,7 +1022,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1068,7 +1068,7 @@
                             ]
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,6, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="6" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1085,7 +1085,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-6" onclick="toggleVisibilityAddForm(1,0,6, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="6" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-6">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1185,7 +1185,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-6" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,6, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="6" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1247,7 +1247,7 @@
                         <div class="pull-left text-preserve-space">
                           90
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1264,7 +1264,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1338,7 +1338,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1377,7 +1377,7 @@
                             Equal Share
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1394,7 +1394,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-2" onclick="toggleVisibilityAddForm(2,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1494,7 +1494,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1556,7 +1556,7 @@
                         <div class="pull-left text-preserve-space">
                           50
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1573,7 +1573,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-0-1" onclick="toggleVisibilityAddForm(3,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1647,7 +1647,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -1709,7 +1709,7 @@
                         <div class="pull-left text-preserve-space">
                           150
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1726,7 +1726,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-0-1" onclick="toggleVisibilityAddForm(4,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1800,7 +1800,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -1859,7 +1859,7 @@
                         <div class="pull-left text-preserve-space">
                           3
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1876,7 +1876,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-0-1" onclick="toggleVisibilityAddForm(5,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1937,7 +1937,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -1976,7 +1976,7 @@
                             N/A
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1993,7 +1993,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-0-2" onclick="toggleVisibilityAddForm(5,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2093,7 +2093,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -2152,7 +2152,7 @@
                         <div class="pull-left text-preserve-space">
                           4
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,0,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2169,7 +2169,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-0-1" onclick="toggleVisibilityAddForm(6,0,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-0-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2230,7 +2230,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-0-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">
@@ -2269,7 +2269,7 @@
                             Equal Share
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,0,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2286,7 +2286,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-0-2" onclick="toggleVisibilityAddForm(6,0,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-0-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2386,7 +2386,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-0-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">
@@ -2468,7 +2468,7 @@
                         <div class="pull-left text-preserve-space">
                           0
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2485,7 +2485,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2559,7 +2559,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -2603,7 +2603,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from benny to Team 1 (own team)
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2620,7 +2620,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2681,7 +2681,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -2757,7 +2757,7 @@
                         <div class="pull-left text-preserve-space">
                           -0.5
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2774,7 +2774,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2835,7 +2835,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -408,7 +408,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -425,7 +425,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-1" onclick="toggleVisibilityAddForm(1,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -512,7 +512,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -558,7 +558,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -575,7 +575,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-2" onclick="toggleVisibilityAddForm(1,0,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -662,7 +662,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -701,7 +701,7 @@
                               <div class="pull-left text-preserve-space">
                                 3.5
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,3, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -718,7 +718,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-3" onclick="toggleVisibilityAddForm(1,0,3, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="3" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-3">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -779,7 +779,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-3" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="3" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -832,7 +832,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,4, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -849,7 +849,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-4" onclick="toggleVisibilityAddForm(1,0,4, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="4" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-4">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -910,7 +910,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-4" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="4" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -949,7 +949,7 @@
                               <div class="pull-left text-preserve-space">
                                 110
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,5, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -966,7 +966,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-5" onclick="toggleVisibilityAddForm(1,0,5, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="5" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-5">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1040,7 +1040,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-5" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="5" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1086,7 +1086,7 @@
                                   ]
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,0,6, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="6" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1103,7 +1103,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-0-6" onclick="toggleVisibilityAddForm(1,0,6, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="6" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-0-6">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1203,7 +1203,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-0-6" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,6, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="6" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1265,7 +1265,7 @@
                               <div class="pull-left text-preserve-space">
                                 90
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1282,7 +1282,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-1" onclick="toggleVisibilityAddForm(2,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1356,7 +1356,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -1395,7 +1395,7 @@
                                   Equal Share
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,0,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1412,7 +1412,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-0-2" onclick="toggleVisibilityAddForm(2,0,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-0-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1512,7 +1512,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-0-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -1574,7 +1574,7 @@
                               <div class="pull-left text-preserve-space">
                                 50
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1591,7 +1591,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-0-1" onclick="toggleVisibilityAddForm(3,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1665,7 +1665,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -1727,7 +1727,7 @@
                               <div class="pull-left text-preserve-space">
                                 150
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1744,7 +1744,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-0-1" onclick="toggleVisibilityAddForm(4,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1818,7 +1818,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -1877,7 +1877,7 @@
                               <div class="pull-left text-preserve-space">
                                 3
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1894,7 +1894,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-0-1" onclick="toggleVisibilityAddForm(5,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1955,7 +1955,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -1994,7 +1994,7 @@
                                   N/A
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,0,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2011,7 +2011,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-0-2" onclick="toggleVisibilityAddForm(5,0,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-0-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2111,7 +2111,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-0-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -2170,7 +2170,7 @@
                               <div class="pull-left text-preserve-space">
                                 4
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,0,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2187,7 +2187,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-0-1" onclick="toggleVisibilityAddForm(6,0,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-0-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2248,7 +2248,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-0-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="6">
@@ -2287,7 +2287,7 @@
                                   Equal Share
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,0,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="0" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2304,7 +2304,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-0-2" onclick="toggleVisibilityAddForm(6,0,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="0" data-responseindex="2" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-0-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2404,7 +2404,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-0-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,0,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="0" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="6">
@@ -2486,7 +2486,7 @@
                               <div class="pull-left text-preserve-space">
                                 0
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2503,7 +2503,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2577,7 +2577,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -2621,7 +2621,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response from benny to Team 1 (own team)
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2638,7 +2638,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2699,7 +2699,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -2864,7 +2864,7 @@
                               <div class="pull-left text-preserve-space">
                                 -0.5
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,2,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="2" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2881,7 +2881,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-2-1" onclick="toggleVisibilityAddForm(1,2,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="2" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-2-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2942,7 +2942,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-2-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="2" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -392,7 +392,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -409,7 +409,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -496,7 +496,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -542,7 +542,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -559,7 +559,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -646,7 +646,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -685,7 +685,7 @@
                         <div class="pull-left text-preserve-space">
                           3.5
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,3, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -702,7 +702,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-3" onclick="toggleVisibilityAddForm(0,1,3, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="3" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-3">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -763,7 +763,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-3" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -816,7 +816,7 @@
                             </li>
                           </ul>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,4, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -833,7 +833,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-4" onclick="toggleVisibilityAddForm(0,1,4, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="4" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-4">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -894,7 +894,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-4" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -933,7 +933,7 @@
                         <div class="pull-left text-preserve-space">
                           110
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,5, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -950,7 +950,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-5" onclick="toggleVisibilityAddForm(0,1,5, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="5" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-5">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1024,7 +1024,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-5" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1070,7 +1070,7 @@
                             ]
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,6, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="6" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1087,7 +1087,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-6" onclick="toggleVisibilityAddForm(0,1,6, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="6" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-6">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1187,7 +1187,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-6" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,6, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="6" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="0">
@@ -1282,7 +1282,7 @@
                         <div class="pull-left text-preserve-space">
                           90
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1299,7 +1299,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1373,7 +1373,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1412,7 +1412,7 @@
                             Equal Share
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1429,7 +1429,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-2" onclick="toggleVisibilityAddForm(1,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1529,7 +1529,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="1">
@@ -1602,7 +1602,7 @@
                         <div class="pull-left text-preserve-space">
                           Response from benny to Team 1 (own team)
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1619,7 +1619,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1680,7 +1680,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="2">
@@ -1775,7 +1775,7 @@
                         <div class="pull-left text-preserve-space">
                           50
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1792,7 +1792,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -1866,7 +1866,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="3">
@@ -1961,7 +1961,7 @@
                         <div class="pull-left text-preserve-space">
                           150
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -1978,7 +1978,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-1-1" onclick="toggleVisibilityAddForm(4,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2052,7 +2052,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="4">
@@ -2139,7 +2139,7 @@
                         <div class="pull-left text-preserve-space">
                           3
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2156,7 +2156,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-1" onclick="toggleVisibilityAddForm(5,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2217,7 +2217,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -2256,7 +2256,7 @@
                             N/A
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2273,7 +2273,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-2" onclick="toggleVisibilityAddForm(5,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2373,7 +2373,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="5">
@@ -2460,7 +2460,7 @@
                         <div class="pull-left text-preserve-space">
                           4
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,1, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2477,7 +2477,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-1" onclick="toggleVisibilityAddForm(6,1,1, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-1">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2538,7 +2538,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-1" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">
@@ -2577,7 +2577,7 @@
                             Equal Share
                           </span>
                         </div>
-                        <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,2, { sectionIndex: 1 })" title="" type="button">
+                        <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                           <span class="glyphicon glyphicon-comment glyphicon-primary">
                           </span>
                         </button>
@@ -2594,7 +2594,7 @@
                                 </p>
                                 You may change comment's visibility using the visibility options on the right hand side.
                               </div>
-                              <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-2" onclick="toggleVisibilityAddForm(6,1,2, { sectionIndex: 1 })">
+                              <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-2">
                                 <span class="glyphicon glyphicon-eye-close">
                                 </span>
                                 Show Visibility Options
@@ -2694,7 +2694,7 @@
                               <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-2" type="button">
                                 Add
                               </a>
-                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                              <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                             </div>
                             <input name="questionid" type="hidden" value="${question.id}">
                             <input name="fsindex" type="hidden" value="6">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -410,7 +410,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -427,7 +427,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-1" onclick="toggleVisibilityAddForm(0,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -514,7 +514,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -560,7 +560,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -577,7 +577,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-2" onclick="toggleVisibilityAddForm(0,1,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -664,7 +664,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -703,7 +703,7 @@
                               <div class="pull-left text-preserve-space">
                                 3.5
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,3, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -720,7 +720,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-3" onclick="toggleVisibilityAddForm(0,1,3, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="3" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-3">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -781,7 +781,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-3" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="3" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -834,7 +834,7 @@
                                   </li>
                                 </ul>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,4, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -851,7 +851,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-4" onclick="toggleVisibilityAddForm(0,1,4, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="4" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-4">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -912,7 +912,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-4" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="4" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -951,7 +951,7 @@
                               <div class="pull-left text-preserve-space">
                                 110
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,5, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -968,7 +968,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-5" onclick="toggleVisibilityAddForm(0,1,5, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="5" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-5">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1042,7 +1042,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-5" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="5" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -1088,7 +1088,7 @@
                                   ]
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(0,1,6, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="6" data-recipientindex="0" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1105,7 +1105,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-0-1-6" onclick="toggleVisibilityAddForm(0,1,6, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="6" data-sectionindex="1" data-sessionindex="0" id="frComment-visibility-options-trigger-1-0-1-6">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1205,7 +1205,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-0-1-6" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,6, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="6" data-recipientindex="0" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="0">
@@ -1300,7 +1300,7 @@
                               <div class="pull-left text-preserve-space">
                                 90
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1317,7 +1317,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-1" onclick="toggleVisibilityAddForm(1,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1391,7 +1391,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1430,7 +1430,7 @@
                                   Equal Share
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(1,1,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1447,7 +1447,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-1-1-2" onclick="toggleVisibilityAddForm(1,1,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="1" id="frComment-visibility-options-trigger-1-1-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1547,7 +1547,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-1-1-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="1" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="1">
@@ -1620,7 +1620,7 @@
                               <div class="pull-left text-preserve-space">
                                 Response from benny to Team 1 (own team)
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(2,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1637,7 +1637,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-2-1-1" onclick="toggleVisibilityAddForm(2,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="2" id="frComment-visibility-options-trigger-1-2-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1698,7 +1698,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-2-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="2" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="2">
@@ -1842,7 +1842,7 @@
                               <div class="pull-left text-preserve-space">
                                 50
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(3,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -1859,7 +1859,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-3-1-1" onclick="toggleVisibilityAddForm(3,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="3" id="frComment-visibility-options-trigger-1-3-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -1933,7 +1933,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-3-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="3" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="3">
@@ -2028,7 +2028,7 @@
                               <div class="pull-left text-preserve-space">
                                 150
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(4,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2045,7 +2045,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-4-1-1" onclick="toggleVisibilityAddForm(4,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="4" id="frComment-visibility-options-trigger-1-4-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2119,7 +2119,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-4-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="4" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="4">
@@ -2283,7 +2283,7 @@
                               <div class="pull-left text-preserve-space">
                                 3
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2300,7 +2300,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-1" onclick="toggleVisibilityAddForm(5,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2361,7 +2361,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -2400,7 +2400,7 @@
                                   N/A
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(5,1,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2417,7 +2417,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-5-1-2" onclick="toggleVisibilityAddForm(5,1,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="5" id="frComment-visibility-options-trigger-1-5-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2517,7 +2517,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-5-1-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="5" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="5">
@@ -2625,7 +2625,7 @@
                               <div class="pull-left text-preserve-space">
                                 4
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,1, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2642,7 +2642,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-1" onclick="toggleVisibilityAddForm(6,1,1, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="1" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-1">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2703,7 +2703,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-1" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="1" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="6">
@@ -2742,7 +2742,7 @@
                                   Equal Share
                                 </span>
                               </div>
-                              <button class="btn btn-default btn-xs icon-button pull-right" data-original-title="Add comment" data-placement="top" data-toggle="tooltip" id="button_add_comment" onclick="showResponseCommentAddForm(6,1,2, { sectionIndex: 1 })" title="" type="button">
+                              <button class="btn btn-default btn-xs icon-button pull-right show-frc-add-form" data-giverindex="1" data-original-title="Add comment" data-placement="top" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" data-toggle="tooltip" id="button_add_comment" title="" type="button">
                                 <span class="glyphicon glyphicon-comment glyphicon-primary">
                                 </span>
                               </button>
@@ -2759,7 +2759,7 @@
                                       </p>
                                       You may change comment's visibility using the visibility options on the right hand side.
                                     </div>
-                                    <a class="btn btn-sm btn-info pull-right" id="frComment-visibility-options-trigger-1-6-1-2" onclick="toggleVisibilityAddForm(6,1,2, { sectionIndex: 1 })">
+                                    <a class="btn btn-sm btn-info pull-right toggle-visib-add-form" data-frcindex="" data-qnindex="1" data-responseindex="2" data-sectionindex="1" data-sessionindex="6" id="frComment-visibility-options-trigger-1-6-1-2">
                                       <span class="glyphicon glyphicon-eye-close">
                                       </span>
                                       Show Visibility Options
@@ -2859,7 +2859,7 @@
                                     <a class="btn btn-primary" href="/page/instructorFeedbackResponseCommentAdd" id="button_save_comment_for_add-1-6-1-2" type="button">
                                       Add
                                     </a>
-                                    <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,2, { sectionIndex: 1 });" type="button" value="Cancel">
+                                    <input class="btn btn-default hide-frc-add-form" data-frcindex="" data-giverindex="1" data-qnindex="2" data-recipientindex="6" data-sectionindex="1" type="button" value="Cancel">
                                   </div>
                                   <input name="questionid" type="hidden" value="${question.id}">
                                   <input name="fsindex" type="hidden" value="6">


### PR DESCRIPTION
Part of #6961
<!-- Fixes #6961, just to satisfy the bot -->

**Outline of Solution**

Removed all `onclick`s found in FRC-related pages and replaced them with proper event delegation. Will have significant conflict with #7418.