### PR TITLE
instructorCourseStudentDetailsEdit and rubric question: Remove spaces inside textarea #7382

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetailsEdit/studentInformationTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/courseStudentDetailsEdit/studentInformationTable.tag
@@ -56,9 +56,7 @@
                 <label class="col-sm-1 control-label">Comments:</label>
                 <div class="col-sm-11">
                     <textarea class="form-control" rows="6" name="<%=Const.ParamsNames.COMMENTS%>"
-                              id="<%=Const.ParamsNames.COMMENTS%>">
-                        <c:out value="${studentInfoTable.comments}"/>
-                    </textarea>
+                            id="<%=Const.ParamsNames.COMMENTS%>"><c:out value="${studentInfoTable.comments}"/></textarea>
                 </div>
             </div>
             <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />

--- a/src/main/webapp/js/instructorFeedbackEdit/questionRubric.es6
+++ b/src/main/webapp/js/instructorFeedbackEdit/questionRubric.es6
@@ -19,8 +19,7 @@ function addRubricRow(questionNum) {
         const rubricRowFragment =
             `<td class="align-center rubricCol-${questionNum}-${cols}">
                 <textarea class="form-control" rows="3" id="rubricDesc-${questionNum}-${newRowNumber - 1}-${cols}"
-                        name="rubricDesc-${newRowNumber - 1}-${cols}">
-                </textarea>
+                        name="rubricDesc-${newRowNumber - 1}-${cols}"></textarea>
             </td>`;
         rubricRowBodyFragments += rubricRowFragment;
     }
@@ -38,8 +37,7 @@ function addRubricRow(questionNum) {
                         <span class="glyphicon glyphicon-remove"></span>
                     </span>
                     <textarea class="form-control" rows="3" id="rubricSubQn-${questionNum}-${newRowNumber - 1}"
-                            name="rubricSubQn-${newRowNumber - 1}">
-                    </textarea>
+                            name="rubricSubQn-${newRowNumber - 1}"></textarea>
                 </div>
             </td>
             ${rubricRowBodyFragments}
@@ -109,8 +107,7 @@ function addRubricCol(questionNum) {
         const rubricRowFragment =
             `<td class="align-center rubricCol-${questionNum}-${newColNumber - 1}">
                 <textarea class="form-control" rows="3" id="rubricDesc-${questionNum}-${rows}-${newColNumber - 1}"
-                        name="rubricDesc-${rows}-${newColNumber - 1}">
-                </textarea>
+                        name="rubricDesc-${rows}-${newColNumber - 1}"></textarea>
             </td>`;
 
         // Insert after previous <td>


### PR DESCRIPTION
Fixes #7382 

**Outline of Solution**

Corrected `textarea` tags as per issue. There shouldn't be any line breaks inside the tag.