### PR TITLE
Instructor: add instructor: 'display to students as' textbox should be enabled only if the checkbox is checked #4043

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -265,7 +265,7 @@ public final class Const {
                 + " E.g. to give access to a colleague for ‘auditing’ your course";
 
         public static final String INSTRUCTOR_DISPLAYED_AS =
-                "Specify the role of this instructor in this course as shown to the students";
+                "Specify the role of this instructor in this course as shown to the students.\n E.g.Co-lecturer, Teaching Assistant";
 
         public static final String STUDENT_COURSE_DETAILS = "View and edit information regarding your team";
 

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -265,7 +265,8 @@ public final class Const {
                 + " E.g. to give access to a colleague for ‘auditing’ your course";
 
         public static final String INSTRUCTOR_DISPLAYED_AS =
-                "Specify the role of this instructor in this course as shown to the students.\n E.g.Co-lecturer, Teaching Assistant";
+                "Specify the role of this instructor in this course as shown to the students."
+                + " E.g.Co-lecturer, Teaching Assistant";
 
         public static final String STUDENT_COURSE_DETAILS = "View and edit information regarding your team";
 

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
@@ -46,11 +46,11 @@
                 <div id="accessControlEditDivForInstr${addInstructorPanel.index}">
                     <div class="form-group">
                         <label class="col-sm-3 control-label">
-                            <input id="display-to-student" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
+                            <input class="display-to-student" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
                             Display to students as:
                         </label>
                         <div class="col-sm-9">
-                            <input class="form-control" id="title-displayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
+                            <input class="form-control title-displayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
                                 value="Instructor" disabled=""
                                 data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_AS%>"/>
                         </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
@@ -46,13 +46,12 @@
                 <div id="accessControlEditDivForInstr${addInstructorPanel.index}">
                     <div class="form-group">
                         <label class="col-sm-3 control-label">
-                            <input type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" checked
-                               data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
+                            <input id="displayToStudent" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
                             Display to students as:
                         </label>
                         <div class="col-sm-9">
-                            <input class="form-control" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
-                                placeholder="E.g.Co-lecturer, Teaching Assistant"
+                            <input class="form-control" id="titleDisplayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
+                                placeholder="Instructor" disabled
                                 data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_AS%>"/>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
@@ -46,12 +46,12 @@
                 <div id="accessControlEditDivForInstr${addInstructorPanel.index}">
                     <div class="form-group">
                         <label class="col-sm-3 control-label">
-                            <input id="displayToStudent" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
+                            <input id="display-to-student" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true" data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_TO_STUDENT%>">
                             Display to students as:
                         </label>
                         <div class="col-sm-9">
-                            <input class="form-control" id="titleDisplayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
-                                placeholder="Instructor" disabled
+                            <input class="form-control" id="title-displayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
+                                value="Instructor" disabled=""
                                 data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_AS%>"/>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorListPanelBody.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorListPanelBody.tag
@@ -64,7 +64,7 @@
 
             <div class="form-group">
                 <label class="col-sm-3 control-label">
-                    <input type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true"
+                    <input class="display-to-student" type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_IS_DISPLAYED_TO_STUDENT%>" value="true"
                             <c:if test="${instructorPanel.instructor.displayedToStudents}">
                                 checked
                             </c:if>
@@ -74,7 +74,7 @@
                 </label>
 
                 <div class="col-sm-9">
-                    <input class="form-control" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
+                    <input class="form-control title-displayed" type="text" name="<%=Const.ParamsNames.INSTRUCTOR_DISPLAY_NAME%>"
                             placeholder="E.g.Co-lecturer, Teaching Assistant" value="${instructorPanel.instructor.displayedName}"
                             data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.INSTRUCTOR_DISPLAYED_AS%>"
                             disabled>

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -136,6 +136,7 @@ function hideTunePermissionDiv(instrNum) {
  */
 function enableFormEditInstructor(number) {
     $(`#instructorTable${number}`).find(':input').not('.immutable').prop('disabled', false);
+    if(!$(`.display-to-student`).prop(`checked`)) $(`.title-displayed`).prop('disabled', true);
     $(`#instrEditLink${number}`).hide();
     $(`#instrCancelLink${number}`).show();
     $(`#accessControlInfoForInstr${number}`).hide();
@@ -530,7 +531,7 @@ $(document).ready(() => {
         showInstructorRoleModal($(e.target).data('role'));
     });
 
-    $('#display-to-student').change((e) => {
-        $('#title-displayed').prop('disabled', !e.target.checked);
+    $('.display-to-student').change((e) => {
+        $('.title-displayed').prop('disabled', !e.target.checked);
     });
 });

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -530,8 +530,7 @@ $(document).ready(() => {
         showInstructorRoleModal($(e.target).data('role'));
     });
 
-    $('#displayToStudent').change(function() {
-        $('#titleDisplayed').attr('disabled',!this.checked)
+    $('#displayToStudent').change(function () {
+        $('#titleDisplayed').attr('disabled', !this.checked);
     });
-
 });

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -136,7 +136,7 @@ function hideTunePermissionDiv(instrNum) {
  */
 function enableFormEditInstructor(number) {
     $(`#instructorTable${number}`).find(':input').not('.immutable').prop('disabled', false);
-    if(!$(`.display-to-student`).prop(`checked`)) $(`.title-displayed`).prop('disabled', true);
+    if (!$('.display-to-student').prop('checked')) $('.title-displayed').prop('disabled', true);
     $(`#instrEditLink${number}`).hide();
     $(`#instrCancelLink${number}`).show();
     $(`#accessControlInfoForInstr${number}`).hide();

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -529,4 +529,9 @@ $(document).ready(() => {
     $(document).on('click', '.view-role-details', (e) => {
         showInstructorRoleModal($(e.target).data('role'));
     });
+
+    $('#displayToStudent').change(function() {
+        $('#titleDisplayed').attr('disabled',!this.checked)
+    });
+
 });

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -530,7 +530,7 @@ $(document).ready(() => {
         showInstructorRoleModal($(e.target).data('role'));
     });
 
-    $('#display-to-student').change( (e) => {
+    $('#display-to-student').change((e) => {
         $('#title-displayed').prop('disabled', !e.target.checked);
     });
 });

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -530,7 +530,7 @@ $(document).ready(() => {
         showInstructorRoleModal($(e.target).data('role'));
     });
 
-    $('#displayToStudent').change(function () {
-        $('#titleDisplayed').attr('disabled', !this.checked);
+    $('#display-to-student').change( (e) => {
+        $('#title-displayed').prop('disabled', !e.target.checked);
     });
 });

--- a/src/main/webapp/dev/js/main/instructorCourseEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorCourseEdit.es6
@@ -136,7 +136,9 @@ function hideTunePermissionDiv(instrNum) {
  */
 function enableFormEditInstructor(number) {
     $(`#instructorTable${number}`).find(':input').not('.immutable').prop('disabled', false);
-    if (!$('.display-to-student').prop('checked')) $('.title-displayed').prop('disabled', true);
+    if (!$(`#instructorTable${number}`).find('.display-to-student').prop('checked')) {
+        $(`#instructorTable${number}`).find('.title-displayed').prop('disabled', true);
+    }
     $(`#instrEditLink${number}`).hide();
     $(`#instrCancelLink${number}`).show();
     $(`#accessControlInfoForInstr${number}`).hide();
@@ -532,6 +534,7 @@ $(document).ready(() => {
     });
 
     $('.display-to-student').change((e) => {
-        $('.title-displayed').prop('disabled', !e.target.checked);
+        const $titleDisplayed = $(e.target).parents('div.form-group').find('.title-displayed');
+        $titleDisplayed.prop('disabled', !e.target.checked);
     });
 });

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -352,7 +352,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3" style="display: none;">

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -239,11 +239,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -348,11 +348,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3" style="display: none;">
@@ -861,11 +861,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -970,11 +970,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1068,11 +1068,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1169,11 +1169,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1270,11 +1270,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1342,11 +1342,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -348,7 +348,7 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
@@ -1342,11 +1342,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -1342,11 +1342,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -243,7 +243,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -352,7 +352,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3" style="display: none;">
@@ -865,7 +865,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -974,7 +974,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1072,7 +1072,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1173,7 +1173,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1274,7 +1274,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1346,7 +1346,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
@@ -30,11 +30,11 @@
     </div>
     <div class="form-group">
       <label class="col-sm-3 control-label">
-        <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+        <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr7" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
@@ -34,7 +34,7 @@
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr7" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
@@ -30,11 +30,11 @@
     </div>
     <div class="form-group">
       <label class="col-sm-3 control-label">
-        <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+        <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr1" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
@@ -34,7 +34,7 @@
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr1" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
@@ -30,11 +30,11 @@
     </div>
     <div class="form-group">
       <label class="col-sm-3 control-label">
-        <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+        <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr1" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
@@ -34,7 +34,7 @@
         Display to students as:
       </label>
       <div class="col-sm-9">
-        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+        <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
       </div>
     </div>
     <div id="accessControlInfoForInstr1" style="display: block;">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -243,7 +243,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -344,7 +344,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -453,7 +453,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -551,7 +551,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -652,7 +652,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -753,7 +753,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -825,7 +825,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -239,11 +239,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -340,11 +340,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -449,11 +449,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -547,11 +547,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -648,11 +648,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -749,11 +749,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -146,11 +146,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -662,11 +662,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -771,11 +771,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -869,11 +869,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -978,11 +978,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1076,11 +1076,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1177,11 +1177,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1278,11 +1278,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -150,7 +150,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -666,7 +666,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -775,7 +775,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -873,7 +873,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -982,7 +982,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1080,7 +1080,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1181,7 +1181,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1282,7 +1282,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1354,7 +1354,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -771,7 +771,7 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -146,11 +146,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -662,11 +662,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -771,11 +771,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -869,11 +869,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -978,11 +978,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1076,11 +1076,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1177,11 +1177,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1278,11 +1278,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -150,7 +150,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -666,7 +666,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -775,7 +775,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -873,7 +873,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -982,7 +982,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1080,7 +1080,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1181,7 +1181,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1282,7 +1282,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1354,7 +1354,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -771,7 +771,7 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
@@ -1350,11 +1350,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -146,11 +146,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -244,11 +244,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -353,11 +353,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -451,11 +451,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -560,11 +560,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -658,11 +658,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -759,11 +759,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -860,11 +860,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -932,11 +932,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -932,11 +932,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -353,7 +353,7 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
@@ -932,11 +932,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -150,7 +150,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -248,7 +248,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -357,7 +357,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -455,7 +455,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -564,7 +564,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -662,7 +662,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -763,7 +763,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -864,7 +864,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -936,7 +936,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -150,7 +150,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -663,7 +663,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -772,7 +772,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -870,7 +870,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -979,7 +979,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1077,7 +1077,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1178,7 +1178,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1279,7 +1279,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1351,7 +1351,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -768,7 +768,7 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
@@ -1347,11 +1347,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -146,11 +146,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1" style="display: none;">
@@ -659,11 +659,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -768,11 +768,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -866,11 +866,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -975,11 +975,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -1073,11 +1073,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -1174,11 +1174,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -1275,11 +1275,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr8">
@@ -1347,11 +1347,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -1347,11 +1347,11 @@
           <div id="accessControlEditDivForInstr9">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -223,7 +223,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -321,7 +321,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -422,7 +422,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -531,7 +531,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -629,7 +629,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -730,7 +730,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -831,7 +831,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -903,7 +903,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -219,11 +219,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -317,11 +317,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -418,11 +418,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -527,11 +527,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -625,11 +625,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -726,11 +726,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -827,11 +827,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -899,11 +899,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -899,11 +899,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -899,11 +899,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -243,7 +243,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -344,7 +344,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -453,7 +453,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -551,7 +551,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -652,7 +652,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -753,7 +753,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -825,7 +825,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -239,11 +239,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -340,11 +340,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -449,11 +449,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -547,11 +547,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -648,11 +648,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -749,11 +749,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -243,7 +243,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -344,7 +344,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -453,7 +453,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -551,7 +551,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -652,7 +652,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -753,7 +753,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -825,7 +825,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -239,11 +239,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -340,11 +340,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -449,11 +449,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -547,11 +547,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -648,11 +648,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -749,11 +749,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -243,7 +243,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -344,7 +344,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -453,7 +453,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -551,7 +551,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -652,7 +652,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -753,7 +753,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -825,7 +825,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -239,11 +239,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr2">
@@ -340,11 +340,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr3">
@@ -449,11 +449,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr4">
@@ -547,11 +547,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr5">
@@ -648,11 +648,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr6">
@@ -749,11 +749,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr7">
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -821,11 +821,11 @@
           <div id="accessControlEditDivForInstr8">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -213,11 +213,11 @@
           <div id="accessControlEditDivForInstr2">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -141,11 +141,11 @@
           </div>
           <div class="form-group">
             <label class="col-sm-3 control-label">
-              <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
+              <input checked="" class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" disabled="" name="instructorisdisplayed" title="" type="checkbox" value="true">
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -213,11 +213,11 @@
           <div id="accessControlEditDivForInstr2">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="display-to-student" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input class="display-to-student" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="title-displayed" name="instructordisplayname" title="" type="text" value="Instructor">
+                <input class="form-control title-displayed" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" title="" type="text" value="Instructor">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -145,7 +145,7 @@
               Display to students as:
             </label>
             <div class="col-sm-9">
-              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
+              <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text" value="Instructor">
             </div>
           </div>
           <div id="accessControlInfoForInstr1">
@@ -217,7 +217,7 @@
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students. E.g.Co-lecturer, Teaching Assistant" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -213,11 +213,11 @@
           <div id="accessControlEditDivForInstr2">
             <div class="form-group">
               <label class="col-sm-3 control-label">
-                <input checked="" data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" name="instructorisdisplayed" title="" type="checkbox" value="true">
+                <input data-original-title="If this is unselected, the instructor will be completely invisible to students. E.g. to give access to a colleague for ‘auditing’ your course" data-placement="top" data-toggle="tooltip" id="displayToStudent" name="instructorisdisplayed" title="" type="checkbox" value="true">
                 Display to students as:
               </label>
               <div class="col-sm-9">
-                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" name="instructordisplayname" placeholder="E.g.Co-lecturer, Teaching Assistant" title="" type="text">
+                <input class="form-control" data-original-title="Specify the role of this instructor in this course as shown to the students" data-placement="top" data-toggle="tooltip" disabled="" id="titleDisplayed" name="instructordisplayname" placeholder="Instructor" title="" type="text">
               </div>
             </div>
             <div class="form-group">

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
@@ -213,7 +213,7 @@
                 <div class="col-sm-10">
                   <div class="panel panel-default panel-body mce-content-body content-editor" id="instructions" spellcheck="false">
                     <p>
-                      updated instructions
+                      Please give your feedback based on the following questions.
                     </p>
                   </div>
                   <input name="instructions" type="hidden">

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
@@ -213,7 +213,7 @@
                 <div class="col-sm-10">
                   <div class="panel panel-default panel-body mce-content-body content-editor" id="instructions" spellcheck="false">
                     <p>
-                      Please give your feedback based on the following questions.
+                      updated instructions
                     </p>
                   </div>
                   <input name="instructions" type="hidden">


### PR DESCRIPTION
Fixes #4043 

**Outline of the solution:**

- The default value of the textbox is changed to `Instructor`
- Default Behaviour: `Displayed to student as` is unchecked and corresponding `Input` element will be disabled.
- On checking the checkbox the input element will be enabled.
- The placeholder `E.g.Co-lecturer, Teaching Assistant` is moved to tooltip as suggested by @taniach. 

- Same behavior can be seen while editing an Instructor.

> Load the page with the checkbox unchecked and a disabled textbox containing the value 'Instructor'. The examples (e.g co-lecturer, teaching assistant) can be given in the tooltip.

Implemented this!