### PR TITLE
Project setup: eliminate the need to set the user.timezone VM flag #7520

### DIFF
--- a/.templates/.idea/runConfigurations/CI_Tests.xml
+++ b/.templates/.idea/runConfigurations/CI_Tests.xml
@@ -15,7 +15,7 @@
     <option name="METHOD_NAME" value="" />
     <option name="GROUP_NAME" value="" />
     <option name="TEST_OBJECT" value="SUITE" />
-    <option name="VM_PARAMETERS" value="-ea -Duser.timezone=UTC -Xss2m" />
+    <option name="VM_PARAMETERS" value="-ea -Xss2m" />
     <option name="PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$" />
     <option name="OUTPUT_DIRECTORY" value="" />

--- a/.templates/.idea/runConfigurations/Failed_Tests.xml
+++ b/.templates/.idea/runConfigurations/Failed_Tests.xml
@@ -10,7 +10,7 @@
     <option name="METHOD_NAME" value="" />
     <option name="GROUP_NAME" value="" />
     <option name="TEST_OBJECT" value="SUITE" />
-    <option name="VM_PARAMETERS" value="-ea -Duser.timezone=UTC -Xss2m" />
+    <option name="VM_PARAMETERS" value="-ea -Xss2m" />
     <option name="PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$" />
     <option name="OUTPUT_DIRECTORY" value="" />

--- a/.templates/.idea/runConfigurations/Local_Tests.xml
+++ b/.templates/.idea/runConfigurations/Local_Tests.xml
@@ -10,7 +10,7 @@
     <option name="METHOD_NAME" value="" />
     <option name="GROUP_NAME" value="" />
     <option name="TEST_OBJECT" value="SUITE" />
-    <option name="VM_PARAMETERS" value="-ea -Duser.timezone=UTC -Dgodmode=true" />
+    <option name="VM_PARAMETERS" value="-ea" />
     <option name="PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="file://$MODULE_DIR$" />
     <option name="OUTPUT_DIRECTORY" value="" />

--- a/.templates/eclipseLaunches/All tests.launch.xml
+++ b/.templates/eclipseLaunches/All tests.launch.xml
@@ -6,7 +6,7 @@
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project.name}"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser.timezone=UTC -Xss2m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xss2m"/>
 <mapAttribute key="org.testng.eclipse.ALL_CLASS_METHODS"/>
 <listAttribute key="org.testng.eclipse.CLASS_TEST_LIST"/>
 <booleanAttribute key="org.testng.eclipse.DEBUG" value="false"/>

--- a/.templates/eclipseLaunches/CI tests.launch.xml
+++ b/.templates/eclipseLaunches/CI tests.launch.xml
@@ -6,7 +6,7 @@
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project.name}"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser.timezone=UTC -Xss2m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xss2m"/>
 <mapAttribute key="org.testng.eclipse.ALL_CLASS_METHODS"/>
 <listAttribute key="org.testng.eclipse.CLASS_TEST_LIST"/>
 <booleanAttribute key="org.testng.eclipse.DEBUG" value="false"/>

--- a/.templates/eclipseLaunches/Failed tests.launch.xml
+++ b/.templates/eclipseLaunches/Failed tests.launch.xml
@@ -7,7 +7,7 @@
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project.name}"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser.timezone=UTC -Xss2m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xss2m"/>
 <mapAttribute key="org.testng.eclipse.ALL_CLASS_METHODS"/>
 <listAttribute key="org.testng.eclipse.CLASS_TEST_LIST"/>
 <booleanAttribute key="org.testng.eclipse.DEBUG" value="false"/>

--- a/.templates/eclipseLaunches/Local tests.launch.xml
+++ b/.templates/eclipseLaunches/Local tests.launch.xml
@@ -6,7 +6,7 @@
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.testng.remote.RemoteTestNG"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="${project.name}"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Duser.timezone=UTC -Xss2m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xss2m"/>
 <mapAttribute key="org.testng.eclipse.ALL_CLASS_METHODS"/>
 <listAttribute key="org.testng.eclipse.CLASS_TEST_LIST"/>
 <booleanAttribute key="org.testng.eclipse.DEBUG" value="false"/>

--- a/build.gradle
+++ b/build.gradle
@@ -529,7 +529,7 @@ compileTestJava.options.encoding = "UTF-8"
 appengine {
     httpPort = 8888
     downloadSdk = true
-    jvmFlags = ["-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8",
+    jvmFlags = ["-Xss2m", "-Dfile.encoding=UTF-8",
                 // absolute paths are not supported, the following is relative to the exploded war directory
                 // this only specifies the datastore path, but the indexes are still generated in
                 // WEB-INF/appengine-generated.
@@ -721,7 +721,7 @@ test {
     maxHeapSize = "1g"
     reports.html.enabled = false
     reports.junitXml.enabled = false
-    jvmArgs "-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8"
+    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
     afterTest afterTestClosure
     testLogging {
         events "passed"
@@ -738,7 +738,7 @@ task localTests(type: Test) {
     maxHeapSize = "1g"
     reports.html.enabled = false
     reports.junitXml.enabled = false
-    jvmArgs "-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8"
+    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
     afterTest afterTestClosure
     testLogging {
         events "passed"
@@ -755,7 +755,7 @@ task failedTests(type: Test) {
     maxHeapSize = "1g"
     reports.html.enabled = false
     reports.junitXml.enabled = false
-    jvmArgs "-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8"
+    jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
     afterTest afterTestClosure
     testLogging {
         events "passed"
@@ -781,9 +781,9 @@ task ciTests {
         reports.html.enabled = false
         reports.junitXml.enabled = false
         if (isTravis) {
-            jvmArgs "-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8", "-Djava.io.tmpdir=" + System.getenv("TRAVIS_BUILD_DIR")
+            jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8", "-Djava.io.tmpdir=" + System.getenv("TRAVIS_BUILD_DIR")
         } else {
-            jvmArgs "-Duser.timezone=UTC", "-Xss2m", "-Dfile.encoding=UTF-8"
+            jvmArgs "-Xss2m", "-Dfile.encoding=UTF-8"
         }
         testLogging {
             events "passed"

--- a/docs/development.md
+++ b/docs/development.md
@@ -150,17 +150,8 @@ You need a student account which can be created by instructors.
 TEAMMATES automated testing requires Firefox or Chrome (works on Windows and OS X).
 It is recommended to use Firefox 46.0 as this is the browser used in CI build (Travis/AppVeyor).
 
-Before running the test suite, both the server and the test environment should be using the UTC time zone. If this has not been done yet, here is the procedure:
-* Stop the dev server if it is running.
-* Specify timezone as a VM argument:
-  * Eclipse
-    * Go to the run configuration Eclipse created when you started the dev server (`Run → Run configurations ...` and select the appropriate one).
-    * Click on the `Arguments` tab and add `-Duser.timezone=UTC` to the `VM arguments` text box.
-    * Save the configuration for future use: Go to the `Common` tab (the last one) and make sure you have selected `Save as → Local file` and `Display in favorites menu → Run, Debug`.
-  * IntelliJ
-    * Go to `Run → Edit Configurations...` and select `Dev Server`.
-    * Add `-Duser.timezone=UTC` to the `VM options` text box. Click `OK`.
-* Start the server again using the run configuration you created in the previous step.
+**NOTE**
+> The dev server sets its time zone to UTC at startup.
 
 ### Using Firefox
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.joda.time.DateTimeZone;
 
@@ -140,6 +141,8 @@ public final class Const {
          */
         public static final String ADMIN_TIME_ZONE = "Asia/Singapore";
         public static final double ADMIN_TIME_ZONE_DOUBLE = 8.0;
+
+        public static final TimeZone TIME_ZONE = TimeZone.getTimeZone("UTC");
 
         public static final String DEFAULT_PROFILE_PICTURE_PATH = "/images/profile_picture_default.png";
 

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -32,7 +32,7 @@ public final class JsonUtils {
      * Json file and also reformat the Json string in pretty-print format.
      */
     private static Gson getTeammatesGson() {
-        return new GsonBuilder().registerTypeAdapter(Date.class, new StandardDateAdapter())
+        return new GsonBuilder().registerTypeAdapter(Date.class, new TeammatesDateAdapter())
                                 .setPrettyPrinting()
                                 .disableHtmlEscaping()
                                 .create();
@@ -85,11 +85,11 @@ public final class JsonUtils {
      * This workaround is necessary as the default GSON date serializer always uses the local time zone,
      * leading to unpredictable JSON output that depends on the system time zone.
      */
-    private static class StandardDateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+    private static class TeammatesDateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
 
         private final DateFormat dateFormat;
 
-        StandardDateAdapter() {
+        TeammatesDateAdapter() {
             dateFormat = new SimpleDateFormat(Const.SystemParams.DEFAULT_DATE_TIME_FORMAT);
             dateFormat.setTimeZone(Const.SystemParams.TIME_ZONE);
         }

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -2,11 +2,20 @@ package teammates.common.util;
 
 import java.lang.reflect.Type;
 import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
 
 /**
@@ -23,8 +32,7 @@ public final class JsonUtils {
      * Json file and also reformat the Json string in pretty-print format.
      */
     private static Gson getTeammatesGson() {
-        return new GsonBuilder().setDateFormat(DateFormat.FULL)
-                                .setDateFormat(Const.SystemParams.DEFAULT_DATE_TIME_FORMAT)
+        return new GsonBuilder().registerTypeAdapter(Date.class, new StandardDateAdapter())
                                 .setPrettyPrinting()
                                 .disableHtmlEscaping()
                                 .create();
@@ -70,6 +78,35 @@ public final class JsonUtils {
     public static JsonElement parse(String json) {
         JsonParser parser = new JsonParser();
         return parser.parse(json);
+    }
+
+    /**
+     * Ensures that JSON date output is in the standard time zone.
+     * This workaround is necessary as the default GSON date serializer always uses the local time zone,
+     * leading to unpredictable JSON output that depends on the system time zone.
+     */
+    private static class StandardDateAdapter implements JsonSerializer<Date>, JsonDeserializer<Date> {
+
+        private final DateFormat dateFormat;
+
+        StandardDateAdapter() {
+            dateFormat = new SimpleDateFormat(Const.SystemParams.DEFAULT_DATE_TIME_FORMAT);
+            dateFormat.setTimeZone(Const.SystemParams.TIME_ZONE);
+        }
+
+        @Override
+        public synchronized JsonElement serialize(Date date, Type type, JsonSerializationContext context) {
+            return new JsonPrimitive(dateFormat.format(date));
+        }
+
+        @Override
+        public synchronized Date deserialize(JsonElement element, Type type, JsonDeserializationContext context) {
+            try {
+                return dateFormat.parse(element.getAsString());
+            } catch (ParseException e) {
+                throw new JsonParseException(e);
+            }
+        }
     }
 
 }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -18,6 +18,8 @@ import teammates.common.util.Const.SystemParams;
  */
 public final class TimeHelper {
 
+    private static final Logger log = Logger.getLogger();
+
     private static final Map<String, String> TIME_ZONE_CITIES_MAP = new HashMap<String, String>();
     private static final List<Double> TIME_ZONE_VALUES = new ArrayList<Double>();
 
@@ -78,6 +80,19 @@ public final class TimeHelper {
     private static void map(String timeZone, String cities) {
         TIME_ZONE_CITIES_MAP.put(timeZone, cities);
         TIME_ZONE_VALUES.add(Double.parseDouble(timeZone));
+    }
+
+    /**
+     * Sets the system time zone if it differs from the standard one defined in {@link SystemParams#TIME_ZONE}.
+     */
+    public static void setSystemTimeZoneIfRequired() {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        if (SystemParams.TIME_ZONE.equals(originalTimeZone)) {
+            return;
+        }
+
+        TimeZone.setDefault(SystemParams.TIME_ZONE);
+        log.info("Time zone set to " + SystemParams.TIME_ZONE.getID() + " (was " + originalTimeZone.getID() + ")");
     }
 
     public static String getCitiesForTimeZone(String zone) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -202,12 +202,17 @@ public final class TimeHelper {
         if (date == null) {
             return "";
         }
-        Calendar c = Calendar.getInstance();
+        SimpleDateFormat sdf = null;
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         c.setTime(date);
         if (c.get(Calendar.HOUR_OF_DAY) == 12 && c.get(Calendar.MINUTE) == 0) {
-            return new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm").format(date) + " NOON";
+            sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm");
+            sdf.setTimeZone(SystemParams.TIME_ZONE);
+            return sdf.format(date) + " NOON";
         }
-        return new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm a").format(date);
+        sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm a");
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
+        return sdf.format(date);
     }
 
     public static String formatDateTimeForComments(Date date) {
@@ -215,7 +220,7 @@ public final class TimeHelper {
             return "";
         }
         SimpleDateFormat sdf = null;
-        Calendar c = Calendar.getInstance();
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         c.setTime(date);
         if (c.get(Calendar.HOUR_OF_DAY) == 12 && c.get(Calendar.MINUTE) == 0) {
             sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm");
@@ -235,7 +240,7 @@ public final class TimeHelper {
             return "";
         }
         SimpleDateFormat sdf = null;
-        Calendar c = Calendar.getInstance();
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         c.setTime(date);
         if (c.get(Calendar.HOUR_OF_DAY) == 12 && c.get(Calendar.MINUTE) == 0) {
             sdf = new SimpleDateFormat("d MMM h:mm");

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -93,7 +93,7 @@ public final class TimeHelper {
      */
     public static Calendar now(double timeZone) {
         return TimeHelper.convertToUserTimeZone(
-                Calendar.getInstance(TimeZone.getTimeZone("UTC")), timeZone);
+                Calendar.getInstance(SystemParams.TIME_ZONE), timeZone);
     }
 
     /**
@@ -122,7 +122,7 @@ public final class TimeHelper {
      * Returns the date object with specified offset in number of days from now.
      */
     public static Date getDateOffsetToCurrentTime(int offsetDays) {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar cal = Calendar.getInstance(SystemParams.TIME_ZONE);
         cal.setTime(cal.getTime());
         cal.add(Calendar.DATE, +offsetDays);
         return cal.getTime();
@@ -132,7 +132,7 @@ public final class TimeHelper {
      * Returns the date object with specified offset in number of ms from now.
      */
     public static Date getMsOffsetToCurrentTime(int offsetMilliseconds) {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar cal = Calendar.getInstance(SystemParams.TIME_ZONE);
         cal.setTime(cal.getTime());
         cal.add(Calendar.MILLISECOND, +offsetMilliseconds);
         return cal.getTime();
@@ -140,7 +140,7 @@ public final class TimeHelper {
 
     public static Date getMsOffsetToCurrentTimeInUserTimeZone(int offset, double timeZone) {
         Date d = getMsOffsetToCurrentTime(offset);
-        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         c.setTime(d);
         return convertToUserTimeZone(c, timeZone).getTime();
     }
@@ -158,7 +158,7 @@ public final class TimeHelper {
      */
     public static int convertToOptionValueInTimeDropDown(Date date) {
         //TODO: see if we can eliminate this method (i.e., merge with convertToDisplayValueInTimeDropDown)
-        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         c.setTime(date);
         int hour = c.get(Calendar.HOUR_OF_DAY);
         int minutes = c.get(Calendar.MINUTE);
@@ -175,7 +175,7 @@ public final class TimeHelper {
             return "";
         }
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
         return sdf.format(date);
     }
 
@@ -204,11 +204,11 @@ public final class TimeHelper {
         c.setTime(date);
         if (c.get(Calendar.HOUR_OF_DAY) == 12 && c.get(Calendar.MINUTE) == 0) {
             sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm");
-            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            sdf.setTimeZone(SystemParams.TIME_ZONE);
             return sdf.format(date) + " NOON UTC";
         }
         sdf = new SimpleDateFormat("EEE, dd MMM yyyy, hh:mm a zzz");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
         return sdf.format(date);
     }
 
@@ -224,11 +224,11 @@ public final class TimeHelper {
         c.setTime(date);
         if (c.get(Calendar.HOUR_OF_DAY) == 12 && c.get(Calendar.MINUTE) == 0) {
             sdf = new SimpleDateFormat("d MMM h:mm");
-            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            sdf.setTimeZone(SystemParams.TIME_ZONE);
             return sdf.format(date) + " NOON";
         }
         sdf = new SimpleDateFormat("d MMM h:mm a");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
         return sdf.format(date);
     }
 
@@ -255,7 +255,7 @@ public final class TimeHelper {
     }
 
     public static Calendar dateToCalendar(Date date) {
-        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
         if (date == null) {
             return c;
         }
@@ -268,7 +268,7 @@ public final class TimeHelper {
      * Example: If now is 1055, this will return 1100
      */
     public static Date getNextHour() {
-        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar cal = Calendar.getInstance(SystemParams.TIME_ZONE);
         cal.add(Calendar.HOUR_OF_DAY, 1);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
@@ -319,10 +319,10 @@ public final class TimeHelper {
      * Precision is at millisecond level.
      */
     public static boolean isWithinPastHour(Date time1, Date time2) {
-        Calendar calendarTime1 = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar calendarTime1 = Calendar.getInstance(SystemParams.TIME_ZONE);
         calendarTime1.setTime(time1);
 
-        Calendar calendarTime2 = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar calendarTime2 = Calendar.getInstance(SystemParams.TIME_ZONE);
         calendarTime2.setTime(time2);
 
         long time1Millis = calendarTime1.getTimeInMillis();
@@ -366,8 +366,8 @@ public final class TimeHelper {
 
     private static Date convertToDate(String date, int time) {
         SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
+        Calendar calendar = Calendar.getInstance(SystemParams.TIME_ZONE);
 
         // Perform date manipulation
         try {

--- a/src/main/java/teammates/ui/controller/ControllerServlet.java
+++ b/src/main/java/teammates/ui/controller/ControllerServlet.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -26,6 +27,7 @@ import teammates.common.util.LogMessageGenerator;
 import teammates.common.util.Logger;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
+import teammates.common.util.TimeHelper;
 import teammates.logic.api.GateKeeper;
 
 /**
@@ -37,6 +39,11 @@ import teammates.logic.api.GateKeeper;
 public class ControllerServlet extends HttpServlet {
 
     private static final Logger log = Logger.getLogger();
+
+    @Override
+    public void init() throws ServletException {
+        TimeHelper.setSystemTimeZoneIfRequired();
+    }
 
     @Override
     public final void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -113,6 +113,7 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
         <description>Servlet that handles all incoming requests</description>
         <servlet-name>ControllerServlet</servlet-name>
         <servlet-class>teammates.ui.controller.ControllerServlet</servlet-class>
+        <load-on-startup>0</load-on-startup>
     </servlet>
     <servlet-mapping>
         <servlet-name>ControllerServlet</servlet-name>

--- a/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
@@ -11,6 +11,7 @@ import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.datastore.Text;
 
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
+import teammates.common.util.Const.SystemParams;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.SanitizationHelper;
 import teammates.storage.entity.StudentProfile;
@@ -57,17 +58,13 @@ public class StudentProfileAttributesTest extends BaseTestCase {
     public void testGetJsonString() throws Exception {
         StudentProfileAttributes spa = new StudentProfileAttributes((StudentProfile) profile.toEntity());
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
         spa.modifiedDate = sdf.parse("2015-05-21 8:34:00");
         assertEquals("{\n  \"googleId\": \"valid.googleId\",\n  \"shortName\": \"shor\","
                      + "\n  \"email\": \"valid@email.com\",\n  \"institute\": \"institute\","
                      + "\n  \"nationality\": \"Lebanese\",\n  \"gender\": \"female\","
                      + "\n  \"moreInfo\": \"moreInfo can have a lot more than this...\","
                      + "\n  \"pictureKey\": \"profile Pic Key\","
-                     /*
-                      *  Be careful:
-                      *  This comparison will fail if the test is run without
-                      *  the VM argument -Duser.timezone=UTC.
-                      */
                      + "\n  \"modifiedDate\": \"2015-05-21 8:34 AM +0000\"\n}",
                      spa.getJsonString());
     }

--- a/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
@@ -1,6 +1,5 @@
 package teammates.test.cases.datatransfer;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,9 +10,9 @@ import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.datastore.Text;
 
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
-import teammates.common.util.Const.SystemParams;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.SanitizationHelper;
+import teammates.common.util.TimeHelper;
 import teammates.storage.entity.StudentProfile;
 import teammates.test.cases.BaseTestCase;
 import teammates.test.driver.AssertHelper;
@@ -57,9 +56,7 @@ public class StudentProfileAttributesTest extends BaseTestCase {
     @Test
     public void testGetJsonString() throws Exception {
         StudentProfileAttributes spa = new StudentProfileAttributes((StudentProfile) profile.toEntity());
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        sdf.setTimeZone(SystemParams.TIME_ZONE);
-        spa.modifiedDate = sdf.parse("2015-05-21 8:34:00");
+        spa.modifiedDate = TimeHelper.convertToDate("2015-05-21 8:34 AM UTC");
         assertEquals("{\n  \"googleId\": \"valid.googleId\",\n  \"shortName\": \"shor\","
                      + "\n  \"email\": \"valid@email.com\",\n  \"institute\": \"institute\","
                      + "\n  \"nationality\": \"Lebanese\",\n  \"gender\": \"female\","


### PR DESCRIPTION
Fixes #7520

**Outline of Solution**
- Set time zone to UTC in `ControllerServlet` init
  - Add `load-on-startup` flag to `ControllerServlet` in `web.xml` to ensure code runs at server startup
- Fix `StudentProfileAttributesTest` to be independent of system time zone
  - Fix `JsonUtils` to always read and write JSON dates in UTC, independent of system time zone (lightens reviewer's burden of checking time zone of date fields in JSON files in PRs that touch them)