### PR TITLE
Instructor: edit question: show spinner while loading visibility preview #5996

### DIFF
--- a/src/main/webapp/dev/js/common/visibilityOptions.es6
+++ b/src/main/webapp/dev/js/common/visibilityOptions.es6
@@ -373,6 +373,9 @@ function updateVisibilityMessageDiv($containingForm) {
         type: 'POST',
         url,
         data: formData,
+        beforeSend() {
+            $visibilityMessageDiv.html("<img height='25' width='25' src='/images/ajax-preload.gif'/>");
+        },
         success(data) {
             // update stored form data
             previousFormDataMap[questionNum] = formData;

--- a/src/main/webapp/dev/js/common/visibilityOptions.es6
+++ b/src/main/webapp/dev/js/common/visibilityOptions.es6
@@ -374,7 +374,7 @@ function updateVisibilityMessageDiv($containingForm) {
         url,
         data: formData,
         beforeSend() {
-            $visibilityMessageDiv.html("<img height='25' width='25' src='/images/ajax-loader.gif'/>");
+            $visibilityMessageDiv.html("<img src='/images/ajax-loader.gif'/>");
         },
         success(data) {
             // update stored form data

--- a/src/main/webapp/dev/js/common/visibilityOptions.es6
+++ b/src/main/webapp/dev/js/common/visibilityOptions.es6
@@ -374,7 +374,7 @@ function updateVisibilityMessageDiv($containingForm) {
         url,
         data: formData,
         beforeSend() {
-            $visibilityMessageDiv.html("<img height='25' width='25' src='/images/ajax-preload.gif'/>");
+            $visibilityMessageDiv.html("<img height='25' width='25' src='/images/ajax-loader.gif'/>");
         },
         success(data) {
             // update stored form data


### PR DESCRIPTION
Fixes #5996 

**Outline of solution**:

Added a `beforeSend` method to the AJAX call in visibilityOptions.es6 where I place the AJAX Loader GIF in `$visibilityMessageDiv.html()`. Borrowed the approach from other AJAX Loader GIFs in other AJAX calls (eg: feedbackResponseComments.es6)