### PR TITLE
Fix AllJsTests failure in Travis #7560

### DIFF
--- a/src/main/resources/package.json
+++ b/src/main/resources/package.json
@@ -13,7 +13,7 @@
     "moment": "2.17.1",
     "moment-timezone": "0.5.11",
     "printthis": "0.1.5",
-    "qunitjs": "2.2.0",
+    "qunitjs": "2.3.3",
     "respond.js": "1.4.2",
     "tinymce": "4.5.5",
     "topojson": "1.6.27"


### PR DESCRIPTION
Fixes #7560 

**Outline of Solution**

Upgraded qunit library to 2.3.3 (latest). This both serves as an upgrade as well as to circumvent the unpkg caching problem. Verified in both Travis CI and AppVeyor.