### PR TITLE
Student: MOTD: include only body of fetched HTML resource file #7794

### DIFF
--- a/src/main/webapp/dev/js/main/studentMotd.es6
+++ b/src/main/webapp/dev/js/main/studentMotd.es6
@@ -6,7 +6,8 @@ function fetchMotd(motdUrl, motdContentSelector, motdContainerSelector) {
         type: 'GET',
         url: `${window.location.origin}/${motdUrl}`,
         success(data) {
-            $(motdContentSelector).html(data);
+            const bodyContent = data.match(/<body[^>]*>[\s\S]*<\/body>/gi);
+            $(motdContentSelector).html(bodyContent);
         },
         error() {
             $(motdContainerSelector).html('');


### PR DESCRIPTION
Fixes #7794 

Modified the [`fetchMotd`](https://github.com/TEAMMATES/teammates/blob/master/src/main/webapp/dev/js/main/studentMotd.es6#L4) function to this 
```javascript
function fetchMotd(motdUrl, motdContentSelector, motdContainerSelector) {
    $.ajax({
        type: 'GET',
        url: `${window.location.origin}/${motdUrl}`,
        success(data) {
            const bodyContent = data.match(/<body[^>]*>[\s\S]*<\/body>/gi);
            $(motdContentSelector).html(bodyContent);
        },
        error() {
            $(motdContainerSelector).html('');
        },
    });
}
```
This updated `fetchMotd` on success will only return the data present inside the `Body element` to `student-motd` container.