### PR TITLE
Success modals: display icon correctly #7708

### DIFF
--- a/src/main/webapp/WEB-INF/tags/statusMessage.tag
+++ b/src/main/webapp/WEB-INF/tags/statusMessage.tag
@@ -10,7 +10,7 @@
     <c:when test="${fn:length(statusMessagesToUser) gt 0}">
         <div id="statusMessagesToUser">
             <c:forEach items="${statusMessagesToUser}" var="statusMessage">
-                <div class="overflow-auto alert alert-${statusMessage.color} statusMessage">
+                <div class="overflow-auto alert alert-${statusMessage.color} icon-${statusMessage.color} statusMessage">
                     ${statusMessage.text}
                 </div>
             </c:forEach>

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -28,16 +28,16 @@ function showModalAlert(titleText, messageText, okButtonText, color) {
         buttons: {
             okay: {
                 label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${color}` || StatusType.DEFAULT,
+                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
             },
         },
     })
     .find('.modal-header')
         // applies bootstrap color to title background
-        .addClass(`alert-${color}` || StatusType.DEFAULT)
+        .addClass(`alert-${color || StatusType.DEFAULT}`)
     .find('.modal-title')
         // adds relevant icon before title
-        .addClass(`icon-${color}` || StatusType.DEFAULT);
+        .addClass(`icon-${color || StatusType.DEFAULT}`);
 }
 
 /**
@@ -61,17 +61,17 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
             },
             ok: {
                 label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${color}` || StatusType.DEFAULT,
+                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
                 callback: okCallback,
             },
         },
     })
     .find('.modal-header')
         // applies bootstrap color to title background
-        .addClass(`alert-${color}` || StatusType.DEFAULT)
+        .addClass(`alert-${color || StatusType.DEFAULT}`)
     .find('.modal-title')
         // adds relevant icon before title
-        .addClass(`icon-${color}` || StatusType.DEFAULT);
+        .addClass(`icon-${color || StatusType.DEFAULT}`);
 }
 
 /**
@@ -91,12 +91,12 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
         buttons: {
             yes: {
                 label: yesButtonText || DEFAULT_YES_TEXT,
-                className: `modal-btn-ok btn-${color}` || StatusType.DEFAULT,
+                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
                 callback: yesButtonCallback,
             },
             no: {
                 label: noButtonText || DEFAULT_NO_TEXT,
-                className: `modal-btn-ok btn-${color}` || StatusType.DEFAULT,
+                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
                 callback: noButtonCallback,
             },
             cancel: {
@@ -108,10 +108,10 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
     })
     .find('.modal-header')
         // applies bootstrap color to title background
-        .addClass(`alert-${color}` || StatusType.DEFAULT)
+        .addClass(`alert-${color || StatusType.DEFAULT}`)
     .find('.modal-title')
         // adds relevant icon before title
-        .addClass(`icon-${color}` || StatusType.DEFAULT);
+        .addClass(`icon-${color || StatusType.DEFAULT}`);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -33,7 +33,9 @@ function showModalAlert(titleText, messageText, okButtonText, color) {
         },
     })
     // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT);
+    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
+    // adds relevant icon before title
+    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -63,7 +65,9 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
         },
     })
     // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT);
+    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
+    // adds relevant icon before title
+    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -99,7 +103,9 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
         },
     })
     // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT);
+    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
+    // adds relevant icon before title
+    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -15,7 +15,7 @@ const DEFAULT_CANCEL_TEXT = 'Cancel';
 const DEFAULT_YES_TEXT = 'Yes';
 const DEFAULT_NO_TEXT = 'No';
 
-function applyStyleForModal(modal, statusType) {
+function applyStyleToModal(modal, statusType) {
     modal.find('.modal-header').addClass(`alert-${statusType || StatusType.DEFAULT}`)
          .find('.modal-title').addClass(`icon-${statusType || StatusType.DEFAULT}`);
 }
@@ -37,7 +37,7 @@ function showModalAlert(titleText, messageText, okButtonText, statusType) {
             },
         },
     });
-    applyStyleForModal(modal, statusType);
+    applyStyleToModal(modal, statusType);
 }
 
 /**
@@ -66,7 +66,7 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
             },
         },
     });
-    applyStyleForModal(modal, statusType);
+    applyStyleToModal(modal, statusType);
 }
 
 /**
@@ -101,7 +101,7 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
             },
         },
     });
-    applyStyleForModal(modal, statusType);
+    applyStyleToModal(modal, statusType);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -17,9 +17,9 @@ const DEFAULT_NO_TEXT = 'No';
 
 function applyStyleForModal(modal, statusType) {
     modal.find('.modal-header')
-        .addClass(`alert-${statusType || StatusType.DEFAULT}`)
+        .addClass(`alert-${statusType}`)
     .find('.modal-title')
-        .addClass(`icon-${statusType || StatusType.DEFAULT}`);
+        .addClass(`icon-${statusType}`);
 }
 
 /**
@@ -28,14 +28,14 @@ function applyStyleForModal(modal, statusType) {
  * Optional params: okButtonText (defaults to "OK")
  *                  statusType (defaults to StatusType.DEFAULT)
  */
-function showModalAlert(titleText, messageText, okButtonText, statusType) {
+function showModalAlert(titleText, messageText, okButtonText = DEFAULT_OK_TEXT, statusType = StatusType.DEFAULT) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             okay: {
-                label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
+                label: okButtonText,
+                className: `modal-btn-ok btn-${statusType}`,
             },
         },
     });
@@ -48,22 +48,23 @@ function showModalAlert(titleText, messageText, okButtonText, statusType) {
  * Optional params: cancelCallBack (defaults to null)
  *                  okButtonText (defaults to "OK")
  *                  cancelButtonText (defaults to "Cancel")
- *                  statusType (defaults to StatusType.INFO)
+ *                  statusType (defaults to StatusType.DEFAULT)
  */
-function showModalConfirmation(titleText, messageText, okCallback, cancelCallback,
-                                okButtonText, cancelButtonText, statusType) {
+function showModalConfirmation(titleText, messageText, okCallback, cancelCallback = null,
+                                okButtonText = DEFAULT_OK_TEXT, cancelButtonText = DEFAULT_CANCEL_TEXT,
+                                statusType = StatusType.DEFAULT) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             cancel: {
-                label: cancelButtonText || DEFAULT_CANCEL_TEXT,
+                label: cancelButtonText,
                 className: 'modal-btn-cancel btn-default',
-                callback: cancelCallback || null,
+                callback: cancelCallback,
             },
             ok: {
-                label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
+                label: okButtonText,
+                className: `modal-btn-ok btn-${statusType}`,
                 callback: okCallback,
             },
         },
@@ -78,28 +79,30 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
  *                  yesButtonText (defaults to "Yes")
  *                  noButtonText (defaults to "No")
  *                  canelButtonText (defaults to "Cancel")
- *                  statusType (defaults to StatusType.INFO)
+ *                  statusType (defaults to StatusType.DEFAULT)
  */
 function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallback, noButtonCallback,
-                                    cancelButtonCallback, yesButtonText, noButtonText, cancelButtonText, statusType) {
+                                    cancelButtonCallback = null, yesButtonText = DEFAULT_YES_TEXT,
+                                    noButtonText = DEFAULT_NO_TEXT, cancelButtonText = DEFAULT_CANCEL_TEXT,
+                                    statusType = StatusType.DEFAULT) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             yes: {
-                label: yesButtonText || DEFAULT_YES_TEXT,
-                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
+                label: yesButtonText,
+                className: `modal-btn-ok btn-${statusType}`,
                 callback: yesButtonCallback,
             },
             no: {
-                label: noButtonText || DEFAULT_NO_TEXT,
-                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
+                label: noButtonText,
+                className: `modal-btn-ok btn-${statusType}`,
                 callback: noButtonCallback,
             },
             cancel: {
-                label: cancelButtonText || DEFAULT_CANCEL_TEXT,
+                label: cancelButtonText,
                 className: 'modal-btn-cancel btn-default',
-                callback: cancelButtonCallback || null,
+                callback: cancelButtonCallback,
             },
         },
     });

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -26,7 +26,7 @@ function applyStyleForModal(modal, statusType) {
  * Custom alert dialog to replace default alert() function
  * Required params: titleText and messageText
  * Optional params: okButtonText (defaults to "OK")
- *                  color (defaults to StatusType.DEFAULT)
+ *                  statusType (defaults to StatusType.DEFAULT)
  */
 function showModalAlert(titleText, messageText, okButtonText, statusType) {
     const modal = bootbox.dialog({
@@ -48,7 +48,7 @@ function showModalAlert(titleText, messageText, okButtonText, statusType) {
  * Optional params: cancelCallBack (defaults to null)
  *                  okButtonText (defaults to "OK")
  *                  cancelButtonText (defaults to "Cancel")
- *                  color (defaults to StatusType.INFO)
+ *                  statusType (defaults to StatusType.INFO)
  */
 function showModalConfirmation(titleText, messageText, okCallback, cancelCallback,
                                 okButtonText, cancelButtonText, statusType) {
@@ -78,7 +78,7 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
  *                  yesButtonText (defaults to "Yes")
  *                  noButtonText (defaults to "No")
  *                  canelButtonText (defaults to "Cancel")
- *                  color (defaults to StatusType.INFO)
+ *                  statusType (defaults to StatusType.INFO)
  */
 function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallback, noButtonCallback,
                                     cancelButtonCallback, yesButtonText, noButtonText, cancelButtonText, statusType) {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -15,29 +15,31 @@ const DEFAULT_CANCEL_TEXT = 'Cancel';
 const DEFAULT_YES_TEXT = 'Yes';
 const DEFAULT_NO_TEXT = 'No';
 
+function applyStyleForModal(modal, statusType) {
+    modal.find('.modal-header')
+        .addClass(`alert-${statusType || StatusType.DEFAULT}`)
+    .find('.modal-title')
+        .addClass(`icon-${statusType || StatusType.DEFAULT}`);
+}
+
 /**
  * Custom alert dialog to replace default alert() function
  * Required params: titleText and messageText
  * Optional params: okButtonText (defaults to "OK")
  *                  color (defaults to StatusType.DEFAULT)
  */
-function showModalAlert(titleText, messageText, okButtonText, color) {
-    bootbox.dialog({
+function showModalAlert(titleText, messageText, okButtonText, statusType) {
+    const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             okay: {
                 label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
             },
         },
-    })
-    .find('.modal-header')
-        // applies bootstrap color to title background
-        .addClass(`alert-${color || StatusType.DEFAULT}`)
-    .find('.modal-title')
-        // adds relevant icon before title
-        .addClass(`icon-${color || StatusType.DEFAULT}`);
+    });
+    applyStyleForModal(modal, statusType);
 }
 
 /**
@@ -49,8 +51,8 @@ function showModalAlert(titleText, messageText, okButtonText, color) {
  *                  color (defaults to StatusType.INFO)
  */
 function showModalConfirmation(titleText, messageText, okCallback, cancelCallback,
-                                okButtonText, cancelButtonText, color) {
-    bootbox.dialog({
+                                okButtonText, cancelButtonText, statusType) {
+    const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
@@ -61,17 +63,12 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
             },
             ok: {
                 label: okButtonText || DEFAULT_OK_TEXT,
-                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: okCallback,
             },
         },
-    })
-    .find('.modal-header')
-        // applies bootstrap color to title background
-        .addClass(`alert-${color || StatusType.DEFAULT}`)
-    .find('.modal-title')
-        // adds relevant icon before title
-        .addClass(`icon-${color || StatusType.DEFAULT}`);
+    });
+    applyStyleForModal(modal, statusType);
 }
 
 /**
@@ -84,19 +81,19 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
  *                  color (defaults to StatusType.INFO)
  */
 function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallback, noButtonCallback,
-                                    cancelButtonCallback, yesButtonText, noButtonText, cancelButtonText, color) {
-    bootbox.dialog({
+                                    cancelButtonCallback, yesButtonText, noButtonText, cancelButtonText, statusType) {
+    const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             yes: {
                 label: yesButtonText || DEFAULT_YES_TEXT,
-                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: yesButtonCallback,
             },
             no: {
                 label: noButtonText || DEFAULT_NO_TEXT,
-                className: `modal-btn-ok btn-${color || StatusType.DEFAULT}`,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: noButtonCallback,
             },
             cancel: {
@@ -105,13 +102,8 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
                 callback: cancelButtonCallback || null,
             },
         },
-    })
-    .find('.modal-header')
-        // applies bootstrap color to title background
-        .addClass(`alert-${color || StatusType.DEFAULT}`)
-    .find('.modal-title')
-        // adds relevant icon before title
-        .addClass(`icon-${color || StatusType.DEFAULT}`);
+    });
+    applyStyleForModal(modal, statusType);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -16,10 +16,8 @@ const DEFAULT_YES_TEXT = 'Yes';
 const DEFAULT_NO_TEXT = 'No';
 
 function applyStyleForModal(modal, statusType) {
-    modal.find('.modal-header')
-        .addClass(`alert-${statusType || StatusType.DEFAULT}`)
-    .find('.modal-title')
-        .addClass(`icon-${statusType || StatusType.DEFAULT}`);
+    modal.find('.modal-header').addClass(`alert-${statusType || StatusType.DEFAULT}`)
+         .find('.modal-title').addClass(`icon-${statusType || StatusType.DEFAULT}`);
 }
 
 /**

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -32,11 +32,12 @@ function showModalAlert(titleText, messageText, okButtonText, color) {
             },
         },
     })
-    // applies bootstrap color to title background and adds relevant icon before title
     .find('.modal-header')
-    .addClass(`alert-${color}` || StatusType.DEFAULT)
+        // applies bootstrap color to title background
+        .addClass(`alert-${color}` || StatusType.DEFAULT)
     .find('.modal-title')
-    .addClass(`icon-${color}` || StatusType.DEFAULT);
+        // adds relevant icon before title
+        .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -65,11 +66,12 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
             },
         },
     })
-    // applies bootstrap color to title background and adds relevant icon before title
     .find('.modal-header')
-    .addClass(`alert-${color}` || StatusType.DEFAULT)
+        // applies bootstrap color to title background
+        .addClass(`alert-${color}` || StatusType.DEFAULT)
     .find('.modal-title')
-    .addClass(`icon-${color}` || StatusType.DEFAULT);
+        // adds relevant icon before title
+        .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -104,11 +106,12 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
             },
         },
     })
-    // applies bootstrap color to title background and adds relevant icon before title
     .find('.modal-header')
-    .addClass(`alert-${color}` || StatusType.DEFAULT)
+        // applies bootstrap color to title background
+        .addClass(`alert-${color}` || StatusType.DEFAULT)
     .find('.modal-title')
-    .addClass(`icon-${color}` || StatusType.DEFAULT);
+        // adds relevant icon before title
+        .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -17,9 +17,9 @@ const DEFAULT_NO_TEXT = 'No';
 
 function applyStyleForModal(modal, statusType) {
     modal.find('.modal-header')
-        .addClass(`alert-${statusType}`)
+        .addClass(`alert-${statusType || StatusType.DEFAULT}`)
     .find('.modal-title')
-        .addClass(`icon-${statusType}`);
+        .addClass(`icon-${statusType || StatusType.DEFAULT}`);
 }
 
 /**
@@ -28,14 +28,14 @@ function applyStyleForModal(modal, statusType) {
  * Optional params: okButtonText (defaults to "OK")
  *                  statusType (defaults to StatusType.DEFAULT)
  */
-function showModalAlert(titleText, messageText, okButtonText = DEFAULT_OK_TEXT, statusType = StatusType.DEFAULT) {
+function showModalAlert(titleText, messageText, okButtonText, statusType) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             okay: {
-                label: okButtonText,
-                className: `modal-btn-ok btn-${statusType}`,
+                label: okButtonText || DEFAULT_OK_TEXT,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
             },
         },
     });
@@ -48,23 +48,22 @@ function showModalAlert(titleText, messageText, okButtonText = DEFAULT_OK_TEXT, 
  * Optional params: cancelCallBack (defaults to null)
  *                  okButtonText (defaults to "OK")
  *                  cancelButtonText (defaults to "Cancel")
- *                  statusType (defaults to StatusType.DEFAULT)
+ *                  statusType (defaults to StatusType.INFO)
  */
-function showModalConfirmation(titleText, messageText, okCallback, cancelCallback = null,
-                                okButtonText = DEFAULT_OK_TEXT, cancelButtonText = DEFAULT_CANCEL_TEXT,
-                                statusType = StatusType.DEFAULT) {
+function showModalConfirmation(titleText, messageText, okCallback, cancelCallback,
+                                okButtonText, cancelButtonText, statusType) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             cancel: {
-                label: cancelButtonText,
+                label: cancelButtonText || DEFAULT_CANCEL_TEXT,
                 className: 'modal-btn-cancel btn-default',
-                callback: cancelCallback,
+                callback: cancelCallback || null,
             },
             ok: {
-                label: okButtonText,
-                className: `modal-btn-ok btn-${statusType}`,
+                label: okButtonText || DEFAULT_OK_TEXT,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: okCallback,
             },
         },
@@ -79,30 +78,28 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
  *                  yesButtonText (defaults to "Yes")
  *                  noButtonText (defaults to "No")
  *                  canelButtonText (defaults to "Cancel")
- *                  statusType (defaults to StatusType.DEFAULT)
+ *                  statusType (defaults to StatusType.INFO)
  */
 function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallback, noButtonCallback,
-                                    cancelButtonCallback = null, yesButtonText = DEFAULT_YES_TEXT,
-                                    noButtonText = DEFAULT_NO_TEXT, cancelButtonText = DEFAULT_CANCEL_TEXT,
-                                    statusType = StatusType.DEFAULT) {
+                                    cancelButtonCallback, yesButtonText, noButtonText, cancelButtonText, statusType) {
     const modal = bootbox.dialog({
         title: titleText,
         message: messageText,
         buttons: {
             yes: {
-                label: yesButtonText,
-                className: `modal-btn-ok btn-${statusType}`,
+                label: yesButtonText || DEFAULT_YES_TEXT,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: yesButtonCallback,
             },
             no: {
-                label: noButtonText,
-                className: `modal-btn-ok btn-${statusType}`,
+                label: noButtonText || DEFAULT_NO_TEXT,
+                className: `modal-btn-ok btn-${statusType || StatusType.DEFAULT}`,
                 callback: noButtonCallback,
             },
             cancel: {
-                label: cancelButtonText,
+                label: cancelButtonText || DEFAULT_CANCEL_TEXT,
                 className: 'modal-btn-cancel btn-default',
-                callback: cancelButtonCallback,
+                callback: cancelButtonCallback || null,
             },
         },
     });

--- a/src/main/webapp/dev/js/common/bootboxWrapper.es6
+++ b/src/main/webapp/dev/js/common/bootboxWrapper.es6
@@ -32,10 +32,11 @@ function showModalAlert(titleText, messageText, okButtonText, color) {
             },
         },
     })
-    // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
-    // adds relevant icon before title
-    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
+    // applies bootstrap color to title background and adds relevant icon before title
+    .find('.modal-header')
+    .addClass(`alert-${color}` || StatusType.DEFAULT)
+    .find('.modal-title')
+    .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -64,10 +65,11 @@ function showModalConfirmation(titleText, messageText, okCallback, cancelCallbac
             },
         },
     })
-    // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
-    // adds relevant icon before title
-    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
+    // applies bootstrap color to title background and adds relevant icon before title
+    .find('.modal-header')
+    .addClass(`alert-${color}` || StatusType.DEFAULT)
+    .find('.modal-title')
+    .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 /**
@@ -102,10 +104,11 @@ function showModalConfirmationWithCancel(titleText, messageText, yesButtonCallba
             },
         },
     })
-    // applies bootstrap color to title background
-    .find('.modal-header').addClass(`alert-${color}` || StatusType.DEFAULT)
-    // adds relevant icon before title
-    .find('.modal-title').addClass(`icon-${color}` || StatusType.DEFAULT);
+    // applies bootstrap color to title background and adds relevant icon before title
+    .find('.modal-header')
+    .addClass(`alert-${color}` || StatusType.DEFAULT)
+    .find('.modal-title')
+    .addClass(`icon-${color}` || StatusType.DEFAULT);
 }
 
 export {

--- a/src/main/webapp/dev/js/common/statusMessage.es6
+++ b/src/main/webapp/dev/js/common/statusMessage.es6
@@ -20,12 +20,10 @@ function populateStatusMessageDiv(message, status) {
     const $statusMessageDivToUser = $(DIV_STATUS_MESSAGE);
     const $statusMessageDivContent = $('<div></div>');
 
-    $statusMessageDivContent.addClass('overflow-auto');
-    $statusMessageDivContent.addClass('alert');
     // Default the status type to info if any invalid status is passed in
-    $statusMessageDivContent.addClass(`alert-${StatusType.isValidType(status) ? status : StatusType.INFO}`);
-    $statusMessageDivContent.addClass(`icon-${StatusType.isValidType(status) ? status : StatusType.INFO}`);
-    $statusMessageDivContent.addClass('statusMessage');
+    const statusType = StatusType.isValidType(status) ? status : StatusType.INFO;
+
+    $statusMessageDivContent.addClass(`overflow-auto alert alert-${statusType} icon-${statusType} statusMessage`);
     $statusMessageDivContent.html(message);
 
     $statusMessageDivToUser.empty();

--- a/src/main/webapp/dev/js/common/statusMessage.es6
+++ b/src/main/webapp/dev/js/common/statusMessage.es6
@@ -24,6 +24,7 @@ function populateStatusMessageDiv(message, status) {
     $statusMessageDivContent.addClass('alert');
     // Default the status type to info if any invalid status is passed in
     $statusMessageDivContent.addClass(`alert-${StatusType.isValidType(status) ? status : StatusType.INFO}`);
+    $statusMessageDivContent.addClass(`icon-${StatusType.isValidType(status) ? status : StatusType.INFO}`);
     $statusMessageDivContent.addClass('statusMessage');
     $statusMessageDivContent.html(message);
 

--- a/src/main/webapp/dev/js/test/CommonJsTest.es6
+++ b/src/main/webapp/dev/js/test/CommonJsTest.es6
@@ -208,31 +208,31 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
         'Default message status without specifying status of message (info)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.INFO);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
         'Info message status by specifying status of message (StatusType.INFO)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.SUCCESS);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-success statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-success icon-success statusMessage',
         'Success message status by specifying status of message (StatusType.SUCCESS)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.WARNING);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-warning statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-warning icon-warning statusMessage',
         'Warning message status by specifying status of message (StatusType.WARNING)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.DANGER);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-danger statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-danger icon-danger statusMessage',
         'Danger message status by specifying status of message (StatusType.DANGER)');
     clearStatusMessages();
 
@@ -249,7 +249,7 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message, 'random');
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
               'Message with random status (defaulted to info)');
 });
 

--- a/src/main/webapp/dev/js/test/CommonJsTest.es6
+++ b/src/main/webapp/dev/js/test/CommonJsTest.es6
@@ -206,37 +206,37 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
     // isError = false: class = overflow-auto alert alert-warning
     // isError = true: class = overflow-auto alert alert-danger
 
-    function getClassesForStatusMessage(color) {
-        return `overflow-auto alert alert-${color} icon-${color} statusMessage`;
+    function getExpectedClasses(statusType) {
+        return `overflow-auto alert alert-${statusType} icon-${statusType} statusMessage`;
     }
 
     setStatusMessage(message);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DEFAULT),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.DEFAULT),
         'Default message status without specifying status of message (info)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.INFO);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.INFO),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.INFO),
         'Info message status by specifying status of message (StatusType.INFO)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.SUCCESS);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.SUCCESS),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.SUCCESS),
         'Success message status by specifying status of message (StatusType.SUCCESS)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.WARNING);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.WARNING),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.WARNING),
         'Warning message status by specifying status of message (StatusType.WARNING)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.DANGER);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DANGER),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.DANGER),
         'Danger message status by specifying status of message (StatusType.DANGER)');
     clearStatusMessages();
 
@@ -253,7 +253,7 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message, 'random');
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DEFAULT),
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getExpectedClasses(StatusType.DEFAULT),
         'Message with random status (defaulted to info)');
 });
 

--- a/src/main/webapp/dev/js/test/CommonJsTest.es6
+++ b/src/main/webapp/dev/js/test/CommonJsTest.es6
@@ -206,38 +206,37 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
     // isError = false: class = overflow-auto alert alert-warning
     // isError = true: class = overflow-auto alert alert-danger
 
+    function getClassesForStatusMessage(color) {
+        return `overflow-auto alert alert-${color} icon-${color} statusMessage`;
+    }
+
     setStatusMessage(message);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DEFAULT),
         'Default message status without specifying status of message (info)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.INFO);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.INFO),
         'Info message status by specifying status of message (StatusType.INFO)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.SUCCESS);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-success icon-success statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.SUCCESS),
         'Success message status by specifying status of message (StatusType.SUCCESS)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.WARNING);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-warning icon-warning statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.WARNING),
         'Warning message status by specifying status of message (StatusType.WARNING)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.DANGER);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-danger icon-danger statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DANGER),
         'Danger message status by specifying status of message (StatusType.DANGER)');
     clearStatusMessages();
 
@@ -254,8 +253,7 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message, 'random');
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage')
-            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === getClassesForStatusMessage(StatusType.DEFAULT),
         'Message with random status (defaulted to info)');
 });
 

--- a/src/main/webapp/dev/js/test/CommonJsTest.es6
+++ b/src/main/webapp/dev/js/test/CommonJsTest.es6
@@ -208,31 +208,36 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
         'Default message status without specifying status of message (info)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.INFO);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
         'Info message status by specifying status of message (StatusType.INFO)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.SUCCESS);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-success icon-success statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-success icon-success statusMessage',
         'Success message status by specifying status of message (StatusType.SUCCESS)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.WARNING);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-warning icon-warning statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-warning icon-warning statusMessage',
         'Warning message status by specifying status of message (StatusType.WARNING)');
     clearStatusMessages();
 
     setStatusMessage(message, StatusType.DANGER);
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-danger icon-danger statusMessage',
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-danger icon-danger statusMessage',
         'Danger message status by specifying status of message (StatusType.DANGER)');
     clearStatusMessages();
 
@@ -249,8 +254,9 @@ QUnit.test('setStatusMessage(message,status)', (assert) => {
 
     setStatusMessage(message, 'random');
     assert.equal($('#statusMessagesToUser .statusMessage').html(), message, 'Normal status message');
-    assert.ok($('#statusMessagesToUser .statusMessage').attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
-              'Message with random status (defaulted to info)');
+    assert.ok($('#statusMessagesToUser .statusMessage')
+            .attr('class') === 'overflow-auto alert alert-info icon-info statusMessage',
+        'Message with random status (defaulted to info)');
 });
 
 QUnit.test('clearStatusMessages()', (assert) => {

--- a/src/main/webapp/dev/js/test/CommonTestFunctions.es6
+++ b/src/main/webapp/dev/js/test/CommonTestFunctions.es6
@@ -33,28 +33,21 @@ function clearBootboxModalStub() {
     $('#test-bootbox-modal-stub').html('');
 }
 
+const bootboxStub = {
+    find() {
+        return this;
+    },
+    addClass() {
+        return this;
+    },
+}
+
 bootbox.dialog = function (params) {
     $('#test-bootbox-modal-stub').html(
         `<div id="test-bootbox-modal-stub-title">${params.title}</div>`
         + `<div id="test-bootbox-modal-stub-message">${params.message}</div>`,
     );
-    return {
-        find() {
-            return {
-                addClass() {
-                    return {
-                        find() {
-                            return {
-                                addClass() {
-                                    // stub the subsequent method calls
-                                },
-                            };
-                        },
-                    };
-                },
-            };
-        },
-    };
+    return bootboxStub;
 };
 
 $.fn.ready = function () {

--- a/src/main/webapp/dev/js/test/CommonTestFunctions.es6
+++ b/src/main/webapp/dev/js/test/CommonTestFunctions.es6
@@ -40,7 +40,7 @@ const bootboxStub = {
     addClass() {
         return this;
     },
-}
+};
 
 bootbox.dialog = function (params) {
     $('#test-bootbox-modal-stub').html(

--- a/src/main/webapp/dev/js/test/CommonTestFunctions.es6
+++ b/src/main/webapp/dev/js/test/CommonTestFunctions.es6
@@ -42,7 +42,15 @@ bootbox.dialog = function (params) {
         find() {
             return {
                 addClass() {
-                    // stub the subsequent method calls
+                    return {
+                        find() {
+                            return {
+                                addClass() {
+                                    // stub the subsequent method calls
+                                }
+                            };
+                        },
+                    };
                 },
             };
         },

--- a/src/main/webapp/dev/js/test/CommonTestFunctions.es6
+++ b/src/main/webapp/dev/js/test/CommonTestFunctions.es6
@@ -47,7 +47,7 @@ bootbox.dialog = function (params) {
                             return {
                                 addClass() {
                                     // stub the subsequent method calls
-                                }
+                                },
                             };
                         },
                     };

--- a/src/main/webapp/dev/js/test/CommonTestFunctions.es6
+++ b/src/main/webapp/dev/js/test/CommonTestFunctions.es6
@@ -33,7 +33,7 @@ function clearBootboxModalStub() {
     $('#test-bootbox-modal-stub').html('');
 }
 
-const bootboxStub = {
+const jQueryObjectStubForBootbox = {
     find() {
         return this;
     },
@@ -47,7 +47,7 @@ bootbox.dialog = function (params) {
         `<div id="test-bootbox-modal-stub-title">${params.title}</div>`
         + `<div id="test-bootbox-modal-stub-message">${params.message}</div>`,
     );
-    return bootboxStub;
+    return jQueryObjectStubForBootbox;
 };
 
 $.fn.ready = function () {

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1170,11 +1170,3 @@ Prevent Long URL From Breaking Out of Container
 /*
 Glyphicon for success status messages
 */
-.alert-success:before {
-    font-family: 'Glyphicons Halflings';
-    display: inline-block;
-    padding-top: .2em;
-    padding-right: .5em;
-    content: '\e084';
-    float: left;
-}

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1173,6 +1173,7 @@ Glyphicon for success status messages
 .alert-success:before {
     font-family: 'Glyphicons Halflings';
     display: inline-block;
-    padding-right: 2px;
+    padding-right: 0.5em;
     content: '\e084';
+    float: left;
 }

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1193,5 +1193,5 @@ Glyphicon for success status messages
     display: inline-block;
     padding-right: .5em;
     content: '\e084';
-    vertical-align: middle;
+    vertical-align: top;
 }

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1170,3 +1170,11 @@ Prevent Long URL From Breaking Out of Container
 /*
 Glyphicon for success status messages
 */
+
+.icon-success:before {
+    font-family: 'Glyphicons Halflings';
+    display: inline-block;
+    padding-right: .5em;
+    content: '\e084';
+    vertical-align: middle;
+}

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1173,7 +1173,7 @@ Glyphicon for success status messages
 .alert-success:before {
     font-family: 'Glyphicons Halflings';
     display: inline-block;
-    padding-right: 0.5em;
+    padding-right: .5em;
     content: '\e084';
     float: left;
 }

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1173,6 +1173,7 @@ Glyphicon for success status messages
 .alert-success:before {
     font-family: 'Glyphicons Halflings';
     display: inline-block;
+    padding-top: .2em;
     padding-right: .5em;
     content: '\e084';
     float: left;

--- a/src/test/resources/pages/adminAccountDetailsRemoveStudent.html
+++ b/src/test/resources/pages/adminAccountDetailsRemoveStudent.html
@@ -52,7 +52,7 @@
     </form>
   </div>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The student has been removed from the course
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
@@ -151,7 +151,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       There are no students in this course. Click
       <a href="/page/instructorCourseEnrollPage?courseid=CCDetailsUiT.CourseWithoutStudents&user=CCDetailsUiT.instr">
         here

--- a/src/test/resources/pages/instructorCourseDetailsStudentDeleteAllSuccessful.html
+++ b/src/test/resources/pages/instructorCourseDetailsStudentDeleteAllSuccessful.html
@@ -76,10 +76,10 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       All the students have been removed from the course
     </div>
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       There are no students in this course. Click
       <a href="/page/instructorCourseEnrollPage?courseid=CCDetailsUiT.CS2104&user=CCDetailsUiT.instr">
         here

--- a/src/test/resources/pages/instructorCourseDetailsStudentDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCourseDetailsStudentDeleteSuccessful.html
@@ -146,7 +146,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The student has been removed from the course
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -67,7 +67,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the instructor Teammates New Instructor has been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -67,7 +67,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the instructor New name has been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -67,7 +67,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the instructor New name has been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -67,7 +67,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the instructor New name has been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEnrollError.html
+++ b/src/test/resources/pages/instructorCourseEnrollError.html
@@ -38,7 +38,7 @@
               </textarea>
               <br>
               <div id="statusMessagesToUser">
-                <div class="overflow-auto alert alert-danger statusMessage">
+                <div class="overflow-auto alert alert-danger icon-danger statusMessage">
                   <p>
                     <span class="bold">
                       Problem in line :

--- a/src/test/resources/pages/instructorCourseStudentDetailsUnregistered.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsUnregistered.html
@@ -6,7 +6,7 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       Normally, we would show the student’s profile here. However, this student has not created a profile yet
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger statusMessage">
+    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
       A course by the same ID already exists in the system, possibly created by another user. Please choose a different course ID
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger statusMessage">
+    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
       "Invalid ID" is not acceptable to TEAMMATES as a/an course ID because it is not in the correct format. A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger statusMessage">
+    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
       "" is not acceptable to TEAMMATES as a/an course name because it is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -54,13 +54,8 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-<<<<<<< HEAD
     <div class="overflow-auto alert alert-danger icon-danger statusMessage">
-      "" is not acceptable to TEAMMATES as a/an course name because it is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
-=======
-    <div class="overflow-auto alert alert-danger statusMessage">
       The field 'course name' is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
->>>>>>> TEAMMATES/master
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course has been added. Click
       <a href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor">
         here

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course CCAddUiTest.CS1101 has been archived. It will not appear in the home page any more.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course CCAddUiTest.course1 has been deleted.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -132,7 +132,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       You have not created any courses yet. Use the form above to create a course.
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -54,7 +54,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course CCAddUiTest.CS1101 has been unarchived.
     </div>
   </div>

--- a/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/instructorEditStudentFeedbackPageModified.html
@@ -11,7 +11,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IESFPTCourseinstr">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-success statusMessage">
+      <div class="overflow-auto alert alert-success icon-success statusMessage">
         All responses submitted successfully!
       </div>
     </div>

--- a/src/test/resources/pages/instructorFeedbackAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been added. Click the "Add New Question" button below to begin adding questions for the feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopySuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been copied. Please modify settings/questions as necessary.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackCopyTrimmedSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyTrimmedSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been copied. Please modify settings/questions as necessary.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -765,7 +765,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="display: block;">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been deleted.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -768,7 +768,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="display: block;">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been copied. Please modify settings/questions as necessary.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -850,7 +850,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="display: block;">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       You have not created any courses yet, or you have no active courses. Go
       <a href="/page/instructorCoursesPage?user=CFeedbackUiT.nocourses">
         here

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -765,7 +765,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="display: block;">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been published. Please allow up to 1 hour for all the notification emails to be sent out.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRankQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -240,7 +240,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -237,7 +237,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -237,7 +237,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       This session seems to have a large number of responses. It is recommended to view the results one question/section at a time. To view responses for a particular question, click on the question below. To view response for a particular section, choose the section from the drop-down box above.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The question has been added to this feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditWeightSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The changes to the question have been updated.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -91,7 +91,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>
@@ -454,7 +454,7 @@
         <button aria-hidden="true" class="bootbox-close-button close" data-dismiss="modal" type="button">
           ×
         </button>
-        <h4 class="modal-title">
+        <h4 class="modal-title icon-warning">
           Feedback Session Not Open
         </h4>
       </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageClosed.html
@@ -11,7 +11,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageGracePeriod.html
@@ -11,7 +11,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="IFSubmitUiT.instr">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>

--- a/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
@@ -755,7 +755,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been added. Click the "Add New Question" button below to begin adding questions for the feedback session.
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -765,7 +765,7 @@
   </form>
   <br>
   <div id="statusMessagesToUser" style="display: block;">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The feedback session has been unpublished.
     </div>
   </div>

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course CHomeUiT.CS1101 has been archived. It will not appear in the home page any more. You can access archived courses from the 'Courses' tab.
       <br>
       Go there to undo the archiving and bring the course back to the home page.

--- a/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       The course CHomeUiT.CS2104 has been deleted.
     </div>
   </div>

--- a/src/test/resources/pages/instructorHomeHTMLEmpty.html
+++ b/src/test/resources/pages/instructorHomeHTMLEmpty.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       New to TEAMMATES? You may wish to have a look at our
       <a href="/instructorHelp.jsp#gs" target="_blank">
         Getting Started Guide

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -104,7 +104,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       Account creation is still in progress. Please reload the page after sometime.
     </div>
   </div>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       New to TEAMMATES? You may wish to have a look at our
       <a href="/instructorHelp.jsp#gs" target="_blank">
         Getting Started Guide

--- a/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       New to TEAMMATES? You may wish to have a look at our
       <a href="/instructorHelp.jsp#gs" target="_blank">
         Getting Started Guide

--- a/src/test/resources/pages/instructorSearchPageDefault.html
+++ b/src/test/resources/pages/instructorSearchPageDefault.html
@@ -123,7 +123,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       Search Tips:
       <br>
       <ul>

--- a/src/test/resources/pages/instructorSearchPageSearchNone.html
+++ b/src/test/resources/pages/instructorSearchPageSearchNone.html
@@ -44,7 +44,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       Search Tips:
       <br>
       <ul>

--- a/src/test/resources/pages/instructorStudentListPageNoCourse.html
+++ b/src/test/resources/pages/instructorStudentListPageNoCourse.html
@@ -130,7 +130,7 @@
     </form>
   </div>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       There are no course or students information to be displayed
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentListPageSearchNoMatch.html
+++ b/src/test/resources/pages/instructorStudentListPageSearchNoMatch.html
@@ -44,7 +44,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       No results found.
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentRecordsPageNoRecords.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageNoRecords.html
@@ -9,10 +9,10 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       Normally, we would show the student’s profile here. However, this student has not created a profile yet
     </div>
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       No records were found for this student
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentRecordsPageWithScriptInjectionProfile.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageWithScriptInjectionProfile.html
@@ -9,7 +9,7 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       No records were found for this student
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentRecordsWithHelperView.html
+++ b/src/test/resources/pages/instructorStudentRecordsWithHelperView.html
@@ -9,10 +9,10 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       Normally, we would show the student’s profile here. However, you do not have access to view this student's profile
     </div>
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       No records were found for this student
     </div>
   </div>

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -26,7 +26,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       New to TEAMMATES? You may wish to have a look at our
       <a href="/instructorHelp.jsp#gs" target="_blank">
         Getting Started Guide

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
@@ -17,7 +17,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="${test.instructor}">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>

--- a/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageCONSTSUM.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONSTSUM.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       You have not received any new feedback but you may review your own submissions below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
@@ -118,7 +118,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       You have not received any new feedback but you may review your own submissions below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageMCQ.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageMSQ.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageMSQ.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageNUMSCALE.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageNUMSCALE.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
@@ -55,10 +55,10 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       You have been successfully added to the course [SFResultsUiT.CS2104] Programming Language Concepts.
     </div>
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageRank.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageRank.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageRubric.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -55,7 +55,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -82,7 +82,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>
@@ -331,7 +331,7 @@
         <button aria-hidden="true" class="bootbox-close-button close" data-dismiss="modal" type="button">
           ×
         </button>
-        <h4 class="modal-title">
+        <h4 class="modal-title icon-warning">
           Feedback Session Not Open
         </h4>
       </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageClosed.html
@@ -17,7 +17,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>

--- a/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageGracePeriod.html
@@ -17,7 +17,7 @@
     <input name="token" type="hidden" value="${sessionToken}">
     <input name="user" type="hidden" value="SFSubmitUiT.alice.b">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-warning statusMessage">
+      <div class="overflow-auto alert alert-warning icon-warning statusMessage">
         <strong>
           The feedback session is currently not open for submissions.
         </strong>

--- a/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
+++ b/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
@@ -6,7 +6,7 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       The feedback session has been deleted and is no longer accessible.
     </div>
   </div>

--- a/src/test/resources/pages/studentHomeHTMLEmpty.html
+++ b/src/test/resources/pages/studentHomeHTMLEmpty.html
@@ -6,7 +6,7 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-warning statusMessage">
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       <div class="align-left">
         <div class="align-center text-color-red text-bold">
           Ooops! Your Google account is not known to TEAMMATES

--- a/src/test/resources/pages/studentProfilePageFilled.html
+++ b/src/test/resources/pages/studentProfilePageFilled.html
@@ -6,7 +6,7 @@
   </h1>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success statusMessage">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
       Your profile picture has been saved successfully
     </div>
   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
@@ -118,7 +118,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -66,7 +66,7 @@
   </div>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-info statusMessage">
+    <div class="overflow-auto alert alert-info icon-info statusMessage">
       You have received feedback from others. Please see below.
     </div>
   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -29,7 +29,7 @@
     <input name="key" type="hidden" value="${regkey.enc}">
     <input name="studentemail" type="hidden" value="drop.out@gmail.tmt">
     <div id="statusMessagesToUser">
-      <div class="overflow-auto alert alert-success statusMessage">
+      <div class="overflow-auto alert alert-success icon-success statusMessage">
         All responses submitted successfully!
       </div>
     </div>


### PR DESCRIPTION
Fixes #7708 

**Outline of solution:**

- ~~Added `float: left` to CSS Class `.alert-success:before`~~ EDIT: A lot has changed :p. In summary, added a new `icon-${color}` class to show icons in both statuses and modals instead of attaching to the existing `alert-${color}` class.
- Changed padding unit from `px` to `em` according to @LiHaoTan's suggestion in the last line of [this comment.](https://github.com/TEAMMATES/teammates/issues/7708#issuecomment-314119186)

**Screenshots:** 

**Before:**

<img width="631" alt="screen shot 2017-07-09 at 3 14 16 am" src="https://user-images.githubusercontent.com/18088721/27989446-91860ada-6456-11e7-8e31-7c6b939b144c.png">

**After:** (EDIT: Updated to reflect all changes from below as requested by @whipermr5)

<img width="645" alt="screen shot 2017-07-25 at 2 16 04 pm" src="https://user-images.githubusercontent.com/18088721/28563536-e911c9b6-7143-11e7-8db1-572be8aa5d35.png">


**Note:** Currently, the value for `padding-right` that I have gone with is `0.5em` (pictured in screenshot above). Let me know if you would like this changed. See options in https://github.com/TEAMMATES/teammates/issues/7708#issuecomment-314349104.
