### PR TITLE
Renamed 'test.properties' to 'test.template.properties'.

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -170,7 +170,7 @@ It is recommended to use Firefox 46.0 as this is the browser used in CI build (T
 * You need to use chromedriver for testing with Chrome.
   * Download the latest stable chromedriver from [here](https://sites.google.com/a/chromium.org/chromedriver/downloads).
     The site will also inform the versions of Chrome that can be used with the driver.
-  * Specify the path to the chromedriver executable in `test.chromedriver.path` value in `test.properties`.
+  * Specify the path to the chromedriver executable in `test.chromedriver.path` value in `test.template.properties`.
 
 * If you are planning to test changes to JavaScript code, disable JavaScript caching for Chrome:
   * Press Ctrl+Shift+J to bring up the Web Console.


### PR DESCRIPTION
 'test.properties' file can not be found. It seems to be renamed into test.template.properties which can be found in 'src/test/resources/'. Therefore it should be renamed to 'test.template.properties'.

