### PR TITLE
Instructor: add courses/sessions: give more specific error messages when a field is empty #4129

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -112,7 +112,7 @@ public class FieldValidator {
 
     // error message components
     public static final String ERROR_INFO =
-            "\"${userInput}\" is not acceptable to TEAMMATES as a/an ${fieldName} because it ${reason}.";
+            "The field ${fieldName} ${reason}.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY =
             "The value of a/an ${fieldName} should be no longer than ${maxLength} characters.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY =

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentAdd.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentAdd.tag
@@ -10,25 +10,25 @@
 <%@ attribute name="fourthIndex" %>
 
 <c:choose>
-    <c:when test="${not empty fourthIndex}">
-        <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}" />
-    </c:when>
-    <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex}">
-        <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}" />
-    </c:when>
+  <c:when test="${not empty fourthIndex}">
+    <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}" />
+  </c:when>
+  <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex}">
+    <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}" />
+  </c:when>
 </c:choose>
 
 <c:set var="submitLink"><%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_ADD %></c:set>
 <li class="list-group-item list-group-item-warning"
     id="showResponseCommentAddForm-${divId}" style="display: none;">
-    <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
-                                        secondIndex="${secondIndex}"
-                                        thirdIndex="${thirdIndex}"
-                                        fourthIndex="${fourthIndex}"
-                                        frc="${frc}"
-                                        divId="${divId}"
-                                        formType="Add"
-                                        textAreaId="responseCommentAddForm"
-                                        submitLink="${submitLink}"
-                                        buttonText="Add" />
+  <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
+      secondIndex="${secondIndex}"
+      thirdIndex="${thirdIndex}"
+      fourthIndex="${fourthIndex}"
+      frc="${frc}"
+      divId="${divId}"
+      formType="Add"
+      textAreaId="responseCommentAddForm"
+      submitLink="${submitLink}"
+      buttonText="Add" />
 </li>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentForm.tag
@@ -18,206 +18,206 @@
 <c:set var="isEditForm" value="${formType eq 'Edit'}" />
 <c:set var="isAddForm" value="${formType eq 'Add'}" />
 <form class="responseComment${formType}Form"<c:if test="${isEditForm}"> style="display: none;" id="responseCommentEditForm-${divId}"</c:if>>
-    <div class="form-group form-inline">
-        <div class="form-group text-muted">
-            <p>
-                Giver: ${fn:escapeXml(frc.responseGiverName)}
-                <br>
-                Recipient: ${fn:escapeXml(frc.responseRecipientName)}
-            </p>
-            You may change comment's visibility using the visibility options on the right hand side.
-        </div>
-        <a id="frComment-visibility-options-trigger-${divId}"
-           class="btn btn-sm btn-info pull-right toggle-visib-${fn:toLowerCase(formType)}-form"
-           data-recipientindex="${fsIndex}" data-giverindex="${secondIndex}"
-           data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
-           <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
-            <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>>
-            <span class="glyphicon glyphicon-eye-close"></span>
-            Show Visibility Options
-        </a>
+  <div class="form-group form-inline">
+    <div class="form-group text-muted">
+      <p>
+        Giver: ${fn:escapeXml(frc.responseGiverName)}
+        <br>
+        Recipient: ${fn:escapeXml(frc.responseRecipientName)}
+      </p>
+      You may change comment's visibility using the visibility options on the right hand side.
     </div>
-    <div id="visibility-options-${divId}" class="panel panel-default" style="display: none;">
-        <div class="panel-heading">
-            Visibility Options
-        </div>
-        <table class="table text-center" style="color: #000;">
-            <tbody>
-                <tr>
-                    <th class="text-center">User/Group</th>
-                    <th class="text-center">Can see this comment</th>
-                    <th class="text-center">Can see comment giver's name</th>
-                </tr>
-                <tr id="response-giver-${divId}">
-                    <td class="text-left">
-                        <div data-toggle="tooltip"
-                             data-placement="top"
-                             title="Control what response giver can view">
-                            Response Giver
-                        </div>
-                    </td>
-                    <td>
-                        <input class="visibilityCheckbox answerCheckbox centered"
-                               name="receiverLeaderCheckbox"
-                               type="checkbox"
-                               value="<%= FeedbackParticipantType.GIVER %>"
-                               <c:if test="${frc.showCommentToResponseGiver}">checked</c:if>>
-                    </td>
-                    <td>
-                        <input class="visibilityCheckbox giverCheckbox"
-                               type="checkbox"
-                               value="<%= FeedbackParticipantType.GIVER %>"
-                               <c:if test="${frc.showGiverNameToResponseGiver}">checked</c:if>>
-                    </td>
-                </tr>
-                <c:if test="${frc.responseVisibleToRecipient}">
-                    <tr id="response-recipient-${divId}">
-                        <td class="text-left">
-                            <div data-toggle="tooltip"
-                                 data-placement="top"
-                                 title="Control what response recipient(s) can view">
-                                Response Recipient(s)
-                            </div>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox answerCheckbox centered"
-                                   name="receiverLeaderCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.RECEIVER %>"
-                                   <c:if test="${frc.showCommentToResponseRecipient}">checked</c:if>>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox giverCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.RECEIVER %>"
-                                   <c:if test="${frc.showGiverNameToResponseRecipient}">checked</c:if>>
-                        </td>
-                    </tr>
-                </c:if>
-                <c:if test="${frc.responseVisibleToGiverTeam}">
-                    <tr id="response-giver-team-${divId}">
-                        <td class="text-left">
-                            <div data-toggle="tooltip"
-                                 data-placement="top"
-                                 title="Control what team members of response giver can view">
-                                Response Giver's Team Members
-                            </div>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox answerCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>"
-                                   <c:if test="${frc.showCommentToResponseGiverTeam}">checked</c:if>>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox giverCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>"
-                                   <c:if test="${frc.showGiverNameToResponseGiverTeam}">checked</c:if>>
-                        </td>
-                    </tr>
-                </c:if>
-                <c:if test="${frc.responseVisibleToRecipientTeam}">
-                    <tr id="response-recipient-team-${divId}">
-                        <td class="text-left">
-                            <div data-toggle="tooltip"
-                                 data-placement="top"
-                                 title="Control what team members of response recipient(s) can view">
-                                Response Recipient's Team Members
-                            </div>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox answerCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>"
-                                   <c:if test="${frc.showCommentToResponseRecipientTeam}">checked</c:if>>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox giverCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>"
-                                   <c:if test="${frc.showGiverNameToResponseRecipientTeam}">checked</c:if>>
-                        </td>
-                    </tr>
-                </c:if>
-                 <c:if test="${frc.responseVisibleToStudents}">
-                    <tr id="response-students-${divId}">
-                        <td class="text-left">
-                            <div data-toggle="tooltip"
-                                 data-placement="top"
-                                 title="Control what other students in this course can view">
-                                Other students in this course
-                            </div>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox answerCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.STUDENTS %>"
-                                   <c:if test="${frc.showCommentToStudents}">checked</c:if>>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox giverCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.STUDENTS %>"
-                                   <c:if test="${frc.showGiverNameToStudents}">checked</c:if>>
-                        </td>
-                    </tr>
-                </c:if>
-                <c:if test="${frc.responseVisibleToInstructors}">
-                    <tr id="response-instructors-${divId}">
-                        <td class="text-left">
-                            <div data-toggle="tooltip"
-                                 data-placement="top"
-                                 title="Control what instructors can view">
-                                Instructors
-                            </div>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox answerCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.INSTRUCTORS %>"
-                                   <c:if test="${frc.showCommentToInstructors}">checked</c:if>>
-                        </td>
-                        <td>
-                            <input class="visibilityCheckbox giverCheckbox"
-                                   type="checkbox"
-                                   value="<%= FeedbackParticipantType.INSTRUCTORS %>"
-                                   <c:if test="${frc.showGiverNameToInstructors}">checked</c:if>>
-                        </td>
-                    </tr>
-                </c:if>
-            </tbody>
-        </table>
+    <a id="frComment-visibility-options-trigger-${divId}"
+        class="btn btn-sm btn-info pull-right toggle-visib-${fn:toLowerCase(formType)}-form"
+        data-recipientindex="${fsIndex}" data-giverindex="${secondIndex}"
+        data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+        <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
+        <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>>
+      <span class="glyphicon glyphicon-eye-close"></span>
+      Show Visibility Options
+    </a>
+  </div>
+  <div id="visibility-options-${divId}" class="panel panel-default" style="display: none;">
+    <div class="panel-heading">
+      Visibility Options
     </div>
-    <div class="form-group">
-        <div class="panel panel-default panel-body" id="${textAreaId}-${divId}">
-            ${frc.commentText}
-        </div>
-        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT %>">
+    <table class="table text-center" style="color: #000;">
+      <tbody>
+        <tr>
+          <th class="text-center">User/Group</th>
+          <th class="text-center">Can see this comment</th>
+          <th class="text-center">Can see comment giver's name</th>
+        </tr>
+        <tr id="response-giver-${divId}">
+          <td class="text-left">
+            <div data-toggle="tooltip"
+                data-placement="top"
+                title="Control what response giver can view">
+              Response Giver
+            </div>
+          </td>
+          <td>
+            <input class="visibilityCheckbox answerCheckbox centered"
+                name="receiverLeaderCheckbox"
+                type="checkbox"
+                value="<%= FeedbackParticipantType.GIVER %>"
+                <c:if test="${frc.showCommentToResponseGiver}">checked</c:if>>
+          </td>
+          <td>
+            <input class="visibilityCheckbox giverCheckbox"
+                type="checkbox"
+                value="<%= FeedbackParticipantType.GIVER %>"
+                <c:if test="${frc.showGiverNameToResponseGiver}">checked</c:if>>
+          </td>
+        </tr>
+        <c:if test="${frc.responseVisibleToRecipient}">
+          <tr id="response-recipient-${divId}">
+            <td class="text-left">
+              <div data-toggle="tooltip"
+                  data-placement="top"
+                  title="Control what response recipient(s) can view">
+                Response Recipient(s)
+              </div>
+            </td>
+            <td>
+              <input class="visibilityCheckbox answerCheckbox centered"
+                  name="receiverLeaderCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.RECEIVER %>"
+                  <c:if test="${frc.showCommentToResponseRecipient}">checked</c:if>>
+            </td>
+            <td>
+              <input class="visibilityCheckbox giverCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.RECEIVER %>"
+                  <c:if test="${frc.showGiverNameToResponseRecipient}">checked</c:if>>
+            </td>
+          </tr>
+        </c:if>
+        <c:if test="${frc.responseVisibleToGiverTeam}">
+          <tr id="response-giver-team-${divId}">
+            <td class="text-left">
+              <div data-toggle="tooltip"
+                  data-placement="top"
+                  title="Control what team members of response giver can view">
+                Response Giver's Team Members
+              </div>
+            </td>
+            <td>
+              <input class="visibilityCheckbox answerCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>"
+                  <c:if test="${frc.showCommentToResponseGiverTeam}">checked</c:if>>
+            </td>
+            <td>
+              <input class="visibilityCheckbox giverCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.OWN_TEAM_MEMBERS %>"
+                  <c:if test="${frc.showGiverNameToResponseGiverTeam}">checked</c:if>>
+            </td>
+          </tr>
+        </c:if>
+        <c:if test="${frc.responseVisibleToRecipientTeam}">
+          <tr id="response-recipient-team-${divId}">
+            <td class="text-left">
+              <div data-toggle="tooltip"
+                  data-placement="top"
+                  title="Control what team members of response recipient(s) can view">
+                Response Recipient's Team Members
+              </div>
+            </td>
+            <td>
+              <input class="visibilityCheckbox answerCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>"
+                  <c:if test="${frc.showCommentToResponseRecipientTeam}">checked</c:if>>
+            </td>
+            <td>
+              <input class="visibilityCheckbox giverCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.RECEIVER_TEAM_MEMBERS %>"
+                  <c:if test="${frc.showGiverNameToResponseRecipientTeam}">checked</c:if>>
+            </td>
+          </tr>
+        </c:if>
+        <c:if test="${frc.responseVisibleToStudents}">
+          <tr id="response-students-${divId}">
+            <td class="text-left">
+              <div data-toggle="tooltip"
+                  data-placement="top"
+                  title="Control what other students in this course can view">
+                Other students in this course
+              </div>
+            </td>
+            <td>
+              <input class="visibilityCheckbox answerCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.STUDENTS %>"
+                  <c:if test="${frc.showCommentToStudents}">checked</c:if>>
+            </td>
+            <td>
+              <input class="visibilityCheckbox giverCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.STUDENTS %>"
+                  <c:if test="${frc.showGiverNameToStudents}">checked</c:if>>
+            </td>
+          </tr>
+        </c:if>
+        <c:if test="${frc.responseVisibleToInstructors}">
+          <tr id="response-instructors-${divId}">
+            <td class="text-left">
+              <div data-toggle="tooltip"
+                  data-placement="top"
+                  title="Control what instructors can view">
+                Instructors
+              </div>
+            </td>
+            <td>
+              <input class="visibilityCheckbox answerCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.INSTRUCTORS %>"
+                  <c:if test="${frc.showCommentToInstructors}">checked</c:if>>
+            </td>
+            <td>
+              <input class="visibilityCheckbox giverCheckbox"
+                  type="checkbox"
+                  value="<%= FeedbackParticipantType.INSTRUCTORS %>"
+                  <c:if test="${frc.showGiverNameToInstructors}">checked</c:if>>
+            </td>
+          </tr>
+        </c:if>
+      </tbody>
+    </table>
+  </div>
+  <div class="form-group">
+    <div class="panel panel-default panel-body" id="${textAreaId}-${divId}">
+      ${frc.commentText}
     </div>
-    <div class="col-sm-offset-5">
-        <a href="${submitLink}"
-           type="button"
-           class="btn btn-primary"
-           id="button_save_comment_for_${fn:toLowerCase(formType)}-${divId}">
-            ${buttonText}
-        </a>
-        <input type="button"
-               class="btn btn-default hide-frc-${fn:toLowerCase(formType)}-form"
-               value="Cancel"
-               data-recipientindex="${fsIndex}" data-giverindex="${secondIndex}"
-               data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
-               <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
-               <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>>
-    </div>
-    <c:if test="${isEditForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}"></c:if>
-    <c:if test="${isAddForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${frc.questionId}"></c:if>
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${fsIndex}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${fn:escapeXml(frc.feedbackResponseId)}">
-    <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
-    <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-    <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWCOMMENTSTO %>" value="${frc.showCommentToString}">
-    <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWGIVERTO %>" value="${frc.showGiverNameToString}">
-    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
+    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT %>">
+  </div>
+  <div class="col-sm-offset-5">
+    <a href="${submitLink}"
+        type="button"
+        class="btn btn-primary"
+        id="button_save_comment_for_${fn:toLowerCase(formType)}-${divId}">
+      ${buttonText}
+    </a>
+    <input type="button"
+        class="btn btn-default hide-frc-${fn:toLowerCase(formType)}-form"
+        value="Cancel"
+        data-recipientindex="${fsIndex}" data-giverindex="${secondIndex}"
+        data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+        <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
+        <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>>
+  </div>
+  <c:if test="${isEditForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}"></c:if>
+  <c:if test="${isAddForm}"><input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>" value="${frc.questionId}"></c:if>
+  <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${fsIndex}">
+  <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${fn:escapeXml(frc.feedbackResponseId)}">
+  <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
+  <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
+  <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+  <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWCOMMENTSTO %>" value="${frc.showCommentToString}">
+  <input type="hidden" name="<%= Const.ParamsNames.RESPONSE_COMMENTS_SHOWGIVERTO %>" value="${frc.showGiverNameToString}">
+  <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
 </form>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
@@ -12,90 +12,91 @@
 <%@ attribute name="frcIndex" %>
 <%@ attribute name="viewType" %>
 <c:choose>
-    <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty fourthIndex && not empty frcIndex}">
-        <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
-    </c:when>
-    <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex && not empty viewType}">
-        <c:set var="divId" value="${viewType}-${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
-    </c:when>
-    <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
-        <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
-    </c:when>
-    <c:otherwise>
-        <c:set var="divId" value="${frc.commentId}" />
-    </c:otherwise>
+  <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty fourthIndex && not empty frcIndex}">
+    <c:set var="divId" value="${fourthIndex}-${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
+  </c:when>
+  <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex && not empty viewType}">
+    <c:set var="divId" value="${viewType}-${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
+  </c:when>
+  <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
+    <c:set var="divId" value="${firstIndex}-${secondIndex}-${thirdIndex}-${frcIndex}" />
+  </c:when>
+  <c:otherwise>
+    <c:set var="divId" value="${frc.commentId}" />
+  </c:otherwise>
 </c:choose>
 
 <li class="list-group-item list-group-item-warning" id="responseCommentRow-${divId}">
-    <div id="commentBar-${divId}">
-        <span class="text-muted">
-            From: ${fn:escapeXml(frc.commentGiverName)} [${frc.createdAt}] ${frc.editedAt}
-        </span>
-        <c:if test="${frc.withVisibilityIcon}">
-            <span class="glyphicon glyphicon-eye-open"
-                  data-toggle="tooltip"
-                  data-placement="top"
-                  style="margin-left: 5px;"
-                  title="This response comment is visible to ${frc.whoCanSeeComment}"></span>
-        </c:if>
-        <c:if test="${frc.editDeleteEnabled}">
-            <form class="responseCommentDeleteForm pull-right">
-                <a href="<%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_DELETE %>"
-                   type="button"
-                   id="commentdelete-${divId}"
-                   class="btn btn-default btn-xs icon-button"
-                   data-toggle="tooltip"
-                   data-placement="top"
-                   title="<%= Const.Tooltips.COMMENT_DELETE %>"
-                   <c:if test="${not frc.editDeleteEnabled}">disabled</c:if>>
-                    <span class="glyphicon glyphicon-trash glyphicon-primary"></span>
-                </a>
-                <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${firstIndex}">
-                <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${frc.feedbackResponseId}">
-                <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}">
-                <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
-                <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
-                <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-                <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
-            </form>
-            <a type="button"
-               id="commentedit-${divId}"
-               <c:choose>
-                   <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
-                       class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form"
-                       data-recipientindex="${firstIndex}" data-giverindex="${secondIndex}"
-                       data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
-                       <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
-                       <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>
-                   </c:when>
-                   <c:otherwise>
-                       class="btn btn-default btn-xs icon-button pull-right"
-                   </c:otherwise>
-               </c:choose>
-               data-toggle="tooltip"
-               data-placement="top"
-               title="<%= Const.Tooltips.COMMENT_EDIT %>"
-               <c:if test="${not frc.editDeleteEnabled}">disabled</c:if>>
-                <span class="glyphicon glyphicon-pencil glyphicon-primary"></span>
-            </a>
-        </c:if>
-    </div>
-    <%-- Do not add whitespace between the opening and closing tags --%>
-    <div id="plainCommentText-${divId}" style="margin-left: 15px;">${frc.commentText}</div>
-    <c:if test="${frc.editDeleteEnabled}">
-        <c:set var="textAreaId"><%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT %></c:set>
-        <c:set var="submitLink"><%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_EDIT %></c:set>
-        <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
-                                            secondIndex="${secondIndex}"
-                                            thirdIndex="${thirdIndex}"
-                                            fourthIndex="${fourthIndex}"
-                                            frcIndex="${frcIndex}"
-                                            frc="${frc}"
-                                            viewType = "${viewType}"
-                                            divId="${divId}"
-                                            formType="Edit"
-                                            textAreaId="${textAreaId}"
-                                            submitLink="${submitLink}"
-                                            buttonText="Save" />
+  <div id="commentBar-${divId}">
+    <span class="text-muted">
+      From: ${fn:escapeXml(frc.commentGiverName)} [${frc.createdAt}] ${frc.editedAt}
+    </span>
+    <c:if test="${frc.withVisibilityIcon}">
+      <span class="glyphicon glyphicon-eye-open"
+          data-toggle="tooltip"
+          data-placement="top"
+          style="margin-left: 5px;"
+          title="This response comment is visible to ${frc.whoCanSeeComment}"></span>
     </c:if>
+    <c:if test="${frc.editDeleteEnabled}">
+      <form class="responseCommentDeleteForm pull-right">
+        <a href="<%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_DELETE %>"
+            type="button"
+            id="commentdelete-${divId}"
+            class="btn btn-default btn-xs icon-button"
+            data-toggle="tooltip"
+            data-placement="top"
+            title="<%= Const.Tooltips.COMMENT_DELETE %>"
+            <c:if test="${not frc.editDeleteEnabled}">
+              disabled
+            </c:if>>
+          <span class="glyphicon glyphicon-trash glyphicon-primary"></span>
+        </a>
+        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${firstIndex}">
+        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${frc.feedbackResponseId}">
+        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}">
+        <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
+        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
+        <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+        <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
+      </form>
+      <a type="button" id="commentedit-${divId}"
+          <c:choose>
+            <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
+              class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form"
+              data-recipientindex="${firstIndex}" data-giverindex="${secondIndex}"
+              data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+              <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
+              <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>
+            </c:when>
+            <c:otherwise>
+              class="btn btn-default btn-xs icon-button pull-right"
+            </c:otherwise>
+          </c:choose>
+          data-toggle="tooltip"
+          data-placement="top"
+          title="<%= Const.Tooltips.COMMENT_EDIT %>"
+          <c:if test="${not frc.editDeleteEnabled}">disabled</c:if>>
+        <span class="glyphicon glyphicon-pencil glyphicon-primary"></span>
+      </a>
+    </c:if>
+  </div>
+  <%-- Do not add whitespace between the opening and closing tags --%>
+  <div id="plainCommentText-${divId}" style="margin-left: 15px;">${frc.commentText}</div>
+  <c:if test="${frc.editDeleteEnabled}">
+    <c:set var="textAreaId"><%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT %></c:set>
+    <c:set var="submitLink"><%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_EDIT %></c:set>
+    <shared:feedbackResponseCommentForm fsIndex="${firstIndex}"
+        secondIndex="${secondIndex}"
+        thirdIndex="${thirdIndex}"
+        fourthIndex="${fourthIndex}"
+        frcIndex="${frcIndex}"
+        frc="${frc}"
+        viewType = "${viewType}"
+        divId="${divId}"
+        formType="Edit"
+        textAreaId="${textAreaId}"
+        submitLink="${submitLink}"
+        buttonText="Save" />
+  </c:if>
 </li>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSessionDetailsPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSessionDetailsPanel.tag
@@ -3,46 +3,50 @@
 <%@ attribute name="feedbackSession" type="teammates.common.datatransfer.attributes.FeedbackSessionAttributes" required="true" %>
 
 <div class="well well-plain" id="course1">
-    <div class="panel-body">
-        <div class="form-horizontal">
-            <div class="panel-heading">
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">Course ID:</label>
-                    <div class="col-sm-10">
-                        <p class="form-control-static"><c:out value="${feedbackSession.courseId}"/></p>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">Session:</label>
-                    <div class="col-sm-10">
-                        <p class="form-control-static"><c:out value="${feedbackSession.feedbackSessionName}"/></p>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">Opening time:</label>
-                    <div class="col-sm-10">
-                        <p class="form-control-static">${feedbackSession.startTimeString}</p>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">Closing time:</label>
-                    <div class="col-sm-10">
-                        <p class="form-control-static">${feedbackSession.endTimeString}</p>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">Instructions:</label>
-                    <div class="col-sm-10">
-                        <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
-                        <p class="form-control-static text-preserve-space">${feedbackSession.instructionsString}</p>
-                    </div>
-                </div>
-            </div>
+  <div class="panel-body">
+    <div class="form-horizontal">
+      <div class="panel-heading">
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Course ID:</label>
+          <div class="col-sm-10">
+            <p class="form-control-static">
+              <c:out value="${feedbackSession.courseId}"/>
+            </p>
+          </div>
         </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Session:</label>
+          <div class="col-sm-10">
+            <p class="form-control-static">
+              <c:out value="${feedbackSession.feedbackSessionName}"/>
+            </p>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Opening time:</label>
+          <div class="col-sm-10">
+            <p class="form-control-static">${feedbackSession.startTimeString}</p>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Closing time:</label>
+          <div class="col-sm-10">
+            <p class="form-control-static">${feedbackSession.endTimeString}</p>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label class="col-sm-2 control-label">Instructions:</label>
+          <div class="col-sm-10">
+            <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
+            <p class="form-control-static text-preserve-space">${feedbackSession.instructionsString}</p>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 <br>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionEdit.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionEdit.tag
@@ -9,58 +9,60 @@
 <%@ attribute name="moderatedPersonName" required="true" %>
 
 <c:set var="jsIncludes">
-    <script type="text/javascript" src="<%= FrontEndLibrary.TINYMCE %>"></script>
-    <script type="text/javascript" src="/js/feedbackSubmissionsEdit.js"></script>
+  <script type="text/javascript" src="<%= FrontEndLibrary.TINYMCE %>"></script>
+  <script type="text/javascript" src="/js/feedbackSubmissionsEdit.js"></script>
 </c:set>
 
 <c:if test="${data.headerHidden}">
-    <c:set var="altHeader">
-        <nav class="navbar navbar-default navbar-fixed-top">
-            <c:choose>
-                <c:when test="${data.preview}">
-                    <h3 class="text-center">Previewing Session as ${isInstructor ? "Instructor" : "Student"} ${moderatedPersonName} (${moderatedPersonEmail})</h3>
-                </c:when>
-                <c:when test="${data.moderation}">
-                    <div class="container">
-                        <div class="col-md-12">
-                            <h3 class="text-center">
-                                You are moderating responses for ${isInstructor ? "instructor" : "student"} ${moderatedPersonName} (${moderatedPersonEmail})
-                                <small><a href="javascript:;" id="moderationHintButton"></a></small>
-                            </h3>
-                            <ul id="moderationHint" class="hidden">
-                                <li>
-                                    The page below resembles the submission page as seen by the respondent ${moderatedPersonName} (${moderatedPersonEmail}).
-                                    You can use it to moderate responses submitted by the respondent or submit responses on behalf of the respondent.
-                                </li>
-                                <li>
-                                    Note that due to visibility settings, questions that are not supposed to show responses to instructors (i.e you) are not shown in the page below.
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </c:when>
-            </c:choose>
-        </nav>
-    </c:set>
+  <c:set var="altHeader">
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <c:choose>
+        <c:when test="${data.preview}">
+          <h3 class="text-center">Previewing Session as ${isInstructor ? "Instructor" : "Student"} ${moderatedPersonName} (${moderatedPersonEmail})</h3>
+        </c:when>
+        <c:when test="${data.moderation}">
+          <div class="container">
+            <div class="col-md-12">
+              <h3 class="text-center">
+                You are moderating responses for ${isInstructor ? "instructor" : "student"} ${moderatedPersonName} (${moderatedPersonEmail})
+                <small>
+                  <a href="javascript:;" id="moderationHintButton"></a>
+                </small>
+              </h3>
+              <ul id="moderationHint" class="hidden">
+                <li>
+                  The page below resembles the submission page as seen by the respondent ${moderatedPersonName} (${moderatedPersonEmail}).
+                  You can use it to moderate responses submitted by the respondent or submit responses on behalf of the respondent.
+                </li>
+                <li>
+                  Note that due to visibility settings, questions that are not supposed to show responses to instructors (i.e you) are not shown in the page below.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </c:when>
+      </c:choose>
+    </nav>
+  </c:set>
 </c:if>
 
 <c:choose>
-    <c:when test="${isInstructor}">
-        <ti:instructorPage pageTitle="TEAMMATES - Submit Feedback" bodyTitle="Submit Feedback" jsIncludes="${jsIncludes}" altNavBar="${altHeader}">
-            <tsfse:feedbackSubmissionForm moderatedPersonEmail="${moderatedPersonEmail}"/>
-        </ti:instructorPage>
-    </c:when>
-    <c:otherwise>
-        <ts:studentPage pageTitle="TEAMMATES - Submit Feedback" bodyTitle="Submit Feedback" jsIncludes="${jsIncludes}" altNavBar="${altHeader}">
-            <c:if test="${not data.headerHidden}">
-                <ts:studentMessageOfTheDay />
-            </c:if>
-            <c:if test="${empty data.account.googleId}">
-                <div id="registerMessage" class="alert alert-info">
-                    ${data.registerMessage}
-                </div>
-            </c:if>
-            <tsfse:feedbackSubmissionForm moderatedPersonEmail="${moderatedPersonEmail}"/>
-        </ts:studentPage>
-    </c:otherwise>
+  <c:when test="${isInstructor}">
+    <ti:instructorPage pageTitle="TEAMMATES - Submit Feedback" bodyTitle="Submit Feedback" jsIncludes="${jsIncludes}" altNavBar="${altHeader}">
+      <tsfse:feedbackSubmissionForm moderatedPersonEmail="${moderatedPersonEmail}"/>
+    </ti:instructorPage>
+  </c:when>
+  <c:otherwise>
+    <ts:studentPage pageTitle="TEAMMATES - Submit Feedback" bodyTitle="Submit Feedback" jsIncludes="${jsIncludes}" altNavBar="${altHeader}">
+      <c:if test="${not data.headerHidden}">
+        <ts:studentMessageOfTheDay />
+      </c:if>
+      <c:if test="${empty data.account.googleId}">
+        <div id="registerMessage" class="alert alert-info">
+          ${data.registerMessage}
+        </div>
+      </c:if>
+      <tsfse:feedbackSubmissionForm moderatedPersonEmail="${moderatedPersonEmail}"/>
+    </ts:studentPage>
+  </c:otherwise>
 </c:choose>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/feedbackSubmissionForm.tag
@@ -7,52 +7,52 @@
 <%@ attribute name="moderatedPersonEmail" required="true" %>
 
 <form method="post" name="form_submit_response" action="${data.submitAction}">
-    <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${data.bundle.feedbackSession.feedbackSessionName}">
-    <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${data.bundle.feedbackSession.courseId}">
-    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
+  <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${data.bundle.feedbackSession.feedbackSessionName}">
+  <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${data.bundle.feedbackSession.courseId}">
+  <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
+
+  <c:choose>
+    <c:when test="${not empty data.account.googleId}">
+      <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+    </c:when>
+    <c:otherwise>
+      <input type="hidden" name="<%=Const.ParamsNames.REGKEY %>" value="${data.encryptedRegkey}">
+      <input type="hidden" name="<%=Const.ParamsNames.STUDENT_EMAIL %>" value="${data.account.email}">
+    </c:otherwise>
+  </c:choose>
+
+  <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
+  <tsfse:feedbackSessionDetailsPanel feedbackSession="${data.bundle.feedbackSession}"/>
+
+  <c:forEach items="${data.questionsWithResponses}" var="questionWithResponses">
+    <tsfse:questionWithResponses isSessionOpenForSubmission="${data.sessionOpenForSubmission}"
+        isShowRealQuestionNumber="${data.showRealQuestionNumber}"
+        questionWithResponses="${questionWithResponses}"/>
+  </c:forEach>
+
+  <div class="bold align-center">
+    <c:if test="${data.moderation}">
+      <input name="moderatedperson" value="${moderatedPersonEmail}" type="hidden">
+    </c:if>
 
     <c:choose>
-        <c:when test="${not empty data.account.googleId}">
-            <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-        </c:when>
-        <c:otherwise>
-            <input type="hidden" name="<%=Const.ParamsNames.REGKEY %>" value="${data.encryptedRegkey}">
-            <input type="hidden" name="<%=Const.ParamsNames.STUDENT_EMAIL %>" value="${data.account.email}">
-        </c:otherwise>
+      <c:when test="${empty data.bundle.questionResponseBundle}">
+        There are no questions for you to answer here!
+      </c:when>
+      <c:otherwise>
+        <input type="checkbox" name="sendsubmissionemail">
+        Send me a confirmation email
+        <button type="submit" class="btn btn-primary center-block margin-top-7px"
+            id="response_submit_button" data-toggle="tooltip"
+            data-placement="top" title="<%= Const.Tooltips.FEEDBACK_SESSION_EDIT_SAVE %>"
+            <c:if test="${data.preview or (not data.submittable)}">
+              disabled style="background: #66727A;"
+            </c:if>>
+          Submit Feedback
+        </button>
+      </c:otherwise>
     </c:choose>
-
-    <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}" />
-    <tsfse:feedbackSessionDetailsPanel feedbackSession="${data.bundle.feedbackSession}"/>
-
-    <c:forEach items="${data.questionsWithResponses}" var="questionWithResponses">
-        <tsfse:questionWithResponses isSessionOpenForSubmission="${data.sessionOpenForSubmission}"
-                                     isShowRealQuestionNumber="${data.showRealQuestionNumber}"
-                                     questionWithResponses="${questionWithResponses}"/>
-    </c:forEach>
-
-    <div class="bold align-center">
-        <c:if test="${data.moderation}">
-            <input name="moderatedperson" value="${moderatedPersonEmail}" type="hidden">
-        </c:if>
-
-        <c:choose>
-            <c:when test="${empty data.bundle.questionResponseBundle}">
-                    There are no questions for you to answer here!
-            </c:when>
-            <c:otherwise>
-                <input type="checkbox" name="sendsubmissionemail">
-                Send me a confirmation email
-                <button type="submit" class="btn btn-primary center-block margin-top-7px"
-                       id="response_submit_button" data-toggle="tooltip"
-                       data-placement="top" title="<%= Const.Tooltips.FEEDBACK_SESSION_EDIT_SAVE %>"
-                       <c:if test="${data.preview or (not data.submittable)}">
-                           disabled style="background: #66727A;"
-                       </c:if>>
-                    Submit Feedback
-                </button>
-            </c:otherwise>
-        </c:choose>
-    </div>
-    <br>
-    <br>
+  </div>
+  <br>
+  <br>
 </form>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/questionWithResponses.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/questionWithResponses.tag
@@ -8,57 +8,57 @@
 <%@ attribute name="isSessionOpenForSubmission" type="java.lang.Boolean" required="true" %>
 
 <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_TYPE %>-${questionWithResponses.question.qnIndx}"
-                     value="${questionWithResponses.question.questionType}">
+    value="${questionWithResponses.question.questionType}">
 
 <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_ID %>-${questionWithResponses.question.qnIndx}"
-                     value="${questionWithResponses.question.questionId}">
+    value="${questionWithResponses.question.questionId}">
 
 <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL %>-${questionWithResponses.question.qnIndx}"
-                     value="${questionWithResponses.numOfResponseBoxes}">
+    value="${questionWithResponses.numOfResponseBoxes}">
 
 <div class="form-horizontal">
-    <div class="panel panel-primary"<c:if test="${questionWithResponses.question.moderatedQuestion}"> id="moderated-question"</c:if>>
+  <div class="panel panel-primary"<c:if test="${questionWithResponses.question.moderatedQuestion}"> id="moderated-question"</c:if>>
 
-        <div class="panel-heading">Question ${isShowRealQuestionNumber ? questionWithResponses.question.questionNumber
-                                                                             : questionWithResponses.question.qnIndx}:
-            <br>
-            <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
-            <span class="text-preserve-space"><c:out value="${questionWithResponses.question.questionText}"/></span>
-        </div>
-
-        <div class="panel-body">
-            <c:if test="${not empty questionWithResponses.question.questionDescription}">
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <b>More details:</b><br><hr>${questionWithResponses.question.questionDescription}
-                    </div>
-                </div>
-
-            </c:if>
-            <p class="text-muted">Only the following persons can see your responses: </p>
-            <ul class="text-muted">
-                <c:if test="${empty questionWithResponses.question.visibilityMessages}">
-                    <li class="unordered">No-one but the feedback session creator can see your responses.</li>
-                </c:if>
-
-                <c:forEach items="${questionWithResponses.question.visibilityMessages}" var="line">
-                    <li class="unordered">${line}</li>
-                </c:forEach>
-            </ul>
-
-            <c:if test="${questionWithResponses.question.giverTeam}">
-                    <p class="text-warning">Please note that you are submitting this response on behalf of your team.</p>
-            </c:if>
-
-            <c:if test="${questionWithResponses.numOfResponseBoxes eq 0}">
-                 <p class="text-warning">${questionWithResponses.question.messageToDisplayIfNoRecipientAvailable}</p>
-            </c:if>
-
-            <c:forEach items="${questionWithResponses.responses}" var="response">
-                <feedbackSubmissionEdit:response response="${response}" isSessionOpenForSubmission="${isSessionOpenForSubmission}"
-                                                 questionWithResponses="${questionWithResponses}"/>
-            </c:forEach>
-        </div>
+    <div class="panel-heading">
+      Question ${isShowRealQuestionNumber ? questionWithResponses.question.questionNumber : questionWithResponses.question.qnIndx}:
+      <br>
+      <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
+      <span class="text-preserve-space"><c:out value="${questionWithResponses.question.questionText}"/></span>
     </div>
+
+    <div class="panel-body">
+      <c:if test="${not empty questionWithResponses.question.questionDescription}">
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <b>More details:</b><br><hr>${questionWithResponses.question.questionDescription}
+          </div>
+        </div>
+
+      </c:if>
+      <p class="text-muted">Only the following persons can see your responses: </p>
+      <ul class="text-muted">
+        <c:if test="${empty questionWithResponses.question.visibilityMessages}">
+          <li class="unordered">No-one but the feedback session creator can see your responses.</li>
+        </c:if>
+
+        <c:forEach items="${questionWithResponses.question.visibilityMessages}" var="line">
+          <li class="unordered">${line}</li>
+        </c:forEach>
+      </ul>
+
+      <c:if test="${questionWithResponses.question.giverTeam}">
+        <p class="text-warning">Please note that you are submitting this response on behalf of your team.</p>
+      </c:if>
+
+      <c:if test="${questionWithResponses.numOfResponseBoxes eq 0}">
+        <p class="text-warning">${questionWithResponses.question.messageToDisplayIfNoRecipientAvailable}</p>
+      </c:if>
+
+      <c:forEach items="${questionWithResponses.responses}" var="response">
+        <feedbackSubmissionEdit:response response="${response}" isSessionOpenForSubmission="${isSessionOpenForSubmission}"
+            questionWithResponses="${questionWithResponses}"/>
+      </c:forEach>
+    </div>
+  </div>
 </div>
 <br><br>

--- a/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/response.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackSubmissionEdit/response.tag
@@ -11,39 +11,39 @@
 <c:set var="isRecipientTeam" value="${questionWithResponses.question.recipientTeam}"/>
 
 <c:choose>
-    <c:when test="${isRecipientNameHidden}"><c:set var="divClassType" value="col-sm-12"/></c:when>
-    <c:when test="${isNumResponsesMax}"><c:set var="divClassType" value="col-sm-10"/></c:when>
-    <c:otherwise><c:set var="divClassType" value="col-sm-8"/></c:otherwise>
+  <c:when test="${isRecipientNameHidden}"><c:set var="divClassType" value="col-sm-12"/></c:when>
+  <c:when test="${isNumResponsesMax}"><c:set var="divClassType" value="col-sm-10"/></c:when>
+  <c:otherwise><c:set var="divClassType" value="col-sm-8"/></c:otherwise>
 </c:choose>
 
 <c:set var="autoWidth" value="" />
 <c:if test="${questionWithResponses.question.questionTypeConstsum}">
-    <c:set var="autoWidth" value="width-auto" />
+  <c:set var="autoWidth" value="width-auto" />
 </c:if>
 
 <br>
 <div class="form-group margin-0">
-    <div ${isNumResponsesMax ? 'class="col-sm-2 form-inline mobile-align-left"' : 'class="col-sm-4 form-inline mobile-align-left"'}
-         ${isRecipientNameHidden ?  'style="display:none"' : 'style="text-align:right"'}>
+  <div ${isNumResponsesMax ? 'class="col-sm-2 form-inline mobile-align-left"' : 'class="col-sm-4 form-inline mobile-align-left"'}
+      ${isRecipientNameHidden ?  'style="display:none"' : 'style="text-align:right"'}>
 
-        <label for="input">To${isRecipientTeam ? ' Team' : ''}: </label>
+    <label for="input">To${isRecipientTeam ? ' Team' : ''}: </label>
 
-        <select class="participantSelect middlealign<c:if test="${not response.existingResponse}"> newResponse</c:if> form-control"
-                name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT %>-${questionWithResponses.question.qnIndx}-${response.responseIndx}"
-                ${isNumResponsesMax ? 'style="display:none;max-width:125px"' : 'style="width:275px;max-width:275px"'}
-                ${isSessionOpenForSubmission ? '' : 'disabled' }>
+    <select class="participantSelect middlealign<c:if test="${not response.existingResponse}"> newResponse</c:if> form-control"
+        name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT %>-${questionWithResponses.question.qnIndx}-${response.responseIndx}"
+        ${isNumResponsesMax ? 'style="display:none;max-width:125px"' : 'style="width:275px;max-width:275px"'}
+        ${isSessionOpenForSubmission ? '' : 'disabled' }>
 
-                <c:forEach items="${response.recipientOptionsForQuestion}" var="option">
-                    ${option}
-                </c:forEach>
-        </select>
-    </div>
-    <div class="${divClassType}<c:if test="${questionWithResponses.question.questionTypeConstsum}"> width-auto</c:if>">
-        ${response.submissionFormHtml}
-        <c:if test="${response.existingResponse}">
-            <input type="hidden"
-                name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>-${questionWithResponses.question.qnIndx}-${response.responseIndx}"
-                value="<c:out value="${response.responseId}"/>">
-        </c:if>
-    </div>
+      <c:forEach items="${response.recipientOptionsForQuestion}" var="option">
+        ${option}
+      </c:forEach>
+    </select>
+  </div>
+  <div class="${divClassType}<c:if test="${questionWithResponses.question.questionTypeConstsum}"> width-auto</c:if>">
+    ${response.submissionFormHtml}
+    <c:if test="${response.existingResponse}">
+      <input type="hidden"
+          name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>-${questionWithResponses.question.qnIndx}-${response.responseIndx}"
+          value="<c:out value="${response.responseId}"/>">
+    </c:if>
+  </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/courseDetails/displayDetails.tag
+++ b/src/main/webapp/WEB-INF/tags/student/courseDetails/displayDetails.tag
@@ -3,12 +3,12 @@
 <%@ attribute name="id" required="true" %>
 
 <div class="form-group">
-    <label class="col-sm-3 control-label">
-        <jsp:invoke fragment="heading"/>
-    </label>
-    <div class="col-sm-9">
-        <p class="form-control-static" id="${id}">
-            <jsp:doBody/>
-        </p>
-    </div>
+  <label class="col-sm-3 control-label">
+    <jsp:invoke fragment="heading"/>
+  </label>
+  <div class="col-sm-9">
+    <p class="form-control-static" id="${id}">
+      <jsp:doBody/>
+    </p>
+  </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/courseDetails/displayInstructors.tag
+++ b/src/main/webapp/WEB-INF/tags/student/courseDetails/displayInstructors.tag
@@ -2,11 +2,11 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <c:forEach items="${data.studentCourseDetailsPanel.instructors}" var="instructor">
-    <c:if test="${instructor.displayedToStudents}">
-        ${instructor.displayedName}:
-        <a href="mailto:${instructor.email}">
-            ${instructor.name} (${instructor.email})
-        </a>
-        <br>
-    </c:if>
+  <c:if test="${instructor.displayedToStudents}">
+    ${instructor.displayedName}:
+    <a href="mailto:${instructor.email}">
+      ${instructor.name} (${instructor.email})
+    </a>
+    <br>
+  </c:if>
 </c:forEach>

--- a/src/main/webapp/WEB-INF/tags/student/courseDetails/displayTeammates.tag
+++ b/src/main/webapp/WEB-INF/tags/student/courseDetails/displayTeammates.tag
@@ -3,34 +3,34 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
 <c:choose>
-    <c:when test="${(empty data.studentCourseDetailsPanel.teammates)
-                         or (fn:length(data.studentCourseDetailsPanel.teammates) eq 1)}">
-        <span style="font-style: italic;">
-            You have no team members or you are not registered in any team
-        </span>
-    </c:when>
+  <c:when test="${(empty data.studentCourseDetailsPanel.teammates)
+      or (fn:length(data.studentCourseDetailsPanel.teammates) eq 1)}">
+    <span style="font-style: italic;">
+      You have no team members or you are not registered in any team
+    </span>
+  </c:when>
 
-    <c:otherwise>
-        <table>
-            <tbody>
-                <c:forEach items="${data.studentCourseDetailsPanel.teammates}" var="student">
-                    <c:if test="${not (student.email eq data.studentCourseDetailsPanel.studentEmail)}">
-                        <tr>
-                            <td class="teamMembersPhotoCell" title="${student.name}" data-toggle="tooltip"
-                                    data-placement="top">
-                                <img id="profilePic" src="${student.publicProfilePictureUrl}"
-                                        class="profile-pic" data-toggle="modal">
-                            </td>
-                            <td class="teamMembersDetailsCell">
-                                <label>Name:</label>
-                                <c:out value=" ${student.name}" /> <br>
-                                <label>Email:</label>
-                                <a href="mailto:${student.email}"><c:out value="${student.email}"/></a>
-                            </td>
-                        </tr>
-                    </c:if>
-                </c:forEach>
-            </tbody>
-        </table>
-    </c:otherwise>
+  <c:otherwise>
+    <table>
+      <tbody>
+        <c:forEach items="${data.studentCourseDetailsPanel.teammates}" var="student">
+          <c:if test="${not (student.email eq data.studentCourseDetailsPanel.studentEmail)}">
+            <tr>
+              <td class="teamMembersPhotoCell" title="${student.name}" data-toggle="tooltip" data-placement="top">
+                <img id="profilePic" src="${student.publicProfilePictureUrl}" class="profile-pic" data-toggle="modal">
+              </td>
+              <td class="teamMembersDetailsCell">
+                <label>Name:</label>
+                <c:out value=" ${student.name}" /> <br>
+                <label>Email:</label>
+                <a href="mailto:${student.email}">
+                  <c:out value="${student.email}"/>
+                </a>
+              </td>
+            </tr>
+          </c:if>
+        </c:forEach>
+      </tbody>
+    </table>
+  </c:otherwise>
 </c:choose>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackResults/displayFeedbackSessionInfo.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackResults/displayFeedbackSessionInfo.tag
@@ -2,12 +2,12 @@
 <%@ attribute name="label" required="true" %>
 
 <div class="form-group">
-    <label class="col-sm-2 control-label">
-        ${label}
-    </label>
-    <div class="col-sm-10">
-        <p class="form-control-static">
-            <jsp:doBody/>
-        </p>
-    </div>
+  <label class="col-sm-2 control-label">
+    ${label}
+  </label>
+  <div class="col-sm-10">
+    <p class="form-control-static">
+      <jsp:doBody/>
+    </p>
+  </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackResults/feedbackSessionDetailsPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackResults/feedbackSessionDetailsPanel.tag
@@ -4,26 +4,26 @@
 <%@ attribute name="feedbackSession" type="teammates.common.datatransfer.attributes.FeedbackSessionAttributes" required="true" %>
 
 <div class="well well-plain">
-    <div class="panel-body">
-        <div class="form-horizontal">
-            <div class="panel-heading">
-                <feedbackResults:displayFeedbackSessionInfo label="Course ID:">
-                    <c:out value="${feedbackSession.courseId}"/>
-                </feedbackResults:displayFeedbackSessionInfo>
+  <div class="panel-body">
+    <div class="form-horizontal">
+      <div class="panel-heading">
+        <feedbackResults:displayFeedbackSessionInfo label="Course ID:">
+          <c:out value="${feedbackSession.courseId}"/>
+        </feedbackResults:displayFeedbackSessionInfo>
 
-                <feedbackResults:displayFeedbackSessionInfo label="Session:">
-                    <c:out value="${feedbackSession.feedbackSessionName}"/>
-                </feedbackResults:displayFeedbackSessionInfo>
+        <feedbackResults:displayFeedbackSessionInfo label="Session:">
+          <c:out value="${feedbackSession.feedbackSessionName}"/>
+        </feedbackResults:displayFeedbackSessionInfo>
 
-                <feedbackResults:displayFeedbackSessionInfo label="Opening time:">
-                    ${feedbackSession.startTimeString}
-                </feedbackResults:displayFeedbackSessionInfo>
+        <feedbackResults:displayFeedbackSessionInfo label="Opening time:">
+          ${feedbackSession.startTimeString}
+        </feedbackResults:displayFeedbackSessionInfo>
 
-                <feedbackResults:displayFeedbackSessionInfo label="Closing time:">
-                    ${feedbackSession.endTimeString}
-                </feedbackResults:displayFeedbackSessionInfo>
-            </div>
-        </div>
+        <feedbackResults:displayFeedbackSessionInfo label="Closing time:">
+          ${feedbackSession.endTimeString}
+        </feedbackResults:displayFeedbackSessionInfo>
+      </div>
     </div>
+  </div>
 </div>
 <br>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackResults/questionWithResponses.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackResults/questionWithResponses.tag
@@ -4,19 +4,19 @@
 <%@ attribute name="questionWithResponses" type="teammates.ui.template.StudentFeedbackResultsQuestionWithResponses" required="true" %>
 
 <div class="panel panel-default">
-    <div class="panel-heading">
-        <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
-        <h4>Question ${questionWithResponses.questionDetails.questionIndex}: <span class="text-preserve-space"><c:out value="${questionWithResponses.questionDetails.questionText}"/>${questionWithResponses.questionDetails.additionalInfo}</span></h4>
+  <div class="panel-heading">
+    <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
+    <h4>Question ${questionWithResponses.questionDetails.questionIndex}: <span class="text-preserve-space"><c:out value="${questionWithResponses.questionDetails.questionText}"/>${questionWithResponses.questionDetails.additionalInfo}</span></h4>
 
-        ${questionWithResponses.questionDetails.questionResultStatistics}
+    ${questionWithResponses.questionDetails.questionResultStatistics}
 
-        <c:if test="${questionWithResponses.questionDetails.individualResponsesShownToStudents}">
+    <c:if test="${questionWithResponses.questionDetails.individualResponsesShownToStudents}">
 
-            <c:forEach items="${questionWithResponses.responseTables}" var="responseTable">
-                <feedbackResults:responseTable responseTable="${responseTable}"/>
-            </c:forEach>
+      <c:forEach items="${questionWithResponses.responseTables}" var="responseTable">
+        <feedbackResults:responseTable responseTable="${responseTable}"/>
+      </c:forEach>
 
-        </c:if>
-    </div>
+    </c:if>
+  </div>
 </div>
 <br>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackResults/response.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackResults/response.tag
@@ -5,24 +5,24 @@
 <%@ attribute name="response" type="teammates.ui.template.FeedbackResultsResponse" required="true" %>
 
 <tr class="resultSubheader">
-    <td>
-        <span class="bold"><b>From:</b></span> ${fn:escapeXml(response.giverName)}
-    </td>
+  <td>
+    <span class="bold"><b>From:</b></span> ${fn:escapeXml(response.giverName)}
+  </td>
 </tr>
 
 <tr>
-    <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
-    <td class="text-preserve-space">${response.answer}</td>
+  <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
+  <td class="text-preserve-space">${response.answer}</td>
 </tr>
 
 <c:if test="${not empty response.comments}">
-    <tr>
-        <td>
-            <ul class="list-group comment-list">
-                <c:forEach items="${response.comments}" var="comment">
-                    <shared:feedbackResponseCommentRow frc="${comment}" />
-                </c:forEach>
-            </ul>
-        </td>
-    </tr>
+  <tr>
+    <td>
+      <ul class="list-group comment-list">
+        <c:forEach items="${response.comments}" var="comment">
+          <shared:feedbackResponseCommentRow frc="${comment}" />
+        </c:forEach>
+      </ul>
+    </td>
+  </tr>
 </c:if>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackResults/responseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackResults/responseTable.tag
@@ -5,21 +5,23 @@
 <%@ attribute name="responseTable" type="teammates.ui.template.FeedbackResultsResponseTable" required="true" %>
 
 <c:choose>
-    <c:when test="${responseTable.giverNameYou}">
-        <c:set value="panel-info" var="panelHeaderClass"/>
-    </c:when>
-    <c:otherwise>
-        <c:set value="panel-primary" var="panelHeaderClass"/>
-    </c:otherwise>
+  <c:when test="${responseTable.giverNameYou}">
+    <c:set value="panel-info" var="panelHeaderClass"/>
+  </c:when>
+  <c:otherwise>
+    <c:set value="panel-primary" var="panelHeaderClass"/>
+  </c:otherwise>
 </c:choose>
 
 <div class="panel ${panelHeaderClass}">
-    <div class="panel-heading"><b>To:</b> ${fn:escapeXml(responseTable.recipientName)}</div>
-    <table class="table">
-        <tbody>
-            <c:forEach items="${responseTable.responses}" var="response">
-                <feedbackResults:response response="${response}"/>
-            </c:forEach>
-        </tbody>
-    </table>
+  <div class="panel-heading">
+    <b>To:</b> ${fn:escapeXml(responseTable.recipientName)}
+  </div>
+  <table class="table">
+    <tbody>
+      <c:forEach items="${responseTable.responses}" var="response">
+        <feedbackResults:response response="${response}"/>
+      </c:forEach>
+    </tbody>
+  </table>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/home/coursePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/coursePanel.tag
@@ -4,18 +4,17 @@
 <%@ tag import="teammates.common.util.Const" %>
 <%@ attribute name="courseTable" type="teammates.ui.template.CourseTable" required="true" %>
 <div class="panel panel-primary">
-    <div class="panel-heading">
-        <strong>
-            [${courseTable.courseId}] : ${fn:escapeXml(courseTable.courseName)}
-        </strong>
-        <span class="pull-right">
-            <c:forEach items="${courseTable.buttons}" var="button">
-                <a class="btn btn-primary btn-xs" data-toggle="tooltip" data-placement="top"
-                   ${button.attributesToString}>
-                    ${button.content}
-                </a>
-            </c:forEach>
-        </span>
-    </div>
-    <jsp:doBody />
+  <div class="panel-heading">
+    <strong>
+      [${courseTable.courseId}] : ${fn:escapeXml(courseTable.courseName)}
+    </strong>
+    <span class="pull-right">
+      <c:forEach items="${courseTable.buttons}" var="button">
+        <a class="btn btn-primary btn-xs" data-toggle="tooltip" data-placement="top" ${button.attributesToString}>
+          ${button.content}
+        </a>
+      </c:forEach>
+    </span>
+  </div>
+  <jsp:doBody />
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
@@ -4,38 +4,37 @@
 <%@ tag import="teammates.common.util.Const" %>
 <%@ attribute name="sessionRows" type="java.util.Collection" required="true" %>
 <table class="table-responsive table table-striped">
-    <c:choose>
-        <c:when test="${not empty sessionRows}">
-            <thead>
-                <tr>
-                    <th>Session Name</th>
-                    <th>Deadline</th>
-                    <th>Status</th>
-                    <th class="studentHomeActions">Action(s)</th>
-                </tr>
-            </thead>
-            <c:forEach items="${sessionRows}" var="sessionRow">
-                <tr class="home_evaluations_row" id="evaluation${sessionRow.index}">
-                    <td>${sessionRow.name}</td>
-                    <td>${sessionRow.endTime}</td>
-                    <td>
-                        <span data-toggle="tooltip" data-placement="top"
-                              title="${sessionRow.tooltip}">
-                            ${sessionRow.status}
-                        </span>
-                    </td>
-                    <td class="studentHomeActions">
-                        <home:rowActions actions="${sessionRow.actions}" index="${sessionRow.index}" />
-                    </td>
-                </tr>
-            </c:forEach>
-        </c:when>
-        <c:otherwise>
-            <tr>
-                <th class="align-center bold color_white">
-                    Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified.
-                </th>
-            </tr>
-        </c:otherwise>
-    </c:choose>
+  <c:choose>
+    <c:when test="${not empty sessionRows}">
+      <thead>
+        <tr>
+          <th>Session Name</th>
+          <th>Deadline</th>
+          <th>Status</th>
+          <th class="studentHomeActions">Action(s)</th>
+        </tr>
+      </thead>
+      <c:forEach items="${sessionRows}" var="sessionRow">
+        <tr class="home_evaluations_row" id="evaluation${sessionRow.index}">
+          <td>${sessionRow.name}</td>
+          <td>${sessionRow.endTime}</td>
+          <td>
+            <span data-toggle="tooltip" data-placement="top" title="${sessionRow.tooltip}">
+              ${sessionRow.status}
+            </span>
+          </td>
+          <td class="studentHomeActions">
+            <home:rowActions actions="${sessionRow.actions}" index="${sessionRow.index}" />
+          </td>
+        </tr>
+      </c:forEach>
+    </c:when>
+    <c:otherwise>
+      <tr>
+        <th class="align-center bold color_white">
+          Currently, there are no open evaluation/feedback sessions in this course. When a session is open for submission you will be notified.
+        </th>
+      </tr>
+    </c:otherwise>
+  </c:choose>
 </table>

--- a/src/main/webapp/WEB-INF/tags/student/home/rowActions.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/rowActions.tag
@@ -4,39 +4,39 @@
 <%@ attribute name="actions" type="teammates.ui.template.StudentFeedbackSessionActions" required="true" %>
 <%@ attribute name="index" required="true" %>
 <a class="btn btn-default btn-xs btn-tm-actions"
-   href="${actions.sessionPublished ? actions.studentFeedbackResultsLink : 'javascript:;'}"
-   name="viewFeedbackResults${index}"
-   id="viewFeedbackResults${index}"
-   data-toggle="tooltip"
-   data-placement="top"
-   title="<%= Const.Tooltips.FEEDBACK_SESSION_RESULTS %>"
-   role="button"
-   <c:if test="${not actions.sessionPublished}">disabled</c:if>>
-    View Responses
+    href="${actions.sessionPublished ? actions.studentFeedbackResultsLink : 'javascript:;'}"
+    name="viewFeedbackResults${index}"
+    id="viewFeedbackResults${index}"
+    data-toggle="tooltip"
+    data-placement="top"
+    title="<%= Const.Tooltips.FEEDBACK_SESSION_RESULTS %>"
+    role="button"
+    <c:if test="${not actions.sessionPublished}">disabled</c:if>>
+  View Responses
 </a>
 <c:choose>
-    <c:when test="${actions.submitted}">
-        <a class="btn btn-default btn-xs btn-tm-actions"
-           href="${actions.studentFeedbackResponseEditLink}"
-           name="editFeedbackResponses${index}"
-           id="editFeedbackResponses${index}"
-           data-toggle="tooltip"
-           data-placement="top"
-           title="${actions.tooltipText}"
-           role="button">
-            ${actions.buttonText}
-        </a>
-    </c:when>
-    <c:otherwise>
-        <a class="btn btn-default btn-xs btn-tm-actions"
-           href="${actions.sessionVisible ? actions.studentFeedbackResponseEditLink : 'javascript:;'}"
-           id="submitFeedback${index}"
-           data-toggle="tooltip"
-           data-placement="top"
-           title="${actions.tooltipText}"
-           role="button"
-           <c:if test="${not actions.sessionVisible}">disabled</c:if>>
-            ${actions.buttonText}
-        </a>
-    </c:otherwise>
+  <c:when test="${actions.submitted}">
+    <a class="btn btn-default btn-xs btn-tm-actions"
+        href="${actions.studentFeedbackResponseEditLink}"
+        name="editFeedbackResponses${index}"
+        id="editFeedbackResponses${index}"
+        data-toggle="tooltip"
+        data-placement="top"
+        title="${actions.tooltipText}"
+        role="button">
+      ${actions.buttonText}
+    </a>
+  </c:when>
+  <c:otherwise>
+    <a class="btn btn-default btn-xs btn-tm-actions"
+        href="${actions.sessionVisible ? actions.studentFeedbackResponseEditLink : 'javascript:;'}"
+        id="submitFeedback${index}"
+        data-toggle="tooltip"
+        data-placement="top"
+        title="${actions.tooltipText}"
+        role="button"
+        <c:if test="${not actions.sessionVisible}">disabled</c:if>>
+      ${actions.buttonText}
+    </a>
+  </c:otherwise>
 </c:choose>

--- a/src/main/webapp/WEB-INF/tags/student/navBar.tag
+++ b/src/main/webapp/WEB-INF/tags/student/navBar.tag
@@ -5,45 +5,47 @@
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <c:set var="isUnregistered" value="${data.unregisteredStudent}" />
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#contentLinks">
-                 <span class="sr-only">Toggle navigation</span>
-                 <span class="icon-bar"></span>
-                 <span class="icon-bar"></span>
-                 <span class="icon-bar"></span>
-            </button>
-            <t:teammatesLogo/>
-        </div>
-        <div class="collapse navbar-collapse" id="contentLinks">
-            <ul class="nav navbar-nav">
-                <li<c:if test="${fn:contains(data.class,'StudentHome')}"> class="active"</c:if>>
-                    <a class="navLinks" id="studentHomeNavLink" href="${data.studentHomeLink}"
-                       <c:if test="${isUnregistered}">data-unreg="true"</c:if>>
-                        Home
-                    </a>
-                </li>
-                <li<c:if test="${fn:contains(data.class,'StudentProfilePage')}"> class="active"</c:if>>
-                    <a class="navLinks" id="studentProfileNavLink" href="${data.studentProfileLink}"
-                       <c:if test="${isUnregistered}">data-unreg="true"</c:if>>
-                        Profile
-                    </a>
-                </li>
-                <li<c:if test="${fn:contains(data.class,'StudentHelp')}"> class="active"</c:if>>
-                    <a id="studentHelpLink" class="nav" href="/studentHelp.jsp" target="_blank" rel="noopener noreferrer">Help</a>
-                </li>
-            </ul>
-            <c:if test="${not empty data.account && not empty data.account.googleId}">
-                <ul class="nav navbar-nav pull-right">
-                    <li>
-                        <a id="btnLogout" class="nav logout" href="<%= Const.ActionURIs.LOGOUT %>">Logout
-                            (<span class="text-info" data-toggle="tooltip" title="${data.account.googleId}" data-placement="bottom">
-                                ${data.account.truncatedGoogleId}
-                            </span>)
-                        </a>
-                    </li>
-                </ul>
-            </c:if>
-        </div>
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#contentLinks">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <t:teammatesLogo/>
     </div>
+    <div class="collapse navbar-collapse" id="contentLinks">
+      <ul class="nav navbar-nav">
+        <li<c:if test="${fn:contains(data.class,'StudentHome')}"> class="active"</c:if>>
+          <a class="navLinks" id="studentHomeNavLink" href="${data.studentHomeLink}"
+              <c:if test="${isUnregistered}">data-unreg="true"</c:if>>
+            Home
+          </a>
+        </li>
+        <li<c:if test="${fn:contains(data.class,'StudentProfilePage')}"> class="active"</c:if>>
+          <a class="navLinks" id="studentProfileNavLink" href="${data.studentProfileLink}"
+              <c:if test="${isUnregistered}">data-unreg="true"</c:if>>
+            Profile
+          </a>
+        </li>
+        <li<c:if test="${fn:contains(data.class,'StudentHelp')}"> class="active"</c:if>>
+          <a id="studentHelpLink" class="nav" href="/studentHelp.jsp" target="_blank" rel="noopener noreferrer">Help</a>
+        </li>
+      </ul>
+      <c:if test="${not empty data.account && not empty data.account.googleId}">
+        <ul class="nav navbar-nav pull-right">
+          <li>
+            <a id="btnLogout" class="nav logout" href="<%= Const.ActionURIs.LOGOUT %>">
+              Logout (
+              <span class="text-info" data-toggle="tooltip" title="${data.account.googleId}" data-placement="bottom">
+                ${data.account.truncatedGoogleId}
+              </span>
+              )
+            </a>
+          </li>
+        </ul>
+      </c:if>
+    </div>
+  </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/profile/studentProfileDiv.tag
+++ b/src/main/webapp/WEB-INF/tags/student/profile/studentProfileDiv.tag
@@ -7,159 +7,158 @@
 <c:set var="FEMALE" value="<%= Const.GenderTypes.FEMALE %>" />
 <c:set var="OTHER" value="<%= Const.GenderTypes.OTHER %>" />
 <div id="editProfileDiv" class="well well-plain well-narrow well-sm-wide">
-    <h3 id="studentName">
-        <strong>${profile.name}</strong>
-    </h3>
-    <br>
-    <div class="form-group row">
-        <div class="col-xs-6 col-sm-5 col-md-3 cursor-pointer"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_PICTURE %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <img id="profilePic"
-                 src="${profile.pictureUrl}"
-                 class="profile-pic"
-                 data-toggle="modal"
-                 data-target="#studentPhotoUploader"
-                 data-edit="${profile.editingPhoto}">
-        </div>
-        <div class="">
-            <button id="uploadEditPhoto"
-                    class="btn btn-primary"
-                    type="button"
-                    data-toggle="modal"
-                    data-target="#studentPhotoUploader">
-                Upload/Edit Photo
-            </button>
-        </div>
+  <h3 id="studentName">
+    <strong>${profile.name}</strong>
+  </h3>
+  <br>
+  <div class="form-group row">
+    <div class="col-xs-6 col-sm-5 col-md-3 cursor-pointer"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_PICTURE %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <img id="profilePic"
+          src="${profile.pictureUrl}"
+          class="profile-pic"
+          data-toggle="modal"
+          data-target="#studentPhotoUploader"
+          data-edit="${profile.editingPhoto}">
     </div>
-    <form class="form center-block"
-          role="form"
-          method="post"
-          action="<%= Const.ActionURIs.STUDENT_PROFILE_EDIT_SAVE %>">
-        <div class="form-group"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_SHORTNAME %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <label for="studentNickname">
-                The name you prefer to be called by Instructors
-            </label>
-            <input id="studentShortname"
-                   name="<%= Const.ParamsNames.STUDENT_SHORT_NAME %>"
-                   class="form-control"
-                   type="text"
-                   data-actual-value="<c:out value="${profile.shortName}"/>"
-                   value="<c:out value="${profile.shortName}"/>"
-                   placeholder="How the instructor should call you">
+    <div class="">
+      <button id="uploadEditPhoto"
+          class="btn btn-primary"
+          type="button"
+          data-toggle="modal"
+          data-target="#studentPhotoUploader">
+        Upload/Edit Photo
+      </button>
+    </div>
+  </div>
+  <form class="form center-block"
+      role="form"
+      method="post"
+      action="<%= Const.ActionURIs.STUDENT_PROFILE_EDIT_SAVE %>">
+    <div class="form-group"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_SHORTNAME %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <label for="studentNickname">
+        The name you prefer to be called by Instructors
+      </label>
+      <input id="studentShortname"
+          name="<%= Const.ParamsNames.STUDENT_SHORT_NAME %>"
+          class="form-control"
+          type="text"
+          data-actual-value="<c:out value="${profile.shortName}"/>"
+          value="<c:out value="${profile.shortName}"/>"
+          placeholder="How the instructor should call you">
+    </div>
+    <div class="form-group"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_EMAIL %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <label for="studentEmail">
+        Long term contact email <em class="font-weight-normal emphasis text-muted small">- only visible to your instructors</em>
+      </label>
+      <input id="studentEmail"
+          name="<%= Const.ParamsNames.STUDENT_PROFILE_EMAIL %>"
+          class="form-control"
+          type="email"
+          data-actual-value="<c:out value="${profile.email}"/>"
+          value="<c:out value="${profile.email}"/>"
+          placeholder="Contact Email (for your instructors to contact you beyond graduation)">
+    </div>
+    <div class="form-group"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_INSTITUTION %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <label for="studentInstitution">
+        Institution
+      </label>
+      <input id="studentInstitution"
+          name="<%= Const.ParamsNames.STUDENT_PROFILE_INSTITUTION %>"
+          class="form-control"
+          type="text"
+          data-actual-value="<c:out value="${profile.institute}"/>"
+          value="<c:out value="${profile.institute}"/>"
+          placeholder="Your Institution">
+    </div>
+    <div class="form-group"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_NATIONALITY %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <label for="studentNationality">
+        Nationality
+      </label>
+      <select id="studentNationality"
+          name="<%=Const.ParamsNames.STUDENT_NATIONALITY%>"
+          class="form-control" style="width: 300px">
+        <c:forEach items="${profile.nationalitySelectField}" var="option">
+          <option ${option.attributesToString}>
+            ${option.content}
+          </option>
+        </c:forEach>
+      </select>
+      <input type="hidden" name="existingNationality" value="${profile.nationality}">
+      <c:if test="${not empty profile.legacyNationalityInstructions}">
+        <div class="text-color-red">
+          ${profile.legacyNationalityInstructions}
         </div>
-        <div class="form-group"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_EMAIL %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <label for="studentEmail">
-                Long term contact email <em class="font-weight-normal emphasis text-muted small">- only visible to your instructors</em>
-            </label>
-            <input id="studentEmail"
-                   name="<%= Const.ParamsNames.STUDENT_PROFILE_EMAIL %>"
-                   class="form-control"
-                   type="email"
-                   data-actual-value="<c:out value="${profile.email}"/>"
-                   value="<c:out value="${profile.email}"/>"
-                   placeholder="Contact Email (for your instructors to contact you beyond graduation)">
-        </div>
-        <div class="form-group"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_INSTITUTION %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <label for="studentInstitution">
-                Institution
-            </label>
-            <input id="studentInstitution"
-                   name="<%= Const.ParamsNames.STUDENT_PROFILE_INSTITUTION %>"
-                   class="form-control"
-                   type="text"
-                   data-actual-value="<c:out value="${profile.institute}"/>"
-                   value="<c:out value="${profile.institute}"/>"
-                   placeholder="Your Institution">
-        </div>
-        <div class="form-group"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_NATIONALITY %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <label for="studentNationality">
-                Nationality
-            </label>
-            <select id="studentNationality"
-                    name="<%=Const.ParamsNames.STUDENT_NATIONALITY%>"
-                    class="form-control" style="width: 300px">
-                <c:forEach items="${profile.nationalitySelectField}"
-                           var="option">
-                    <option ${option.attributesToString}>
-                        ${option.content}
-                    </option>
-                </c:forEach>
-            </select>
-            <input type="hidden" name="existingNationality" value="${profile.nationality}">
-            <c:if test="${not empty profile.legacyNationalityInstructions}">
-                <div class="text-color-red">
-                    ${profile.legacyNationalityInstructions}
-                </div>
-            </c:if>
-        </div>
-        <div class="form-group">
-            <label for="studentGender">
-                Gender
-            </label>
-            <div id="studentGender">
-                <label for="genderMale" class="radio-inline">
-                    <input id="genderMale"
-                           name="<%= Const.ParamsNames.STUDENT_GENDER %>"
-                           class="radio"
-                           type="radio"
-                           value="<%= Const.GenderTypes.MALE %>"
-                           <c:if test="${profile.gender == MALE}">checked</c:if>> Male
-                </label>
-                <label for="genderFemale" class="radio-inline">
-                    <input id="genderFemale"
-                           name="<%= Const.ParamsNames.STUDENT_GENDER %>"
-                           class="radio"
-                           type="radio"
-                           value="<%= Const.GenderTypes.FEMALE %>"
-                           <c:if test="${profile.gender == FEMALE}">checked</c:if>> Female
-                </label>
-                <label class="radio-inline" for="genderOther">
-                    <input id="genderOther"
-                           name="<%= Const.ParamsNames.STUDENT_GENDER %>"
-                           class="radio"
-                           type="radio"
-                           value="<%= Const.GenderTypes.OTHER %>"
-                           <c:if test="${profile.gender == OTHER}">checked</c:if>> Not Specified
-                </label>
-            </div>
-        </div>
-        <div class="form-group"
-             title="<%= Const.Tooltips.STUDENT_PROFILE_MOREINFO %>"
-             data-toggle="tooltip"
-             data-placement="top">
-            <label for="studentNationality">
-                More info about yourself
-            </label>
-            <%-- Do not add whitespace between the opening and closing tags --%>
-            <textarea id="studentMoreInfo"
-                      name="<%= Const.ParamsNames.STUDENT_PROFILE_MOREINFO %>"
-                      rows="4"
-                      class="form-control"
-                      placeholder="<%= Const.Tooltips.STUDENT_PROFILE_MOREINFO %>">${profile.moreInfo}</textarea>
-        </div>
-        <br>
-        <button type="submit" id="profileEditSubmit" class="btn btn-primary center-block">
-            Save Profile
-        </button>
-        <br>
-        <p class="text-muted text-color-disclaimer">
-            <i>* This profile will be visible to all your Instructors and Coursemates</i>
-        </p>
-        <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${profile.googleId}">
-        <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
-    </form>
+      </c:if>
+    </div>
+    <div class="form-group">
+      <label for="studentGender">
+        Gender
+      </label>
+      <div id="studentGender">
+        <label for="genderMale" class="radio-inline">
+          <input id="genderMale"
+              name="<%= Const.ParamsNames.STUDENT_GENDER %>"
+              class="radio"
+              type="radio"
+              value="<%= Const.GenderTypes.MALE %>"
+              <c:if test="${profile.gender == MALE}">checked</c:if>> Male
+        </label>
+        <label for="genderFemale" class="radio-inline">
+          <input id="genderFemale"
+              name="<%= Const.ParamsNames.STUDENT_GENDER %>"
+              class="radio"
+              type="radio"
+              value="<%= Const.GenderTypes.FEMALE %>"
+              <c:if test="${profile.gender == FEMALE}">checked</c:if>> Female
+        </label>
+        <label class="radio-inline" for="genderOther">
+          <input id="genderOther"
+              name="<%= Const.ParamsNames.STUDENT_GENDER %>"
+              class="radio"
+              type="radio"
+              value="<%= Const.GenderTypes.OTHER %>"
+              <c:if test="${profile.gender == OTHER}">checked</c:if>> Not Specified
+        </label>
+      </div>
+    </div>
+    <div class="form-group"
+        title="<%= Const.Tooltips.STUDENT_PROFILE_MOREINFO %>"
+        data-toggle="tooltip"
+        data-placement="top">
+      <label for="studentNationality">
+        More info about yourself
+      </label>
+      <%-- Do not add whitespace between the opening and closing tags --%>
+      <textarea id="studentMoreInfo"
+          name="<%= Const.ParamsNames.STUDENT_PROFILE_MOREINFO %>"
+          rows="4"
+          class="form-control"
+          placeholder="<%= Const.Tooltips.STUDENT_PROFILE_MOREINFO %>">${profile.moreInfo}</textarea>
+    </div>
+    <br>
+    <button type="submit" id="profileEditSubmit" class="btn btn-primary center-block">
+      Save Profile
+    </button>
+    <br>
+    <p class="text-muted text-color-disclaimer">
+      <i>* This profile will be visible to all your Instructors and Coursemates</i>
+    </p>
+    <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${profile.googleId}">
+    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
+  </form>
 </div>

--- a/src/main/webapp/WEB-INF/tags/student/profile/uploadPhotoModal.tag
+++ b/src/main/webapp/WEB-INF/tags/student/profile/uploadPhotoModal.tag
@@ -5,125 +5,125 @@
 <%@ attribute name="sessionToken" required="true" %>
 <c:set var="DEFAULT_PROFILE_PICTURE_PATH" value="<%= Const.SystemParams.DEFAULT_PROFILE_PICTURE_PATH %>" />
 <div class="modal fade"
-     id="studentPhotoUploader"
-     role="dialog"
-     aria-labelledby="myModalLabel"
-     aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
+    id="studentPhotoUploader"
+    role="dialog"
+    aria-labelledby="myModalLabel"
+    aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button"
+            class="close"
+            data-dismiss="modal"
+            aria-hidden="true">
+          &times;
+        </button>
+        <h4 class="modal-title">
+          Upload/Edit Photo
+        </h4>
+      </div>
+      <div class="modal-body center-block align-center">
+        <br>
+        <div class="row">
+          <div class="col-xs-4 profile-pic-edit-col">
+            <div class="center-block align-center">
+              <form id="profilePictureUploadForm" method="post">
+                <span class="btn btn-primary profile-pic-file-selector">
+                  Browse...
+                  <input id="studentPhoto"
+                      type="file"
+                      name="<%= Const.ParamsNames.STUDENT_PROFILE_PHOTO %>">
+                </span>
+                <input type="text" class="filename-preview" value="No File Selected" disabled>
+                <p class="help-block align-left">
+                  Max Size: 5 MB
+                </p>
                 <button type="button"
-                        class="close"
-                        data-dismiss="modal"
-                        aria-hidden="true">
-                    &times;
+                    id="profileUploadPictureSubmit"
+                    class="btn btn-primary width-100-pc"
+                    disabled>
+                  Upload Picture
                 </button>
-                <h4 class="modal-title">
-                    Upload/Edit Photo
-                </h4>
+                <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${modal.googleId}">
+              </form>
             </div>
-            <div class="modal-body center-block align-center">
-                <br>
-                <div class="row">
-                    <div class="col-xs-4 profile-pic-edit-col">
-                        <div class="center-block align-center">
-                            <form id="profilePictureUploadForm" method="post">
-                                <span class="btn btn-primary profile-pic-file-selector">
-                                    Browse...
-                                    <input id="studentPhoto"
-                                           type="file"
-                                           name="<%= Const.ParamsNames.STUDENT_PROFILE_PHOTO %>">
-                                </span>
-                                <input type="text" class="filename-preview" value="No File Selected" disabled>
-                                <p class="help-block align-left">
-                                    Max Size: 5 MB
-                                </p>
-                                <button type="button"
-                                        id="profileUploadPictureSubmit"
-                                        class="btn btn-primary width-100-pc"
-                                        disabled>
-                                    Upload Picture
-                                </button>
-                                <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${modal.googleId}">
-                            </form>
-                        </div>
+          </div>
+          <div class="col-xs-8 profile-pic-edit-col border-left-gray">
+            <c:choose>
+              <c:when test="${modal.pictureUrl == DEFAULT_PROFILE_PICTURE_PATH}">
+                <div class="alert alert-warning">
+                  Please upload a photo to start editing.
+                </div>
+              </c:when>
+              <c:otherwise>
+                <div class="profile-pic-edit">
+                  <div class="alert alert-info">
+                    Zoom, pan and rotate to crop your image to the desired area.
+                  </div>
+                  <button id="profilePicEditPanUp" type="button" class="btn btn-primary">
+                    <span class="glyphicon glyphicon-arrow-up"></span>
+                  </button>
+                  <div class="profile-pic-edit-container row">
+                    <div class="col-xs-2">
+                      <button id="profilePicEditPanLeft" type="button" class="btn btn-primary">
+                        <span class="glyphicon glyphicon-arrow-left"></span>
+                      </button>
                     </div>
-                    <div class="col-xs-8 profile-pic-edit-col border-left-gray">
-                        <c:choose>
-                            <c:when test="${modal.pictureUrl == DEFAULT_PROFILE_PICTURE_PATH}">
-                                <div class="alert alert-warning">
-                                    Please upload a photo to start editing.
-                                </div>
-                            </c:when>
-                            <c:otherwise>
-                                <div class="profile-pic-edit">
-                                    <div class="alert alert-info">
-                                        Zoom, pan and rotate to crop your image to the desired area.
-                                    </div>
-                                    <button id="profilePicEditPanUp" type="button" class="btn btn-primary">
-                                        <span class="glyphicon glyphicon-arrow-up"></span>
-                                    </button>
-                                    <div class="profile-pic-edit-container row">
-                                        <div class="col-xs-2">
-                                            <button id="profilePicEditPanLeft" type="button" class="btn btn-primary">
-                                                <span class="glyphicon glyphicon-arrow-left"></span>
-                                            </button>
-                                        </div>
-                                        <div class="col-xs-8">
-                                            <img id="editableProfilePicture" src="${modal.pictureUrl}">
-                                        </div>
-                                        <div class="col-xs-2">
-                                            <button id="profilePicEditPanRight" type="button" class="btn btn-primary">
-                                                <span class="glyphicon glyphicon-arrow-right"></span>
-                                            </button>
-                                        </div>
-                                    </div>
-                                    <button id="profilePicEditPanDown" type="button" class="btn btn-primary">
-                                        <span class="glyphicon glyphicon-arrow-down"></span>
-                                    </button>
-                                    <div class="profile-pic-edit-toolbar">
-                                        <button id="profilePicEditRotateLeft" type="button" class="btn btn-primary">
-                                            <span class="glyphicon glyphicon-repeat glyphicon-flipped"></span>
-                                        </button>
-                                        <button id="profilePicEditZoomIn" type="button" class="btn btn-primary">
-                                            <span class="glyphicon glyphicon-zoom-in"></span>
-                                        </button>
-                                        <button id="profilePicEditZoomOut" type="button" class="btn btn-primary">
-                                            <span class="glyphicon glyphicon-zoom-out"></span>
-                                        </button>
-                                        <button id="profilePicEditRotateRight" type="button" class="btn btn-primary">
-                                            <span class="glyphicon glyphicon-repeat"></span>
-                                        </button>
-                                    </div>
-                                    <label for="editableProfilePicture">
-                                        Your Photo
-                                    </label>
-                                    <br>
-                                </div>
-                                <form id="profilePictureEditForm" method="post" action="<%= Const.ActionURIs.STUDENT_PROFILE_PICTURE_EDIT %>">
-                                    <input id="pictureHeight" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_HEIGHT %>" value="">
-                                    <input id="pictureWidth" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_WIDTH %>" value="">
-                                    <input id="cropBoxLeftX" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_LEFTX %>" value="">
-                                    <input id="cropBoxTopY" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_TOPY %>" value="">
-                                    <input id="cropBoxRightX" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_RIGHTX %>" value="">
-                                    <input id="cropBoxBottomY" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_BOTTOMY %>" value="">
-                                    <input id="rotate" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_ROTATE %>" value="">
-                                    <input id="blobKey" type="hidden" name="<%= Const.ParamsNames.BLOB_KEY %>" value="${modal.pictureKey}">
-                                    <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${modal.googleId}">
-                                    <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
-                                    <button type="button"
-                                            id="profileEditPictureSubmit"
-                                            class="btn btn-primary">
-                                        Save Edited Photo
-                                    </button>
-                                </form>
-                            </c:otherwise>
-                        </c:choose>
+                    <div class="col-xs-8">
+                      <img id="editableProfilePicture" src="${modal.pictureUrl}">
                     </div>
-                </div><%-- /.row --%>
-            </div><%-- /.modal-body --%>
-            <div class="modal-footer">
-            </div>
-        </div><%-- /.modal-content --%>
-    </div><%-- /.modal-dialog --%>
+                    <div class="col-xs-2">
+                      <button id="profilePicEditPanRight" type="button" class="btn btn-primary">
+                        <span class="glyphicon glyphicon-arrow-right"></span>
+                      </button>
+                    </div>
+                  </div>
+                  <button id="profilePicEditPanDown" type="button" class="btn btn-primary">
+                    <span class="glyphicon glyphicon-arrow-down"></span>
+                  </button>
+                  <div class="profile-pic-edit-toolbar">
+                    <button id="profilePicEditRotateLeft" type="button" class="btn btn-primary">
+                      <span class="glyphicon glyphicon-repeat glyphicon-flipped"></span>
+                    </button>
+                    <button id="profilePicEditZoomIn" type="button" class="btn btn-primary">
+                      <span class="glyphicon glyphicon-zoom-in"></span>
+                    </button>
+                    <button id="profilePicEditZoomOut" type="button" class="btn btn-primary">
+                      <span class="glyphicon glyphicon-zoom-out"></span>
+                    </button>
+                    <button id="profilePicEditRotateRight" type="button" class="btn btn-primary">
+                      <span class="glyphicon glyphicon-repeat"></span>
+                    </button>
+                  </div>
+                  <label for="editableProfilePicture">
+                    Your Photo
+                  </label>
+                  <br>
+                </div>
+                <form id="profilePictureEditForm" method="post" action="<%= Const.ActionURIs.STUDENT_PROFILE_PICTURE_EDIT %>">
+                  <input id="pictureHeight" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_HEIGHT %>" value="">
+                  <input id="pictureWidth" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_WIDTH %>" value="">
+                  <input id="cropBoxLeftX" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_LEFTX %>" value="">
+                  <input id="cropBoxTopY" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_TOPY %>" value="">
+                  <input id="cropBoxRightX" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_RIGHTX %>" value="">
+                  <input id="cropBoxBottomY" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_BOTTOMY %>" value="">
+                  <input id="rotate" type="hidden" name="<%= Const.ParamsNames.PROFILE_PICTURE_ROTATE %>" value="">
+                  <input id="blobKey" type="hidden" name="<%= Const.ParamsNames.BLOB_KEY %>" value="${modal.pictureKey}">
+                  <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${modal.googleId}">
+                  <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${sessionToken}">
+                  <button type="button"
+                      id="profileEditPictureSubmit"
+                      class="btn btn-primary">
+                    Save Edited Photo
+                  </button>
+                </form>
+              </c:otherwise>
+            </c:choose>
+          </div>
+        </div><%-- /.row --%>
+      </div><%-- /.modal-body --%>
+      <div class="modal-footer">
+      </div>
+    </div><%-- /.modal-content --%>
+  </div><%-- /.modal-dialog --%>
 </div><%-- /.modal --%>

--- a/src/main/webapp/WEB-INF/tags/student/studentMessageOfTheDay.tag
+++ b/src/main/webapp/WEB-INF/tags/student/studentMessageOfTheDay.tag
@@ -3,34 +3,34 @@
 <%@ tag import="teammates.common.util.Config" %>
 <c:set var="motdUrl" value="<%= Config.STUDENT_MOTD_URL %>" />
 <c:if test="${not empty motdUrl}">
-    <div id="student-motd-wrapper">
-        <input type="hidden" id="motd-url" value="<c:out value="${motdUrl}" />">
-        <script type="text/javascript" src="/js/studentMotd.js" defer></script>
-        <div class="container theme-showcase" id="student-motd-container">
-            <div class="row">
+  <div id="student-motd-wrapper">
+    <input type="hidden" id="motd-url" value="<c:out value="${motdUrl}" />">
+    <script type="text/javascript" src="/js/studentMotd.js" defer></script>
+    <div class="container theme-showcase" id="student-motd-container">
+      <div class="row">
+        <div class="col-sm-12">
+          <div class="panel panel-default">
+            <div class="panel-body padding-top-0">
+              <div class="row">
                 <div class="col-sm-12">
-                    <div class="panel panel-default">
-                        <div class="panel-body padding-top-0">
-                            <div class="row">
-                                <div class="col-sm-12">
-                                    <p class="padding-15px margin-0">
-                                        <b class="text-color-gray">TEAMMATES Message of the day</b>
-                                        &nbsp;
-                                        <button type="button" id="btn-close-motd" class="close" aria-label="Close">
-                                            <span aria-hidden="true">&times;</span>
-                                        </button>
-                                    </p>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-sm-12" id="student-motd">
-                                    <%-- Message of the day loads here --%>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                  <p class="padding-15px margin-0">
+                    <b class="text-color-gray">TEAMMATES Message of the day</b>
+                    &nbsp;
+                    <button type="button" id="btn-close-motd" class="close" aria-label="Close">
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </p>
                 </div>
+              </div>
+              <div class="row">
+                <div class="col-sm-12" id="student-motd">
+                  <%-- Message of the day loads here --%>
+                </div>
+              </div>
             </div>
+          </div>
         </div>
+      </div>
     </div>
+  </div>
 </c:if>

--- a/src/main/webapp/WEB-INF/tags/student/studentPage.tag
+++ b/src/main/webapp/WEB-INF/tags/student/studentPage.tag
@@ -8,23 +8,27 @@
 <%@ attribute name="bodyTitle" required="true" %>
 <%@ attribute name="altNavBar" %>
 <%@ attribute name="altFooter" %>
-<c:set var="defaultNavBar"><ts:navBar /></c:set>
-<c:set var="defaultFooter"><t:bodyFooter /></c:set>
+<c:set var="defaultNavBar">
+  <ts:navBar />
+</c:set>
+<c:set var="defaultFooter">
+  <t:bodyFooter />
+</c:set>
 
 <t:page pageTitle="${pageTitle}" bodyTitle="${bodyTitle}">
-    <jsp:attribute name="cssIncludes">
-        ${cssIncludes}
-    </jsp:attribute>
-    <jsp:attribute name="jsIncludes">
-        ${jsIncludes}
-    </jsp:attribute>
-    <jsp:attribute name="navBar">
-        ${empty altNavBar ? defaultNavBar : altNavBar}
-    </jsp:attribute>
-    <jsp:attribute name="bodyFooter">
-        ${empty altFooter ? defaultFooter : altFooter}
-    </jsp:attribute>
-    <jsp:body>
-        <jsp:doBody />
-    </jsp:body>
+  <jsp:attribute name="cssIncludes">
+    ${cssIncludes}
+  </jsp:attribute>
+  <jsp:attribute name="jsIncludes">
+    ${jsIncludes}
+  </jsp:attribute>
+  <jsp:attribute name="navBar">
+    ${empty altNavBar ? defaultNavBar : altNavBar}
+  </jsp:attribute>
+  <jsp:attribute name="bodyFooter">
+    ${empty altFooter ? defaultFooter : altFooter}
+  </jsp:attribute>
+  <jsp:body>
+    <jsp:doBody />
+  </jsp:body>
 </t:page>

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -85,7 +85,9 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
         String expectedStatus =
-                "\"!Not starting with alphanumeric\" is not acceptable to TEAMMATES as a/an email subject";
+                "The field email subject starts with a non-alphanumeric character. All email subject "
+                     + "must start with an alphanumeric character, and cannot contain any vertical "
+                     + "bar (|) or percent sign (%).";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;
@@ -268,7 +270,8 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         expectedLogSegment = Const.ACTION_RESULT_FAILURE;
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
-        expectedStatus = "\"\" is not acceptable to TEAMMATES as a/an email subject";
+        expectedStatus = "The field email subject is empty. The value of a/an email subject "
+                             + "should be no longer than 200 characters. It should not be empty.";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;

--- a/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
@@ -89,8 +89,7 @@ public class AdminInstructorAccountAddActionTest extends BaseActionTest {
                 Const.ParamsNames.INSTRUCTOR_INSTITUTION, institute);
 
         String expectedError =
-                "\"" + invalidName + "\" is not acceptable to TEAMMATES as a/an person name because "
-                + "it contains invalid characters. All person name must start with an "
+                "The field person name contains invalid characters. All person name must start with an "
                 + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).";
 
         AjaxResult rInvalidParam = getAjaxResult(a);

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackAddActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackAddActionTest.java
@@ -95,8 +95,7 @@ public class InstructorFeedbackAddActionTest extends BaseActionTest {
         assertTrue(pr.isError);
 
         expectedString =
-                teammatesLog + "Servlet Action Failure : " + "\"" + longFsName + "\" "
-                + "is not acceptable to TEAMMATES as a/an feedback session name because it is too long. "
+                teammatesLog + "Servlet Action Failure : The field feedback session name is too long. "
                 + "The value of a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackAdd";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -150,9 +150,9 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
 
         expectedString =
                 teammatesLogMessage + "Servlet Action Failure : "
-                + "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
-                + "The value of a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackCopy";
+                + "The field feedback session name is empty. The value of a/an feedback session "
+                + "name should be no longer than 38 characters. It should not be empty."
+                + "|||/page/instructorFeedbackCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Masquerade mode");

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
@@ -268,16 +268,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
+        expectedString = "The field feedback session name is empty. The value of a/an feedback "
+                         + "session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -297,16 +297,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
+        expectedString = "The field feedback session name is empty. The value of a/an feedback "
+                         + "session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -326,16 +326,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
+        expectedString = "The field feedback session name is empty. The value of a/an feedback "
+                         + "session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -355,16 +355,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
+        expectedString = "The field feedback session name is empty. The value of a/an feedback "
+                         + "session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
@@ -73,8 +73,7 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         feedbackEditPage.getFsCopyToModal().waitForFormSubmissionErrorMessagePresence();
         assertTrue(feedbackEditPage.getFsCopyToModal().isFormSubmissionStatusMessageVisible());
         feedbackEditPage.getFsCopyToModal().verifyStatusMessage(
-                "\"" + invalidNameforFs + "\" is not acceptable to TEAMMATES as a/an "
-                + "feedback session name because it contains invalid characters. "
+                "The field feedback session name contains invalid characters. "
                 + "All feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -481,8 +481,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         feedbackPage.copyFeedbackSession("(New Session ##)", newSession.getCourseId());
         feedbackPage.verifyStatus(
-                "\"(New Session ##)\" is not acceptable to TEAMMATES as a/an feedback session name because "
-                + "it starts with a non-alphanumeric character. "
+                "The field feedback session name starts with a non-alphanumeric character. "
                 + "All feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
@@ -533,10 +532,9 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.getFsCopyToModal().waitForFormSubmissionErrorMessagePresence();
         assertTrue(feedbackPage.getFsCopyToModal().isFormSubmissionStatusMessageVisible());
         feedbackPage.getFsCopyToModal().verifyStatusMessage(
-                "\"Invalid name | for feedback session\" is not acceptable to TEAMMATES as a/an "
-                + "feedback session name because it contains invalid characters. "
-                + "All feedback session name must start with an alphanumeric character, "
-                + "and cannot contain any vertical bar (|) or percent sign (%).");
+                "The field feedback session name contains invalid characters. All feedback session "
+                + "name must start with an alphanumeric character, and cannot contain any vertical "
+                + "bar (|) or percent sign (%).");
 
         feedbackPage.getFsCopyToModal().clickCloseButton();
 

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -819,12 +819,11 @@ public class CoursesLogicTest extends BaseLogicTest {
         CourseAttributes invalidCourse = new CourseAttributes("invalid id", "Fresh course for tccai", "InvalidTimeZone");
 
         String expectedError =
-                "\"" + invalidCourse.getId() + "\" is not acceptable to TEAMMATES as a/an course ID because"
-                + " it is not in the correct format. "
+                "The field course ID is not in the correct format. "
                 + "A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
                 + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces."
                 + EOL
-                + "\"InvalidTimeZone\" is not acceptable to TEAMMATES as a/an course time zone because it not available "
+                + "The field course time zone not available "
                 + "as a choice. The value must be one of the values from the time zone dropdown selector.";
 
         try {

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -192,8 +192,7 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
 
         frComment.courseId = "invalid course name";
         String expectedError =
-                "\"" + frComment.courseId + "\" is not acceptable to TEAMMATES as a/an course ID "
-                + "because it is not in the correct format. A course ID can contain letters, "
+                "The field course ID is not in the correct format. A course ID can contain letters, "
                 + "numbers, fullstops, hyphens, underscores, and dollar signs. It cannot be longer "
                 + "than 40 characters, cannot be empty and cannot contain spaces.";
         verifyExceptionThrownWhenUpdateFrComment(frComment, expectedError);

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -272,10 +272,9 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             fsLogic.createFeedbackSession(fs);
             signalFailureToDetectException();
         } catch (Exception e) {
-            assertEquals("\"test %| test\" is not acceptable to TEAMMATES as a/an feedback session name "
-                             + "because it contains invalid characters. All feedback session name "
-                             + "must start with an alphanumeric character, and cannot contain "
-                             + "any vertical bar (|) or percent sign (%).",
+            assertEquals("The field feedback session name contains invalid characters. "
+                             + "All feedback session name must start with an alphanumeric "
+                             + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                          e.getMessage());
         }
 

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -92,8 +92,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         instr.email = "invalidEmail.tmt";
         String expectedError =
-                "\"" + instr.email + "\" is not acceptable to TEAMMATES as a/an email "
-                + "because it is not in the correct format. An email address contains "
+                "The field email is not in the correct format. An email address contains "
                 + "some text followed by one '@' sign followed by some more text. "
                 + "It cannot be longer than 254 characters, cannot be empty and "
                 + "cannot contain spaces.";

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -54,7 +54,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
             AssertHelper.assertContains(
-                    "not acceptable to TEAMMATES as a/an course ID because it is not in the correct format",
+                    "The field course ID is not in the correct format",
                     e.getMessage());
         }
 
@@ -64,7 +64,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.createEntity(invalidNameCourse);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is too long",
+            AssertHelper.assertContains("The field course name is too long",
                                         e.getMessage());
         }
 
@@ -75,7 +75,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.createEntity(invalidTimeZoneCourse);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
+            AssertHelper.assertContains("The field course time zone",
                                          e.getMessage());
         }
 
@@ -134,11 +134,11 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.updateCourse(invalidCourse);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course ID because it is empty",
+            AssertHelper.assertContains("The field course ID is empty",
                                         e.getMessage());
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is empty",
+            AssertHelper.assertContains("The field course name is empty",
                                         e.getMessage());
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
+            AssertHelper.assertContains("The field course time zone",
                                         e.getMessage());
         }
 

--- a/src/test/java/teammates/test/cases/util/AdminLogQueryTest.java
+++ b/src/test/java/teammates/test/cases/util/AdminLogQueryTest.java
@@ -22,7 +22,8 @@ public class AdminLogQueryTest extends BaseTestCase {
         Calendar cal = new GregorianCalendar();
         cal.set(1994, Calendar.MAY, 7, 15, 30, 12);
         long startTime = cal.getTimeInMillis();
-        long endTime = startTime + 22 * 365 * 24 * 60 * 60 * 1000; // about 22 years later
+        cal.add(Calendar.YEAR, 22);
+        long endTime = cal.getTimeInMillis();
         AdminLogQuery query = new AdminLogQuery(versionList, startTime, endTime);
         assertEquals(startTime, query.getStartTime());
         assertEquals(endTime, query.getEndTime());
@@ -45,8 +46,9 @@ public class AdminLogQueryTest extends BaseTestCase {
         versionList.add("5-44");
         Calendar cal = new GregorianCalendar();
         cal.set(2016, 4, 7, 15, 30, 12);
-        Long startTime = cal.getTimeInMillis();
-        Long endTime = startTime + 3 * 24 * 60 * 60 * 1000; // 3 days later
+        long startTime = cal.getTimeInMillis();
+        cal.add(Calendar.DATE, 3);
+        long endTime = cal.getTimeInMillis();
         AdminLogQuery query = new AdminLogQuery(versionList, startTime, endTime);
         Long fourHours = Long.valueOf(4 * 60 * 60 * 1000);
         query.moveTimePeriodBackward(fourHours); // 4 hours before endTime

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -56,15 +56,14 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongName = StringHelperExtension.generateStringOfLength(maxLength + 1);
         assertEquals("invalid: too long",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not acceptable to TEAMMATES "
-                         + "as a/an my field because it is too long. The value of a/an my field should be no "
+                     "The field my field is too long. The value of a/an my field should be no "
                          + "longer than 50 characters. It should not be empty.",
                      FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
                              maxLength, tooLongName));
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "\"\" is not acceptable to TEAMMATES as a/an my field because it is empty. The value of "
+                     "The field my field is empty. The value of "
                          + "a/an my field should be no longer than 50 characters. It should not be empty.",
                      FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
                              maxLength, emptyValue));
@@ -152,8 +151,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongName = StringHelperExtension.generateStringOfLength(maxLength + 1);
         assertEquals("invalid: too long",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not acceptable to TEAMMATES "
-                         + "as a/an my field because it is too long. The value of a/an my field should be no "
+                     "The field my field is too long. The value of a/an my field should be no "
                          + "longer than 50 characters.",
                      validator.getValidityInfoForSizeCappedPossiblyEmptyString(typicalFieldName, maxLength,
                                                                                tooLongName));
@@ -188,8 +186,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameContainInvalidChars = "Dr. Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"Dr. Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is "
-                         + "not acceptable to TEAMMATES as a/an name field because it contains invalid "
+                     "The field name field contains invalid "
                          + "characters. All name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
@@ -199,8 +196,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithNonAlphaNumChar = "!Amy-Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"!Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
-                         + "acceptable to TEAMMATES as a/an name field because it starts with a "
+                     "The field name field starts with a "
                          + "non-alphanumeric character. All name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
@@ -210,8 +206,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithBracesButHasInvalidChar = "{Amy} -Bén s/o O'&|% 2\t\n (~!@#$^*+_={}[]\\:;\"<>?)";
         assertEquals("invalid: typical length with invalid characters",
-                     "\"{Amy} -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
-                         + "acceptable to TEAMMATES as a/an name field because it contains invalid "
+                     "The field name field contains invalid "
                          + "characters. All name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
@@ -221,8 +216,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String nameStartedWithCurlyBracketButHasNoEnd = "{Amy -Bén s/o O'&|% 2\t\n (~!@#$^*+_={[]\\:;\"<>?)";
         assertEquals("invalid: typical length started with non-alphanumeric character",
-                     "\"{Amy -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={[]\\:;&quot;&lt;&gt;?)\" is not "
-                         + "acceptable to TEAMMATES as a/an name field because it starts with a "
+                     "The field name field starts with a "
                          + "non-alphanumeric character. All name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
@@ -250,8 +244,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongName = StringHelperExtension.generateStringOfLength(maxLength + 1);
         assertEquals("invalid: too long",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not acceptable to TEAMMATES "
-                         + "as a/an name field because it is too long. The value of a/an name field should "
+                     "The field name field is too long. The value of a/an name field should "
                          + "be no longer than 50 characters. It should not be empty.",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength, tooLongName));
 
@@ -259,8 +252,8 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "\"\" is not acceptable to TEAMMATES as a/an name field because it is empty. The value "
-                         + "of a/an name field should be no longer than 50 characters. It should not be empty.",
+                     "The field name field is empty. The value of a/an name field should be no "
+                         + "longer than 50 characters. It should not be empty.",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength, emptyValue));
 
         ______TS("failure: untrimmed value");
@@ -277,7 +270,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidPersonName = "";
         String actual = validator.getInvalidityInfoForPersonName(invalidPersonName);
         assertEquals("Invalid person name (empty) should return error message that is specific to person name",
-                     "\"\" is not acceptable to TEAMMATES as a/an person name because it is empty. The value "
+                     "The field person name is empty. The value "
                          + "of a/an person name should be no longer than 100 characters. It should not be empty.",
                      actual);
     }
@@ -287,8 +280,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidInstituteName = StringHelperExtension.generateStringOfLength(INSTITUTE_NAME_MAX_LENGTH + 1);
         String actual = validator.getInvalidityInfoForInstituteName(invalidInstituteName);
         assertEquals("Invalid institute name (too long) should return error message that is specific to institute name",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not "
-                         + "acceptable to TEAMMATES as a/an institute name because it is too long. The value "
+                     "The field institute name is too long. The value "
                          + "of a/an institute name should be no longer than 64 characters. It should not be empty.",
                      actual);
     }
@@ -318,7 +310,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidTeamName = "";
         String actual = validator.getInvalidityInfoForTeamName(invalidTeamName);
         assertEquals("Invalid team name (empty) should return error message that is specific to team name",
-                     "\"\" is not acceptable to TEAMMATES as a/an team name because it is empty. The value "
+                     "The field team name is empty. The value "
                          + "of a/an team name should be no longer than 60 characters. It should not be empty.",
                      actual);
     }
@@ -328,8 +320,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidSectionName = "Percent Symbol % Section";
         String actual = validator.getInvalidityInfoForSectionName(invalidSectionName);
         assertEquals("Invalid section name (invalid char) should return error string that is specific to section name",
-                     "\"Percent Symbol % Section\" is not acceptable to TEAMMATES as a/an section name "
-                         + "because it contains invalid characters. All section name must start with an "
+                     "The field section name contains invalid characters. All section name must start with an "
                          + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }
@@ -339,8 +330,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidCourseName = "Vertical Bar | Course";
         String actual = validator.getInvalidityInfoForCourseName(invalidCourseName);
         assertEquals("Invalid course name (invalid char) should return error string that is specific to course name",
-                     "\"Vertical Bar | Course\" is not acceptable to TEAMMATES as a/an course name because "
-                         + "it contains invalid characters. All course name must start with an alphanumeric "
+                     "The field course name contains invalid characters. All course name must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }
@@ -351,8 +341,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = validator.getInvalidityInfoForFeedbackSessionName(invalidSessionName);
         assertEquals("Invalid feedback session name (too long) should return error message specific to feedback "
                          + "session name",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not acceptable to TEAMMATES as a/an "
-                         + "feedback session name because it is too long. The value of a/an feedback session "
+                     "The field feedback session name is too long. The value of a/an feedback session "
                          + "name should be no longer than 38 characters. It should not be empty.",
                      actual);
     }
@@ -362,9 +351,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidEmailSubject = "";
         String actual = validator.getInvalidityInfoForEmailSubject(invalidEmailSubject);
         assertEquals("Invalid email subject (empty) should return error message that is specific to email subject",
-                     "\"\" is not acceptable to TEAMMATES as a/an email subject because it is empty. The "
-                         + "value of a/an email subject should be no longer than 200 characters. It should "
-                         + "not be empty.",
+                     "The field email subject is empty. The value of a/an email subject "
+                         + "should be no longer than 200 characters. It should not be empty.",
                      actual);
     }
 
@@ -440,9 +428,9 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForGoogleId_invalid_returnErrorString() {
         String emptyId = "";
         assertEquals("Invalid Google ID (empty) should return appropriate error message",
-                     "\"\" is not acceptable to TEAMMATES as a/an Google ID because it is empty. A Google "
-                         + "ID must be a valid id already registered with Google. It cannot be longer than "
-                         + "254 characters, cannot be empty and cannot contain spaces.",
+                     "The field Google ID is empty. A Google ID must be a valid id already registered "
+                         + "with Google. It cannot be longer than 254 characters, "
+                         + "cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(emptyId));
 
         String whitespaceId = "     ";
@@ -457,26 +445,21 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongId = StringHelperExtension.generateStringOfLength(GOOGLE_ID_MAX_LENGTH + 1);
         assertEquals("Invalid Google ID (too long) should return appropriate error message",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaa\" is not acceptable to TEAMMATES as a/an Google ID because it is too "
-                         + "long. A Google ID must be a valid id already registered with Google. It cannot "
-                         + "be longer than 254 characters, cannot be empty and cannot contain spaces.",
+                     "The field Google ID is too long. A Google ID must be a valid id already "
+                         + "registered with Google. It cannot be longer than 254 characters, cannot "
+                         + "be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(tooLongId));
 
         String idWithSpaces = "invalid google id with spaces";
         assertEquals("Invalid Google ID (with spaces) should return appropriate error message",
-                     "\"invalid google id with spaces\" is not acceptable to TEAMMATES as a/an Google ID "
-                         + "because it is not in the correct format. A Google ID must be a valid id already "
+                     "The field Google ID is not in the correct format. A Google ID must be a valid id already "
                          + "registered with Google. It cannot be longer than 254 characters, cannot be empty "
                          + "and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(idWithSpaces));
 
         String idWithInvalidHtmlChar = "invalid google id with HTML/< special characters";
         assertEquals("Invalid Google ID (contains HTML characters) should return appropriate error message",
-                     "\"invalid google id with HTML&#x2f;&lt; special characters\" is not acceptable to "
-                         + "TEAMMATES as a/an Google ID because it is not in the correct format. A Google ID "
+                     "The field Google ID is not in the correct format. A Google ID "
                          + "must be a valid id already registered with Google. It cannot be longer than 254 "
                          + "characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(idWithInvalidHtmlChar));
@@ -512,9 +495,9 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForEmail_invalid_returnErrorString() {
         String emptyEmail = "";
         assertEquals("Invalid email (empty) should return appropriate error string",
-                     "\"\" is not acceptable to TEAMMATES as a/an email because it is empty. An email "
-                         + "address contains some text followed by one '@' sign followed by some more text. "
-                         + "It cannot be longer than 254 characters, cannot be empty and cannot contain spaces.",
+                     "The field email is empty. An email address contains some text followed by "
+                         + "one '@' sign followed by some more text. It cannot be longer than 254 characters, "
+                         + "cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emptyEmail));
 
         String untrimmedEmail = "  untrimmed@email.com  ";
@@ -529,36 +512,33 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongEmail = StringHelperExtension.generateStringOfLength(EMAIL_MAX_LENGTH + 1) + "@c.gov";
         assertEquals("Invalid email (too long) should return appropriate error string",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                         + "aaaaaaaa@c.gov\" is not acceptable to TEAMMATES as a/an email because it is too "
-                         + "long. An email address contains some text followed by one '@' sign followed by "
-                         + "some more text. It cannot be longer than 254 characters, cannot be empty and "
+                     "The field email is too long. An email address contains some text "
+                         + "followed by one '@' sign followed by some more text. It "
+                         + "cannot be longer than 254 characters, cannot be empty and "
                          + "cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(tooLongEmail));
 
         String emailWithSpaceAfterAtSymbol = "woMAN@com. sg";
         assertEquals("Invalid email (space character after '@') should return appropriate error string",
-                     "\"woMAN@com. sg\" is not acceptable to TEAMMATES as a/an email because it is not in "
-                         + "the correct format. An email address contains some text followed by one '@' sign "
-                         + "followed by some more text. It cannot be longer than 254 characters, cannot be "
+                     "The field email is not in the correct format. An email address contains "
+                         + "some text followed by one '@' sign followed by some more text. "
+                         + "It cannot be longer than 254 characters, cannot be "
                          + "empty and cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emailWithSpaceAfterAtSymbol));
 
         String emailWithSpaceBeforeAtSymbol = "man woman@com.sg";
         assertEquals("Invalid email (space character before '@') should return appropriate error string",
-                     "\"man woman@com.sg\" is not acceptable to TEAMMATES as a/an email because it "
-                         + "is not in the correct format. An email address contains some text followed by "
-                         + "one '@' sign followed by some more text. It cannot be longer than 254 "
-                         + "characters, cannot be empty and cannot contain spaces.",
+                     "The field email is not in the correct format. An email address contains "
+                         + "some text followed by one '@' sign followed by some more text. "
+                         + "It cannot be longer than 254 characters, cannot be empty and "
+                         + "cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emailWithSpaceBeforeAtSymbol));
 
         String emailWithMultipleAtSymbol = "man@woman@com.lk";
         assertEquals("Invalid email (multiple '@' characters) should return appropriate error string",
-                     "\"man@woman@com.lk\" is not acceptable to TEAMMATES as a/an email because it is not "
-                         + "in the correct format. An email address contains some text followed by one '@' "
-                         + "sign followed by some more text. It cannot be longer than 254 characters, "
+                     "The field email is not in the correct format. An email address "
+                         + "contains some text followed by one '@' sign followed by "
+                         + "some more text. It cannot be longer than 254 characters, "
                          + "cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emailWithMultipleAtSymbol));
     }
@@ -619,9 +599,9 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForCourseId_invalid_returnErrorString() {
         String emptyCourseId = "";
         assertEquals("Invalid Course ID (empty) should return appropriate error string",
-                     "\"\" is not acceptable to TEAMMATES as a/an course ID because it is empty. A course ID "
-                         + "can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
-                         + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.",
+                     "The field course ID is empty. A course ID can contain letters, numbers, "
+                         + "fullstops, hyphens, underscores, and dollar signs. It cannot be "
+                         + "longer than 40 characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(emptyCourseId));
 
         String untrimmedCourseId = " $cs1101-sem1.2_ ";
@@ -636,25 +616,23 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String tooLongCourseId = StringHelperExtension.generateStringOfLength(COURSE_ID_MAX_LENGTH + 1);
         assertEquals("Invalid Course ID (too long) should return appropriate error string",
-                     "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is not acceptable to TEAMMATES as a/an "
-                         + "course ID because it is too long. A course ID can contain letters, numbers, "
+                     "The field course ID is too long. A course ID can contain letters, numbers, "
                          + "fullstops, hyphens, underscores, and dollar signs. It cannot be longer than 40 "
                          + "characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(tooLongCourseId));
 
         String courseIdWithSpaces = "my course id with spaces";
         assertEquals("Invalid Course ID (contains spaces) should return appropriate error string",
-                     "\"my course id with spaces\" is not acceptable to TEAMMATES as a/an course ID because "
-                         + "it is not in the correct format. A course ID can contain letters, numbers, "
+                     "The field course ID is not in the correct format. A course ID can contain letters, numbers, "
                          + "fullstops, hyphens, underscores, and dollar signs. It cannot be longer than 40 "
                          + "characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(courseIdWithSpaces));
 
         String courseIdWithInvalidChar = "cour@s*hy#";
         assertEquals("Invalid Course ID (invalid char) should return appropriate error string",
-                     "\"cour@s*hy#\" is not acceptable to TEAMMATES as a/an course ID because it is not in "
-                         + "the correct format. A course ID can contain letters, numbers, fullstops, "
-                         + "hyphens, underscores, and dollar signs. It cannot be longer than 40 characters, "
+                     "The field course ID is not in the correct format. A course ID can "
+                         + "contain letters, numbers, fullstops, hyphens, underscores, "
+                         + "and dollar signs. It cannot be longer than 40 characters, "
                          + "cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(courseIdWithInvalidChar));
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -358,7 +358,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         return getConstSumPointsForEachRecipientBox(NEW_QUESTION_NUM);
     }
 
-    public WebElement getRubicSubQuestionBox(int qnNumber, int subQnIndex) {
+    public WebElement getRubricSubQuestionBox(int qnNumber, int subQnIndex) {
         String idSuffix = getIdSuffix(qnNumber);
 
         String elemId = Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_SUBQUESTION + idSuffix + "-" + subQnIndex;
@@ -367,13 +367,13 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
 
     public boolean isRubricSubQuestionBoxFocused(int qnNumber, int subQnIndex) {
-        WebElement subQnBox = getRubicSubQuestionBox(qnNumber, subQnIndex);
+        WebElement subQnBox = getRubricSubQuestionBox(qnNumber, subQnIndex);
 
         return subQnBox.equals(browser.driver.switchTo().activeElement());
     }
 
     public void fillRubricSubQuestionBox(String subQuestion, int qnNumber, int subQnIndex) {
-        WebElement subQnBox = getRubicSubQuestionBox(qnNumber, subQnIndex);
+        WebElement subQnBox = getRubricSubQuestionBox(qnNumber, subQnIndex);
 
         fillTextBox(subQnBox, subQuestion);
     }

--- a/src/test/resources/pages/instructorCourseEnrollError.html
+++ b/src/test/resources/pages/instructorCourseEnrollError.html
@@ -62,7 +62,7 @@
                     </span>
                     <br>
                     <span class="problemDetail">
-                      • "bjack.gmail.tmt" is not acceptable to TEAMMATES as a/an email because it is not in the correct format. An email address contains some text followed by one '@' sign followed by some more text. It cannot be longer than 254 characters, cannot be empty and cannot contain spaces.
+                      • The field email is not in the correct format. An email address contains some text followed by one '@' sign followed by some more text. It cannot be longer than 254 characters, cannot be empty and cannot contain spaces.
                     </span>
                   </p>
                   <br>
@@ -75,7 +75,7 @@
                     </span>
                     <br>
                     <span class="problemDetail">
-                      • "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not acceptable to TEAMMATES as a/an team name because it is too long. The value of a/an team name should be no longer than 60 characters. It should not be empty.
+                      • The field team name is too long. The value of a/an team name should be no longer than 60 characters. It should not be empty.
                     </span>
                   </p>
                   <br>
@@ -88,7 +88,7 @@
                     </span>
                     <br>
                     <span class="problemDetail">
-                      • "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" is not acceptable to TEAMMATES as a/an person name because it is too long. The value of a/an person name should be no longer than 100 characters. It should not be empty.
+                      • The field person name is too long. The value of a/an person name should be no longer than 100 characters. It should not be empty.
                     </span>
                   </p>
                 </div>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -55,7 +55,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-danger statusMessage">
-      "Invalid ID" is not acceptable to TEAMMATES as a/an course ID because it is not in the correct format. A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.
+      The field course ID is not in the correct format. A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -55,7 +55,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-danger statusMessage">
-      "" is not acceptable to TEAMMATES as a/an course name because it is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
+      The field course name is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">


### PR DESCRIPTION
Fixes #4129 

- Changed the string **`ERROR_INFO`** from **`"\"${userInput}\" is not acceptable to TEAMMATES as a/an ${fieldName} because it ${reason}.";`** _to this_ **`"The field ${fieldName} ${reason}."`**
