### PR TITLE
Fix gramatical errors commit Issue #7755

### DIFF
--- a/src/main/java/teammates/ui/template/FeedbackSubmissionEditQuestion.java
+++ b/src/main/java/teammates/ui/template/FeedbackSubmissionEditQuestion.java
@@ -52,12 +52,12 @@ public class FeedbackSubmissionEditQuestion {
             messageToDisplayIfNoRecipientAvailable = "This question is for team members and you don't have any team members."
                                                      + " Therefore, you will not be able to answer this question.";
         } else if (questionAttributes.recipientType == FeedbackParticipantType.TEAMS) {
-            messageToDisplayIfNoRecipientAvailable = "This question is for other teams in this course and this course don't "
+            messageToDisplayIfNoRecipientAvailable = "This question is for other teams in this course and this course doesn't "
                                                      + "have any other team. Therefore, you will not be able to answer this "
                                                      + "question.";
         } else if (questionAttributes.recipientType == FeedbackParticipantType.STUDENTS) {
             messageToDisplayIfNoRecipientAvailable = "This question is for other students in this course and this course "
-                                                     + "don't have any other student. Therefore, you will not be able to "
+                                                     + "doesn't have any other student. Therefore, you will not be able to "
                                                      + "answer this question.";
         }
     }


### PR DESCRIPTION
Fixes #7755 
- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
Changing words don't on line 55 and 60 to doesn't.
However when running ./gradlew lint i have encountered this mistake
`dominik-dev@Praisey:~/CSD3600/teammates$ ./gradlew lint
:compileJava UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:checkstyleMain UP-TO-DATE
:findbugsMain UP-TO-DATE
:pmdMain UP-TO-DATE
:lintMain UP-TO-DATE
:compileTestJava
/home/dominik-dev/CSD3600/teammates/src/test/java/teammates/test/pageobjects/AppPage.java:175: error: no suitable method found for getNewPageInstance(Browser,TestProper[...]class)
        return getNewPageInstance(browser, TestProperties.isDevServer() ? DevServerLoginPage.class
               ^
    method AppPage.<T#1>getNewPageInstance(Browser,Url,Class<T#1>) is not applicable
      (cannot infer type-variable(s) T#1
        (actual and formal argument lists differ in length))
    method AppPage.<T#2>getNewPageInstance(Browser,Class<T#2>) is not applicable
      (inferred type does not conform to equality constraint(s)
        inferred: GoogleLoginPage
        equality constraints(s): GoogleLoginPage,DevServerLoginPage)
  where T#1,T#2 are type-variables:
    T#1 extends AppPage declared in method <T#1>getNewPageInstance(Browser,Url,Class<T#1>)
    T#2 extends AppPage declared in method <T#2>getNewPageInstance(Browser,Class<T#2>)
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
1 error
:compileTestJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileTestJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 7.402 secs
`
