### PR TITLE
InstructorFeedbacksPage: rename boolean methods #7552

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackPageUiTest.java
@@ -250,9 +250,9 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickNeverVisibleTimeButton();
 
         //verify that timeFrameTable, instructions and ResponseVisTable are all hidden
-        assertTrue(feedbackPage.verifyHidden(By.id("timeFramePanel")));
-        assertTrue(feedbackPage.verifyHidden(By.id("responsesVisibleFromColumn")));
-        assertTrue(feedbackPage.verifyHidden(By.id("instructionsRow")));
+        assertTrue(feedbackPage.isHidden(By.id("timeFramePanel")));
+        assertTrue(feedbackPage.isHidden(By.id("responsesVisibleFromColumn")));
+        assertTrue(feedbackPage.isHidden(By.id("instructionsRow")));
 
         newSession.setFeedbackSessionName("private session of characters1234567 #");
         newSession.setCourseId("CFeedbackUiT.CS2104");
@@ -662,20 +662,20 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickCustomPublishTimeButton();
         feedbackPage.clickCustomVisibleTimeButton();
 
-        assertTrue(feedbackPage.verifyEnabled(By.id("visibledate")));
-        assertTrue(feedbackPage.verifyEnabled(By.id("visibletime")));
-        assertTrue(feedbackPage.verifyEnabled(By.id("publishdate")));
-        assertTrue(feedbackPage.verifyEnabled(By.id("publishtime")));
+        assertTrue(feedbackPage.isEnabled(By.id("visibledate")));
+        assertTrue(feedbackPage.isEnabled(By.id("visibletime")));
+        assertTrue(feedbackPage.isEnabled(By.id("publishdate")));
+        assertTrue(feedbackPage.isEnabled(By.id("publishtime")));
 
         ______TS("all 4 datetime elements disabled when custom is deselected");
 
         feedbackPage.clickDefaultPublishTimeButton();
         feedbackPage.clickDefaultVisibleTimeButton();
 
-        assertTrue(feedbackPage.verifyDisabled(By.id("visibledate")));
-        assertTrue(feedbackPage.verifyDisabled(By.id("visibletime")));
-        assertTrue(feedbackPage.verifyDisabled(By.id("publishdate")));
-        assertTrue(feedbackPage.verifyDisabled(By.id("publishtime")));
+        assertTrue(feedbackPage.isDisabled(By.id("visibledate")));
+        assertTrue(feedbackPage.isDisabled(By.id("visibletime")));
+        assertTrue(feedbackPage.isDisabled(By.id("publishdate")));
+        assertTrue(feedbackPage.isDisabled(By.id("publishtime")));
     }
 
     private void testDatePickerScripts() {
@@ -968,9 +968,9 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
                                                            "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                                            FieldValidator.REASON_EMPTY,
                                                            FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
-        assertTrue(feedbackPage.verifyVisible(By.id("timeFramePanel")));
-        assertTrue(feedbackPage.verifyVisible(By.id("responsesVisibleFromColumn")));
-        assertTrue(feedbackPage.verifyVisible(By.id("instructionsRow")));
+        assertTrue(feedbackPage.isVisible(By.id("timeFramePanel")));
+        assertTrue(feedbackPage.isVisible(By.id("responsesVisibleFromColumn")));
+        assertTrue(feedbackPage.isVisible(By.id("instructionsRow")));
     }
 
     private InstructorFeedbacksPage getFeedbackPageForInstructor(String instructorId) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
@@ -469,19 +469,19 @@ public class InstructorFeedbacksPage extends AppPage {
         }
     }
 
-    public boolean verifyHidden(By locator) {
+    public boolean isHidden(By locator) {
         return !browser.driver.findElement(locator).isDisplayed();
     }
 
-    public boolean verifyEnabled(By locator) {
+    public boolean isEnabled(By locator) {
         return browser.driver.findElement(locator).isEnabled();
     }
 
-    public boolean verifyDisabled(By locator) {
+    public boolean isDisabled(By locator) {
         return !browser.driver.findElement(locator).isEnabled();
     }
 
-    public boolean verifyVisible(By locator) {
+    public boolean isVisible(By locator) {
         return browser.driver.findElement(locator).isDisplayed();
     }
 


### PR DESCRIPTION
Fixes #7552

Outline of Solution
InstructorFeedbacksPage.java:
Boolean methods verifyHidden, verifyEnabled, verifyDisabled and verifyVisible are be ranamed to isHidden , isEnabled, isDisabled and isVisible repectively 
