### PR TITLE
Features page: make the font size consistent #7228

### DIFF
--- a/src/main/webapp/features.jsp
+++ b/src/main/webapp/features.jsp
@@ -2,186 +2,217 @@
 <t:staticPage currentPage="features">
   <div class="container">
     <div class="lead">
-      Here is an overview of some notable TEAMMATES features.
-      The <a href="instructorHelp.jsp">help page</a> contains more details about how to use these features.
+      <h1 class="color_orange">
+        Features
+      </h1>
+      <p class="h5"> Here is an overview of some notable TEAMMATES features.
+        The <a href="instructorHelp.jsp">help page</a> contains more details about how to use these features.
+      </p>
     </div>
+
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Team peer evaluations</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-teampeerevaluations.png" alt="Team peer evaluations">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer feedback to team members.
-          <br><br>
-          Students can provide confidential peer evaluations to you too.
-        </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/feature-teampeerevaluations.png" alt="Team peer evaluations">
+          <div class="col-xs-9 col-sm-9">
+            <div class="features-page-text">
+              Have a team project in your course? Set up a 'team peer evaluation session' for students to give anonymous peer feedback to team members.
+              <br><br>
+              Students can provide confidential peer evaluations to you too.
+            </div>
+          </div>
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Flexible feedback paths</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          There are many other feedback paths available. Some examples:<br>
-          a) feedback between teams<br>
-          b) from instructors to students<br>
-          c) from each student to three other students
+        <img class="img-responsive features-page-img" src="images/feature-flexiblefeedbackpaths.png" alt="Flexible feedback paths">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            There are many other feedback paths available. Some examples:<br>
+            a) feedback between teams<br>
+            b) from instructors to students<br>
+            c) from each student to three other students
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Powerful visibility control</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can see the<br>
-          (i) response text,<br>
-          (ii) the identity of the feedback giver, and<br>
-          (iii) the identity of the feedback receiver.
+        <img class="img-responsive features-page-img" src="images/feature-powerfullvisibilitycontrol.png" alt="Powerful visibility control">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            If you plan to publish the responses collected, you can set the visibility level for each question i.e. who can see the<br>
+            (i) response text,<br>
+            (ii) the identity of the feedback giver, and<br>
+            (iii) the identity of the feedback receiver.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Reports and statistics</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-reportsandstatistics.png" alt="Reports and statistics">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
-          <br><br>
-          Some statistics for the responses are available too.
+        <img class="img-responsive features-page-img" src="images/feature-reportsandstatistics.png" alt="Reports and statistics">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            There are many report formats for viewing responses collected, e.g. Group by team, then by feedback giver.
+            <br><br>
+            Some statistics for the responses are available too.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Fine-grain access control</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different access levels.
-          <br><br>
-          If required, you can even set which sessions of which section of students are accessible to a particular instructor.
+        <img class="img-responsive features-page-img" src="images/feature-finegrainaccesscontrol.png" alt="Fine-grain access control">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            You can add more instructors (e.g. co-lecturers, visitors, tutors, etc.) to your courses and give them different access levels.
+            <br><br>
+            If required, you can even set which sessions of which section of students are accessible to a particular instructor.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Different question types</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-differentquestiontypes.png" alt="Different question types">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, ‘Distribute a fixed number of points among options’ questions, questions measuring contribution in team projects, and more choices coming soon...
-          <br><br>
-          You can even generate MCQ options from student names, as illustrated in the above example.
+        <img class="img-responsive features-page-img" src="images/feature-differentquestiontypes.png" alt="Different question types">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            Essay questions, MCQ questions, Multiple select questions, Numeric scale questions, 'Distribute a fixed number of points among options' questions, questions measuring contribution in team projects, and more choices coming soon...
+            <br><br>
+            You can even generate MCQ options from student names, as illustrated in the above example.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Reuse past questions</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-reusepastquestions.png" alt="Reuse past questions">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          Once you have a perfect set of questions configured for a session, you can reuse those questions later, without needing to configure the same questions from scratch again.
-          <br><br>
-          TEAMMATES also provides some session templates to choose from.
+        <img class="img-responsive features-page-img" src="images/feature-reusepastquestions.png" alt="Reuse past questions">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            Once you have a perfect set of questions configured for a session, you can reuse those questions later, without needing to configure the same questions from scratch again.
+            <br><br>
+            TEAMMATES also provides some session templates to choose from.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">No signup required for students</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-nosignuprequired.png" alt="No signup required for students">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to login or signup.
-          <br><br>
-          If they login to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
+        <img class="img-responsive features-page-img" src="images/feature-nosignuprequired.png" alt="No signup required for students">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            Students can submit responses and view published responses using the unique links TEAMMATES emails them, without having to login or signup.
+            <br><br>
+            If they login to TEAMMATES using their Google accounts (optional), they can access all TEAMMATES courses in one page and access even more features such as setting up profiles.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Downloadable data</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-downloadbledata.png" alt="Downloadable data">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          You can download the collected responses (and statistics) as spreadsheets.
-          <br><br>
-          The collected data belongs to you and you may delete your data from TEAMMATES any time.
+        <img class="img-responsive features-page-img" src="images/feature-downloadbledata.png" alt="Downloadable data">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            You can download the collected responses (and statistics) as spreadsheets.
+            <br><br>
+            The collected data belongs to you and you may delete your data from TEAMMATES any time.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Shareable comments</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-sharablecomments.png" alt="Sharable">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          You can add comments about responses collected. You can even share these comments with students/instructors.
-          <br><br>
-          Fine-grained visibility control is available for comments too.
-          For example, you can give a comment to a student that the receiving student can see while other students in the course can only see the comment text but cannot see the recipient name.
+        <img class="img-responsive features-page-img" src="images/feature-sharablecomments.png" alt="Sharable">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            You can add comments about responses collected. You can even share these comments with students/instructors.
+            <br><br>
+            Fine-grained visibility control is available for comments too.
+            For example, you can give a comment to a student that the receiving student can see while other students in the course can only see the comment text but cannot see the recipient name.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Student profiles</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-studentprofiles.png" alt="Student profiles">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          You can get students to upload more information about themselves, including a profile picture.
-          Such extra data can help you remember current/past students better.
-          <span class="tiny-text"> [<a href="https://www.flickr.com/photos/meatheadmovers">photo source</a>]</span>
-          <br><br>
-          You can access all data about a student in one page, just by typing a part of the student’s name in our search box. In a single page you can see,<br>
-          * Student’s profile<br>
-          * All feedback given/received by the student<br>
-          * All comments received by the student
+        <img class="img-responsive features-page-img" src="images/feature-studentprofiles.png" alt="Student profiles">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            You can get students to upload more information about themselves, including a profile picture.
+            Such extra data can help you remember current/past students better.
+            <span class="tiny-text"> [<a href="https://www.flickr.com/photos/meatheadmovers">photo source</a>]</span>
+            <br><br>
+            You can access all data about a student in one page, just by typing a part of the student’s name in our search box. In a single page you can see,<br>
+            * Student’s profile<br>
+            * All feedback given/received by the student<br>
+            * All comments received by the student
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Powerful search</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-powerfulsearch.png" alt="Powerful search">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          TEAMMATES has a powerful search feature to locate details about students or past comments.
-          <br><br>
-          Given above is an example of searching for a student whose name you are not very sure of.
+        <img class="img-responsive features-page-img" src="images/feature-powerfulsearch.png" alt="Powerful search">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            TEAMMATES has a powerful search feature to locate details about students or past comments.
+            <br><br>
+            Given above is an example of searching for a student whose name you are not very sure of.
+          </div>
         </div>
-        <img class="img-responsive" src="images/raised-edge.png">
+        <img class="img-responsive features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
     <section class="row">
       <div class="col-xs-12 col-sm-8 col-sm-offset-2">
         <h2 class="color_orange col-xs-12">Support for big courses</h2>
-        <img class="img-responsive col-xs-12" src="images/feature-supportforbigcourses.png" alt="Support for big courses">
-        <div class="col-xs-12 col-sm-10 col-sm-offset-1">
-          TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into sections of no more than 100 students.
-          There is no limit on the number of courses or sessions you could have either.
+        <img class="img-responsive features-page-img" src="images/feature-supportforbigcourses.png" alt="Support for big courses">
+        <div class="col-xs-9 col-sm-9">
+          <div class="features-page-text">
+            TEAMMATES can support a course of any size (even beyond 1,000 students), as long as you divide the students into sections of no more than 100 students.
+            There is no limit on the number of courses or sessions you could have either.
+          </div>
         </div>
-        <img class="row img-responsive" src="images/raised-edge.png">
+        <img class="row features-page-img" src="images/raised-edge.png">
       </div>
     </section>
 
-    <div class="row">
+    <div class="features-page-text-bottom">
       <p class="col-xs-12 col-sm-8 col-sm-offset-2">
         For more details about these features, visit the <a href="instructorHelp.jsp" target="_blank" rel="noopener noreferrer">Instructor Help</a> page or <a href="contact.jsp">email us</a>.
       </p>

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -935,6 +935,24 @@ Default to alert color for visibility titles used within an alert context.
     content: attr(data-placeholder);
 }
 
+/* features page */
+
+.features-page-img {
+    height: 75%;
+    max-width: 75%;
+}
+
+@media screen and (min-width: 480px) {
+    .features-page-text {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+}
+
+.features-page-text-bottom {
+    margin-top: 15px;
+}
+
 .remind-no-response {
     display: inline-block;
     padding-right: 5px;


### PR DESCRIPTION
Fixes #7228 

Made the images and text font smaller.

Also added a the title "Features" at the top of the page to match the other main pages (Contact, About Us, Terms of Use).

![734c2c3e-440d-11e7-96ae-b68e494b2087](https://user-images.githubusercontent.com/28169978/27257784-e3573cea-53b1-11e7-9de6-5f8fd78af601.PNG)
