### PR TITLE
InstructorFeedbackSessionsPageUiTest: remove dependency on browser time zone #7669

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -273,13 +273,16 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
 
-        feedbackPage.addFeedbackSessionWithStandardTimeZone(
+        feedbackPage.addFeedbackSession(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 null, null, null, null,
                 null, -1);
 
         savedSession = BackDoor.getFeedbackSession(newSession.getCourseId(), newSession.getFeedbackSessionName());
+        // start time and time zone are autodetected and set by the browser
+        // since they vary from system to system, we do not test for their values
         newSession.setStartTime(savedSession.getStartTime());
+        newSession.setTimeZone(savedSession.getTimeZone());
 
         assertEquals(newSession.toString(), savedSession.toString());
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -243,7 +243,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getInstructions(), newSession.getGracePeriod());
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_EXISTS);
 
-        ______TS("success case: private session, boundary length name, timezone = 5.75, only results email");
+        ______TS("success case: private session, boundary length name, only results email");
 
         feedbackPage = getFeedbackPageForInstructor(idOfInstructorWithSessions);
         feedbackPage.clickEditUncommonSettingsButtons();
@@ -256,7 +256,6 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         newSession.setFeedbackSessionName("private session of characters1234567 #");
         newSession.setCourseId("CFeedbackUiT.CS2104");
-        newSession.setTimeZone(5.75);
         newSession.setEndTime(null);
         newSession.setSessionVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
         newSession.setResultsVisibleFromTime(Const.TIME_REPRESENTS_NEVER);
@@ -274,10 +273,10 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
 
-        feedbackPage.addFeedbackSessionWithTimeZone(
+        feedbackPage.addFeedbackSession(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 null, null, null, null,
-                null, -1, newSession.getTimeZone());
+                null, -1);
 
         savedSession = BackDoor.getFeedbackSession(newSession.getCourseId(), newSession.getFeedbackSessionName());
         newSession.setStartTime(savedSession.getStartTime());

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -187,14 +187,14 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         Text instructions = newSession.getInstructions();
 
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getEndTime(), newSession.getStartTime(), null, null,
                 instructions, newSession.getGracePeriod());
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_END_TIME_EARLIER_THAN_START_TIME);
         assertEquals("<p>" + instructions.getValue() + "</p>", feedbackPage.getInstructions());
 
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 instructions, newSession.getGracePeriod());
@@ -221,7 +221,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.selectSessionType("Team peer evaluation session");
 
         String templateSessionName = "Team Peer Evaluation Session";
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 templateSessionName, newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(), newSession.getGracePeriod());
@@ -237,7 +237,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         feedbackPage = getFeedbackPageForInstructor(idOfInstructorWithSessions);
 
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(), newSession.getGracePeriod());
@@ -273,7 +273,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         newSession.setFeedbackSessionType(FeedbackSessionType.PRIVATE);
 
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 null, null, null, null,
                 null, -1);
@@ -406,7 +406,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         newSession.setGracePeriod(30);
         newSession.setInstructions(new Text("Test instructions"));
 
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(),
                 newSession.getSessionVisibleFromTime(), newSession.getResultsVisibleFromTime(),
@@ -436,7 +436,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         newSession.setFeedbackSessionName("bad name %% #");
         newSession.setEndTime(Const.TIME_REPRESENTS_LATER);
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(), newSession.getGracePeriod());
@@ -919,7 +919,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         feedbackPage.selectSessionType("Session with your own questions");
         String templateSessionName = "!Invalid name";
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 templateSessionName, newSession.getCourseId(),
                 TimeHelper.convertToDate("2035-04-01 10:00 PM UTC"),
                 TimeHelper.convertToDate("2035-04-30 10:00 PM UTC"),
@@ -958,7 +958,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         newSession.setEndTime(Const.TIME_REPRESENTS_LATER);
         feedbackPage.clickEditUncommonSettingsButtons();
         feedbackPage.clickNeverPublishTimeButton();
-        feedbackPage.addFeedbackSession(
+        feedbackPage.addFeedbackSessionWithStandardTimeZone(
                 newSession.getFeedbackSessionName(), newSession.getCourseId(),
                 newSession.getStartTime(), newSession.getEndTime(), null, null,
                 newSession.getInstructions(),

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -206,7 +206,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         click(sendPublishedEmailCheckbox);
     }
 
-    public void addFeedbackSessionWithTimeZone(
+    public void addFeedbackSession(
             String feedbackSessionName,
             String courseId,
             Date startTime,
@@ -214,20 +214,9 @@ public class InstructorFeedbackSessionsPage extends AppPage {
             Date visibleTime,
             Date publishTime,
             Text instructions,
-            int gracePeriod,
-            double timeZone) {
+            int gracePeriod) {
 
         fillTextBox(fsNameTextBox, feedbackSessionName);
-
-        String timeZoneString = Double.toString(timeZone);
-
-        double fractionalPart = timeZone % 1;
-
-        if (fractionalPart == 0.0) {
-            timeZoneString = Integer.toString((int) timeZone);
-        }
-
-        selectDropdownByActualValue(timezoneDropdown, timeZoneString);
 
         waitForElementVisibility(courseIdDropdown);
         selectDropdownByVisibleValue(courseIdDropdown, courseId);
@@ -249,6 +238,30 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         }
 
         clickSubmitButton();
+    }
+
+    public void addFeedbackSessionWithTimeZone(
+            String feedbackSessionName,
+            String courseId,
+            Date startTime,
+            Date endTime,
+            Date visibleTime,
+            Date publishTime,
+            Text instructions,
+            int gracePeriod,
+            double timeZone) {
+
+        String timeZoneString = Double.toString(timeZone);
+
+        double fractionalPart = timeZone % 1;
+
+        if (fractionalPart == 0.0) {
+            timeZoneString = Integer.toString((int) timeZone);
+        }
+
+        selectDropdownByActualValue(timezoneDropdown, timeZoneString);
+
+        addFeedbackSession(feedbackSessionName, courseId, startTime, endTime, visibleTime, publishTime, instructions, gracePeriod);
     }
 
     public void copyFeedbackSession(String feedbackSessionName, String courseId) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -391,7 +391,7 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         return (String) executeScript("return (-(new Date()).getTimezoneOffset() / 60).toString()");
     }
 
-    public void addFeedbackSession(String feedbackSessionName, String courseId, Date startTime,
+    public void addFeedbackSessionWithStandardTimeZone(String feedbackSessionName, String courseId, Date startTime,
             Date endTime, Date visibleTime, Date publishTime, Text instructions, int gracePeriod) {
 
         addFeedbackSessionWithTimeZone(feedbackSessionName, courseId, startTime, endTime,

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -257,6 +257,13 @@ public class InstructorFeedbackSessionsPage extends AppPage {
                 feedbackSessionName, courseId, startTime, endTime, visibleTime, publishTime, instructions, gracePeriod);
     }
 
+    public void addFeedbackSessionWithStandardTimeZone(String feedbackSessionName, String courseId, Date startTime,
+            Date endTime, Date visibleTime, Date publishTime, Text instructions, int gracePeriod) {
+
+        addFeedbackSessionWithTimeZone(
+                feedbackSessionName, courseId, startTime, endTime, visibleTime, publishTime, instructions, gracePeriod, 8.0);
+    }
+
     private void selectTimeZone(double timeZone) {
         String timeZoneString = Double.toString(timeZone);
 
@@ -407,13 +414,6 @@ public class InstructorFeedbackSessionsPage extends AppPage {
 
     public String getClientTimeZone() {
         return (String) executeScript("return (-(new Date()).getTimezoneOffset() / 60).toString()");
-    }
-
-    public void addFeedbackSessionWithStandardTimeZone(String feedbackSessionName, String courseId, Date startTime,
-            Date endTime, Date visibleTime, Date publishTime, Text instructions, int gracePeriod) {
-
-        addFeedbackSessionWithTimeZone(feedbackSessionName, courseId, startTime, endTime,
-                visibleTime, publishTime, instructions, gracePeriod, 8.0);
     }
 
     public WebElement getViewResponseLink(String courseId, String sessionName) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -240,16 +240,8 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         clickSubmitButton();
     }
 
-    public void addFeedbackSessionWithTimeZone(
-            String feedbackSessionName,
-            String courseId,
-            Date startTime,
-            Date endTime,
-            Date visibleTime,
-            Date publishTime,
-            Text instructions,
-            int gracePeriod,
-            double timeZone) {
+    public void addFeedbackSessionWithTimeZone(String feedbackSessionName, String courseId, Date startTime,
+            Date endTime, Date visibleTime, Date publishTime, Text instructions, int gracePeriod, double timeZone) {
 
         selectTimeZone(timeZone);
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -251,6 +251,13 @@ public class InstructorFeedbackSessionsPage extends AppPage {
             int gracePeriod,
             double timeZone) {
 
+        selectTimeZone(timeZone);
+
+        addFeedbackSession(
+                feedbackSessionName, courseId, startTime, endTime, visibleTime, publishTime, instructions, gracePeriod);
+    }
+
+    private void selectTimeZone(double timeZone) {
         String timeZoneString = Double.toString(timeZone);
 
         double fractionalPart = timeZone % 1;
@@ -260,8 +267,6 @@ public class InstructorFeedbackSessionsPage extends AppPage {
         }
 
         selectDropdownByActualValue(timezoneDropdown, timeZoneString);
-
-        addFeedbackSession(feedbackSessionName, courseId, startTime, endTime, visibleTime, publishTime, instructions, gracePeriod);
     }
 
     public void copyFeedbackSession(String feedbackSessionName, String courseId) {

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -1014,7 +1014,7 @@
                     </a>
                   </li>
                   <li>
-                    <a class="session-publish-for-test" data-fsname="private session of characters1234567 #" data-sending-published-email="true" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&next=%2Fpage%2FinstructorFeedbackSessionsPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
+                    <a class="session-publish-for-test" data-fsname="private session of characters1234567 #" data-sending-published-email="true" disabled="" href="/page/instructorFeedbackPublish?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&next=%2Fpage%2FinstructorFeedbackSessionsPage&user=CFeedbackUiT.instructor&token=${sessionToken}">
                       Publish Results
                     </a>
                   </li>


### PR DESCRIPTION
Fixes #7669, fixes #7789

**Outline of Solution**

The root issue is that the session start time of the session created via UI in the test is inconsistent across systems with different time zones. This results in inconsistent behaviour of the publish button, whose disabled state depends on whether or not the session is waiting to open (and subsequently has a dependency on the session start time).

It turns out that one of the test sessions created during the test had start time unspecified. The test was relying on the browser to fill in the correct start time, based on the default date picker behaviour (next hour from current time). This is fine, except that the same test also specified a time zone (5.75). Now this poses a problem. While start time is autodetected (next hour based on the original browser time zone), the selected time zone is hardcoded. Since start time is interpreted as local time based on the selected time zone, the discrepancy results in an interpretation that differs across systems on different time zones.

To fix, the hardcoded time zone was removed from the test case, allowing the browser to fill in the time zone, too. Different time zones are already tested through other test cases.