### PR TITLE
Instructor: remove unnecessary unboxing of Boolean value #7716

### DIFF
--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -189,7 +189,7 @@ public class Instructor extends BaseEntity {
         if (this.isDisplayedToStudents == null) {
             return true;
         }
-        return isDisplayedToStudents.booleanValue();
+        return isDisplayedToStudents;
     }
 
     public void setIsDisplayedToStudents(boolean shouldDisplayToStudents) {


### PR DESCRIPTION
Fixes #7716 

Removed the function call to booleanValue to avoid unnecessary unboxing of the boolean value.

Fixes #7716

