### PR TITLE
Instructor: add courses/sessions: give more specific error messages when a field is empty #4129

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -112,7 +112,7 @@ public class FieldValidator {
 
     // error message components
     public static final String EMPTY_STRING_ERROR_INFO =
-            "The field ${fieldName} ${reason}.";
+            "The field ${fieldName} is empty.";
     public static final String ERROR_INFO =
             "\"${userInput}\" is not acceptable to TEAMMATES as a/an ${fieldName} because it ${reason}.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY =

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -304,7 +304,7 @@ public class FieldValidator {
         String sanitizedValue = SanitizationHelper.sanitizeForHtml(email);
 
         if (email.isEmpty()) {
-            return getPopulatedEmptyStringErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, email, EMAIL_FIELD_NAME,
+            return getPopulatedEmptyStringErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, EMAIL_FIELD_NAME,
                                             EMAIL_MAX_LENGTH);
         } else if (isUntrimmed(email)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", EMAIL_FIELD_NAME);
@@ -336,7 +336,7 @@ public class FieldValidator {
         boolean isValidEmailWithoutDomain = StringHelper.isMatching(googleId, REGEX_GOOGLE_ID_NON_EMAIL);
 
         if (googleId.isEmpty()) {
-            return getPopulatedEmptyStringErrorMessage(GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, googleId,
+            return getPopulatedEmptyStringErrorMessage(GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING,
                                             GOOGLE_ID_FIELD_NAME, GOOGLE_ID_MAX_LENGTH);
         } else if (isUntrimmed(googleId)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", GOOGLE_ID_FIELD_NAME);
@@ -361,7 +361,7 @@ public class FieldValidator {
         Assumption.assertTrue("Non-null value expected", courseId != null);
 
         if (courseId.isEmpty()) {
-            return getPopulatedEmptyStringErrorMessage(COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, courseId,
+            return getPopulatedEmptyStringErrorMessage(COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                                             COURSE_ID_FIELD_NAME, COURSE_ID_MAX_LENGTH);
         }
         if (isUntrimmed(courseId)) {
@@ -543,7 +543,7 @@ public class FieldValidator {
 
         if (value.isEmpty()) {
             return getPopulatedEmptyStringErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                                            value, fieldName, maxLength);
+                                            fieldName, maxLength);
         }
         if (isUntrimmed(value)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);
@@ -763,14 +763,13 @@ public class FieldValidator {
     }
 
     public static String getPopulatedEmptyStringErrorMessage(
-            String messageTemplate, String userInput, String fieldName, int maxLength) {
+            String messageTemplate, String fieldName, int maxLength) {
         return getPopulatedEmptyStringErrorMessage(messageTemplate, userInput, fieldName)
                    .replace("${maxLength}", String.valueOf(maxLength));
     }
 
     private static String getPopulatedEmptyStringErrorMessage(
-            String messageTemplate, String userInput, String fieldName) {
-        return messageTemplate.replace("${userInput}", userInput)
-                              .replace("${fieldName}", fieldName);
+            String messageTemplate, String fieldName) {
+        return messageTemplate.replace("${fieldName}", fieldName);
     }
 }

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -762,14 +762,9 @@ public class FieldValidator {
                               .replace("${reason}", errorReason);
     }
 
-    public static String getPopulatedEmptyStringErrorMessage(
-            String messageTemplate, String fieldName, int maxLength) {
-        return getPopulatedEmptyStringErrorMessage(messageTemplate, userInput, fieldName)
-                   .replace("${maxLength}", String.valueOf(maxLength));
-    }
-
-    private static String getPopulatedEmptyStringErrorMessage(
-            String messageTemplate, String fieldName) {
-        return messageTemplate.replace("${fieldName}", fieldName);
+    public static String getPopulatedEmptyStringErrorMessage(String messageTemplate,
+            String fieldName, int maxLength) {
+        return messageTemplate.replace("${fieldName}", fieldName)
+                              .replace("${maxLength}", String.valueOf(maxLength));
     }
 }

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -292,7 +292,7 @@ public class FieldValidator {
         String sanitizedValue = SanitizationHelper.sanitizeForHtml(email);
 
         if (email.isEmpty()) {
-            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, email, EMAIL_FIELD_NAME, REASON_EMPTY,
+            return getPopulatedEmptyStringErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, email, EMAIL_FIELD_NAME,
                                             EMAIL_MAX_LENGTH);
         } else if (isUntrimmed(email)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", EMAIL_FIELD_NAME);
@@ -324,8 +324,8 @@ public class FieldValidator {
         boolean isValidEmailWithoutDomain = StringHelper.isMatching(googleId, REGEX_GOOGLE_ID_NON_EMAIL);
 
         if (googleId.isEmpty()) {
-            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, googleId, GOOGLE_ID_FIELD_NAME,
-                                            REASON_EMPTY, GOOGLE_ID_MAX_LENGTH);
+            return getPopulatedEmptyStringErrorMessage(GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, googleId,
+                                            GOOGLE_ID_FIELD_NAME, GOOGLE_ID_MAX_LENGTH);
         } else if (isUntrimmed(googleId)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", GOOGLE_ID_FIELD_NAME);
         } else if (googleId.length() > GOOGLE_ID_MAX_LENGTH) {
@@ -349,8 +349,8 @@ public class FieldValidator {
         Assumption.assertTrue("Non-null value expected", courseId != null);
 
         if (courseId.isEmpty()) {
-            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, courseId, COURSE_ID_FIELD_NAME,
-                                            REASON_EMPTY, COURSE_ID_MAX_LENGTH);
+            return getPopulatedEmptyStringErrorMessage(COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, courseId,
+                                            COURSE_ID_FIELD_NAME, COURSE_ID_MAX_LENGTH);
         }
         if (isUntrimmed(courseId)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}",
@@ -514,8 +514,8 @@ public class FieldValidator {
         Assumption.assertTrue("Non-null value expected for " + fieldName, value != null);
 
         if (value.isEmpty()) {
-            return getPopulatedErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, value, fieldName,
-                                            REASON_EMPTY, maxLength);
+            return getPopulatedEmptyStringErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                                            value, fieldName, maxLength);
         }
         if (isUntrimmed(value)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);
@@ -732,5 +732,17 @@ public class FieldValidator {
         return messageTemplate.replace("${userInput}", userInput)
                               .replace("${fieldName}", fieldName)
                               .replace("${reason}", errorReason);
+    }
+
+    public static String getPopulatedEmptyStringErrorMessage(
+            String messageTemplate, String userInput, String fieldName, int maxLength) {
+        return getPopulatedEmptyStringErrorMessage(messageTemplate, userInput, fieldName)
+                   .replace("${maxLength}", String.valueOf(maxLength));
+    }
+
+    private static String getPopulatedEmptyStringErrorMessage(
+            String messageTemplate, String userInput, String fieldName) {
+        return messageTemplate.replace("${userInput}", userInput)
+                              .replace("${fieldName}", fieldName);
     }
 }

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -121,7 +121,7 @@ public class FieldValidator {
 
     // error message components
     public static final String EMPTY_STRING_ERROR_INFO =
-            "The field ${fieldName} is empty.";
+            "The field '${fieldName}' is empty.";
     public static final String ERROR_INFO =
             "\"${userInput}\" is not acceptable to TEAMMATES as a/an ${fieldName} because it ${reason}.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY =

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -149,9 +149,9 @@ public class FieldValidator {
             "An email address contains some text followed by one '@' sign followed by some more text. "
             + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES;
     public static final String EMAIL_ERROR_MESSAGE =
-           ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
+            ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
     public static final String EMAIL_ERROR_MESSAGE_EMPTY_STRING =
-           EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
+            EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
 
     public static final String HINT_FOR_CORRECT_COURSE_ID =
             "A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -111,6 +111,8 @@ public class FieldValidator {
     public static final String REASON_UNAVAILABLE_AS_CHOICE = "not available as a choice";
 
     // error message components
+    public static final String EMPTY_STRING_ERROR_INFO =
+            "The field ${fieldName} ${reason}.";
     public static final String ERROR_INFO =
             "\"${userInput}\" is not acceptable to TEAMMATES as a/an ${fieldName} because it ${reason}.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY =
@@ -126,6 +128,8 @@ public class FieldValidator {
     // generic (i.e., not specific to any field) error messages
     public static final String SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY;
+    public static final String SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING =
+            EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY;
     public static final String SIZE_CAPPED_POSSIBLY_EMPTY_STRING_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY;
     public static final String INVALID_NAME_ERROR_MESSAGE =
@@ -145,19 +149,25 @@ public class FieldValidator {
             "An email address contains some text followed by one '@' sign followed by some more text. "
             + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES;
     public static final String EMAIL_ERROR_MESSAGE =
-            ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
+           ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
+    public static final String EMAIL_ERROR_MESSAGE_EMPTY_STRING =
+           EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_EMAIL;
 
     public static final String HINT_FOR_CORRECT_COURSE_ID =
             "A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
             + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES;
     public static final String COURSE_ID_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_COURSE_ID;
+    public static final String COURSE_ID_ERROR_MESSAGE_EMPTY_STRING =
+            EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_COURSE_ID;
 
     public static final String HINT_FOR_CORRECT_FORMAT_OF_GOOGLE_ID =
             "A Google ID must be a valid id already registered with Google. "
             + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES;
     public static final String GOOGLE_ID_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_OF_GOOGLE_ID;
+    public static final String GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING =
+            EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_OF_GOOGLE_ID;
 
     public static final String HINT_FOR_CORRECT_COURSE_TIME_ZONE =
             "The value must be one of the values from the time zone dropdown selector.";
@@ -282,7 +292,7 @@ public class FieldValidator {
         String sanitizedValue = SanitizationHelper.sanitizeForHtml(email);
 
         if (email.isEmpty()) {
-            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE, email, EMAIL_FIELD_NAME, REASON_EMPTY,
+            return getPopulatedErrorMessage(EMAIL_ERROR_MESSAGE_EMPTY_STRING, email, EMAIL_FIELD_NAME, REASON_EMPTY,
                                             EMAIL_MAX_LENGTH);
         } else if (isUntrimmed(email)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", EMAIL_FIELD_NAME);
@@ -314,7 +324,7 @@ public class FieldValidator {
         boolean isValidEmailWithoutDomain = StringHelper.isMatching(googleId, REGEX_GOOGLE_ID_NON_EMAIL);
 
         if (googleId.isEmpty()) {
-            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE, googleId, GOOGLE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, googleId, GOOGLE_ID_FIELD_NAME,
                                             REASON_EMPTY, GOOGLE_ID_MAX_LENGTH);
         } else if (isUntrimmed(googleId)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", GOOGLE_ID_FIELD_NAME);
@@ -339,7 +349,7 @@ public class FieldValidator {
         Assumption.assertTrue("Non-null value expected", courseId != null);
 
         if (courseId.isEmpty()) {
-            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE, courseId, COURSE_ID_FIELD_NAME,
+            return getPopulatedErrorMessage(COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, courseId, COURSE_ID_FIELD_NAME,
                                             REASON_EMPTY, COURSE_ID_MAX_LENGTH);
         }
         if (isUntrimmed(courseId)) {
@@ -504,7 +514,7 @@ public class FieldValidator {
         Assumption.assertTrue("Non-null value expected for " + fieldName, value != null);
 
         if (value.isEmpty()) {
-            return getPopulatedErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, value, fieldName,
+            return getPopulatedErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, value, fieldName,
                                             REASON_EMPTY, maxLength);
         }
         if (isUntrimmed(value)) {

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -113,6 +113,20 @@ public class BaseTestCase {
                                      null, new Object[] { messageTemplate, userInput, fieldName, errorReason, maxLength });
     }
 
+    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String userInput,
+                                                     String fieldName)
+            throws ReflectiveOperationException {
+        return getPopulatedEmptyStringErrorMessage(messageTemplate, userInput, fieldName, 0);
+    }
+
+    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String userInput,
+                                                     String fieldName, int maxLength)
+            throws ReflectiveOperationException {
+        return (String) invokeMethod(FieldValidator.class, "getPopulatedEmptyStringErrorMessage",
+                                     new Class<?>[] { String.class, String.class, String.class, int.class },
+                                     null, new Object[] { messageTemplate, userInput, fieldName, maxLength });
+    }
+
     /*
      * Here are some of the most common assertion methods provided by JUnit.
      * They are copied here to prevent repetitive importing in test classes.

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -113,11 +113,8 @@ public class BaseTestCase {
                                      null, new Object[] { messageTemplate, userInput, fieldName, errorReason, maxLength });
     }
 
-    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String fieldName, int maxLength)
-            throws ReflectiveOperationException {
-        return (String) invokeMethod(FieldValidator.class, "getPopulatedEmptyStringErrorMessage",
-                                     new Class<?>[] { String.class, String.class, int.class },
-                                     null, new Object[] { messageTemplate, fieldName, maxLength });
+    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String fieldName, int maxLength) {
+        return FieldValidator.getPopulatedEmptyStringErrorMessage(messageTemplate, fieldName, maxLength);
     }
 
     /*

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -113,18 +113,11 @@ public class BaseTestCase {
                                      null, new Object[] { messageTemplate, userInput, fieldName, errorReason, maxLength });
     }
 
-    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String userInput,
-                                                     String fieldName)
-            throws ReflectiveOperationException {
-        return getPopulatedEmptyStringErrorMessage(messageTemplate, userInput, fieldName, 0);
-    }
-
-    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String userInput,
-                                                     String fieldName, int maxLength)
+    protected static String getPopulatedEmptyStringErrorMessage(String messageTemplate, String fieldName, int maxLength)
             throws ReflectiveOperationException {
         return (String) invokeMethod(FieldValidator.class, "getPopulatedEmptyStringErrorMessage",
-                                     new Class<?>[] { String.class, String.class, String.class, int.class },
-                                     null, new Object[] { messageTemplate, userInput, fieldName, maxLength });
+                                     new Class<?>[] { String.class, String.class, int.class },
+                                     null, new Object[] { messageTemplate, fieldName, maxLength });
     }
 
     /*

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -268,7 +268,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         expectedLogSegment = Const.ACTION_RESULT_FAILURE;
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
-        expectedStatus = "The field email subject";
+        expectedStatus = "The field email subject is empty. The value of a/an email subject should be no";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -268,7 +268,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         expectedLogSegment = Const.ACTION_RESULT_FAILURE;
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
-        expectedStatus = "The field email subject is empty. The value of a/an email subject should be no";
+        expectedStatus = "The field email subject is empty.";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -268,7 +268,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         expectedLogSegment = Const.ACTION_RESULT_FAILURE;
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
-        expectedStatus = "\"\" is not acceptable to TEAMMATES as a/an email subject";
+        expectedStatus = "The field email subject";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -268,7 +268,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         expectedLogSegment = Const.ACTION_RESULT_FAILURE;
         AssertHelper.assertContains(expectedLogSegment, action.getLogMessage());
 
-        expectedStatus = "The field email subject is empty.";
+        expectedStatus = "The field 'email subject' is empty.";
         AssertHelper.assertContains(expectedStatus, pageResult.getStatusMessage());
 
         data = (AdminEmailComposePageData) pageResult.data;

--- a/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
@@ -87,7 +87,7 @@ public class InstructorCourseEditSaveActionTest extends BaseActionTest {
         redirectResult = getRedirectResult(courseEditSaveAction);
 
         // get updated results and compare
-        statusMessage = getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE,
+        statusMessage = getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                             courseName, FieldValidator.COURSE_NAME_FIELD_NAME,
                             FieldValidator.REASON_EMPTY, FieldValidator.COURSE_NAME_MAX_LENGTH);
         assertEquals(statusMessage, redirectResult.getStatusMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
@@ -88,7 +88,7 @@ public class InstructorCourseEditSaveActionTest extends BaseActionTest {
 
         // get updated results and compare
         statusMessage = getPopulatedEmptyStringErrorMessage(
-                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, courseName,
+                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                             FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH);
         assertEquals(statusMessage, redirectResult.getStatusMessage());
         assertEquals(

--- a/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseEditSaveActionTest.java
@@ -87,9 +87,9 @@ public class InstructorCourseEditSaveActionTest extends BaseActionTest {
         redirectResult = getRedirectResult(courseEditSaveAction);
 
         // get updated results and compare
-        statusMessage = getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                            courseName, FieldValidator.COURSE_NAME_FIELD_NAME,
-                            FieldValidator.REASON_EMPTY, FieldValidator.COURSE_NAME_MAX_LENGTH);
+        statusMessage = getPopulatedEmptyStringErrorMessage(
+                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, courseName,
+                            FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH);
         assertEquals(statusMessage, redirectResult.getStatusMessage());
         assertEquals(
                 getPageResultDestination(

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -151,7 +151,7 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
 
         expectedString =
                 teammatesLogMessage + "Servlet Action Failure : "
-                + "The field feedback session name is empty. "
+                + "The field 'feedback session name' is empty. "
                 + "The value of a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -143,8 +143,9 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
                            .toString(),
                      pageResult.getDestinationWithParams());
         assertTrue(pageResult.isError);
-        assertEquals(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                         FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
+        assertEquals(getPopulatedEmptyStringErrorMessage(
+                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                         FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                          FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH),
                      pageResult.getStatusMessage());
 

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -143,14 +143,14 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
                            .toString(),
                      pageResult.getDestinationWithParams());
         assertTrue(pageResult.isError);
-        assertEquals(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+        assertEquals(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                          FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                          FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH),
                      pageResult.getStatusMessage());
 
         expectedString =
                 teammatesLogMessage + "Servlet Action Failure : "
-                + "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
+                + "The field feedback session name is empty. "
                 + "The value of a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -144,7 +144,7 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
                      pageResult.getDestinationWithParams());
         assertTrue(pageResult.isError);
         assertEquals(getPopulatedEmptyStringErrorMessage(
-                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                          FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                          FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH),
                      pageResult.getStatusMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
@@ -268,7 +268,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field feedback session name is empty. "
+        expectedString = "The field 'feedback session name' is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -276,7 +276,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
                 + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
@@ -297,7 +297,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field feedback session name is empty. "
+        expectedString = "The field 'feedback session name' is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -305,7 +305,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
                 + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
@@ -326,7 +326,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field feedback session name is empty. "
+        expectedString = "The field 'feedback session name' is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -334,7 +334,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
                 + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
@@ -355,7 +355,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field feedback session name is empty. "
+        expectedString = "The field 'feedback session name' is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -363,7 +363,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
                 + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
@@ -268,7 +268,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
+        expectedString = "The field feedback session name is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -276,8 +276,8 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -297,7 +297,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
+        expectedString = "The field feedback session name is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -305,8 +305,8 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -326,7 +326,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
+        expectedString = "The field feedback session name is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -334,8 +334,8 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
@@ -355,7 +355,7 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "\"\" is not acceptable to TEAMMATES as a/an feedback session name because it is empty. "
+        expectedString = "The field feedback session name is empty. "
                          + "The value of a/an feedback session name should be no longer than 38 characters. "
                          + "It should not be empty.";
         assertEquals(expectedString, editCopyData.errorMessage);
@@ -363,8 +363,8 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : \"\" is not acceptable to TEAMMATES as a/an feedback session name "
-                + "because it is empty. The value of a/an feedback session name should be no longer than 38 characters. "
+                + "Servlet Action Failure : The field feedback session name is empty. The value of "
+                + "a/an feedback session name should be no longer than 38 characters. "
                 + "It should not be empty.|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 

--- a/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
@@ -185,7 +185,7 @@ public class AdminEmailPageUiTest extends BaseUiTestCase {
     private boolean hasStatusMessageNoSubject() throws Exception {
         return emailPage.getStatus().equals(
                 getPopulatedErrorMessage(
-                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                     FieldValidator.EMAIL_SUBJECT_FIELD_NAME, FieldValidator.REASON_EMPTY,
                     FieldValidator.EMAIL_SUBJECT_MAX_LENGTH));
     }

--- a/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
@@ -184,10 +184,9 @@ public class AdminEmailPageUiTest extends BaseUiTestCase {
 
     private boolean hasStatusMessageNoSubject() throws Exception {
         return emailPage.getStatus().equals(
-                getPopulatedErrorMessage(
+                getPopulatedEmptyStringErrorMessage(
                     FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                    FieldValidator.EMAIL_SUBJECT_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                    FieldValidator.EMAIL_SUBJECT_MAX_LENGTH));
+                    FieldValidator.EMAIL_SUBJECT_FIELD_NAME, FieldValidator.EMAIL_SUBJECT_MAX_LENGTH));
     }
 
     private boolean hasErrorMessage() {

--- a/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminEmailPageUiTest.java
@@ -185,7 +185,7 @@ public class AdminEmailPageUiTest extends BaseUiTestCase {
     private boolean hasStatusMessageNoSubject() throws Exception {
         return emailPage.getStatus().equals(
                 getPopulatedEmptyStringErrorMessage(
-                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                     FieldValidator.EMAIL_SUBJECT_FIELD_NAME, FieldValidator.EMAIL_SUBJECT_MAX_LENGTH));
     }
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
@@ -745,7 +745,7 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         courseEditPage.clickSaveCourseButton();
         courseEditPage.changePageType(InstructorCourseEditPage.class);
         courseEditPage.verifyStatus(
-                getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                                          FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                                          FieldValidator.COURSE_NAME_MAX_LENGTH));
     }

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
@@ -745,9 +745,9 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         courseEditPage.clickSaveCourseButton();
         courseEditPage.changePageType(InstructorCourseEditPage.class);
         courseEditPage.verifyStatus(
-                getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                                         FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                                         FieldValidator.COURSE_NAME_MAX_LENGTH));
+                getPopulatedEmptyStringErrorMessage(
+                                     FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                                     FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH));
     }
 
     private void testDeleteCourseAction() {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
@@ -743,7 +743,7 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         courseEditPage.changePageType(InstructorCourseEditPage.class);
         courseEditPage.verifyStatus(
                 getPopulatedEmptyStringErrorMessage(
-                                     FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                                     FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH));
     }
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
@@ -65,7 +65,7 @@ public class InstructorCourseStudentDetailsEditPageUiTest extends BaseUiTestCase
 
         editPage.submitUnsuccessfully(null, "", null, null)
                 .verifyStatus(getPopulatedErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                                   FieldValidator.TEAM_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                                   FieldValidator.TEAM_NAME_MAX_LENGTH));
 
@@ -73,7 +73,7 @@ public class InstructorCourseStudentDetailsEditPageUiTest extends BaseUiTestCase
         String newTeamName = "New teamname";
         editPage.submitUnsuccessfully("", newTeamName, null, null)
                 .verifyStatus(getPopulatedErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                                   FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                                   FieldValidator.PERSON_NAME_MAX_LENGTH));
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
@@ -64,18 +64,16 @@ public class InstructorCourseStudentDetailsEditPageUiTest extends BaseUiTestCase
         ______TS("input validation");
 
         editPage.submitUnsuccessfully(null, "", null, null)
-                .verifyStatus(getPopulatedErrorMessage(
+                .verifyStatus(getPopulatedEmptyStringErrorMessage(
                                   FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                                  FieldValidator.TEAM_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                                  FieldValidator.TEAM_NAME_MAX_LENGTH));
+                                  FieldValidator.TEAM_NAME_FIELD_NAME, FieldValidator.TEAM_NAME_MAX_LENGTH));
 
         ______TS("empty student name and the team field is edited");
         String newTeamName = "New teamname";
         editPage.submitUnsuccessfully("", newTeamName, null, null)
-                .verifyStatus(getPopulatedErrorMessage(
+                .verifyStatus(getPopulatedEmptyStringErrorMessage(
                                   FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                                  FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                                  FieldValidator.PERSON_NAME_MAX_LENGTH));
+                                  FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH));
 
         ______TS("long student name and the team field is not edited");
         String invalidStudentName = StringHelperExtension.generateStringOfLength(FieldValidator.PERSON_NAME_MAX_LENGTH + 1);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseStudentDetailsEditPageUiTest.java
@@ -65,14 +65,14 @@ public class InstructorCourseStudentDetailsEditPageUiTest extends BaseUiTestCase
 
         editPage.submitUnsuccessfully(null, "", null, null)
                 .verifyStatus(getPopulatedEmptyStringErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                   FieldValidator.TEAM_NAME_FIELD_NAME, FieldValidator.TEAM_NAME_MAX_LENGTH));
 
         ______TS("empty student name and the team field is edited");
         String newTeamName = "New teamname";
         editPage.submitUnsuccessfully("", newTeamName, null, null)
                 .verifyStatus(getPopulatedEmptyStringErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                   FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH));
 
         ______TS("long student name and the team field is not edited");

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -196,10 +196,10 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
 
         //one invalid case
         coursesPage.addCourse("", "").verifyStatus(
-                getPopulatedErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE, "",
+                getPopulatedErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                     FieldValidator.COURSE_ID_MAX_LENGTH) + "\n"
-                + getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                + getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                       FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.COURSE_NAME_MAX_LENGTH));
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -196,10 +196,10 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
 
         //one invalid case
         coursesPage.addCourse("", "").verifyStatus(
-                getPopulatedEmptyStringErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
+                getPopulatedEmptyStringErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + "\n"
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH));
 
         //Checking max-length enforcement by the text boxes

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -196,12 +196,11 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
 
         //one invalid case
         coursesPage.addCourse("", "").verifyStatus(
-                getPopulatedErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
-                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                    FieldValidator.COURSE_ID_MAX_LENGTH) + "\n"
-                + getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.COURSE_NAME_MAX_LENGTH));
+                getPopulatedEmptyStringErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
+                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + "\n"
+                + getPopulatedEmptyStringErrorMessage(
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH));
 
         //Checking max-length enforcement by the text boxes
         String maxLengthCourseId = StringHelperExtension.generateStringOfLength(FieldValidator.COURSE_ID_MAX_LENGTH);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -966,7 +966,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getGracePeriod());
         feedbackPage.verifyStatus(getPopulatedEmptyStringErrorMessage(
                                             FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                                            "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
+                                            FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                             FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
         assertTrue(feedbackPage.isVisible(By.id("timeFramePanel")));
         assertTrue(feedbackPage.isVisible(By.id("responsesVisibleFromColumn")));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -964,7 +964,8 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(),
                 newSession.getGracePeriod());
-        feedbackPage.verifyStatus(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+        feedbackPage.verifyStatus(getPopulatedErrorMessage(
+                                                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                                            "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                                            FieldValidator.REASON_EMPTY,
                                                            FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -964,7 +964,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(),
                 newSession.getGracePeriod());
-        feedbackPage.verifyStatus(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE,
+        feedbackPage.verifyStatus(getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                                            "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                                            FieldValidator.REASON_EMPTY,
                                                            FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -964,10 +964,9 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(),
                 newSession.getGracePeriod());
-        feedbackPage.verifyStatus(getPopulatedErrorMessage(
+        feedbackPage.verifyStatus(getPopulatedEmptyStringErrorMessage(
                                             FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                             "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
-                                            FieldValidator.REASON_EMPTY,
                                             FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
         assertTrue(feedbackPage.isVisible(By.id("timeFramePanel")));
         assertTrue(feedbackPage.isVisible(By.id("responsesVisibleFromColumn")));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -965,10 +965,10 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getInstructions(),
                 newSession.getGracePeriod());
         feedbackPage.verifyStatus(getPopulatedErrorMessage(
-                                                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                                                           "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
-                                                           FieldValidator.REASON_EMPTY,
-                                                           FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
+                                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                                            "", FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
+                                            FieldValidator.REASON_EMPTY,
+                                            FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
         assertTrue(feedbackPage.isVisible(By.id("timeFramePanel")));
         assertTrue(feedbackPage.isVisible(By.id("responsesVisibleFromColumn")));
         assertTrue(feedbackPage.isVisible(By.id("instructionsRow")));

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -40,10 +40,9 @@ public class AccountAttributesTest extends BaseAttributesTest {
 
         account = createInvalidAccountAttributesObject();
         String expectedError =
-                getPopulatedErrorMessage(
+                getPopulatedEmptyStringErrorMessage(
                     FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                    FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                    FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
+                    FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.GOOGLE_ID_ERROR_MESSAGE, "invalid google id",
                       FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -41,7 +41,7 @@ public class AccountAttributesTest extends BaseAttributesTest {
         account = createInvalidAccountAttributesObject();
         String expectedError =
                 getPopulatedErrorMessage(
-                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                     FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                     FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -41,7 +41,7 @@ public class AccountAttributesTest extends BaseAttributesTest {
         account = createInvalidAccountAttributesObject();
         String expectedError =
                 getPopulatedEmptyStringErrorMessage(
-                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                     FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.GOOGLE_ID_ERROR_MESSAGE, "invalid google id",

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -36,7 +36,7 @@ public class CourseAttributesTest extends BaseTestCase {
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                     FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, invalidCourse.getName(),
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, invalidCourse.getName(),
                       FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.COURSE_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -36,7 +36,7 @@ public class CourseAttributesTest extends BaseTestCase {
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                     FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, invalidCourse.getName(),
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidCourse.getTimeZone(),

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -35,10 +35,9 @@ public class CourseAttributesTest extends BaseTestCase {
                     FieldValidator.COURSE_ID_ERROR_MESSAGE, invalidCourse.getId(),
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                     FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
-                + getPopulatedErrorMessage(
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, invalidCourse.getName(),
-                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.COURSE_NAME_MAX_LENGTH) + EOL
+                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidCourse.getTimeZone(),
                       FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -84,20 +84,17 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
         assertFalse(fq.isValid());
 
-        String errorMessage = getPopulatedErrorMessage(
+        String errorMessage = getPopulatedEmptyStringErrorMessage(
                                   FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
                                   FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
-                                  FieldValidator.REASON_EMPTY,
                                   FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH) + EOL
-                              + getPopulatedErrorMessage(
+                              + getPopulatedEmptyStringErrorMessage(
                                     FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, fq.courseId,
-                                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                                    FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
+                                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                               + "Invalid creator's email: "
-                                    + getPopulatedErrorMessage(
-                                          FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
-                                          FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                                          FieldValidator.EMAIL_MAX_LENGTH) + EOL
+                              + getPopulatedEmptyStringErrorMessage(
+                                    FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
+                                    FieldValidator.EMAIL_FIELD_NAME, FieldValidator.EMAIL_MAX_LENGTH) + EOL
                               + String.format(FieldValidator.PARTICIPANT_TYPE_ERROR_MESSAGE, fq.giverType.toString(),
                                               FieldValidator.GIVER_TYPE_NAME) + EOL
                               + String.format(FieldValidator.PARTICIPANT_TYPE_ERROR_MESSAGE, fq.recipientType.toString(),

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -85,15 +85,15 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertFalse(fq.isValid());
 
         String errorMessage = getPopulatedEmptyStringErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                                   FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                   FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH) + EOL
                               + getPopulatedEmptyStringErrorMessage(
-                                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, fq.courseId,
+                                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                               + "Invalid creator's email: "
                               + getPopulatedEmptyStringErrorMessage(
-                                    FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
+                                    FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING,
                                     FieldValidator.EMAIL_FIELD_NAME, FieldValidator.EMAIL_MAX_LENGTH) + EOL
                               + String.format(FieldValidator.PARTICIPANT_TYPE_ERROR_MESSAGE, fq.giverType.toString(),
                                               FieldValidator.GIVER_TYPE_NAME) + EOL

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -85,17 +85,17 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertFalse(fq.isValid());
 
         String errorMessage = getPopulatedErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, fq.creatorEmail,
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
                                   FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                   FieldValidator.REASON_EMPTY,
                                   FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH) + EOL
                               + getPopulatedErrorMessage(
-                                    FieldValidator.COURSE_ID_ERROR_MESSAGE, fq.courseId,
+                                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, fq.courseId,
                                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                                     FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                               + "Invalid creator's email: "
                                     + getPopulatedErrorMessage(
-                                          FieldValidator.EMAIL_ERROR_MESSAGE, fq.creatorEmail,
+                                          FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, fq.creatorEmail,
                                           FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_EMPTY,
                                           FieldValidator.EMAIL_MAX_LENGTH) + EOL
                               + String.format(FieldValidator.PARTICIPANT_TYPE_ERROR_MESSAGE, fq.giverType.toString(),

--- a/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
@@ -177,10 +177,10 @@ public class InstructorAttributesTest extends BaseAttributesTest {
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
+                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, i.email,
@@ -194,10 +194,10 @@ public class InstructorAttributesTest extends BaseAttributesTest {
         assertFalse("invalid value", i.isValid());
         errorMessage =
                 getPopulatedEmptyStringErrorMessage(
-                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
+                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, i.email,

--- a/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
@@ -176,11 +176,11 @@ public class InstructorAttributesTest extends BaseAttributesTest {
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.COURSE_ID_ERROR_MESSAGE, i.courseId,
+                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
                       FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, i.name,
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
@@ -194,11 +194,11 @@ public class InstructorAttributesTest extends BaseAttributesTest {
         assertFalse("invalid value", i.isValid());
         errorMessage =
                 getPopulatedErrorMessage(
-                    FieldValidator.COURSE_ID_ERROR_MESSAGE, i.courseId,
+                    FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
                     FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                     FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, i.name,
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(

--- a/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/InstructorAttributesTest.java
@@ -175,14 +175,12 @@ public class InstructorAttributesTest extends BaseAttributesTest {
                     FieldValidator.GOOGLE_ID_ERROR_MESSAGE, i.googleId,
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + EOL
-                + getPopulatedErrorMessage(
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
-                      FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
-                + getPopulatedErrorMessage(
+                      FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
-                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
+                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, i.email,
                       FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
@@ -193,14 +191,12 @@ public class InstructorAttributesTest extends BaseAttributesTest {
 
         assertFalse("invalid value", i.isValid());
         errorMessage =
-                getPopulatedErrorMessage(
+                getPopulatedEmptyStringErrorMessage(
                     FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, i.courseId,
-                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                    FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
-                + getPopulatedErrorMessage(
+                    FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + EOL
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, i.name,
-                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
+                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, i.email,
                       FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
@@ -94,7 +94,7 @@ public class StudentAttributesTest extends BaseTestCase {
         invalidStudent = new StudentAttributes("section", "team", "name", "e@e.com", "c", "");
         assertFalse(invalidStudent.isValid());
         assertEquals(getPopulatedEmptyStringErrorMessage(
-                         FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, invalidStudent.course,
+                         FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                          FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
 
@@ -113,14 +113,14 @@ public class StudentAttributesTest extends BaseTestCase {
         assertFalse(invalidStudent.isValid());
         assertEquals(invalidStudent.getInvalidityInfo().get(0),
                      getPopulatedEmptyStringErrorMessage(
-                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                          FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH));
 
         ______TS("Failure case: empty email");
         invalidStudent = new StudentAttributes("sect", "t1", "n", "", "c", courseId);
         assertFalse(invalidStudent.isValid());
         assertEquals(getPopulatedEmptyStringErrorMessage(
-                         FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, "",
+                         FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING,
                          FieldValidator.EMAIL_FIELD_NAME, FieldValidator.EMAIL_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
 
@@ -201,7 +201,7 @@ public class StudentAttributesTest extends BaseTestCase {
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
+                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + Const.EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, "invalid email",
@@ -217,7 +217,7 @@ public class StudentAttributesTest extends BaseTestCase {
                       FieldValidator.STUDENT_ROLE_COMMENTS_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                       FieldValidator.STUDENT_ROLE_COMMENTS_MAX_LENGTH) + Const.EOL
                 + getPopulatedEmptyStringErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH);
         assertEquals("invalid value", errorMessage, StringHelper.toString(s.getInvalidityInfo()));
     }

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
@@ -93,10 +93,9 @@ public class StudentAttributesTest extends BaseTestCase {
         ______TS("Failure case: empty course id");
         invalidStudent = new StudentAttributes("section", "team", "name", "e@e.com", "c", "");
         assertFalse(invalidStudent.isValid());
-        assertEquals(getPopulatedErrorMessage(
+        assertEquals(getPopulatedEmptyStringErrorMessage(
                          FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, invalidStudent.course,
-                         FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                         FieldValidator.COURSE_ID_MAX_LENGTH),
+                         FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
 
         ______TS("Failure case: invalid course id");
@@ -113,18 +112,16 @@ public class StudentAttributesTest extends BaseTestCase {
                                                "c", courseId);
         assertFalse(invalidStudent.isValid());
         assertEquals(invalidStudent.getInvalidityInfo().get(0),
-                     getPopulatedErrorMessage(
+                     getPopulatedEmptyStringErrorMessage(
                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                         FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                         FieldValidator.PERSON_NAME_MAX_LENGTH));
+                         FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH));
 
         ______TS("Failure case: empty email");
         invalidStudent = new StudentAttributes("sect", "t1", "n", "", "c", courseId);
         assertFalse(invalidStudent.isValid());
-        assertEquals(getPopulatedErrorMessage(
+        assertEquals(getPopulatedEmptyStringErrorMessage(
                          FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, "",
-                         FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                         FieldValidator.EMAIL_MAX_LENGTH),
+                         FieldValidator.EMAIL_FIELD_NAME, FieldValidator.EMAIL_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
 
         ______TS("Failure case: section name too long");
@@ -203,10 +200,9 @@ public class StudentAttributesTest extends BaseTestCase {
                     FieldValidator.GOOGLE_ID_ERROR_MESSAGE, "invalid@google@id",
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
-                + getPopulatedErrorMessage(
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
-                      FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.COURSE_ID_MAX_LENGTH) + Const.EOL
+                      FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.COURSE_ID_MAX_LENGTH) + Const.EOL
                 + getPopulatedErrorMessage(
                       FieldValidator.EMAIL_ERROR_MESSAGE, "invalid email",
                       FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
@@ -220,10 +216,9 @@ public class StudentAttributesTest extends BaseTestCase {
                       FieldValidator.SIZE_CAPPED_POSSIBLY_EMPTY_STRING_ERROR_MESSAGE, s.comments,
                       FieldValidator.STUDENT_ROLE_COMMENTS_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                       FieldValidator.STUDENT_ROLE_COMMENTS_MAX_LENGTH) + Const.EOL
-                + getPopulatedErrorMessage(
+                + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
-                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                      FieldValidator.PERSON_NAME_MAX_LENGTH);
+                      FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH);
         assertEquals("invalid value", errorMessage, StringHelper.toString(s.getInvalidityInfo()));
     }
 

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
@@ -94,7 +94,7 @@ public class StudentAttributesTest extends BaseTestCase {
         invalidStudent = new StudentAttributes("section", "team", "name", "e@e.com", "c", "");
         assertFalse(invalidStudent.isValid());
         assertEquals(getPopulatedErrorMessage(
-                         FieldValidator.COURSE_ID_ERROR_MESSAGE, invalidStudent.course,
+                         FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, invalidStudent.course,
                          FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                          FieldValidator.COURSE_ID_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
@@ -114,7 +114,7 @@ public class StudentAttributesTest extends BaseTestCase {
         assertFalse(invalidStudent.isValid());
         assertEquals(invalidStudent.getInvalidityInfo().get(0),
                      getPopulatedErrorMessage(
-                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                          FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                          FieldValidator.PERSON_NAME_MAX_LENGTH));
 
@@ -122,7 +122,7 @@ public class StudentAttributesTest extends BaseTestCase {
         invalidStudent = new StudentAttributes("sect", "t1", "n", "", "c", courseId);
         assertFalse(invalidStudent.isValid());
         assertEquals(getPopulatedErrorMessage(
-                         FieldValidator.EMAIL_ERROR_MESSAGE, "",
+                         FieldValidator.EMAIL_ERROR_MESSAGE_EMPTY_STRING, "",
                          FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_EMPTY,
                          FieldValidator.EMAIL_MAX_LENGTH),
                      invalidStudent.getInvalidityInfo().get(0));
@@ -204,7 +204,7 @@ public class StudentAttributesTest extends BaseTestCase {
                     FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                     FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.COURSE_ID_ERROR_MESSAGE, "",
+                      FieldValidator.COURSE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
                       FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.COURSE_ID_MAX_LENGTH) + Const.EOL
                 + getPopulatedErrorMessage(
@@ -221,7 +221,7 @@ public class StudentAttributesTest extends BaseTestCase {
                       FieldValidator.STUDENT_ROLE_COMMENTS_FIELD_NAME, FieldValidator.REASON_TOO_LONG,
                       FieldValidator.STUDENT_ROLE_COMMENTS_MAX_LENGTH) + Const.EOL
                 + getPopulatedErrorMessage(
-                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, "",
+                      FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, "",
                       FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                       FieldValidator.PERSON_NAME_MAX_LENGTH);
         assertEquals("invalid value", errorMessage, StringHelper.toString(s.getInvalidityInfo()));

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -134,9 +134,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.updateCourse(invalidCourse);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("The field course ID is empty",
+            AssertHelper.assertContains("The field 'course ID' is empty",
                                         e.getMessage());
-            AssertHelper.assertContains("The field course name is empty",
+            AssertHelper.assertContains("The field 'course name' is empty",
                                         e.getMessage());
             AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
                                         e.getMessage());

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -134,9 +134,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.updateCourse(invalidCourse);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course ID because it is empty",
+            AssertHelper.assertContains("The field course ID is empty",
                                         e.getMessage());
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is empty",
+            AssertHelper.assertContains("The field course name is empty",
                                         e.getMessage());
             AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
                                         e.getMessage());

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -344,7 +344,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         } catch (InvalidParametersException e) {
             AssertHelper.assertContains(
                     getPopulatedErrorMessage(
-                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, instructorToEdit.name,
+                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
                         FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                         FieldValidator.PERSON_NAME_MAX_LENGTH) + Const.EOL
                     + getPopulatedErrorMessage(
@@ -422,7 +422,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
                         FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
                     + getPopulatedErrorMessage(
-                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, instructorToEdit.name,
+                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
                           FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
                           FieldValidator.PERSON_NAME_MAX_LENGTH),
                     e.getMessage());

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -347,7 +347,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         } catch (InvalidParametersException e) {
             AssertHelper.assertContains(
                     getPopulatedEmptyStringErrorMessage(
-                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
+                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                         FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + Const.EOL
                     + getPopulatedErrorMessage(
                           FieldValidator.EMAIL_ERROR_MESSAGE, instructorToEdit.email,
@@ -427,7 +427,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
                         FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
                     + getPopulatedEmptyStringErrorMessage(
-                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
+                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                           FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + Const.EOL
                     + String.format(FieldValidator.ROLE_ERROR_MESSAGE, instructorToEdit.role),
                     e.getMessage());

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -343,10 +343,9 @@ public class InstructorsDbTest extends BaseComponentTestCase {
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
             AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+                    getPopulatedEmptyStringErrorMessage(
                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
-                        FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                        FieldValidator.PERSON_NAME_MAX_LENGTH) + Const.EOL
+                        FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH) + Const.EOL
                     + getPopulatedErrorMessage(
                           FieldValidator.EMAIL_ERROR_MESSAGE, instructorToEdit.email,
                           FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
@@ -421,10 +420,9 @@ public class InstructorsDbTest extends BaseComponentTestCase {
                         FieldValidator.GOOGLE_ID_ERROR_MESSAGE, instructorToEdit.googleId,
                         FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.GOOGLE_ID_MAX_LENGTH) + Const.EOL
-                    + getPopulatedErrorMessage(
+                    + getPopulatedEmptyStringErrorMessage(
                           FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, instructorToEdit.name,
-                          FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                          FieldValidator.PERSON_NAME_MAX_LENGTH),
+                          FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH),
                     e.getMessage());
         }
 

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -70,10 +70,9 @@ public class ProfilesDbTest extends BaseComponentTestCase {
             profilesDb.updateStudentProfile(StudentProfileAttributes.builder().build());
             signalFailureToDetectException(" - InvalidParametersException");
         } catch (InvalidParametersException ipe) {
-            assertEquals(getPopulatedErrorMessage(
+            assertEquals(getPopulatedEmptyStringErrorMessage(
                              FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
-                             FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
-                             FieldValidator.GOOGLE_ID_MAX_LENGTH),
+                             FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.GOOGLE_ID_MAX_LENGTH),
                          ipe.getMessage());
         }
     }

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -71,7 +71,7 @@ public class ProfilesDbTest extends BaseComponentTestCase {
             signalFailureToDetectException(" - InvalidParametersException");
         } catch (InvalidParametersException ipe) {
             assertEquals(getPopulatedErrorMessage(
-                             FieldValidator.GOOGLE_ID_ERROR_MESSAGE, "",
+                             FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
                              FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_EMPTY,
                              FieldValidator.GOOGLE_ID_MAX_LENGTH),
                          ipe.getMessage());

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -71,7 +71,7 @@ public class ProfilesDbTest extends BaseComponentTestCase {
             signalFailureToDetectException(" - InvalidParametersException");
         } catch (InvalidParametersException ipe) {
             assertEquals(getPopulatedEmptyStringErrorMessage(
-                             FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING, "",
+                             FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING,
                              FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.GOOGLE_ID_MAX_LENGTH),
                          ipe.getMessage());
         }

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -65,7 +65,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "The field my field is empty. The value of a/an my field should be no longer "
+                     "The field 'my field' is empty. The value of a/an my field should be no longer "
                          + "than 50 characters. It should not be empty.",
                      FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
                              maxLength, emptyValue));
@@ -260,7 +260,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "The field name field is empty. The value of a/an name field should be no longer "
+                     "The field 'name field' is empty. The value of a/an name field should be no longer "
                          + "than 50 characters. It should not be empty.",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength, emptyValue));
 
@@ -278,7 +278,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidPersonName = "";
         String actual = validator.getInvalidityInfoForPersonName(invalidPersonName);
         assertEquals("Invalid person name (empty) should return error message that is specific to person name",
-                     "The field person name is empty. The value of a/an person name should be no longer "
+                     "The field 'person name' is empty. The value of a/an person name should be no longer "
                          + "than 100 characters. It should not be empty.",
                      actual);
     }
@@ -319,7 +319,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidTeamName = "";
         String actual = validator.getInvalidityInfoForTeamName(invalidTeamName);
         assertEquals("Invalid team name (empty) should return error message that is specific to team name",
-                     "The field team name is empty. The value of a/an team name should be no longer "
+                     "The field 'team name' is empty. The value of a/an team name should be no longer "
                          + "than 60 characters. It should not be empty.",
                      actual);
     }
@@ -363,7 +363,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidEmailSubject = "";
         String actual = validator.getInvalidityInfoForEmailSubject(invalidEmailSubject);
         assertEquals("Invalid email subject (empty) should return error message that is specific to email subject",
-                     "The field email subject is empty. The value of a/an email subject should be no longer than "
+                     "The field 'email subject' is empty. The value of a/an email subject should be no longer than "
                          + "200 characters. It should not be empty.",
                      actual);
     }
@@ -473,7 +473,7 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForGoogleId_invalid_returnErrorString() {
         String emptyId = "";
         assertEquals("Invalid Google ID (empty) should return appropriate error message",
-                     "The field Google ID is empty. A Google ID must be a valid id "
+                     "The field 'Google ID' is empty. A Google ID must be a valid id "
                          + "already registered with Google. It cannot be longer than "
                          + "254 characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(emptyId));
@@ -545,7 +545,7 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForEmail_invalid_returnErrorString() {
         String emptyEmail = "";
         assertEquals("Invalid email (empty) should return appropriate error string",
-                     "The field email is empty. An email address contains some text followed by one "
+                     "The field 'email' is empty. An email address contains some text followed by one "
                          + "'@' sign followed by some more text. It cannot be longer than 254 "
                          + "characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emptyEmail));
@@ -652,7 +652,7 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForCourseId_invalid_returnErrorString() {
         String emptyCourseId = "";
         assertEquals("Invalid Course ID (empty) should return appropriate error string",
-                     "The field course ID is empty. A course ID can contain letters, numbers, "
+                     "The field 'course ID' is empty. A course ID can contain letters, numbers, "
                          + "fullstops, hyphens, underscores, and dollar signs. It cannot be "
                          + "longer than 40 characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(emptyCourseId));

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -64,8 +64,8 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "\"\" is not acceptable to TEAMMATES as a/an my field because it is empty. The value of "
-                         + "a/an my field should be no longer than 50 characters. It should not be empty.",
+                     "The field my field is empty. The value of a/an my field should be no longer "
+                         + "than 50 characters. It should not be empty.",
                      FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
                              maxLength, emptyValue));
 

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -259,8 +259,8 @@ public class FieldValidatorTest extends BaseTestCase {
 
         String emptyValue = "";
         assertEquals("invalid: empty",
-                     "\"\" is not acceptable to TEAMMATES as a/an name field because it is empty. The value "
-                         + "of a/an name field should be no longer than 50 characters. It should not be empty.",
+                     "The field name field is empty. The value of a/an name field should be no longer "
+                         + "than 50 characters. It should not be empty.",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength, emptyValue));
 
         ______TS("failure: untrimmed value");
@@ -277,8 +277,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidPersonName = "";
         String actual = validator.getInvalidityInfoForPersonName(invalidPersonName);
         assertEquals("Invalid person name (empty) should return error message that is specific to person name",
-                     "\"\" is not acceptable to TEAMMATES as a/an person name because it is empty. The value "
-                         + "of a/an person name should be no longer than 100 characters. It should not be empty.",
+                     "The field person name is empty. The value of a/an person name should be no longer "
+                         + "than 100 characters. It should not be empty.",
                      actual);
     }
 
@@ -318,8 +318,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidTeamName = "";
         String actual = validator.getInvalidityInfoForTeamName(invalidTeamName);
         assertEquals("Invalid team name (empty) should return error message that is specific to team name",
-                     "\"\" is not acceptable to TEAMMATES as a/an team name because it is empty. The value "
-                         + "of a/an team name should be no longer than 60 characters. It should not be empty.",
+                     "The field team name is empty. The value of a/an team name should be no longer "
+                         + "than 60 characters. It should not be empty.",
                      actual);
     }
 
@@ -362,9 +362,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String invalidEmailSubject = "";
         String actual = validator.getInvalidityInfoForEmailSubject(invalidEmailSubject);
         assertEquals("Invalid email subject (empty) should return error message that is specific to email subject",
-                     "\"\" is not acceptable to TEAMMATES as a/an email subject because it is empty. The "
-                         + "value of a/an email subject should be no longer than 200 characters. It should "
-                         + "not be empty.",
+                     "The field email subject is empty. The value of a/an email subject should be no longer than "
+                         + "200 characters. It should not be empty.",
                      actual);
     }
 
@@ -440,8 +439,8 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForGoogleId_invalid_returnErrorString() {
         String emptyId = "";
         assertEquals("Invalid Google ID (empty) should return appropriate error message",
-                     "\"\" is not acceptable to TEAMMATES as a/an Google ID because it is empty. A Google "
-                         + "ID must be a valid id already registered with Google. It cannot be longer than "
+                     "The field Google ID is empty. A Google ID must be a valid id "
+                         + "already registered with Google. It cannot be longer than "
                          + "254 characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForGoogleId(emptyId));
 
@@ -512,9 +511,9 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForEmail_invalid_returnErrorString() {
         String emptyEmail = "";
         assertEquals("Invalid email (empty) should return appropriate error string",
-                     "\"\" is not acceptable to TEAMMATES as a/an email because it is empty. An email "
-                         + "address contains some text followed by one '@' sign followed by some more text. "
-                         + "It cannot be longer than 254 characters, cannot be empty and cannot contain spaces.",
+                     "The field email is empty. An email address contains some text followed by one "
+                         + "'@' sign followed by some more text. It cannot be longer than 254 "
+                         + "characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForEmail(emptyEmail));
 
         String untrimmedEmail = "  untrimmed@email.com  ";
@@ -619,9 +618,9 @@ public class FieldValidatorTest extends BaseTestCase {
     public void testGetInvalidityInfoForCourseId_invalid_returnErrorString() {
         String emptyCourseId = "";
         assertEquals("Invalid Course ID (empty) should return appropriate error string",
-                     "\"\" is not acceptable to TEAMMATES as a/an course ID because it is empty. A course ID "
-                         + "can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
-                         + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.",
+                     "The field course ID is empty. A course ID can contain letters, numbers, "
+                         + "fullstops, hyphens, underscores, and dollar signs. It cannot be "
+                         + "longer than 40 characters, cannot be empty and cannot contain spaces.",
                      validator.getInvalidityInfoForCourseId(emptyCourseId));
 
         String untrimmedCourseId = " $cs1101-sem1.2_ ";

--- a/src/test/java/teammates/test/driver/FieldValidatorExtension.java
+++ b/src/test/java/teammates/test/driver/FieldValidatorExtension.java
@@ -31,7 +31,7 @@ public final class FieldValidatorExtension {
 
         if (value.isEmpty()) {
             return FieldValidator.getPopulatedEmptyStringErrorMessage(
-                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, value, fieldName, maxLength);
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, fieldName, maxLength);
         }
         if (FieldValidator.isUntrimmed(value)) {
             return FieldValidator.WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);

--- a/src/test/java/teammates/test/driver/FieldValidatorExtension.java
+++ b/src/test/java/teammates/test/driver/FieldValidatorExtension.java
@@ -30,8 +30,8 @@ public final class FieldValidatorExtension {
         Assumption.assertTrue("Non-null value expected for " + fieldName, value != null);
 
         if (value.isEmpty()) {
-            return FieldValidator.getPopulatedErrorMessage(FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE, value,
-                    fieldName, FieldValidator.REASON_EMPTY, maxLength);
+            return FieldValidator.getPopulatedEmptyStringErrorMessage(
+                    FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING, value, fieldName, maxLength);
         }
         if (FieldValidator.isUntrimmed(value)) {
             return FieldValidator.WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -55,7 +55,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-danger statusMessage">
-      "" is not acceptable to TEAMMATES as a/an course name because it is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
+      The field course name is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -55,7 +55,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-danger statusMessage">
-      The field course name is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
+      The field 'course name' is empty. The value of a/an course name should be no longer than 64 characters. It should not be empty.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">


### PR DESCRIPTION
Fixes #4129 

Change error message from 

_[this]_

`
"" is not acceptable to TEAMMATES as feedback session name because it is empty. 
`


_[to this]_

`
The field <field_name> is empty. 
`
