### PR TITLE
InstructorFeedbackResultsPageUiTest: improve stability of hover-triggered popover image verification #7686

### DIFF
--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -55,7 +55,11 @@ public abstract class AppPage {
     /** Browser instance the page is loaded into. */
     protected Browser browser;
 
+    /** Use for retrying due to persistence delays. */
     protected RetryManager persistenceRetryManager = new RetryManager(TestProperties.PERSISTENCE_RETRY_PERIOD_IN_S / 2);
+
+    /** Use for retrying due to transient UI issues. */
+    protected RetryManager uiRetryManager = new RetryManager((TestProperties.TEST_TIMEOUT + 1) / 2);
 
     // These are elements common to most pages in our app
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -341,8 +341,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
         browser.driver.findElement(By.cssSelector(panelBodySelector + " .profile-pic-icon-click a")).click();
 
-        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
-        verifyImageUrl(urlRegex, imgSrc);
+        verifyPopoverImageUrl(popoverSelector, urlRegex);
     }
 
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex) {
@@ -352,8 +351,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         moveToElement(By.cssSelector(headingSelector + " .profile-pic-icon-hover"));
         waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
-        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
-        verifyImageUrl(urlRegex, imgSrc);
+        verifyPopoverImageUrl(popoverSelector, urlRegex);
     }
 
     public void hoverAndViewStudentPhotoOnBody(String panelBodyIndex, String urlRegex) {
@@ -362,8 +360,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
         moveToElement(By.cssSelector(bodyRowSelector + " .profile-pic-icon-hover"));
 
-        String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
-        verifyImageUrl(urlRegex, imgSrc);
+        verifyPopoverImageUrl(popoverSelector, urlRegex);
     }
 
     public void hoverClickAndViewPhotoOnTableCell(int questionBodyIndex, int tableRow,
@@ -376,6 +373,10 @@ public class InstructorFeedbackResultsPage extends AppPage {
         moveToElement(By.cssSelector(cellSelector + " .profile-pic-icon-hover"));
         waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
+        verifyPopoverImageUrl(popoverSelector, urlRegex);
+    }
+
+    private void verifyPopoverImageUrl(String popoverSelector, String urlRegex) {
         String imgSrc = getElementSrcWithRetryAfterWaitForPresence(By.cssSelector(popoverSelector + " > img"));
         verifyImageUrl(urlRegex, imgSrc);
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -339,7 +339,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;
         String popoverSelector = panelBodySelector + " .popover-content";
 
-        browser.driver.findElement(By.cssSelector(panelBodySelector + " .profile-pic-icon-click a")).click();
+        waitForElementPresence(By.cssSelector(panelBodySelector + " .profile-pic-icon-click a")).click();
 
         verifyPopoverImageUrl(popoverSelector, urlRegex);
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -513,6 +513,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     private String getElementSrcWithRetryAfterWaitForPresence(By by) {
         try {
+            waitForAjaxLoaderGifToDisappear();
             return waitForElementPresence(by).getAttribute("src");
         } catch (StaleElementReferenceException e) {
             // Element changed (e.g. loading gif changed to actual image)

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -347,8 +347,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex) {
         String headingSelector = "#panelHeading-" + panelHeadingIndex;
         String popoverSelector = headingSelector + " .popover-content";
+        String hoverSelector = headingSelector + " .profile-pic-icon-hover";
 
-        moveToElement(By.cssSelector(headingSelector + " .profile-pic-icon-hover"));
+        moveToElement(By.cssSelector(hoverSelector));
         waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
         verifyPopoverImageUrl(popoverSelector, urlRegex);
@@ -357,8 +358,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
     public void hoverAndViewStudentPhotoOnBody(String panelBodyIndex, String urlRegex) {
         String bodyRowSelector = "#panelBodyCollapse-" + panelBodyIndex + " > .panel-body > .row";
         String popoverSelector = bodyRowSelector + " .popover-content";
+        String hoverSelector = bodyRowSelector + " .profile-pic-icon-hover";
 
-        moveToElement(By.cssSelector(bodyRowSelector + " .profile-pic-icon-hover"));
+        moveToElement(By.cssSelector(hoverSelector));
 
         verifyPopoverImageUrl(popoverSelector, urlRegex);
     }
@@ -369,8 +371,9 @@ public class InstructorFeedbackResultsPage extends AppPage {
                               + " tr:nth-child(" + (tableRow + 1) + ")"
                               + " td:nth-child(" + (tableCol + 1) + ")";
         String popoverSelector = cellSelector + " .popover-content";
+        String hoverSelector = cellSelector + " .profile-pic-icon-hover";
 
-        moveToElement(By.cssSelector(cellSelector + " .profile-pic-icon-hover"));
+        moveToElement(By.cssSelector(hoverSelector));
         waitForElementPresence(By.cssSelector(popoverSelector + " > a")).click();
 
         verifyPopoverImageUrl(popoverSelector, urlRegex);

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -338,13 +338,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
         }
     }
 
-    public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) {
+    public void clickViewPhotoLink(String panelBodyIndex, String urlRegex) throws MaximumRetriesExceededException {
         String panelBodySelector = "#panelBodyCollapse-" + panelBodyIndex;
         String popoverSelector = panelBodySelector + " .popover-content";
+        String clickSelector = panelBodySelector + " .profile-pic-icon-click a";
 
-        waitForElementPresence(By.cssSelector(panelBodySelector + " .profile-pic-icon-click a")).click();
+        waitForElementPresence(By.cssSelector(clickSelector)).click();
 
-        verifyPopoverImageUrl(popoverSelector, urlRegex);
+        verifyPopoverImageUrlWithClickRetry(popoverSelector, clickSelector, urlRegex, "Click and verify photo");
     }
 
     public void hoverClickAndViewStudentPhotoOnHeading(String panelHeadingIndex, String urlRegex)
@@ -404,6 +405,25 @@ public class InstructorFeedbackResultsPage extends AppPage {
             @Override
             public void beforeRetry() {
                 moveToElement(By.cssSelector(hoverSelector));
+            }
+        }, WebDriverException.class);
+    }
+
+    /**
+     * Similar to {@link #verifyPopoverImageUrlWithHoverRetry}, but for click actions.
+     */
+    private void verifyPopoverImageUrlWithClickRetry(
+            final String popoverSelector, final String clickSelector, final String urlRegex, String taskName)
+            throws MaximumRetriesExceededException {
+        uiRetryManager.runUntilNoRecognizedException(new RetryableTask(taskName) {
+            @Override
+            public void run() {
+                verifyPopoverImageUrl(popoverSelector, urlRegex);
+            }
+
+            @Override
+            public void beforeRetry() {
+                waitForElementPresence(By.cssSelector(clickSelector)).click();
             }
         }, WebDriverException.class);
     }


### PR DESCRIPTION
Fixes #7686

**Outline of Solution**
- Use `RetryManager` to retry hover-click process (fixes main `NoSuchElementException` and occasional `StaleElementReferenceException`)

**Other Stability Improvements**
- Use `waitForElementPresence` to get link element in `clickViewPhotoLink` (fixes occasional `TimeoutException`)
- Handle case when AJAX loader GIF URL is encountered instead of profile photo URL (fixes occasional `AssertionError`)

**Stability Measure**
- Number of CI builds where `InstructorFeedbackResultsPageUiTest`'s `testViewPhotoAndAjaxForLargeScaledSession` passed on first try: `55`/`55`