### PR TITLE
.travis.yml: downgrade to Precise image #7548

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
   email: false
 
 sudo: required
-dist: trusty
+dist: precise
 
 addons:
   firefox: "46.0"


### PR DESCRIPTION
Fixes #7548

**Outline of Solution**

This is the quickest way to fix #7548 before the Wednesday, 21 June 2017, 14:30 UTC deadline. The more advanced way involves updating to JDK 8, which requires the AppEngine SDK to be updated first (#7529) and also has a caveat that several test cases need to be fixed due to a change in iteration order for HashMaps and HashSets when going from JDK 7 to JDK 8 (https://github.com/TEAMMATES/teammates/commit/69c3ce3988c5f6e4022274ac0a604334af47b8e2). This will be attempted at a later date.