### PR TITLE
Move sorting of instructors from storage layer to logic layer #7795

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -19,7 +19,7 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
     public static final String DEFAULT_DISPLAY_NAME = "Instructor";
 
     /**
-     * Sort the Instructors list alphabetically by name.
+     * Sorts the Instructors list alphabetically by name.
      */
     public static Comparator<InstructorAttributes> compareByName = new Comparator<InstructorAttributes>() {
         public int compare(InstructorAttributes one, InstructorAttributes other) {

--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -19,8 +19,8 @@ public class InstructorAttributes extends EntityAttributes<Instructor> {
     public static final String DEFAULT_DISPLAY_NAME = "Instructor";
 
     /**
-    * Sort the Instructors list alphabetically by name.
-    */
+     * Sort the Instructors list alphabetically by name.
+     */
     public static Comparator<InstructorAttributes> compareByName = new Comparator<InstructorAttributes>() {
         public int compare(InstructorAttributes one, InstructorAttributes other) {
             return one.name.toLowerCase().compareTo(other.name.toLowerCase());

--- a/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/InstructorAttributes.java
@@ -1,6 +1,7 @@
 package teammates.common.datatransfer.attributes;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import teammates.common.datatransfer.InstructorPrivileges;
@@ -16,6 +17,15 @@ import teammates.storage.entity.Instructor;
 public class InstructorAttributes extends EntityAttributes<Instructor> {
 
     public static final String DEFAULT_DISPLAY_NAME = "Instructor";
+
+    /**
+    * Sort the Instructors list alphabetically by name.
+    */
+    public static Comparator<InstructorAttributes> compareByName = new Comparator<InstructorAttributes>() {
+        public int compare(InstructorAttributes one, InstructorAttributes other) {
+            return one.name.toLowerCase().compareTo(other.name.toLowerCase());
+        }
+    };
 
     // Note: be careful when changing these variables as their names are used in *.json files.
 

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -121,6 +121,7 @@ public final class InstructorsLogic {
     public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
         List<InstructorAttributes> instructorReturnList = instructorsDb.getInstructorsForCourse(courseId);
         Collections.sort(instructorReturnList, InstructorAttributes.compareByName);
+
         return instructorReturnList;
     }
 

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import teammates.common.datatransfer.InstructorSearchResultBundle;
@@ -118,8 +119,9 @@ public final class InstructorsLogic {
     }
 
     public List<InstructorAttributes> getInstructorsForCourse(String courseId) {
-
-        return instructorsDb.getInstructorsForCourse(courseId);
+        List<InstructorAttributes> instructorReturnList = instructorsDb.getInstructorsForCourse(courseId);
+        Collections.sort(instructorReturnList, InstructorAttributes.compareByName);
+        return instructorReturnList;
     }
 
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId) {

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -4,7 +4,6 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import com.google.appengine.api.search.Results;
@@ -389,9 +388,7 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
     }
 
     private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
-        List<Instructor> instructorReturnList = load().filter("courseId =", courseId).list();
-        Collections.sort(instructorReturnList, Instructor.compareByName);
-        return instructorReturnList;
+        return load().filter("courseId =", courseId).list();
     }
 
     private List<Instructor> getInstructorEntities() {

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -1,7 +1,6 @@
 package teammates.storage.entity;
 
 import java.security.SecureRandom;
-import java.util.Comparator;
 
 import com.google.appengine.api.datastore.Text;
 
@@ -17,15 +16,6 @@ import com.googlecode.objectify.annotation.Unindex;
 @Entity
 @Index
 public class Instructor extends BaseEntity {
-
-    /**
-    * Sort the Instructors list alphabetically by name.
-    */
-    public static Comparator<Instructor> compareByName = new Comparator<Instructor>() {
-        public int compare(Instructor one, Instructor other) {
-            return one.name.toLowerCase().compareTo(other.name.toLowerCase());
-        }
-    };
 
     /**
      * The primary key. Format: email%courseId e.g., adam@gmail.com%cs1101


### PR DESCRIPTION
Fixes #7795

- moved Comparator method `compareByName` from `Instructor` to `InstructorAttributes`.
- moved the sort logic from `InstructorsDb` to `InstructorsLogic`.

Apologies for my mistake in PR #7680