### PR TITLE
Instructor: download results: fix NullPointerException #7170

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -555,6 +555,9 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             FeedbackSessionResultsBundle bundle, List<String> teamNames) {
         Map<String, List<String>> teamMembersEmail = new LinkedHashMap<>();
         for (String teamName : teamNames) {
+            if (Const.USER_TEAM_FOR_INSTRUCTOR.equals(teamName)) {
+                continue;
+            }
             List<String> memberEmails = new ArrayList<>(bundle.rosterTeamNameMembersTable.get(teamName));
             Collections.sort(memberEmails);
             teamMembersEmail.put(teamName, memberEmails);

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -556,6 +556,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         Map<String, List<String>> teamMembersEmail = new LinkedHashMap<>();
         for (String teamName : teamNames) {
             if (Const.USER_TEAM_FOR_INSTRUCTOR.equals(teamName)) {
+                // skip instructors team (contrib questions should only have responses from student teams)
                 continue;
             }
             List<String> memberEmails = new ArrayList<>(bundle.rosterTeamNameMembersTable.get(teamName));


### PR DESCRIPTION
Fixes #7170, fixes #7373

**Outline of Solution**

`FeedbackContributionQuestionDetails`: Skip results from "Instructors" team when building the (team name)-(team members' emails) map

**Details**

There seems to be an assumption throughout `FeedbackContributionQuestionDetails` that all team members' emails (provided by the method `getTeamMembersEmail`) are student emails. For example, the method `getStudentResults` assigns the name `studentEmail` when it iterates through the team members' emails ([link](https://github.com/TEAMMATES/teammates/blob/2a9b3988d59ea1ad33ba446aef7d8797aa72b7b1/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java#L484)):
```
for (String studentEmail : teamEmails) {
```
and the method `getTeamResults` has this assignment ([link](https://github.com/TEAMMATES/teammates/blob/2a9b3988d59ea1ad33ba446aef7d8797aa72b7b1/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java#L503)):
```
teamEvalResult.studentEmails = teamMembersEmail.get(team);
```

However, the method `getTeamMembersEmail` gets members from `FeedbackSessionResultsBundle`'s `rosterTeamNameMembersTable`. This table is populated by `getTeamNameToEmailsTableFromRoster`, a method in `FeedbackSessionResultsBundle` that adds both students as well as instructors to the table. The instructors are added to a team named "Instructors" ([link](https://github.com/TEAMMATES/teammates/blob/2a9b3988d59ea1ad33ba446aef7d8797aa72b7b1/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java#L2081-L2088)):
```
List<InstructorAttributes> instructors = courseroster.getInstructors();
String instructorsTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
Set<String> instructorEmails = new HashSet<>();

for (InstructorAttributes instructor : instructors) {
    instructorEmails.add(instructor.email);
    teamNameToEmails.put(instructorsTeam, instructorEmails);
}
```

This "instructors" team should be skipped when building the map in `getTeamMembersEmail`, since it is not relevant for contribution questions.