### PR TITLE
Fix lintspaces on Windows #7469

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:test": "eslint src/main/webapp/dev -c static-analysis/teammates-eslint.yml --ext .es6",
     "lint:json": "eslint src/main/webapp/js/*.json src/main/resources/*.json src/test/resources/data/*.json -c static-analysis/teammates-eslint-json.yml",
     "lint:css": "stylelint src/main/webapp/stylesheets/*.css --config static-analysis/teammates-stylelint.yml",
-    "lint:spaces": "lintspaces -n -t -d spaces -l 1 -. 'src/**/*.jsp' 'src/**/*.tag' 'src/main/**/*.html' 'src/**/*.xml' 'src/**/*.json' 'src/**/*.css' 'src/**/*.java' 'src/**/*.es6' 'src/**/*.properties' '*.yml' '*.gradle' 'static-analysis/*.*ml'",
+    "lint:spaces": "lintspaces -n -t -d spaces -l 1 -. \"src/**/*.jsp\" \"src/**/*.tag\" \"src/main/**/*.html\" \"src/**/*.xml\" \"src/**/*.json\" \"src/**/*.css\" \"src/**/*.java\" \"src/**/*.es6\" \"src/**/*.properties\" \"*.yml\" \"*.gradle\" \"static-analysis/*.*ml\"",
     "lint": "npm run lint:src && npm run lint:test && npm run lint:json && npm run lint:css && npm run lint:spaces"
   }
 }


### PR DESCRIPTION
Fixes #7469


Use double quotes for options in lintspaces as single quotes does not work on Windows.