### PR TITLE
Instructor: view results: 'expand' button collides with the status message #7485

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
@@ -6,7 +6,6 @@
 
 <%@ attribute name="questionPanels" type="java.util.List" required="true" %>
 
-<br>
 
 <c:forEach items="${questionPanels}" var="questionPanel" varStatus="i">
     <results:questionPanel questionIndex="${i.index}" isShowingResponses="${isShowingResponses}"

--- a/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
@@ -6,7 +6,6 @@
 
 <%@ attribute name="questionPanels" type="java.util.List" required="true" %>
 
-
 <c:forEach items="${questionPanels}" var="questionPanel" varStatus="i">
     <results:questionPanel questionIndex="${i.index}" isShowingResponses="${isShowingResponses}"
                            questionPanel="${questionPanel}"/>

--- a/src/main/webapp/WEB-INF/tags/instructor/results/bySectionPanels.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/bySectionPanels.tag
@@ -9,7 +9,7 @@
 <%@ attribute name="isGroupedByQuestion" type="java.lang.Boolean" required="true" %>
 <%@ attribute name="isGroupedByTeam" type="java.lang.Boolean" required="true" %>
 
-<br>
+
 <c:set var="teamIndex" value="${0}"/>
 <c:forEach items="${data.sectionPanels}" var="sectionPanel" varStatus="i">
     <results:sectionPanel isShowingAll="${isShowingAll}" sectionPanel="${sectionPanel.value}"

--- a/src/main/webapp/WEB-INF/tags/instructor/results/bySectionPanels.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/bySectionPanels.tag
@@ -9,7 +9,6 @@
 <%@ attribute name="isGroupedByQuestion" type="java.lang.Boolean" required="true" %>
 <%@ attribute name="isGroupedByTeam" type="java.lang.Boolean" required="true" %>
 
-
 <c:set var="teamIndex" value="${0}"/>
 <c:forEach items="${data.sectionPanels}" var="sectionPanel" varStatus="i">
     <results:sectionPanel isShowingAll="${isShowingAll}" sectionPanel="${sectionPanel.value}"

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -94,7 +94,7 @@
         </div>
     </div>
 
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="position:relative;top:70px">
         <c:choose>
             <c:when test="${not showAll}">
                 <div style="display:inline-block;" class="pull-right" data-toggle="tooltip" title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below.">

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -95,7 +95,6 @@
     </div>
 
     <div class="pull-right" style="margin-top:50px">
-        <p>
         <c:choose>
             <c:when test="${not showAll}">
                 <div style="display:inline-block;" class="pull-right" data-toggle="tooltip" title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below.">
@@ -110,9 +109,8 @@
                 </a>
             </c:otherwise>
         </c:choose>
-        </p>
     </div>
-
+	
     <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_SESSION_NAME%>"
         value="${filterPanel.feedbackSessionName}">
     <input type="hidden" name="<%=Const.ParamsNames.COURSE_ID%>"

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -110,7 +110,7 @@
             </c:otherwise>
         </c:choose>
     </div>
-	
+
     <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_SESSION_NAME%>"
         value="${filterPanel.feedbackSessionName}">
     <input type="hidden" name="<%=Const.ParamsNames.COURSE_ID%>"

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -3,7 +3,7 @@
 <%@ tag import="teammates.common.util.Const" %>
 <%@ attribute name="filterPanel" type="teammates.ui.template.InstructorFeedbackResultsFilterPanel" required="true" %>
 <%@ attribute name="showAll" required="true" %>
-<form class="form-horizontal" style="margin-bottom: 35px" role="form" method="post" action="${filterPanel.resultsLink}">
+<form class="form-horizontal" role="form" method="post" action="${filterPanel.resultsLink}">
     <div class="panel panel-info margin-0">
         <div class="panel-body">
             <div class="row">
@@ -94,7 +94,7 @@
         </div>
     </div>
 
-    <div class="pull-right" style="position:relative;top:70px">
+    <div class="pull-right" style="margin-top:70px">
         <c:choose>
             <c:when test="${not showAll}">
                 <div style="display:inline-block;" class="pull-right" data-toggle="tooltip" title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below.">

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -95,6 +95,7 @@
     </div>
 
     <div class="pull-right" style="margin-top:50px">
+        <p>
         <c:choose>
             <c:when test="${not showAll}">
                 <div style="display:inline-block;" class="pull-right" data-toggle="tooltip" title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below.">
@@ -109,6 +110,7 @@
                 </a>
             </c:otherwise>
         </c:choose>
+        </p>
     </div>
 
     <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_SESSION_NAME%>"

--- a/src/main/webapp/jsp/instructorFeedbackResultsTop.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsTop.jsp
@@ -14,7 +14,9 @@
                    showAll="${showAll}" />
 </c:if>
 <br>
+<div style="position:relative;top:20px">
 <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
+</div>
 <br>
 <c:if test="${noResponses and showAll}">
     <div class="bold color_red align-center">There are no responses for this feedback session yet or you do not have access to the responses collected so far.</div>

--- a/src/main/webapp/jsp/instructorFeedbackResultsTop.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsTop.jsp
@@ -13,11 +13,9 @@
     <r:filterPanel filterPanel="${data.filterPanel}"
                    showAll="${showAll}" />
 </c:if>
-<br>
-<div style="position:relative;top:20px">
+<div style="margin-top:100px">
 <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
 </div>
-<br>
 <c:if test="${noResponses and showAll}">
     <div class="bold color_red align-center">There are no responses for this feedback session yet or you do not have access to the responses collected so far.</div>
 </c:if>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <div class="pull-right" data-original-title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below." data-toggle="tooltip" style="display:inline-block;" title="">
         <a class="btn btn-default btn-xs pull-right" disabled="" id="collapse-panels-button">
           Expand All Questions
@@ -238,16 +238,15 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
-      This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser">
+      <div class="overflow-auto alert alert-warning statusMessage">
+        This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+      </div>
     </div>
+    <script defer="" src="/js/statusMessage.js" type="text/javascript">
+    </script>
   </div>
-  <script defer="" src="/js/statusMessage.js" type="text/javascript">
-  </script>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -142,7 +142,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper1" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper1" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -224,7 +224,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <div class="pull-right" data-original-title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below." data-toggle="tooltip" style="display:inline-block;" title="">
         <a class="btn btn-default btn-xs pull-right" disabled="" id="collapse-panels-button">
           Expand All Questions
@@ -235,16 +235,15 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.helper1">
   </form>
-  <br>
-  <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
-      This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser">
+      <div class="overflow-auto alert alert-warning statusMessage">
+        This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+      </div>
     </div>
+    <script defer="" src="/js/statusMessage.js" type="text/javascript">
+    </script>
   </div>
-  <script defer="" src="/js/statusMessage.js" type="text/javascript">
-  </script>
-  <br>
-  <br>
   <div class="panel panel-default">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -142,7 +142,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper2" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper2" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -224,7 +224,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <div class="pull-right" data-original-title="This button is disabled because this session contains more data than we can retrieve at one go. You can still expand one panel at a time by clicking on the panels below." data-toggle="tooltip" style="display:inline-block;" title="">
         <a class="btn btn-default btn-xs pull-right" disabled="" id="collapse-panels-button">
           Expand All Questions
@@ -235,16 +235,15 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.helper2">
   </form>
-  <br>
-  <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
-      This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser">
+      <div class="overflow-auto alert alert-warning statusMessage">
+        This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
+      </div>
     </div>
+    <script defer="" src="/js/statusMessage.js" type="text/javascript">
+    </script>
   </div>
-  <script defer="" src="/js/statusMessage.js" type="text/javascript">
-  </script>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
@@ -145,14 +145,13 @@
       </div>
     </div>
   </div>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
   <div class="bold color_red align-center">
     There are no responses for this feedback session yet or you do not have access to the responses collected so far.
   </div>
-  <br>
   <div class="panel panel-default">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="responseRateForm" id="responseRate" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -223,7 +223,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -305,7 +305,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Collapse all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Collapse All Questions
       </a>
@@ -314,11 +314,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
@@ -142,14 +142,13 @@
       </div>
     </div>
   </div>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
   <div class="bold color_red align-center">
     There are no responses for this feedback session yet or you do not have access to the responses collected so far.
   </div>
-  <br>
   <div class="panel panel-default">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -142,7 +142,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper2" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.helper2" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -224,7 +224,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -233,11 +233,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.helper2">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
     <input name="user" type="hidden" value="FRankUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
     <input name="user" type="hidden" value="FRankUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
     <input name="user" type="hidden" value="FRankUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
     <input name="user" type="hidden" value="FRankUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRankUiT.CS4221&fsname=Instructor+Session&user=FRankUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="FRankUiT.CS4221">
     <input name="user" type="hidden" value="FRankUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -204,7 +204,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -213,11 +213,10 @@
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -204,7 +204,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -213,11 +213,10 @@
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -204,7 +204,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -213,11 +213,10 @@
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -204,7 +204,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -213,11 +213,10 @@
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=FRubricQnUiT.CS2104&fsname=Second+Session&user=FRubricQnUiT.instructor" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -204,7 +204,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -213,11 +213,10 @@
     <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104">
     <input name="user" type="hidden" value="FRubricQnUiT.instructor">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.SanitizedTeam&fsname=Sanitized+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.SanitizedTeam&fsname=Sanitized+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -224,7 +224,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -233,11 +233,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=First+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Collapse all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Collapse All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-default">
     <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Questions
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -145,7 +145,7 @@
       </div>
     </div>
   </div>
-  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form" style="margin-bottom: 35px">
+  <form action="/page/instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&fsname=Second+Session&user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
     <div class="panel panel-info margin-0">
       <div class="panel-body">
         <div class="row">
@@ -227,7 +227,7 @@
         </div>
       </div>
     </div>
-    <div class="pull-right" style="margin-top:50px">
+    <div class="pull-right" style="margin-top:70px">
       <a class="btn btn-default btn-xs pull-right" data-original-title="Expand all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" title="">
         Expand All Sections
       </a>
@@ -236,11 +236,10 @@
     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
     <input name="user" type="hidden" value="CFResultsUiT.instr">
   </form>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
-  <br>
   <div class="panel panel-success">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-section-0-1" id="panelHeading-section-0-1" style="cursor: pointer;">
       <div class="row">

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackResultsPage.html
@@ -145,14 +145,13 @@
       </div>
     </div>
   </div>
-  <br>
-  <div id="statusMessagesToUser" style="display: none;">
+  <div style="margin-top:100px">
+    <div id="statusMessagesToUser" style="display: none;">
+    </div>
   </div>
-  <br>
   <div class="bold color_red align-center">
     There are no responses for this feedback session yet or you do not have access to the responses collected so far.
   </div>
-  <br>
   <div class="panel panel-info">
     <div class="panel-heading ajax_auto" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
       <form action="/page/instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">

--- a/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
@@ -2261,7 +2261,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2272,15 +2276,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2394,15 +2427,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
@@ -66,7 +66,7 @@
               </label>
               <div class="col-sm-10">
                 <p class="form-control-static">
-                  ${datetime.now}
+                  Wed, 28 Jun 2017, 07:54 PM
                 </p>
               </div>
             </div>
@@ -357,7 +357,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -368,15 +372,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -486,15 +519,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageModified.html
@@ -2491,7 +2491,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2502,15 +2506,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageOpen.html
@@ -2235,7 +2235,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2246,15 +2250,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2367,15 +2400,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
@@ -2246,7 +2246,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2257,15 +2261,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2379,15 +2412,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -2409,7 +2409,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2420,15 +2424,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2547,15 +2580,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2674,15 +2736,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2801,15 +2892,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -2369,7 +2369,11 @@
                 <a data-target="#more-info-equal-share-modal" data-toggle="modal" href="javascript:;" id="more-info-equal-share-modal-link">
                   <span class="glyphicon glyphicon-info-sign">
                   </span>
-                  More info about the equal share scale
+                  More info about the
+                  <code>
+                    Equal Share
+                  </code>
+                  scale
                 </a>
               </div>
               <div class="modal fade" id="more-info-equal-share-modal" role="dialog">
@@ -2380,15 +2384,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2508,15 +2541,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2635,15 +2697,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>
@@ -2762,15 +2853,44 @@
                         ×
                       </button>
                       <h4 class="modal-title">
-                        More info about the 'Equal Share' scale
+                        More info about the
+                        <code>
+                          Equal Share
+                        </code>
+                        scale
                       </h4>
                     </div>
                     <div class="modal-body">
                       <p>
-                        Equal share is a relative measure of individual contribution to a team.
+                        <code>
+                          Equal share
+                        </code>
+                        is a relative measure of individual contribution to a team task.
                       </p>
                       <p>
-                        For example, in a 3 person team, 'equal share' means a third of the work done.
+                        For example, in a 3-person team,
+                        <code>
+                          equal share
+                        </code>
+                        means a third of the work done.
+                      </p>
+                      <p>
+                        <code>
+                          Equal share + 10%
+                        </code>
+                        means the person did about 10%
+                        <em>
+                          more
+                        </em>
+                        than an equal share,
+                        <code>
+                          Equal share - 10%
+                        </code>
+                        means about 10%
+                        <em>
+                          less
+                        </em>
+                        than an equal share, and so on.
                       </p>
                     </div>
                   </div>


### PR DESCRIPTION
Fixes #7485 

Edits to `instructorFeedbackResultsTop.jsp:`
* added a `<div>` tag around the status message tag
* added inline style, to align as expected 
* extra `<br>`'s were removed. There was gap between Expand all button and the questions (Question panel). 

Edits to `filterPanel.tag`
* the form element that encloses the entire tag file, had a bottom margin, which has been removed
* the Expand/Collapse element (line 97) has been given extra top margins for formatting purposes

`byQuestionResults.tag` and `bySectionPanels.tag` had some `<br>` which were removed for formatting purposes.


![expand-collapse-changes](https://user-images.githubusercontent.com/10449636/27647907-84ceeb86-5c4a-11e7-82a5-a6cdf8a4522b.JPG)

This is how, the page would appear normally: 
![image](https://user-images.githubusercontent.com/10449636/27648730-128e5400-5c4d-11e7-9ce4-bbb59cffc794.png)



