### PR TITLE
*FeedbackSubmitPageUiTest: Fix dependency on current time #7808

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -149,7 +149,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     public String getStartTimeString() {
         if (startTime == null) {
-            return "";
+            return "-";
         }
         Date startTimeInUtc = TimeHelper.convertLocalDateToUtc(startTime, timeZone);
         return TimeHelper.formatDateTimeForSessions(startTimeInUtc, timeZone);
@@ -157,7 +157,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
 
     public String getEndTimeString() {
         if (endTime == null) {
-            return "";
+            return "-";
         }
         Date endTimeInUtc = TimeHelper.convertLocalDateToUtc(endTime, timeZone);
         return TimeHelper.formatDateTimeForSessions(endTimeInUtc, timeZone);

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -148,11 +148,17 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getStartTimeString() {
+        if (startTime == null) {
+            return "";
+        }
         Date startTimeInUtc = TimeHelper.convertLocalDateToUtc(startTime, timeZone);
         return TimeHelper.formatDateTimeForSessions(startTimeInUtc, timeZone);
     }
 
     public String getEndTimeString() {
+        if (endTime == null) {
+            return "";
+        }
         Date endTimeInUtc = TimeHelper.convertLocalDateToUtc(endTime, timeZone);
         return TimeHelper.formatDateTimeForSessions(endTimeInUtc, timeZone);
     }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -173,6 +173,9 @@ public final class TimeHelper {
      */
     @Deprecated
     public static Date convertLocalDateToUtc(Date localDate, double localTimeZone) {
+        if (localDate == null) {
+            return null;
+        }
         Calendar localCal = dateToCalendar(localDate);
         localCal.add(Calendar.MINUTE, (int) (60 * (-localTimeZone)));
         return localCal.getTime();

--- a/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -1,7 +1,6 @@
 package teammates.test.cases.browsertests;
 
 import java.util.Calendar;
-import java.util.TimeZone;
 
 import org.openqa.selenium.By;
 import org.testng.annotations.Test;

--- a/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -16,6 +16,7 @@ import teammates.common.datatransfer.questions.FeedbackMsqResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleResponseDetails;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.TestProperties;
 import teammates.test.pageobjects.AppPage;
@@ -90,7 +91,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         FeedbackSessionAttributes fs = BackDoor.getFeedbackSession("SFSubmitUiT.CS2104",
                                                                    "Grace Period Session");
 
-        Calendar endDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        Calendar endDate = TimeHelper.now(fs.getTimeZone());
         endDate.add(Calendar.MINUTE, -1);
         fs.setGracePeriod(10);
         fs.setEndTime(endDate.getTime());

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
@@ -52,7 +52,6 @@
               </label>
               <div class="col-sm-10">
                 <p class="form-control-static">
-                  ${datetime.now} UTC+0800
                 </p>
               </div>
             </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePrivate.html
@@ -52,6 +52,7 @@
               </label>
               <div class="col-sm-10">
                 <p class="form-control-static">
+                  -
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Fixes #7808 

Fixes the recent slew of Travis build errors between UTC 1600 and UTC 0000. The builds were failing due to some aspects being overlooked in #7740. The exact causes are explained by @leeyimin in the Issue Description.

**Outline of solution**
- Handle null end time in a44db4e. This prevents the build error for InstructorFeedbackSubmitPageUiTest.
- Set the session end time to current time in the session's time zone instead of UTC in 5916ccc. This prevents the build error for StudentFeedbackSubmitPageUiTest.

Sorry for taking so long to push these changes. As I explained in https://github.com/TEAMMATES/teammates/issues/7808#issuecomment-317053489, I missed [this line](https://github.com/TEAMMATES/teammates/blob/master/src/test/java/teammates/test/driver/HtmlHelper.java#L394) in HtmlHelper which converts the current time to the time zone it sees on the page. Because I missed that, I thought that only the current time in UTC would be replaced and was confused about why the current behaviour was then, not working. Sincere apologies once again for the oversight.

Side note: Perhaps as a result of this issue, we could make it a rule for all time-related changes to be run on Travis at least twice over a 24 hour period with at least a 12-hour gap between the two test runs? This suggestion is based on the current behaviour of HtmlHelper which replaces current time only depending on DD/MM/YYYY.  