### PR TITLE
Fix browser tests that fail on Chrome #7699

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ skip_commits:
     - docs/**/*
 
 install:
-  - choco install firefox --version 46.0
   - npm install
 
 build_script:

--- a/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
@@ -78,7 +78,7 @@ public class AdminEmailPageUiTest extends BaseUiTestCase {
 
         emailPage.clearRecipientBox();
         emailPage.clearSubjectBox();
-        emailPage.inputGroupRecipient("invalidGroupList.xlxs");
+        emailPage.inputGroupRecipient("invalidGroupList.xlsx");
         emailPage.verifyStatus("Group receiver list upload failed. Please try again.");
 
         ______TS("send email to group - no subject");

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -86,7 +86,15 @@ public final class TestProperties {
     static {
         Properties prop = new Properties();
         try {
-            prop.load(new FileInputStream("src/test/resources/test.properties"));
+            String propertiesFilename;
+            if (isTravis()) {
+                propertiesFilename = "test.travis.properties";
+            } else if (isAppveyor()) {
+                propertiesFilename = "test.appveyor.properties";
+            } else {
+                propertiesFilename = "test.properties";
+            }
+            prop.load(new FileInputStream("src/test/resources/" + propertiesFilename));
 
             TEAMMATES_URL = Url.trimTrailingSlash(prop.getProperty("test.app.url"));
 
@@ -150,8 +158,16 @@ public final class TestProperties {
         // access static fields directly
     }
 
+    public static boolean isTravis() {
+        return System.getenv("TRAVIS") != null;
+    }
+
+    public static boolean isAppveyor() {
+        return System.getenv("APPVEYOR") != null;
+    }
+
     public static boolean isCiEnvironment() {
-        return System.getenv("TRAVIS") != null || System.getenv("APPVEYOR") != null;
+        return isTravis() || isAppveyor();
     }
 
     public static boolean isDevServer() {

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -15,8 +15,8 @@ import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.remote.UselessFileDetector;
@@ -32,6 +32,7 @@ import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
 import teammates.common.util.retry.MaximumRetriesExceededException;
 import teammates.common.util.retry.RetryManager;
+import teammates.common.util.retry.RetryableTask;
 import teammates.common.util.retry.RetryableTaskReturnsThrows;
 import teammates.test.driver.AssertHelper;
 import teammates.test.driver.FileHelper;
@@ -943,34 +944,21 @@ public abstract class AppPage {
 
     /**
      * Verifies the status message in the page is same as the one specified.
-     * @return The page (for chaining method calls).
+     * The check is done multiple times with waiting times in between to account for
+     * timing issues due to page load, inconsistencies in Selenium API, etc.
      */
-    public AppPage verifyStatus(String expectedStatus) {
-
-        // The check is done multiple times with waiting times in between to account for
-        // timing issues due to page load, inconsistencies in Selenium API, etc.
-        for (int i = 0; i < VERIFICATION_RETRY_COUNT; i++) {
-            if (i == VERIFICATION_RETRY_COUNT - 1) {
-                // Last retry count: do one last attempt and if it still fails,
-                // throw assertion error and show the difference
-                waitForElementVisibility(statusMessage);
-                assertEquals(expectedStatus, getStatus());
-                break;
-            }
-            try {
-                waitForElementVisibility(statusMessage);
-                if (expectedStatus.equals(getStatus())) {
-                    break;
+    public void verifyStatus(final String expectedStatus) {
+        try {
+            uiRetryManager.runUntilNoRecognizedException(new RetryableTask("Verify status to user") {
+                @Override
+                public void run() {
+                    waitForElementVisibility(statusMessage);
+                    assertEquals(expectedStatus, getStatus());
                 }
-            } catch (NoSuchElementException | StaleElementReferenceException e) {
-                // Might occur if the page reloads, which makes the previous WebElement
-                // stored in the variable statusMessage "stale"
-                ThreadHelper.waitFor(0);
-            }
-            ThreadHelper.waitFor(VERIFICATION_RETRY_DELAY_IN_MS);
+            }, WebDriverException.class, AssertionError.class);
+        } catch (MaximumRetriesExceededException e) {
+            assertEquals(expectedStatus, getStatus());
         }
-
-        return this;
     }
 
     /**

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -592,7 +592,7 @@ public class InstructorFeedbackEditPage extends AppPage {
 
     public int getSelectedQuestionNumber(int qnNumber) {
         Select qnNumSelect = new Select(getSelectQuestionNumberDropdown(qnNumber));
-        return Integer.parseInt(qnNumSelect.getFirstSelectedOption().getText());
+        return Integer.parseInt(qnNumSelect.getFirstSelectedOption().getText().trim());
     }
 
     /**

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -192,7 +192,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
         WebElement editorElement = waitForElementPresence(By.cssSelector("#" + addResponseCommentId + " .mce-content-body"));
         waitForRichTextEditorToLoad(editorElement.getAttribute("id"));
         fillRichTextEditor(editorElement.getAttribute("id"), commentText);
-        click(addResponseCommentForm.findElement(By.className("col-sm-offset-5")).findElement(By.tagName("a")));
+        WebElement saveButton = addResponseCommentForm
+                .findElement(By.className("col-sm-offset-5"))
+                .findElement(By.tagName("a"));
+        if ("chrome".equals(TestProperties.BROWSER)) {
+            // Focus on save button to fire events triggered when the editor loses focus
+            focusViaClickAction(saveButton);
+        }
+        click(saveButton);
         if (commentText.isEmpty()) {
             // empty comment: wait until the textarea is clickable again
             waitForElementToBeClickable(editorElement);
@@ -529,6 +536,10 @@ public class InstructorFeedbackResultsPage extends AppPage {
     private void moveToElement(By by) {
         WebElement element = browser.driver.findElement(by);
         new Actions(browser.driver).moveToElement(element).perform();
+    }
+
+    private void focusViaClickAction(WebElement element) {
+        new Actions(browser.driver).moveToElement(element).click().perform();
     }
 
     private String getElementSrcWithRetryAfterWaitForPresence(By by) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -189,7 +189,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
         WebElement parentContainer = addResponseCommentForm.findElement(By.xpath("../.."));
         WebElement showResponseCommentAddFormButton = parentContainer.findElement(By.id("button_add_comment"));
         click(showResponseCommentAddFormButton);
-        WebElement editorElement = addResponseCommentForm.findElement(By.className("mce-content-body"));
+        WebElement editorElement = waitForElementPresence(By.cssSelector("#" + addResponseCommentId + " .mce-content-body"));
         waitForRichTextEditorToLoad(editorElement.getAttribute("id"));
         fillRichTextEditor(editorElement.getAttribute("id"), commentText);
         click(addResponseCommentForm.findElement(By.className("col-sm-offset-5")).findElement(By.tagName("a")));

--- a/src/test/resources/test.appveyor.properties
+++ b/src/test/resources/test.appveyor.properties
@@ -1,0 +1,9 @@
+#-----------------------------------------------------------------------------
+# This file contains specific configuration values for testing on AppVeyor.
+#-----------------------------------------------------------------------------
+
+test.app.url=http\://localhost\:8888
+test.backdoor.key=samplekey
+test.selenium.browser=chrome
+test.chromedriver.path=C:\\Tools\\WebDriver\\chromedriver.exe
+test.timeout=15

--- a/src/test/resources/test.travis.properties
+++ b/src/test/resources/test.travis.properties
@@ -1,0 +1,9 @@
+#-----------------------------------------------------------------------------
+# This file contains specific configuration values for testing on Travis.
+#-----------------------------------------------------------------------------
+
+test.app.url=http\://localhost\:8888
+test.backdoor.key=samplekey
+test.selenium.browser=firefox
+test.firefox.path=
+test.timeout=15


### PR DESCRIPTION
Fixes #7699

**Outline of Solution**
- Fix browser tests on Chrome
- Use Chrome for AppVeyor build
  - Remove Firefox install from `appveyor.yml`
  - Add Travis- and AppVeyor-specific test properties files

**Results**
- AppVeyor build (Chrome) is [passing](https://ci.appveyor.com/project/whipermr5/teammates/build/1.0.221)
  - Using Chrome decreases the build time by 3 minutes 🎉
    - Edit: this is probably due to some tests being [skipped](https://github.com/TEAMMATES/teammates/blob/99aaeabcbbf95cdbcbb40b1c80377d9ec87530c7/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackResultsPageUiTest.java#L353-L356)
- Travis build (Firefox) is [passing](https://travis-ci.org/whipermr5/teammates/builds/252042555)