### PR TITLE
BackDoorLogic: optimize persistDataBundle method #2258

### DIFF
--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -33,6 +33,7 @@ import teammates.logic.api.Logic;
 import teammates.storage.api.AccountsDb;
 import teammates.storage.api.AdminEmailsDb;
 import teammates.storage.api.CoursesDb;
+import teammates.storage.api.EntitiesDb;
 import teammates.storage.api.FeedbackQuestionsDb;
 import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.storage.api.FeedbackResponsesDb;
@@ -81,7 +82,7 @@ public class BackDoorLogic extends Logic {
         accountsDb.createAccounts(accounts.values(), true);
 
         Map<String, CourseAttributes> courses = dataBundle.courses;
-        coursesDb.createCourses(courses.values());
+        coursesDb.createEntitiesDeferred(courses.values());
 
         Map<String, InstructorAttributes> instructors = dataBundle.instructors;
         List<AccountAttributes> instructorAccounts = new ArrayList<>();
@@ -100,7 +101,7 @@ public class BackDoorLogic extends Logic {
             }
         }
         accountsDb.createAccounts(instructorAccounts, false);
-        instructorsDb.createInstructorsWithoutSearchability(instructors.values());
+        instructorsDb.createEntitiesDeferred(instructors.values());
 
         Map<String, StudentAttributes> students = dataBundle.students;
         List<AccountAttributes> studentAccounts = new ArrayList<>();
@@ -117,13 +118,13 @@ public class BackDoorLogic extends Logic {
             }
         }
         accountsDb.createAccounts(studentAccounts, false);
-        studentsDb.createStudentsWithoutSearchability(students.values());
+        studentsDb.createEntitiesDeferred(students.values());
 
         Map<String, FeedbackSessionAttributes> sessions = dataBundle.feedbackSessions;
         for (FeedbackSessionAttributes session : sessions.values()) {
             cleanSessionData(session);
         }
-        fbDb.createFeedbackSessions(sessions.values());
+        fbDb.createEntitiesDeferred(sessions.values());
 
         Map<String, FeedbackQuestionAttributes> questions = dataBundle.feedbackQuestions;
         List<FeedbackQuestionAttributes> questionList = new ArrayList<>(questions.values());
@@ -131,13 +132,17 @@ public class BackDoorLogic extends Logic {
         for (FeedbackQuestionAttributes question : questionList) {
             question.removeIrrelevantVisibilityOptions();
         }
-        fqDb.createFeedbackQuestions(questionList);
+        fqDb.createEntitiesDeferred(questionList);
+
+        EntitiesDb.flush();
 
         Map<String, FeedbackResponseAttributes> responses = dataBundle.feedbackResponses;
         for (FeedbackResponseAttributes response : responses.values()) {
             injectRealIds(response);
         }
-        frDb.createFeedbackResponses(responses.values());
+        frDb.createEntitiesDeferred(responses.values());
+
+        EntitiesDb.flush();
 
         Set<String> sessionIds = new HashSet<>();
 
@@ -155,12 +160,12 @@ public class BackDoorLogic extends Logic {
         for (FeedbackResponseCommentAttributes responseComment : responseComments.values()) {
             injectRealIds(responseComment);
         }
-        fcDb.createFeedbackResponseComments(responseComments.values());
+        fcDb.createEntitiesDeferred(responseComments.values());
 
         Map<String, AdminEmailAttributes> adminEmails = dataBundle.adminEmails;
-        for (AdminEmailAttributes email : adminEmails.values()) {
-            adminEmailsDb.createAdminEmail(email);
-        }
+        adminEmailsDb.createEntitiesDeferred(adminEmails.values());
+
+        EntitiesDb.flush();
 
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
     }

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -103,14 +103,7 @@ public class BackDoorLogic extends Logic {
         processQuestionsAndPopulateMap(questions, sessionQuestionsMap);
 
         SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
-        for (FeedbackResponseAttributes response : responses) {
-            String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
-            sessionResponsesMap.put(sessionKey, response);
-        }
-
-        for (FeedbackSessionAttributes session : sessions) {
-            cleanSessionData(session);
-            String sessionKey = makeSessionKey(session.getFeedbackSessionName(), session.getCourseId());
+        processResponsesAndPopulateMap(responses, sessionResponsesMap);
 
             Set<InstructorAttributes> courseInstructors = courseInstructorsMap.get(session.getCourseId());
             Set<FeedbackQuestionAttributes> sessionQuestions = sessionQuestionsMap.get(sessionKey);
@@ -398,6 +391,14 @@ public class BackDoorLogic extends Logic {
 
             String sessionKey = makeSessionKey(question.feedbackSessionName, question.courseId);
             sessionQuestionsMap.put(sessionKey, question);
+        }
+    }
+
+    private void processResponsesAndPopulateMap(Collection<FeedbackResponseAttributes> responses,
+            SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap) {
+        for (FeedbackResponseAttributes response : responses) {
+            String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
+            sessionResponsesMap.put(sessionKey, response);
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -67,12 +67,9 @@ public class BackDoorLogic extends Logic {
      *         info (if any)' e.g., "[BACKEND_STATUS_SUCCESS]" e.g.,
      *         "[BACKEND_STATUS_FAILURE]NullPointerException at ..."
      */
-    public String persistDataBundle(DataBundle dataBundle)
-            throws InvalidParametersException, EntityDoesNotExistException {
-
+    public String persistDataBundle(DataBundle dataBundle) throws InvalidParametersException, EntityDoesNotExistException {
         if (dataBundle == null) {
-            throw new InvalidParametersException(
-                    Const.StatusCodes.NULL_PARAMETER, "Null data bundle");
+            throw new InvalidParametersException(Const.StatusCodes.NULL_PARAMETER, "Null data bundle");
         }
 
         Map<String, CourseAttributes> courses = dataBundle.courses;
@@ -81,18 +78,19 @@ public class BackDoorLogic extends Logic {
         Map<String, InstructorAttributes> instructors = dataBundle.instructors;
         List<AccountAttributes> instructorAccounts = new ArrayList<>();
         for (InstructorAttributes instructor : instructors.values()) {
-
             validateInstructorPrivileges(instructor);
 
-            if (instructor.googleId != null && !instructor.googleId.isEmpty()) {
-                AccountAttributes account = new AccountAttributes(instructor.googleId, instructor.name, true,
-                                                                  instructor.email, "TEAMMATES Test Institute 1");
-                if (account.studentProfile == null) {
-                    account.studentProfile = StudentProfileAttributes.builder().build();
-                    account.studentProfile.googleId = account.googleId;
-                }
-                instructorAccounts.add(account);
+            if (instructor.googleId == null || instructor.googleId.isEmpty()) {
+                continue;
             }
+
+            AccountAttributes account = new AccountAttributes(
+                    instructor.googleId, instructor.name, true, instructor.email, "TEAMMATES Test Institute 1");
+            if (account.studentProfile == null) {
+                account.studentProfile = StudentProfileAttributes.builder().build();
+                account.studentProfile.googleId = account.googleId;
+            }
+            instructorAccounts.add(account);
         }
         accountsDb.createAccountsDeferred(instructorAccounts);
         instructorsDb.createEntitiesDeferred(instructors.values());
@@ -101,15 +99,18 @@ public class BackDoorLogic extends Logic {
         List<AccountAttributes> studentAccounts = new ArrayList<>();
         for (StudentAttributes student : students.values()) {
             student.section = student.section == null ? "None" : student.section;
-            if (student.googleId != null && !student.googleId.isEmpty()) {
-                AccountAttributes account = new AccountAttributes(student.googleId, student.name, false,
-                                                                  student.email, "TEAMMATES Test Institute 1");
-                if (account.studentProfile == null) {
-                    account.studentProfile = StudentProfileAttributes.builder().build();
-                    account.studentProfile.googleId = account.googleId;
-                }
-                studentAccounts.add(account);
+
+            if (student.googleId == null || student.googleId.isEmpty()) {
+                continue;
             }
+
+            AccountAttributes account = new AccountAttributes(
+                    student.googleId, student.name, false, student.email, "TEAMMATES Test Institute 1");
+            if (account.studentProfile == null) {
+                account.studentProfile = StudentProfileAttributes.builder().build();
+                account.studentProfile.googleId = account.googleId;
+            }
+            studentAccounts.add(account);
         }
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students.values());

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -87,17 +87,7 @@ public class BackDoorLogic extends Logic {
 
         SetMultimap<String, InstructorAttributes> courseInstructorsMap = HashMultimap.create();
         List<AccountAttributes> instructorAccounts = new ArrayList<>();
-        for (InstructorAttributes instructor : instructors) {
-            validateInstructorPrivileges(instructor);
-
-            courseInstructorsMap.put(instructor.courseId, instructor);
-
-            if (StringHelper.isEmpty(instructor.googleId)) {
-                continue;
-            }
-
-            instructorAccounts.add(makeAccount(instructor));
-        }
+        processInstructorsAndPopulateMapAndAccounts(instructors, courseInstructorsMap, instructorAccounts);
         accountsDb.createAccountsDeferred(instructorAccounts);
         instructorsDb.createEntitiesDeferred(instructors);
 
@@ -384,6 +374,21 @@ public class BackDoorLogic extends Logic {
         FeedbackQuestionAttributes feedbackQuestion =
                 JsonUtils.fromJson(feedbackQuestionJson, FeedbackQuestionAttributes.class);
         updateFeedbackQuestion(feedbackQuestion);
+    }
+
+    private void processInstructorsAndPopulateMapAndAccounts(Collection<InstructorAttributes> instructors,
+            SetMultimap<String, InstructorAttributes> courseInstructorsMap, List<AccountAttributes> instructorAccounts) {
+        for (InstructorAttributes instructor : instructors) {
+            validateInstructorPrivileges(instructor);
+
+            courseInstructorsMap.put(instructor.courseId, instructor);
+
+            if (StringHelper.isEmpty(instructor.googleId)) {
+                continue;
+            }
+
+            instructorAccounts.add(makeAccount(instructor));
+        }
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -60,13 +60,18 @@ public class BackDoorLogic extends Logic {
     private static final AdminEmailsDb adminEmailsDb = new AdminEmailsDb();
 
     /**
-     * Persists given data in the datastore Works ONLY if the data is correct.
-     *  //Any existing copies of the data in the datastore will be overwritten.
-     *      - edit: use removeDataBundle to remove.
-     *              made this change for speed when deletion is not necessary.
-     * @return status of the request in the form 'status meassage'+'additional
-     *         info (if any)' e.g., "[BACKEND_STATUS_SUCCESS]" e.g.,
-     *         "[BACKEND_STATUS_FAILURE]NullPointerException at ..."
+     * Persists data in the given {@link DataBundle} to the Datastore, including
+     * accounts, courses, instructors, students, sessions, questions, responses, comments and admin emails.
+     *
+     * <p>Accounts are generated for students and instructors with Google IDs
+     * if the corresponding accounts are not found in the data bundle.
+     * For question ID injection in responses and comments to work properly, all questions
+     * referenced by responses and comments must be included in the data bundle.
+     * For session respondent lists to be properly populated, all instructors, questions and responses
+     * relevant to each session must be included in the data bundle.</p>
+     *
+     * @return {@link Const.StatusCodes#BACKDOOR_STATUS_SUCCESS} if successful.
+     * @throws InvalidParametersException if invalid data is encountered.
      */
     public String persistDataBundle(DataBundle dataBundle) throws InvalidParametersException {
         if (dataBundle == null) {

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -146,7 +146,7 @@ public class BackDoorLogic extends Logic {
 
         Set<String> sessionIds = new HashSet<>();
         for (FeedbackResponseAttributes response : responses.values()) {
-            String sessionId = response.feedbackSessionName + "%" + response.courseId;
+            String sessionId = makeSessionKey(response.feedbackSessionName, response.courseId);
             if (sessionIds.contains(sessionId)) {
                 continue;
             }
@@ -155,6 +155,10 @@ public class BackDoorLogic extends Logic {
         }
 
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
+    }
+
+    private String makeSessionKey(String feedbackSessionName, String courseId) {
+        return feedbackSessionName + "%" + courseId;
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -118,12 +118,7 @@ public class BackDoorLogic extends Logic {
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students);
 
-        for (AccountAttributes account : accounts) {
-            if (account.studentProfile == null) {
-                account.studentProfile = StudentProfileAttributes.builder().build();
-                account.studentProfile.googleId = account.googleId;
-            }
-        }
+        populateNullStudentProfiles(accounts);
         accountsDb.createAccountsDeferred(accounts);
 
         Map<String, List<FeedbackQuestionAttributes>> sessionQuestionsMap = new HashMap<>();
@@ -497,12 +492,7 @@ public class BackDoorLogic extends Logic {
         // We don't attempt to delete them again, to save time.
         deleteCourses(dataBundle.courses.values());
 
-        for (AccountAttributes account : dataBundle.accounts.values()) {
-            if (account.studentProfile == null) {
-                account.studentProfile = StudentProfileAttributes.builder().build();
-                account.studentProfile.googleId = account.googleId;
-            }
-        }
+        populateNullStudentProfiles(dataBundle.accounts.values());
         accountsDb.deleteAccounts(dataBundle.accounts.values());
 
         for (AdminEmailAttributes email : dataBundle.adminEmails.values()) {
@@ -529,6 +519,14 @@ public class BackDoorLogic extends Logic {
             fqDb.deleteFeedbackQuestionsForCourses(courseIds);
             frDb.deleteFeedbackResponsesForCourses(courseIds);
             fcDb.deleteFeedbackResponseCommentsForCourses(courseIds);
+        }
+    }
+
+    private void populateNullStudentProfiles(Collection<AccountAttributes> accounts) {
+        for (AccountAttributes account : accounts) {
+            if (account.studentProfile == null) {
+                account.studentProfile = StudentProfileAttributes.builder().withGoogleId(account.googleId).build();
+            }
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -144,6 +144,13 @@ public class BackDoorLogic extends Logic {
         injectRealIdsIntoResponses(responses.values(), cachedRealQuestionIds);
         frDb.createEntitiesDeferred(responses.values());
 
+        Map<String, FeedbackResponseCommentAttributes> responseComments = dataBundle.feedbackResponseComments;
+        injectRealIdsIntoResponseComments(responseComments.values(), cachedRealQuestionIds);
+        fcDb.createEntitiesDeferred(responseComments.values());
+
+        Map<String, AdminEmailAttributes> adminEmails = dataBundle.adminEmails;
+        adminEmailsDb.createEntitiesDeferred(adminEmails.values());
+
         EntitiesDb.flush();
 
         Set<String> sessionIds = new HashSet<>();
@@ -157,15 +164,6 @@ public class BackDoorLogic extends Logic {
                 sessionIds.add(sessionId);
             }
         }
-
-        Map<String, FeedbackResponseCommentAttributes> responseComments = dataBundle.feedbackResponseComments;
-        injectRealIdsIntoResponseComments(responseComments.values(), cachedRealQuestionIds);
-        fcDb.createEntitiesDeferred(responseComments.values());
-
-        Map<String, AdminEmailAttributes> adminEmails = dataBundle.adminEmails;
-        adminEmailsDb.createEntitiesDeferred(adminEmails.values());
-
-        EntitiesDb.flush();
 
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
     }

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -185,6 +185,21 @@ public class BackDoorLogic extends Logic {
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
     }
 
+    public String createFeedbackResponseAndUpdateSessionRespondents(FeedbackResponseAttributes response)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        try {
+            int questionNumber = Integer.parseInt(response.feedbackQuestionId);
+            response.feedbackQuestionId = feedbackQuestionsLogic
+                    .getFeedbackQuestion(response.feedbackSessionName, response.courseId, questionNumber)
+                    .getId(); // inject real question ID
+        } catch (NumberFormatException e) {
+            // question ID already injected
+        }
+        frDb.createEntityWithoutExistenceCheck(response);
+        updateRespondents(response.feedbackSessionName, response.courseId);
+        return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
+    }
+
     private void updateRespondents(FeedbackSessionAttributes session, List<InstructorAttributes> courseInstructors,
             List<FeedbackQuestionAttributes> sessionQuestions, List<FeedbackResponseAttributes> sessionResponses) {
         String sessionKey = makeSessionKey(session.getFeedbackSessionName(), session.getCourseId());

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -141,9 +141,18 @@ public class BackDoorLogic extends Logic {
         }
         fqDb.createEntitiesDeferred(questions.values());
 
+        Map<String, FeedbackResponseAttributes> responses = dataBundle.feedbackResponses;
+        Map<String, List<FeedbackResponseAttributes>> sessionResponsesMap = new HashMap<>();
+        for (FeedbackResponseAttributes response : responses.values()) {
+            String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
+            if (!sessionResponsesMap.containsKey(sessionKey)) {
+                sessionResponsesMap.put(sessionKey, new ArrayList<FeedbackResponseAttributes>());
+            }
+            sessionResponsesMap.get(sessionKey).add(response);
+        }
+
         EntitiesDb.flush();
 
-        Map<String, FeedbackResponseAttributes> responses = dataBundle.feedbackResponses;
         Map<List<String>, String> cachedRealQuestionIds = new HashMap<>();
         injectRealIdsIntoResponses(responses.values(), cachedRealQuestionIds);
         frDb.createEntitiesDeferred(responses.values());

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -30,6 +30,7 @@ import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
 import teammates.common.util.JsonUtils;
+import teammates.common.util.StringHelper;
 import teammates.logic.api.Logic;
 import teammates.storage.api.AccountsDb;
 import teammates.storage.api.AdminEmailsDb;
@@ -92,7 +93,7 @@ public class BackDoorLogic extends Logic {
             }
             courseInstructorsMap.get(instructor.courseId).add(instructor);
 
-            if (instructor.googleId == null || instructor.googleId.isEmpty()) {
+            if (StringHelper.isEmpty(instructor.googleId)) {
                 continue;
             }
 
@@ -107,7 +108,7 @@ public class BackDoorLogic extends Logic {
         for (StudentAttributes student : students) {
             populateNullSection(student);
 
-            if (student.googleId == null || student.googleId.isEmpty()) {
+            if (StringHelper.isEmpty(student.googleId)) {
                 continue;
             }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -84,26 +84,21 @@ public class BackDoorLogic extends Logic {
         Collection<AdminEmailAttributes> adminEmails = dataBundle.adminEmails.values();
 
         Map<String, AccountAttributes> googleIdAccountMap = new HashMap<>();
-        processAccountsAndPopulateMap(accounts, googleIdAccountMap);
-
-        coursesDb.createEntitiesDeferred(courses);
-
         SetMultimap<String, InstructorAttributes> courseInstructorsMap = HashMultimap.create();
-        processInstructorsAndPopulateMapAndAccounts(instructors, courseInstructorsMap, googleIdAccountMap);
-        instructorsDb.createEntitiesDeferred(instructors);
+        SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
+        SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
 
+        processAccountsAndPopulateMap(accounts, googleIdAccountMap);
+        processInstructorsAndPopulateMapAndAccounts(instructors, courseInstructorsMap, googleIdAccountMap);
         processStudentsAndPopulateAccounts(students, googleIdAccountMap);
-        studentsDb.createEntitiesDeferred(students);
+        processQuestionsAndPopulateMap(questions, sessionQuestionsMap);
+        processResponsesAndPopulateMap(responses, sessionResponsesMap);
+        processSessionsAndUpdateRespondents(sessions, courseInstructorsMap, sessionQuestionsMap, sessionResponsesMap);
 
         accountsDb.createAccountsDeferred(googleIdAccountMap.values());
-
-        SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
-        processQuestionsAndPopulateMap(questions, sessionQuestionsMap);
-
-        SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
-        processResponsesAndPopulateMap(responses, sessionResponsesMap);
-
-        processSessionsAndUpdateRespondents(sessions, courseInstructorsMap, sessionQuestionsMap, sessionResponsesMap);
+        coursesDb.createEntitiesDeferred(courses);
+        instructorsDb.createEntitiesDeferred(instructors);
+        studentsDb.createEntitiesDeferred(students);
         fbDb.createEntitiesDeferred(sessions);
 
         // This also flushes all previously deferred operations

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -434,8 +434,14 @@ public class BackDoorLogic extends Logic {
     private void injectRealIdsIntoResponses(Collection<FeedbackResponseAttributes> responses,
             Map<String, String> questionRealQuestionIdMap) {
         for (FeedbackResponseAttributes response : responses) {
+            int questionNumber;
+            try {
+                questionNumber = Integer.parseInt(response.feedbackQuestionId);
+            } catch (NumberFormatException e) {
+                // question ID already injected
+                continue;
+            }
             String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
-            String questionNumber = response.feedbackQuestionId; // contains question number before injection
             String questionKey = makeQuestionKey(sessionKey, questionNumber);
             response.feedbackQuestionId = questionRealQuestionIdMap.get(questionKey);
         }
@@ -454,8 +460,14 @@ public class BackDoorLogic extends Logic {
     private void injectRealIdsIntoResponseComments(Collection<FeedbackResponseCommentAttributes> responseComments,
             Map<String, String> questionRealQuestionIdMap) {
         for (FeedbackResponseCommentAttributes comment : responseComments) {
+            int questionNumber;
+            try {
+                questionNumber = Integer.parseInt(comment.feedbackQuestionId);
+            } catch (NumberFormatException e) {
+                // question ID already injected
+                continue;
+            }
             String sessionKey = makeSessionKey(comment.feedbackSessionName, comment.courseId);
-            String questionNumber = comment.feedbackQuestionId; // contains question number before injection
             String questionKey = makeQuestionKey(sessionKey, questionNumber);
             comment.feedbackQuestionId = questionRealQuestionIdMap.get(questionKey);
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -347,8 +347,9 @@ public class BackDoorLogic extends Logic {
 
         SetMultimap<String, String> instructorQuestionKeysMap = HashMultimap.create();
         for (InstructorAttributes instructor : courseInstructors) {
-            List<FeedbackQuestionAttributes> questionsForInstructor = feedbackQuestionsLogic
-                    .getFeedbackQuestionsForInstructor(new ArrayList(sessionQuestions), session.isCreator(instructor.email));
+            List<FeedbackQuestionAttributes> questionsForInstructor =
+                    feedbackQuestionsLogic.getFeedbackQuestionsForInstructor(
+                            new ArrayList<>(sessionQuestions), session.isCreator(instructor.email));
 
             List<String> questionKeys = makeQuestionKeys(questionsForInstructor, sessionKey);
             instructorQuestionKeysMap.putAll(instructor.email, questionKeys);

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -152,15 +152,13 @@ public class BackDoorLogic extends Logic {
         EntitiesDb.flush();
 
         Set<String> sessionIds = new HashSet<>();
-
         for (FeedbackResponseAttributes response : responses.values()) {
-
             String sessionId = response.feedbackSessionName + "%" + response.courseId;
-
-            if (!sessionIds.contains(sessionId)) {
-                updateRespondents(response.feedbackSessionName, response.courseId);
-                sessionIds.add(sessionId);
+            if (sessionIds.contains(sessionId)) {
+                continue;
             }
+            updateRespondents(response.feedbackSessionName, response.courseId);
+            sessionIds.add(sessionId);
         }
 
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -105,12 +105,7 @@ public class BackDoorLogic extends Logic {
         SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
         processResponsesAndPopulateMap(responses, sessionResponsesMap);
 
-            Set<InstructorAttributes> courseInstructors = courseInstructorsMap.get(session.getCourseId());
-            Set<FeedbackQuestionAttributes> sessionQuestions = sessionQuestionsMap.get(sessionKey);
-            Set<FeedbackResponseAttributes> sessionResponses = sessionResponsesMap.get(sessionKey);
-
-            updateRespondents(session, courseInstructors, sessionQuestions, sessionResponses);
-        }
+        processSessionsAndUpdateRespondents(sessions, courseInstructorsMap, sessionQuestionsMap, sessionResponsesMap);
         fbDb.createEntitiesDeferred(sessions);
 
         // This also flushes all previously deferred operations
@@ -399,6 +394,22 @@ public class BackDoorLogic extends Logic {
         for (FeedbackResponseAttributes response : responses) {
             String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
             sessionResponsesMap.put(sessionKey, response);
+        }
+    }
+
+    private void processSessionsAndUpdateRespondents(Collection<FeedbackSessionAttributes> sessions,
+            SetMultimap<String, InstructorAttributes> courseInstructorsMap,
+            SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap,
+            SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap) {
+        for (FeedbackSessionAttributes session : sessions) {
+            cleanSessionData(session);
+            String sessionKey = makeSessionKey(session.getFeedbackSessionName(), session.getCourseId());
+
+            Set<InstructorAttributes> courseInstructors = courseInstructorsMap.get(session.getCourseId());
+            Set<FeedbackQuestionAttributes> sessionQuestions = sessionQuestionsMap.get(sessionKey);
+            Set<FeedbackResponseAttributes> sessionResponses = sessionResponsesMap.get(sessionKey);
+
+            updateRespondents(session, courseInstructors, sessionQuestions, sessionResponses);
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -86,10 +86,6 @@ public class BackDoorLogic extends Logic {
 
             AccountAttributes account = new AccountAttributes(
                     instructor.googleId, instructor.name, true, instructor.email, "TEAMMATES Test Institute 1");
-            if (account.studentProfile == null) {
-                account.studentProfile = StudentProfileAttributes.builder().build();
-                account.studentProfile.googleId = account.googleId;
-            }
             instructorAccounts.add(account);
         }
         accountsDb.createAccountsDeferred(instructorAccounts);
@@ -106,10 +102,6 @@ public class BackDoorLogic extends Logic {
 
             AccountAttributes account = new AccountAttributes(
                     student.googleId, student.name, false, student.email, "TEAMMATES Test Institute 1");
-            if (account.studentProfile == null) {
-                account.studentProfile = StudentProfileAttributes.builder().build();
-                account.studentProfile.googleId = account.googleId;
-            }
             studentAccounts.add(account);
         }
         accountsDb.createAccountsDeferred(studentAccounts);

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -92,15 +92,7 @@ public class BackDoorLogic extends Logic {
         instructorsDb.createEntitiesDeferred(instructors);
 
         List<AccountAttributes> studentAccounts = new ArrayList<>();
-        for (StudentAttributes student : students) {
-            populateNullSection(student);
-
-            if (StringHelper.isEmpty(student.googleId)) {
-                continue;
-            }
-
-            studentAccounts.add(makeAccount(student));
-        }
+        processStudentsAndPopulateAccounts(students, studentAccounts);
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students);
 
@@ -388,6 +380,19 @@ public class BackDoorLogic extends Logic {
             }
 
             instructorAccounts.add(makeAccount(instructor));
+        }
+    }
+
+    private void processStudentsAndPopulateAccounts(Collection<StudentAttributes> students,
+            List<AccountAttributes> studentAccounts) {
+        for (StudentAttributes student : students) {
+            populateNullSection(student);
+
+            if (StringHelper.isEmpty(student.googleId)) {
+                continue;
+            }
+
+            studentAccounts.add(makeAccount(student));
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -76,9 +76,15 @@ public class BackDoorLogic extends Logic {
         coursesDb.createEntitiesDeferred(courses.values());
 
         Map<String, InstructorAttributes> instructors = dataBundle.instructors;
+        Map<String, List<InstructorAttributes>> courseInstructorsMap = new HashMap<>();
         List<AccountAttributes> instructorAccounts = new ArrayList<>();
         for (InstructorAttributes instructor : instructors.values()) {
             validateInstructorPrivileges(instructor);
+
+            if (!courseInstructorsMap.containsKey(instructor.courseId)) {
+                courseInstructorsMap.put(instructor.courseId, new ArrayList<InstructorAttributes>());
+            }
+            courseInstructorsMap.get(instructor.courseId).add(instructor);
 
             if (instructor.googleId == null || instructor.googleId.isEmpty()) {
                 continue;

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -122,12 +122,6 @@ public class BackDoorLogic extends Logic {
         }
         accountsDb.createAccountsDeferred(accounts.values());
 
-        Map<String, FeedbackSessionAttributes> sessions = dataBundle.feedbackSessions;
-        for (FeedbackSessionAttributes session : sessions.values()) {
-            cleanSessionData(session);
-        }
-        fbDb.createEntitiesDeferred(sessions.values());
-
         Map<String, FeedbackQuestionAttributes> questions = dataBundle.feedbackQuestions;
         Map<String, List<FeedbackQuestionAttributes>> sessionQuestionsMap = new HashMap<>();
         for (FeedbackQuestionAttributes question : questions.values()) {
@@ -150,6 +144,12 @@ public class BackDoorLogic extends Logic {
             }
             sessionResponsesMap.get(sessionKey).add(response);
         }
+
+        Map<String, FeedbackSessionAttributes> sessions = dataBundle.feedbackSessions;
+        for (FeedbackSessionAttributes session : sessions.values()) {
+            cleanSessionData(session);
+        }
+        fbDb.createEntitiesDeferred(sessions.values());
 
         EntitiesDb.flush();
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -95,7 +95,7 @@ public class BackDoorLogic extends Logic {
         processResponsesAndPopulateMap(responses, sessionResponsesMap);
         processSessionsAndUpdateRespondents(sessions, courseInstructorsMap, sessionQuestionsMap, sessionResponsesMap);
 
-        accountsDb.createAccountsDeferred(googleIdAccountMap.values());
+        accountsDb.createEntitiesDeferred(googleIdAccountMap.values());
         coursesDb.createEntitiesDeferred(courses);
         instructorsDb.createEntitiesDeferred(instructors);
         studentsDb.createEntitiesDeferred(students);

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -423,15 +423,20 @@ public class BackDoorLogic extends Logic {
     private void injectRealIds(
             Collection<FeedbackResponseAttributes> responses, Collection<FeedbackResponseCommentAttributes> responseComments,
             List<FeedbackQuestionAttributes> createdQuestions) {
+        Map<String, String> questionRealQuestionIdMap = makeQuestionIdMap(createdQuestions);
+
+        injectRealIdsIntoResponses(responses, questionRealQuestionIdMap);
+        injectRealIdsIntoResponseComments(responseComments, questionRealQuestionIdMap);
+    }
+
+    private Map<String, String> makeQuestionIdMap(List<FeedbackQuestionAttributes> createdQuestions) {
         Map<String, String> questionRealQuestionIdMap = new HashMap<>();
         for (FeedbackQuestionAttributes createdQuestion : createdQuestions) {
             String sessionKey = makeSessionKey(createdQuestion.feedbackSessionName, createdQuestion.courseId);
             String questionKey = makeQuestionKey(sessionKey, createdQuestion.questionNumber);
             questionRealQuestionIdMap.put(questionKey, createdQuestion.getId());
         }
-
-        injectRealIdsIntoResponses(responses, questionRealQuestionIdMap);
-        injectRealIdsIntoResponseComments(responseComments, questionRealQuestionIdMap);
+        return questionRealQuestionIdMap;
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -135,7 +135,7 @@ public class BackDoorLogic extends Logic {
 
         Map<String, FeedbackResponseAttributes> responses = dataBundle.feedbackResponses;
         for (FeedbackResponseAttributes response : responses.values()) {
-            response = injectRealIds(response);
+            injectRealIds(response);
         }
         frDb.createFeedbackResponses(responses.values());
 
@@ -341,12 +341,11 @@ public class BackDoorLogic extends Logic {
      * of private sessions by setting the feedbackSessionType field as PRIVATE
      * in the json file.
      */
-    private FeedbackSessionAttributes cleanSessionData(FeedbackSessionAttributes session) {
+    private void cleanSessionData(FeedbackSessionAttributes session) {
         if (session.getFeedbackSessionType().equals(FeedbackSessionType.PRIVATE)) {
             session.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
             session.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
         }
-        return session;
     }
 
     /**
@@ -359,7 +358,7 @@ public class BackDoorLogic extends Logic {
     * This method will then generate the correct ID and replace the field.
      * @throws EntityDoesNotExistException
     **/
-    private FeedbackResponseAttributes injectRealIds(FeedbackResponseAttributes response)
+    private void injectRealIds(FeedbackResponseAttributes response)
             throws EntityDoesNotExistException {
         try {
             int qnNumber = Integer.parseInt(response.feedbackQuestionId);
@@ -374,8 +373,6 @@ public class BackDoorLogic extends Logic {
         } catch (NumberFormatException e) {
             // Correct question ID was already attached to response.
         }
-
-        return response;
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -97,9 +97,7 @@ public class BackDoorLogic extends Logic {
                 continue;
             }
 
-            AccountAttributes account = new AccountAttributes(
-                    instructor.googleId, instructor.name, true, instructor.email, "TEAMMATES Test Institute 1");
-            instructorAccounts.add(account);
+            instructorAccounts.add(makeAccount(instructor));
         }
         accountsDb.createAccountsDeferred(instructorAccounts);
         instructorsDb.createEntitiesDeferred(instructors);
@@ -112,9 +110,7 @@ public class BackDoorLogic extends Logic {
                 continue;
             }
 
-            AccountAttributes account = new AccountAttributes(
-                    student.googleId, student.name, false, student.email, "TEAMMATES Test Institute 1");
-            studentAccounts.add(account);
+            studentAccounts.add(makeAccount(student));
         }
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students);
@@ -179,6 +175,16 @@ public class BackDoorLogic extends Logic {
         EntitiesDb.flush();
 
         return Const.StatusCodes.BACKDOOR_STATUS_SUCCESS;
+    }
+
+    private AccountAttributes makeAccount(InstructorAttributes instructor) {
+        return new AccountAttributes(
+                instructor.googleId, instructor.name, true, instructor.email, "TEAMMATES Test Institute 1");
+    }
+
+    private AccountAttributes makeAccount(StudentAttributes student) {
+        return new AccountAttributes(
+                student.googleId, student.name, false, student.email, "TEAMMATES Test Institute 1");
     }
 
     public String createFeedbackResponseAndUpdateSessionRespondents(FeedbackResponseAttributes response)

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -100,12 +100,7 @@ public class BackDoorLogic extends Logic {
         accountsDb.createAccountsDeferred(accounts);
 
         SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
-        for (FeedbackQuestionAttributes question : questions) {
-            question.removeIrrelevantVisibilityOptions();
-
-            String sessionKey = makeSessionKey(question.feedbackSessionName, question.courseId);
-            sessionQuestionsMap.put(sessionKey, question);
-        }
+        processQuestionsAndPopulateMap(questions, sessionQuestionsMap);
 
         SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
         for (FeedbackResponseAttributes response : responses) {
@@ -393,6 +388,16 @@ public class BackDoorLogic extends Logic {
             }
 
             studentAccounts.add(makeAccount(student));
+        }
+    }
+
+    private void processQuestionsAndPopulateMap(Collection<FeedbackQuestionAttributes> questions,
+            SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap) {
+        for (FeedbackQuestionAttributes question : questions) {
+            question.removeIrrelevantVisibilityOptions();
+
+            String sessionKey = makeSessionKey(question.feedbackSessionName, question.courseId);
+            sessionQuestionsMap.put(sessionKey, question);
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -96,7 +96,8 @@ public class BackDoorLogic extends Logic {
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students);
 
-        processAccounts(accounts);
+        Map<String, AccountAttributes> googleIdAccountMap = new HashMap<>();
+        processAccountsAndPopulateMap(accounts, googleIdAccountMap);
         accountsDb.createAccountsDeferred(accounts);
 
         SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
@@ -294,8 +295,12 @@ public class BackDoorLogic extends Logic {
         }
     }
 
-    private void processAccounts(Collection<AccountAttributes> accounts) {
+    private void processAccountsAndPopulateMap(Collection<AccountAttributes> accounts,
+            Map<String, AccountAttributes> googleIdAccountMap) {
         populateNullStudentProfiles(accounts);
+        for (AccountAttributes account : accounts) {
+            googleIdAccountMap.put(account.googleId, account);
+        }
     }
 
     private void processQuestionsAndPopulateMap(Collection<FeedbackQuestionAttributes> questions,

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -83,7 +83,10 @@ public class BackDoorLogic extends Logic {
         Collection<FeedbackResponseCommentAttributes> responseComments = dataBundle.feedbackResponseComments.values();
         Collection<AdminEmailAttributes> adminEmails = dataBundle.adminEmails.values();
 
+        // For ensuring only one account per Google ID is created
         Map<String, AccountAttributes> googleIdAccountMap = new HashMap<>();
+
+        // For updating the student and instructor respondent lists in sessions before they are persisted
         SetMultimap<String, InstructorAttributes> courseInstructorsMap = HashMultimap.create();
         SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
         SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -65,7 +65,7 @@ public class BackDoorLogic extends Logic {
      *         info (if any)' e.g., "[BACKEND_STATUS_SUCCESS]" e.g.,
      *         "[BACKEND_STATUS_FAILURE]NullPointerException at ..."
      */
-    public String persistDataBundle(DataBundle dataBundle) throws InvalidParametersException, EntityDoesNotExistException {
+    public String persistDataBundle(DataBundle dataBundle) throws InvalidParametersException {
         if (dataBundle == null) {
             throw new InvalidParametersException(Const.StatusCodes.NULL_PARAMETER, "Null data bundle");
         }

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -423,20 +423,20 @@ public class BackDoorLogic extends Logic {
     private void injectRealIds(
             Collection<FeedbackResponseAttributes> responses, Collection<FeedbackResponseCommentAttributes> responseComments,
             List<FeedbackQuestionAttributes> createdQuestions) {
-        Map<String, String> questionRealQuestionIdMap = makeQuestionIdMap(createdQuestions);
+        Map<String, String> questionIdMap = makeQuestionIdMap(createdQuestions);
 
-        injectRealIdsIntoResponses(responses, questionRealQuestionIdMap);
-        injectRealIdsIntoResponseComments(responseComments, questionRealQuestionIdMap);
+        injectRealIdsIntoResponses(responses, questionIdMap);
+        injectRealIdsIntoResponseComments(responseComments, questionIdMap);
     }
 
     private Map<String, String> makeQuestionIdMap(List<FeedbackQuestionAttributes> createdQuestions) {
-        Map<String, String> questionRealQuestionIdMap = new HashMap<>();
+        Map<String, String> questionIdMap = new HashMap<>();
         for (FeedbackQuestionAttributes createdQuestion : createdQuestions) {
             String sessionKey = makeSessionKey(createdQuestion.feedbackSessionName, createdQuestion.courseId);
             String questionKey = makeQuestionKey(sessionKey, createdQuestion.questionNumber);
-            questionRealQuestionIdMap.put(questionKey, createdQuestion.getId());
+            questionIdMap.put(questionKey, createdQuestion.getId());
         }
-        return questionRealQuestionIdMap;
+        return questionIdMap;
     }
 
     /**
@@ -449,7 +449,7 @@ public class BackDoorLogic extends Logic {
     * This method will then generate the correct ID and replace the field.
     **/
     private void injectRealIdsIntoResponses(Collection<FeedbackResponseAttributes> responses,
-            Map<String, String> questionRealQuestionIdMap) {
+            Map<String, String> questionIdMap) {
         for (FeedbackResponseAttributes response : responses) {
             int questionNumber;
             try {
@@ -460,7 +460,7 @@ public class BackDoorLogic extends Logic {
             }
             String sessionKey = makeSessionKey(response.feedbackSessionName, response.courseId);
             String questionKey = makeQuestionKey(sessionKey, questionNumber);
-            response.feedbackQuestionId = questionRealQuestionIdMap.get(questionKey);
+            response.feedbackQuestionId = questionIdMap.get(questionKey);
         }
     }
 
@@ -475,7 +475,7 @@ public class BackDoorLogic extends Logic {
     * This method will then generate the correct ID and replace the field.
     **/
     private void injectRealIdsIntoResponseComments(Collection<FeedbackResponseCommentAttributes> responseComments,
-            Map<String, String> questionRealQuestionIdMap) {
+            Map<String, String> questionIdMap) {
         for (FeedbackResponseCommentAttributes comment : responseComments) {
             int questionNumber;
             try {
@@ -486,7 +486,7 @@ public class BackDoorLogic extends Logic {
             }
             String sessionKey = makeSessionKey(comment.feedbackSessionName, comment.courseId);
             String questionKey = makeQuestionKey(sessionKey, questionNumber);
-            comment.feedbackQuestionId = questionRealQuestionIdMap.get(questionKey);
+            comment.feedbackQuestionId = questionIdMap.get(questionKey);
 
             String[] responseIdParam = comment.feedbackResponseId.split("%");
             comment.feedbackResponseId = comment.feedbackQuestionId + "%" + responseIdParam[1] + "%" + responseIdParam[2];

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -216,27 +216,6 @@ public class BackDoorLogic extends Logic {
         session.setRespondingStudentList(respondingStudents);
     }
 
-    private List<String> makeQuestionKeys(List<FeedbackQuestionAttributes> questions, String sessionKey) {
-        List<String> questionKeys = new ArrayList<>();
-        for (FeedbackQuestionAttributes question : questions) {
-            String questionKey = makeQuestionKey(sessionKey, question.questionNumber);
-            questionKeys.add(questionKey);
-        }
-        return questionKeys;
-    }
-
-    private String makeSessionKey(String feedbackSessionName, String courseId) {
-        return feedbackSessionName + "%" + courseId;
-    }
-
-    private String makeQuestionKey(String sessionKey, int questionNumber) {
-        return makeQuestionKey(sessionKey, String.valueOf(questionNumber));
-    }
-
-    private String makeQuestionKey(String sessionKey, String questionNumber) {
-        return sessionKey + "%" + questionNumber;
-    }
-
     /**
      * Checks if the role of {@code instructor} matches its privileges.
      *
@@ -491,6 +470,27 @@ public class BackDoorLogic extends Logic {
             String[] responseIdParam = comment.feedbackResponseId.split("%");
             comment.feedbackResponseId = comment.feedbackQuestionId + "%" + responseIdParam[1] + "%" + responseIdParam[2];
         }
+    }
+
+    private List<String> makeQuestionKeys(List<FeedbackQuestionAttributes> questions, String sessionKey) {
+        List<String> questionKeys = new ArrayList<>();
+        for (FeedbackQuestionAttributes question : questions) {
+            String questionKey = makeQuestionKey(sessionKey, question.questionNumber);
+            questionKeys.add(questionKey);
+        }
+        return questionKeys;
+    }
+
+    private String makeSessionKey(String feedbackSessionName, String courseId) {
+        return feedbackSessionName + "%" + courseId;
+    }
+
+    private String makeQuestionKey(String sessionKey, int questionNumber) {
+        return makeQuestionKey(sessionKey, String.valueOf(questionNumber));
+    }
+
+    private String makeQuestionKey(String sessionKey, String questionNumber) {
+        return sessionKey + "%" + questionNumber;
     }
 
     public void removeDataBundle(DataBundle dataBundle) {

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -129,8 +129,15 @@ public class BackDoorLogic extends Logic {
         fbDb.createEntitiesDeferred(sessions.values());
 
         Map<String, FeedbackQuestionAttributes> questions = dataBundle.feedbackQuestions;
+        Map<String, List<FeedbackQuestionAttributes>> sessionQuestionsMap = new HashMap<>();
         for (FeedbackQuestionAttributes question : questions.values()) {
             question.removeIrrelevantVisibilityOptions();
+
+            String sessionKey = makeSessionKey(question.feedbackSessionName, question.courseId);
+            if (!sessionQuestionsMap.containsKey(sessionKey)) {
+                sessionQuestionsMap.put(sessionKey, new ArrayList<FeedbackQuestionAttributes>());
+            }
+            sessionQuestionsMap.get(sessionKey).add(question);
         }
         fqDb.createEntitiesDeferred(questions.values());
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -105,7 +105,7 @@ public class BackDoorLogic extends Logic {
 
         List<AccountAttributes> studentAccounts = new ArrayList<>();
         for (StudentAttributes student : students) {
-            student.section = student.section == null ? "None" : student.section;
+            populateNullSection(student);
 
             if (student.googleId == null || student.googleId.isEmpty()) {
                 continue;
@@ -401,7 +401,7 @@ public class BackDoorLogic extends Logic {
     public void editStudentAsJson(String originalEmail, String newValues)
             throws InvalidParametersException, EntityDoesNotExistException {
         StudentAttributes student = JsonUtils.fromJson(newValues, StudentAttributes.class);
-        student.section = student.section == null ? "None" : student.section;
+        populateNullSection(student);
         updateStudentWithoutDocument(originalEmail, student);
     }
 
@@ -528,6 +528,10 @@ public class BackDoorLogic extends Logic {
                 account.studentProfile = StudentProfileAttributes.builder().withGoogleId(account.googleId).build();
             }
         }
+    }
+
+    private void populateNullSection(StudentAttributes student) {
+        student.section = student.section == null ? "None" : student.section;
     }
 
     public boolean isPicturePresentInGcs(String pictureKey) {

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -130,12 +130,10 @@ public class BackDoorLogic extends Logic {
         fbDb.createEntitiesDeferred(sessions.values());
 
         Map<String, FeedbackQuestionAttributes> questions = dataBundle.feedbackQuestions;
-        List<FeedbackQuestionAttributes> questionList = new ArrayList<>(questions.values());
-
-        for (FeedbackQuestionAttributes question : questionList) {
+        for (FeedbackQuestionAttributes question : questions.values()) {
             question.removeIrrelevantVisibilityOptions();
         }
-        fqDb.createEntitiesDeferred(questionList);
+        fqDb.createEntitiesDeferred(questions.values());
 
         EntitiesDb.flush();
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -146,17 +146,9 @@ public class BackDoorLogic extends Logic {
         // This also flushes all previously deferred operations
         List<FeedbackQuestionAttributes> createdQuestions = fqDb.createFeedbackQuestionsWithoutExistenceCheck(questions);
 
-        Map<String, String> questionRealQuestionIdMap = new HashMap<>();
-        for (FeedbackQuestionAttributes createdQuestion : createdQuestions) {
-            String sessionKey = makeSessionKey(createdQuestion.feedbackSessionName, createdQuestion.courseId);
-            String questionKey = makeQuestionKey(sessionKey, createdQuestion.questionNumber);
-            questionRealQuestionIdMap.put(questionKey, createdQuestion.getId());
-        }
+        injectRealIds(responses, responseComments, createdQuestions);
 
-        injectRealIdsIntoResponses(responses, questionRealQuestionIdMap);
         frDb.createEntitiesDeferred(responses);
-
-        injectRealIdsIntoResponseComments(responseComments, questionRealQuestionIdMap);
         fcDb.createEntitiesDeferred(responseComments);
 
         adminEmailsDb.createEntitiesDeferred(adminEmails);
@@ -426,6 +418,20 @@ public class BackDoorLogic extends Logic {
             session.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
             session.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
         }
+    }
+
+    private void injectRealIds(
+            Collection<FeedbackResponseAttributes> responses, Collection<FeedbackResponseCommentAttributes> responseComments,
+            List<FeedbackQuestionAttributes> createdQuestions) {
+        Map<String, String> questionRealQuestionIdMap = new HashMap<>();
+        for (FeedbackQuestionAttributes createdQuestion : createdQuestions) {
+            String sessionKey = makeSessionKey(createdQuestion.feedbackSessionName, createdQuestion.courseId);
+            String questionKey = makeQuestionKey(sessionKey, createdQuestion.questionNumber);
+            questionRealQuestionIdMap.put(questionKey, createdQuestion.getId());
+        }
+
+        injectRealIdsIntoResponses(responses, questionRealQuestionIdMap);
+        injectRealIdsIntoResponseComments(responseComments, questionRealQuestionIdMap);
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -75,15 +75,6 @@ public class BackDoorLogic extends Logic {
                     Const.StatusCodes.NULL_PARAMETER, "Null data bundle");
         }
 
-        Map<String, AccountAttributes> accounts = dataBundle.accounts;
-        for (AccountAttributes account : accounts.values()) {
-            if (account.studentProfile == null) {
-                account.studentProfile = StudentProfileAttributes.builder().build();
-                account.studentProfile.googleId = account.googleId;
-            }
-        }
-        accountsDb.createAccounts(accounts.values(), true);
-
         Map<String, CourseAttributes> courses = dataBundle.courses;
         coursesDb.createEntitiesDeferred(courses.values());
 
@@ -103,7 +94,7 @@ public class BackDoorLogic extends Logic {
                 instructorAccounts.add(account);
             }
         }
-        accountsDb.createAccounts(instructorAccounts, false);
+        accountsDb.createAccountsDeferred(instructorAccounts);
         instructorsDb.createEntitiesDeferred(instructors.values());
 
         Map<String, StudentAttributes> students = dataBundle.students;
@@ -120,8 +111,17 @@ public class BackDoorLogic extends Logic {
                 studentAccounts.add(account);
             }
         }
-        accountsDb.createAccounts(studentAccounts, false);
+        accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students.values());
+
+        Map<String, AccountAttributes> accounts = dataBundle.accounts;
+        for (AccountAttributes account : accounts.values()) {
+            if (account.studentProfile == null) {
+                account.studentProfile = StudentProfileAttributes.builder().build();
+                account.studentProfile.googleId = account.googleId;
+            }
+        }
+        accountsDb.createAccountsDeferred(accounts.values());
 
         Map<String, FeedbackSessionAttributes> sessions = dataBundle.feedbackSessions;
         for (FeedbackSessionAttributes session : sessions.values()) {

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -88,7 +88,7 @@ public class BackDoorLogic extends Logic {
         SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
         SetMultimap<String, FeedbackResponseAttributes> sessionResponsesMap = HashMultimap.create();
 
-        processAccountsAndPopulateMap(accounts, googleIdAccountMap);
+        processAccountsAndPopulateAccountsMap(accounts, googleIdAccountMap);
         processInstructorsAndPopulateMapAndAccounts(instructors, courseInstructorsMap, googleIdAccountMap);
         processStudentsAndPopulateAccounts(students, googleIdAccountMap);
         processQuestionsAndPopulateMap(questions, sessionQuestionsMap);
@@ -259,6 +259,14 @@ public class BackDoorLogic extends Logic {
         updateFeedbackQuestion(feedbackQuestion);
     }
 
+    private void processAccountsAndPopulateAccountsMap(Collection<AccountAttributes> accounts,
+            Map<String, AccountAttributes> googleIdAccountMap) {
+        populateNullStudentProfiles(accounts);
+        for (AccountAttributes account : accounts) {
+            googleIdAccountMap.put(account.googleId, account);
+        }
+    }
+
     private void processInstructorsAndPopulateMapAndAccounts(Collection<InstructorAttributes> instructors,
             SetMultimap<String, InstructorAttributes> courseInstructorsMap,
             Map<String, AccountAttributes> googleIdAccountMap) {
@@ -286,14 +294,6 @@ public class BackDoorLogic extends Logic {
                 continue;
             }
             googleIdAccountMap.put(student.googleId, makeAccount(student));
-        }
-    }
-
-    private void processAccountsAndPopulateMap(Collection<AccountAttributes> accounts,
-            Map<String, AccountAttributes> googleIdAccountMap) {
-        populateNullStudentProfiles(accounts);
-        for (AccountAttributes account : accounts) {
-            googleIdAccountMap.put(account.googleId, account);
         }
     }
 

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -96,7 +96,7 @@ public class BackDoorLogic extends Logic {
         accountsDb.createAccountsDeferred(studentAccounts);
         studentsDb.createEntitiesDeferred(students);
 
-        populateNullStudentProfiles(accounts);
+        processAccounts(accounts);
         accountsDb.createAccountsDeferred(accounts);
 
         SetMultimap<String, FeedbackQuestionAttributes> sessionQuestionsMap = HashMultimap.create();
@@ -292,6 +292,10 @@ public class BackDoorLogic extends Logic {
 
             studentAccounts.add(makeAccount(student));
         }
+    }
+
+    private void processAccounts(Collection<AccountAttributes> accounts) {
+        populateNullStudentProfiles(accounts);
     }
 
     private void processQuestionsAndPopulateMap(Collection<FeedbackQuestionAttributes> questions,

--- a/src/main/java/teammates/logic/backdoor/BackDoorOperation.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorOperation.java
@@ -89,6 +89,9 @@ public enum BackDoorOperation {
     /** Operation type: checking if profile picture is present in GCS. */
     OPERATION_IS_PICTURE_PRESENT_IN_GCS,
 
+    /** Operation type: creating a feedback response in the datastore. */
+    OPERATION_CREATE_FEEDBACK_RESPONSE,
+
     /** Operation type: persisting data bundle into the datastore. */
     OPERATION_PERSIST_DATABUNDLE,
 
@@ -114,6 +117,7 @@ public enum BackDoorOperation {
     public static final String PARAMETER_DATABUNDLE_JSON = "PARAMETER_DATABUNDLE_JSON";
     public static final String PARAMETER_FEEDBACK_QUESTION_ID = "PARAMETER_FEEDBACK_QUESTION_ID";
     public static final String PARAMETER_FEEDBACK_QUESTION_NUMBER = "PARAMETER_FEEDBACK_QUESTION_NUMBER";
+    public static final String PARAMETER_FEEDBACK_RESPONSE_JSON = "PARAMETER_FEEDBACK_RESPONSE_JSON";
     public static final String PARAMETER_FEEDBACK_SESSION_NAME = "PARAMETER_FEEDBACK_SESSION_NAME";
     public static final String PARAMETER_GIVER_EMAIL = "PARAMETER_GIVER_EMAIL";
     public static final String PARAMETER_GOOGLE_ID = "PARAMETER_GOOGLE_ID";

--- a/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
@@ -183,6 +183,11 @@ public class BackDoorServlet extends HttpServlet {
         case OPERATION_IS_PICTURE_PRESENT_IN_GCS:
             String pictureKey = req.getParameter(BackDoorOperation.PARAMETER_PICTURE_KEY);
             return String.valueOf(backDoorLogic.isPicturePresentInGcs(pictureKey));
+        case OPERATION_CREATE_FEEDBACK_RESPONSE:
+            String feedbackResponseJsonString = req.getParameter(BackDoorOperation.PARAMETER_FEEDBACK_RESPONSE_JSON);
+            FeedbackResponseAttributes feedbackResponse =
+                    JsonUtils.fromJson(feedbackResponseJsonString, FeedbackResponseAttributes.class);
+            return backDoorLogic.createFeedbackResponseAndUpdateSessionRespondents(feedbackResponse);
         case OPERATION_PERSIST_DATABUNDLE:
             String dataBundleJsonString = req.getParameter(BackDoorOperation.PARAMETER_DATABUNDLE_JSON);
             DataBundle dataBundle = JsonUtils.fromJson(dataBundleJsonString, DataBundle.class);

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -72,26 +72,14 @@ public class AccountsDb extends EntitiesDb<Account, AccountAttributes> {
     }
 
     /* This function is used for persisting data bundle in testing process */
-    public void createAccounts(Collection<AccountAttributes> accountsToAdd, boolean updateAccount)
+    public void createAccountsDeferred(Collection<AccountAttributes> accountsToAdd)
             throws InvalidParametersException {
         List<StudentProfileAttributes> profilesToAdd = new LinkedList<>();
         for (AccountAttributes accountToAdd : accountsToAdd) {
             profilesToAdd.add(accountToAdd.studentProfile);
         }
-        profilesDb.createEntities(profilesToAdd);
-
-        List<AccountAttributes> accountsToUpdate = createEntities(accountsToAdd);
-        if (updateAccount) {
-            for (AccountAttributes account : accountsToUpdate) {
-                try {
-                    updateAccount(account, true);
-                } catch (EntityDoesNotExistException e) {
-                    // This situation is not tested as replicating such a situation is
-                    // difficult during testing
-                    Assumption.fail("Account found to be already existing and not existing simultaneously");
-                }
-            }
-        }
+        profilesDb.createEntitiesDeferred(profilesToAdd);
+        createEntitiesDeferred(accountsToAdd);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -71,15 +71,15 @@ public class AccountsDb extends EntitiesDb<Account, AccountAttributes> {
         }
     }
 
-    /* This function is used for persisting data bundle in testing process */
-    public void createAccountsDeferred(Collection<AccountAttributes> accountsToAdd)
+    @Override
+    public List<Account> createEntitiesDeferred(Collection<AccountAttributes> accountsToAdd)
             throws InvalidParametersException {
         List<StudentProfileAttributes> profilesToAdd = new LinkedList<>();
         for (AccountAttributes accountToAdd : accountsToAdd) {
             profilesToAdd.add(accountToAdd.studentProfile);
         }
         profilesDb.createEntitiesDeferred(profilesToAdd);
-        createEntitiesDeferred(accountsToAdd);
+        return super.createEntitiesDeferred(accountsToAdd);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -87,6 +87,19 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
     }
 
     /**
+     * Creates multiple entities without checking for existence. Also calls {@link #flush()},
+     * leading to any previously deferred operations being written immediately.
+     *
+     * @return list of created entities.
+     */
+    @SuppressWarnings("PMD.UnnecessaryLocalBeforeReturn") // Needs to flush before returning
+    public List<E> createEntitiesWithoutExistenceCheck(Collection<A> entitiesToAdd) throws InvalidParametersException {
+        List<E> createdEntities = createEntitiesDeferred(entitiesToAdd);
+        flush();
+        return createdEntities;
+    }
+
+    /**
      * Queues creation of multiple entities. No actual writes are done until {@link #flush()} is called.
      * Note that there is no check for existence - existing entities will be overwritten.
      * If multiple entities with the same key are queued, only the last one queued will be created.

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -86,7 +86,14 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
         return entitiesToUpdate;
     }
 
-    public void createEntitiesDeferred(Collection<A> entitiesToAdd) throws InvalidParametersException {
+    /**
+     * Queues creation of multiple entities. No actual writes are done until {@link #flush()} is called.
+     * Note that there is no check for existence - existing entities will be overwritten.
+     * If multiple entities with the same key are queued, only the last one queued will be created.
+     *
+     * @return list of created entities.
+     */
+    public List<E> createEntitiesDeferred(Collection<A> entitiesToAdd) throws InvalidParametersException {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entitiesToAdd);
 
         List<E> entities = new ArrayList<>();
@@ -103,6 +110,8 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
         }
 
         saveEntitiesDeferred(entities, entitiesToAdd);
+
+        return entities;
     }
 
     /**

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -44,14 +44,14 @@ public class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, FeedbackQu
 
     /**
      * Creates multiple questions without checking for existence. Also calls {@link #flush()},
-     * leading to any previously deferred operations being written immediately.
+     * leading to any previously deferred operations being written immediately. This is needed
+     * to update the question entities with actual question IDs.
      *
      * @returns list of created {@link FeedbackQuestionAttributes} containing actual question IDs.
      */
     public List<FeedbackQuestionAttributes> createFeedbackQuestionsWithoutExistenceCheck(
             Collection<FeedbackQuestionAttributes> questions) throws InvalidParametersException {
-        List<FeedbackQuestion> createdQuestions = createEntitiesDeferred(questions);
-        flush(); // needed to update question entities with actual question IDs
+        List<FeedbackQuestion> createdQuestions = createEntitiesWithoutExistenceCheck(questions);
         return makeAttributes(createdQuestions);
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -43,6 +43,19 @@ public class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, FeedbackQu
     }
 
     /**
+     * Creates multiple questions without checking for existence. Also calls {@link #flush()},
+     * leading to any previously deferred operations being written immediately.
+     *
+     * @returns list of created {@link FeedbackQuestionAttributes} containing actual question IDs.
+     */
+    public List<FeedbackQuestionAttributes> createFeedbackQuestionsWithoutExistenceCheck(
+            Collection<FeedbackQuestionAttributes> questions) throws InvalidParametersException {
+        List<FeedbackQuestion> createdQuestions = createEntitiesDeferred(questions);
+        flush(); // needed to update question entities with actual question IDs
+        return makeAttributes(createdQuestions);
+    }
+
+    /**
      * Preconditions: <br>
      * * All parameters are non-null.
      * @return Null if not found.

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -125,20 +125,6 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         }
     }
 
-    public void createInstructorsWithoutSearchability(Collection<InstructorAttributes> instructorsToAdd)
-            throws InvalidParametersException {
-
-        List<InstructorAttributes> instructorsToUpdate = createEntities(instructorsToAdd);
-
-        for (InstructorAttributes instructor : instructorsToUpdate) {
-            try {
-                updateInstructorByEmail(instructor);
-            } catch (EntityDoesNotExistException e) {
-                Assumption.fail("Entity found be already existing and not existing simultaneously");
-            }
-        }
-    }
-
     public InstructorAttributes createInstructor(InstructorAttributes instructorToAdd)
             throws InvalidParametersException, EntityAlreadyExistsException {
         Instructor instructor = createEntity(instructorToAdd);

--- a/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
+++ b/src/main/java/teammates/ui/controller/AdminInstructorAccountAddAction.java
@@ -25,7 +25,6 @@ import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
 import teammates.common.util.StringHelper;
 import teammates.common.util.Templates;
-import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
 import teammates.logic.api.EmailGenerator;
 import teammates.logic.backdoor.BackDoorLogic;
@@ -191,14 +190,7 @@ public class AdminInstructorAccountAddAction extends Action {
         DataBundle data = JsonUtils.fromJson(jsonString, DataBundle.class);
 
         BackDoorLogic backDoorLogic = new BackDoorLogic();
-
-        try {
-            backDoorLogic.persistDataBundle(data);
-        } catch (EntityDoesNotExistException e) {
-            ThreadHelper.waitFor(Config.PERSISTENCE_CHECK_DURATION);
-            backDoorLogic.persistDataBundle(data);
-            log.warning("Data Persistence was Checked Twice in This Request");
-        }
+        backDoorLogic.persistDataBundle(data);
 
         List<FeedbackResponseCommentAttributes> frComments =
                 logic.getFeedbackResponseCommentForGiver(courseId, pageData.instructorEmail);

--- a/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
@@ -112,7 +112,7 @@ public class InstructorSearchTest extends BaseSearchTest {
 
         ______TS("success: search for instructors in whole system; instructors created without searchability unsearchable");
 
-        instructorsDb.createInstructorsWithoutSearchability(Arrays.asList(ins1InCourse1));
+        instructorsDb.createEntitiesWithoutExistenceCheck(Arrays.asList(ins1InCourse1));
         results = instructorsDb.searchInstructorsInWholeSystem("instructor1");
         verifySearchResults(results, ins1InCourse2, ins1InTestingSanitizationCourse);
 

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -357,9 +357,10 @@ public final class BackDoor {
      * Persists a feedback response into the datastore.
      */
     public static String createFeedbackResponse(FeedbackResponseAttributes feedbackResponse) {
-        DataBundle dataBundle = new DataBundle();
-        dataBundle.feedbackResponses.put("dummy-key", feedbackResponse);
-        return restoreDataBundle(dataBundle);
+        String feedbackResponseJson = JsonUtils.toJson(feedbackResponse);
+        Map<String, String> params = createParamMap(BackDoorOperation.OPERATION_CREATE_FEEDBACK_RESPONSE);
+        params.put(BackDoorOperation.PARAMETER_FEEDBACK_RESPONSE_JSON, feedbackResponseJson);
+        return makePostRequest(params);
     }
 
     /**


### PR DESCRIPTION
Fixes #2258 

**Outline of Solution**
- Use Objectify deferred operations to queue many writes and flush them at one go
- Save created question entities when writing for later lookup of question IDs
  - Avoids the need to perform additional Datastore reads later on when injecting the real IDs into the responses and comments
- Create local mappings of course instructors, session questions and session responses for later lookup when updating session respondents
  - The entire update session respondents routine can then be performed completely locally even before any of the data is persisted, eliminating the need to perform additional Datastore reads later
  - This also means that persist data bundle only works for self-contained bundles, i.e. the bundle must contain all the instructors, sessions and questions corresponding to the responses
    - This is true almost all the time; the only exception is the create feedback response backdoor method, which persists a data bundle containing nothing but a feedback response
    - A new backdoor operation has been implemented to support this; it works by calling the old logic update respondents method which depends on Datastore reads

**Results**
- The persist data bundle operation for the add instructor action now completes in 1.5 seconds, down from 6.5 seconds
- The entire add instructor process now takes 6.5 seconds, down from 10.5-11.5 seconds:
    - Initialisation (1.5 seconds)
    - Persist demo data bundle (1.5 seconds)
    - Re-read instructors, students and comments then put documents (1.5-2 seconds)
    - Re-read instructors again to generate join link then send email (1-1.5 seconds)
- Time taken measured on my staging server, via log message timestamps