### PR TITLE
Instructor: response comments: fix misalignment of edit/delete buttons #7719

### DIFF
--- a/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/shared/feedbackResponseCommentRow.tag
@@ -27,59 +27,63 @@
 </c:choose>
 
 <li class="list-group-item list-group-item-warning" id="responseCommentRow-${divId}">
-  <div id="commentBar-${divId}">
+  <div id="commentBar-${divId}" class="row">
+    <div class="col-xs-10">
     <span class="text-muted">
       From: ${fn:escapeXml(frc.commentGiverName)} [${frc.createdAt}] ${frc.editedAt}
     </span>
-    <c:if test="${frc.withVisibilityIcon}">
-      <span class="glyphicon glyphicon-eye-open"
-          data-toggle="tooltip"
-          data-placement="top"
-          style="margin-left: 5px;"
-          title="This response comment is visible to ${frc.whoCanSeeComment}"></span>
-    </c:if>
-    <c:if test="${frc.editDeleteEnabled}">
-      <form class="responseCommentDeleteForm pull-right">
-        <a href="<%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_DELETE %>"
-            type="button"
-            id="commentdelete-${divId}"
-            class="btn btn-default btn-xs icon-button"
+      <c:if test="${frc.withVisibilityIcon}">
+        <span class="glyphicon glyphicon-eye-open"
             data-toggle="tooltip"
             data-placement="top"
-            title="<%= Const.Tooltips.COMMENT_DELETE %>"
-            <c:if test="${not frc.editDeleteEnabled}">
-              disabled
-            </c:if>>
-          <span class="glyphicon glyphicon-trash glyphicon-primary"></span>
+            style="margin-left: 5px;"
+            title="This response comment is visible to ${frc.whoCanSeeComment}"></span>
+      </c:if>
+    </div>
+    <div class="col-xs-2">
+      <c:if test="${frc.editDeleteEnabled}">
+        <form class="responseCommentDeleteForm pull-right">
+          <a href="<%= Const.ActionURIs.INSTRUCTOR_FEEDBACK_RESPONSE_COMMENT_DELETE %>"
+              type="button"
+              id="commentdelete-${divId}"
+              class="btn btn-default btn-xs icon-button"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="<%= Const.Tooltips.COMMENT_DELETE %>"
+              <c:if test="${not frc.editDeleteEnabled}">
+                disabled
+              </c:if>>
+            <span class="glyphicon glyphicon-trash glyphicon-primary"></span>
+          </a>
+          <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${firstIndex}">
+          <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${frc.feedbackResponseId}">
+          <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}">
+          <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
+          <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
+          <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
+          <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
+        </form>
+        <a type="button" id="commentedit-${divId}"
+            <c:choose>
+              <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
+                class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form"
+                data-recipientindex="${firstIndex}" data-giverindex="${secondIndex}"
+                data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
+                <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
+                <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>
+              </c:when>
+              <c:otherwise>
+                class="btn btn-default btn-xs icon-button pull-right"
+              </c:otherwise>
+            </c:choose>
+            data-toggle="tooltip"
+            data-placement="top"
+            title="<%= Const.Tooltips.COMMENT_EDIT %>"
+            <c:if test="${not frc.editDeleteEnabled}">disabled</c:if>>
+          <span class="glyphicon glyphicon-pencil glyphicon-primary"></span>
         </a>
-        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_INDEX %>" value="${firstIndex}">
-        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_ID %>" value="${frc.feedbackResponseId}">
-        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID %>" value="${frc.commentId}">
-        <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${frc.courseId}">
-        <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${frc.feedbackSessionName}">
-        <input type="hidden" name="<%= Const.ParamsNames.USER_ID %>" value="${data.account.googleId}">
-        <input type="hidden" name="<%= Const.ParamsNames.SESSION_TOKEN %>" value="${data.sessionToken}">
-      </form>
-      <a type="button" id="commentedit-${divId}"
-          <c:choose>
-            <c:when test="${not empty firstIndex && not empty secondIndex && not empty thirdIndex && not empty frcIndex}">
-              class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form"
-              data-recipientindex="${firstIndex}" data-giverindex="${secondIndex}"
-              data-qnindex="${thirdIndex}" data-frcindex="${frcIndex}"
-              <c:if test="${not empty fourthIndex}">data-sectionindex="${fourthIndex}"</c:if>
-              <c:if test="${not empty viewType}">data-viewtype="${viewType}"</c:if>
-            </c:when>
-            <c:otherwise>
-              class="btn btn-default btn-xs icon-button pull-right"
-            </c:otherwise>
-          </c:choose>
-          data-toggle="tooltip"
-          data-placement="top"
-          title="<%= Const.Tooltips.COMMENT_EDIT %>"
-          <c:if test="${not frc.editDeleteEnabled}">disabled</c:if>>
-        <span class="glyphicon glyphicon-pencil glyphicon-primary"></span>
-      </a>
-    </c:if>
+      </c:if>
+    </div>
   </div>
   <%-- Do not add whitespace between the opening and closing tags --%>
   <div id="plainCommentText-${divId}" style="margin-left: 15px;">${frc.commentText}</div>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -356,27 +356,31 @@
                             </div>
                             <ul class="list-group" id="responseCommentTable-0-0-1-1" style="margin-top: 15px;">
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-1-0-1-1">
-                                <div id="commentBar-0-1-0-1-1">
-                                  <span class="text-muted">
-                                    From: Teammates Test [${datetime.now} UTC+0800]
-                                  </span>
-                                  <form class="responseCommentDeleteForm pull-right">
-                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-1-0-1-1" title="" type="button">
-                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                <div class="row" id="commentBar-0-1-0-1-1">
+                                  <div class="col-xs-10">
+                                    <span class="text-muted">
+                                      From: Teammates Test [${datetime.now} UTC+0800]
+                                    </span>
+                                  </div>
+                                  <div class="col-xs-2">
+                                    <form class="responseCommentDeleteForm pull-right">
+                                      <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-1-0-1-1" title="" type="button">
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                        </span>
+                                      </a>
+                                      <input name="fsindex" type="hidden" value="1">
+                                      <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                      <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
+                                      <input name="fsname" type="hidden" value="First Session">
+                                      <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                      <input name="token" type="hidden" value="${sessionToken}">
+                                    </form>
+                                    <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-1" title="" type="button">
+                                      <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                       </span>
                                     </a>
-                                    <input name="fsindex" type="hidden" value="1">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
-                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                    <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
-                                    <input name="fsname" type="hidden" value="First Session">
-                                    <input name="user" type="hidden" value="CFResultsUiT.instr">
-                                    <input name="token" type="hidden" value="${sessionToken}">
-                                  </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-1" title="" type="button">
-                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                    </span>
-                                  </a>
+                                  </div>
                                 </div>
                                 <div id="plainCommentText-0-1-0-1-1" style="margin-left: 15px;">
                                   <p>
@@ -458,27 +462,31 @@
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-1-0-1-2">
-                                <div id="commentBar-0-1-0-1-2">
-                                  <span class="text-muted">
-                                    From: Teammates Test [${datetime.now} UTC+0800]
-                                  </span>
-                                  <form class="responseCommentDeleteForm pull-right">
-                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-1-0-1-2" title="" type="button">
-                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                <div class="row" id="commentBar-0-1-0-1-2">
+                                  <div class="col-xs-10">
+                                    <span class="text-muted">
+                                      From: Teammates Test [${datetime.now} UTC+0800]
+                                    </span>
+                                  </div>
+                                  <div class="col-xs-2">
+                                    <form class="responseCommentDeleteForm pull-right">
+                                      <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-1-0-1-2" title="" type="button">
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                        </span>
+                                      </a>
+                                      <input name="fsindex" type="hidden" value="1">
+                                      <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                      <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
+                                      <input name="fsname" type="hidden" value="First Session">
+                                      <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                      <input name="token" type="hidden" value="${sessionToken}">
+                                    </form>
+                                    <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-2" title="" type="button">
+                                      <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                       </span>
                                     </a>
-                                    <input name="fsindex" type="hidden" value="1">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
-                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                    <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
-                                    <input name="fsname" type="hidden" value="First Session">
-                                    <input name="user" type="hidden" value="CFResultsUiT.instr">
-                                    <input name="token" type="hidden" value="${sessionToken}">
-                                  </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-1-0-1-2" title="" type="button">
-                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                    </span>
-                                  </a>
+                                  </div>
                                 </div>
                                 <div id="plainCommentText-0-1-0-1-2" style="margin-left: 15px;">
                                   <p>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -356,29 +356,33 @@
                             </div>
                             <ul class="list-group" id="responseCommentTable-0-0-1-1" style="margin-top:15px;">
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-0-1-1-1">
-                                <div id="commentBar-0-0-1-1-1">
-                                  <span class="text-muted">
-                                    From: Teammates Test [${datetime.now} UTC+0800]
-                                  </span>
-                                  <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
-                                  </span>
-                                  <form class="responseCommentDeleteForm pull-right">
-                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-0-1-1-1" title="" type="button">
-                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                <div class="row" id="commentBar-0-0-1-1-1">
+                                  <div class="col-xs-10">
+                                    <span class="text-muted">
+                                      From: Teammates Test [${datetime.now} UTC+0800]
+                                    </span>
+                                    <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
+                                    </span>
+                                  </div>
+                                  <div class="col-xs-2">
+                                    <form class="responseCommentDeleteForm pull-right">
+                                      <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-0-1-1-1" title="" type="button">
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                        </span>
+                                      </a>
+                                      <input name="fsindex" type="hidden" value="0">
+                                      <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                      <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
+                                      <input name="fsname" type="hidden" value="First Session">
+                                      <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                      <input name="token" type="hidden" value="${sessionToken}">
+                                    </form>
+                                    <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-1" title="" type="button">
+                                      <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                       </span>
                                     </a>
-                                    <input name="fsindex" type="hidden" value="0">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
-                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                    <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
-                                    <input name="fsname" type="hidden" value="First Session">
-                                    <input name="user" type="hidden" value="CFResultsUiT.instr">
-                                    <input name="token" type="hidden" value="${sessionToken}">
-                                  </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-1" title="" type="button">
-                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                    </span>
-                                  </a>
+                                  </div>
                                 </div>
                                 <div id="plainCommentText-0-0-1-1-1" style="margin-left: 15px;">
                                   <p>
@@ -460,29 +464,33 @@
                                 </form>
                               </li>
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-0-1-1-2">
-                                <div id="commentBar-0-0-1-1-2">
-                                  <span class="text-muted">
-                                    From: Teammates Test [${datetime.now} UTC+0800]
-                                  </span>
-                                  <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
-                                  </span>
-                                  <form class="responseCommentDeleteForm pull-right">
-                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-0-1-1-2" title="" type="button">
-                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                <div class="row" id="commentBar-0-0-1-1-2">
+                                  <div class="col-xs-10">
+                                    <span class="text-muted">
+                                      From: Teammates Test [${datetime.now} UTC+0800]
+                                    </span>
+                                    <span class="glyphicon glyphicon-eye-open" data-original-title="This response comment is visible to response giver" data-placement="top" data-toggle="tooltip" style="margin-left: 5px;" title="">
+                                    </span>
+                                  </div>
+                                  <div class="col-xs-2">
+                                    <form class="responseCommentDeleteForm pull-right">
+                                      <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-0-0-1-1-2" title="" type="button">
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                        </span>
+                                      </a>
+                                      <input name="fsindex" type="hidden" value="0">
+                                      <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
+                                      <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
+                                      <input name="fsname" type="hidden" value="First Session">
+                                      <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                      <input name="token" type="hidden" value="${sessionToken}">
+                                    </form>
+                                    <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-2" title="" type="button">
+                                      <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                       </span>
                                     </a>
-                                    <input name="fsindex" type="hidden" value="0">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.instr@gmail.tmt%%GENERAL%">
-                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                    <input name="courseid" type="hidden" value="CFResultsUiT.CS2104">
-                                    <input name="fsname" type="hidden" value="First Session">
-                                    <input name="user" type="hidden" value="CFResultsUiT.instr">
-                                    <input name="token" type="hidden" value="${sessionToken}">
-                                  </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="0" data-sectionindex="0" data-toggle="tooltip" id="commentedit-0-0-1-1-2" title="" type="button">
-                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                    </span>
-                                  </a>
+                                  </div>
                                 </div>
                                 <div id="plainCommentText-0-0-1-1-2" style="margin-left: 15px;">
                                   <p>

--- a/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
@@ -403,27 +403,31 @@
                             </div>
                             <ul class="list-group" id="responseCommentTable-1-1-0-1" style="margin-top:15px;">
                               <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-0-1-1">
-                                <div id="commentBar-1-1-0-1-1">
-                                  <span class="text-muted">
-                                    From: Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
-                                  </span>
-                                  <form class="responseCommentDeleteForm pull-right">
-                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-0-1-1" title="" type="button">
-                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                <div class="row" id="commentBar-1-1-0-1-1">
+                                  <div class="col-xs-10">
+                                    <span class="text-muted">
+                                      From: Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
+                                    </span>
+                                  </div>
+                                  <div class="col-xs-2">
+                                    <form class="responseCommentDeleteForm pull-right">
+                                      <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-1-1-0-1-1" title="" type="button">
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                        </span>
+                                      </a>
+                                      <input name="fsindex" type="hidden" value="1">
+                                      <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
+                                      <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                      <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
+                                      <input name="fsname" type="hidden" value="Sanitized Session">
+                                      <input name="user" type="hidden" value="CFResultsUiT.instr">
+                                      <input name="token" type="hidden" value="${sessionToken}">
+                                    </form>
+                                    <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="commentedit-1-1-0-1-1" title="" type="button">
+                                      <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                       </span>
                                     </a>
-                                    <input name="fsindex" type="hidden" value="1">
-                                    <input name="responseid" type="hidden" value="${question.id}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt">
-                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                    <input name="courseid" type="hidden" value="CFResultsUiT.SanitizedTeam">
-                                    <input name="fsname" type="hidden" value="Sanitized Session">
-                                    <input name="user" type="hidden" value="CFResultsUiT.instr">
-                                    <input name="token" type="hidden" value="${sessionToken}">
-                                  </form>
-                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="0" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-sectionindex="1" data-toggle="tooltip" id="commentedit-1-1-0-1-1" title="" type="button">
-                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                    </span>
-                                  </a>
+                                  </div>
                                 </div>
                                 <div id="plainCommentText-1-1-0-1-1" style="margin-left: 15px;">
                                   <p>

--- a/src/test/resources/pages/instructorSearchPageSearchCommentsAsHelper.html
+++ b/src/test/resources/pages/instructorSearchPageSearchCommentsAsHelper.html
@@ -107,10 +107,14 @@
                   <td>
                     <ul class="list-group comments" id="responseCommentTable-1-1-1">
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
-                        <div id="commentBar-1-1-1-1">
-                          <span class="text-muted">
-                            From: Anonymous [Tue, 03 Feb 2015, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-1-1-1">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Anonymous [Tue, 03 Feb 2015, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">
                           Anonymous
@@ -121,10 +125,14 @@
                         </div>
                       </li>
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-2">
-                        <div id="commentBar-1-1-1-2">
-                          <span class="text-muted">
-                            From: Instructor Instructor2 Course1 [Wed, 04 Feb 2015, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-1-1-2">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor2 Course1 [Wed, 04 Feb 2015, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-1-1-2" style="margin-left: 15px;">
                           Instructor 2
@@ -139,10 +147,14 @@
                         </div>
                       </li>
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-3">
-                        <div id="commentBar-1-1-1-3">
-                          <span class="text-muted">
-                            From: Instructor Instructor2 Course1 [Thu, 05 Feb 2015, 01:59 AM UTC+0200] (last edited by Instructor Instructor3 Course1 at Fri, 06 Feb 2015, 01:59 AM UTC+0200)
-                          </span>
+                        <div class="row" id="commentBar-1-1-1-3">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor2 Course1 [Thu, 05 Feb 2015, 01:59 AM UTC+0200] (last edited by Instructor Instructor3 Course1 at Fri, 06 Feb 2015, 01:59 AM UTC+0200)
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-1-1-3" style="margin-left: 15px;">
                           Instructor 3 edited

--- a/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
+++ b/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
@@ -101,10 +101,14 @@
                   <td>
                     <ul class="list-group comments" id="responseCommentTable-1-1-1">
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
-                        <div id="commentBar-1-1-1-1">
-                          <span class="text-muted">
-                            From: Instructor Instructor1 Course1 [Mon, 02 Mar 2026, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-1-1-1">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor1 Course1 [Mon, 02 Mar 2026, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">
                           Instructor 1
@@ -161,10 +165,14 @@
                   <td>
                     <ul class="list-group comments" id="responseCommentTable-1-2-1">
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-2-1-1">
-                        <div id="commentBar-1-2-1-1">
-                          <span class="text-muted">
-                            From: Instructor Instructor1 Course1 [Mon, 02 Feb 2015, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-2-1-1">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor1 Course1 [Mon, 02 Feb 2015, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-2-1-1" style="margin-left: 15px;">
                           Instructor 1
@@ -175,10 +183,14 @@
                         </div>
                       </li>
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-2-1-2">
-                        <div id="commentBar-1-2-1-2">
-                          <span class="text-muted">
-                            From: Anonymous [Tue, 03 Feb 2015, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-2-1-2">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Anonymous [Tue, 03 Feb 2015, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-2-1-2" style="margin-left: 15px;">
                           Anonymous
@@ -189,10 +201,14 @@
                         </div>
                       </li>
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-2-1-3">
-                        <div id="commentBar-1-2-1-3">
-                          <span class="text-muted">
-                            From: Instructor Instructor2 Course1 [Wed, 04 Feb 2015, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-2-1-3">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor2 Course1 [Wed, 04 Feb 2015, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-2-1-3" style="margin-left: 15px;">
                           Instructor 2
@@ -207,10 +223,14 @@
                         </div>
                       </li>
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-2-1-4">
-                        <div id="commentBar-1-2-1-4">
-                          <span class="text-muted">
-                            From: Instructor Instructor2 Course1 [Thu, 05 Feb 2015, 01:59 AM UTC+0200] (last edited by Instructor Instructor3 Course1 at Fri, 06 Feb 2015, 01:59 AM UTC+0200)
-                          </span>
+                        <div class="row" id="commentBar-1-2-1-4">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: Instructor Instructor2 Course1 [Thu, 05 Feb 2015, 01:59 AM UTC+0200] (last edited by Instructor Instructor3 Course1 at Fri, 06 Feb 2015, 01:59 AM UTC+0200)
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-2-1-4" style="margin-left: 15px;">
                           Instructor 3 edited

--- a/src/test/resources/pages/instructorSearchPageSearchTestingSanitization.html
+++ b/src/test/resources/pages/instructorSearchPageSearchTestingSanitization.html
@@ -117,10 +117,14 @@
                   <td>
                     <ul class="list-group comments" id="responseCommentTable-1-1-1">
                       <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
-                        <div id="commentBar-1-1-1-1">
-                          <span class="text-muted">
-                            From: inst&lt;script&gt;alert(&#39;hi!&#39;);&lt;&#x2f;script&gt; Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 01:59 AM UTC+0200]
-                          </span>
+                        <div class="row" id="commentBar-1-1-1-1">
+                          <div class="col-xs-10">
+                            <span class="text-muted">
+                              From: inst&lt;script&gt;alert(&#39;hi!&#39;);&lt;&#x2f;script&gt; Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 01:59 AM UTC+0200]
+                            </span>
+                          </div>
+                          <div class="col-xs-2">
+                          </div>
                         </div>
                         <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">
                           Comment value. Testing quotation marks '" Testing unclosed tags  Testing script injection

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -241,27 +241,31 @@
                           </div>
                           <ul class="list-group" id="responseCommentTable-0-1-1-GRQ" style="margin-top:15px;">
                             <li class="list-group-item list-group-item-warning" id="responseCommentRow-RGQ-1-1-1-1">
-                              <div id="commentBar-RGQ-1-1-1-1">
-                                <span class="text-muted">
-                                  From: Teammates Test [Mon, 02 Mar 2026, 01:59 AM UTC+0200] (last edited by Teammates Test at Tue, 03 Mar 2026, 01:59 AM UTC+0200)
-                                </span>
-                                <form class="responseCommentDeleteForm pull-right">
-                                  <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-RGQ-1-1-1-1" title="" type="button">
-                                    <span class="glyphicon glyphicon-trash glyphicon-primary">
+                              <div class="row" id="commentBar-RGQ-1-1-1-1">
+                                <div class="col-xs-10">
+                                  <span class="text-muted">
+                                    From: Teammates Test [Mon, 02 Mar 2026, 01:59 AM UTC+0200] (last edited by Teammates Test at Tue, 03 Mar 2026, 01:59 AM UTC+0200)
+                                  </span>
+                                </div>
+                                <div class="col-xs-2">
+                                  <form class="responseCommentDeleteForm pull-right">
+                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-RGQ-1-1-1-1" title="" type="button">
+                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                      </span>
+                                    </a>
+                                    <input name="fsindex" type="hidden" value="1">
+                                    <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                    <input name="courseid" type="hidden" value="ISR.CS2104">
+                                    <input name="fsname" type="hidden" value="First feedback session">
+                                    <input name="user" type="hidden" value="ISR.teammates.test">
+                                    <input name="token" type="hidden" value="${sessionToken}">
+                                  </form>
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-toggle="tooltip" data-viewtype="RGQ" id="commentedit-RGQ-1-1-1-1" title="" type="button">
+                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
-                                  <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
-                                  <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                  <input name="courseid" type="hidden" value="ISR.CS2104">
-                                  <input name="fsname" type="hidden" value="First feedback session">
-                                  <input name="user" type="hidden" value="ISR.teammates.test">
-                                  <input name="token" type="hidden" value="${sessionToken}">
-                                </form>
-                                <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="1" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-toggle="tooltip" data-viewtype="RGQ" id="commentedit-RGQ-1-1-1-1" title="" type="button">
-                                  <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                  </span>
-                                </a>
+                                </div>
                               </div>
                               <div id="plainCommentText-RGQ-1-1-1-1" style="margin-left: 15px;">
                                 Instructor first comment to Alice about feedback to Benny
@@ -365,27 +369,31 @@
                               </form>
                             </li>
                             <li class="list-group-item list-group-item-warning" id="responseCommentRow-RGQ-1-1-1-2">
-                              <div id="commentBar-RGQ-1-1-1-2">
-                                <span class="text-muted">
-                                  From: Teammates Test [Tue, 03 Mar 2026, 01:59 AM UTC+0200]
-                                </span>
-                                <form class="responseCommentDeleteForm pull-right">
-                                  <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-RGQ-1-1-1-2" title="" type="button">
-                                    <span class="glyphicon glyphicon-trash glyphicon-primary">
+                              <div class="row" id="commentBar-RGQ-1-1-1-2">
+                                <div class="col-xs-10">
+                                  <span class="text-muted">
+                                    From: Teammates Test [Tue, 03 Mar 2026, 01:59 AM UTC+0200]
+                                  </span>
+                                </div>
+                                <div class="col-xs-2">
+                                  <form class="responseCommentDeleteForm pull-right">
+                                    <a class="btn btn-default btn-xs icon-button" data-original-title="Delete this comment" data-placement="top" data-toggle="tooltip" href="/page/instructorFeedbackResponseCommentDelete" id="commentdelete-RGQ-1-1-1-2" title="" type="button">
+                                      <span class="glyphicon glyphicon-trash glyphicon-primary">
+                                      </span>
+                                    </a>
+                                    <input name="fsindex" type="hidden" value="1">
+                                    <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
+                                    <input name="responsecommentid" type="hidden" value="${comment.id}">
+                                    <input name="courseid" type="hidden" value="ISR.CS2104">
+                                    <input name="fsname" type="hidden" value="First feedback session">
+                                    <input name="user" type="hidden" value="ISR.teammates.test">
+                                    <input name="token" type="hidden" value="${sessionToken}">
+                                  </form>
+                                  <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-toggle="tooltip" data-viewtype="RGQ" id="commentedit-RGQ-1-1-1-2" title="" type="button">
+                                    <span class="glyphicon glyphicon-pencil glyphicon-primary">
                                     </span>
                                   </a>
-                                  <input name="fsindex" type="hidden" value="1">
-                                  <input name="responseid" type="hidden" value="${question.id}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt">
-                                  <input name="responsecommentid" type="hidden" value="${comment.id}">
-                                  <input name="courseid" type="hidden" value="ISR.CS2104">
-                                  <input name="fsname" type="hidden" value="First feedback session">
-                                  <input name="user" type="hidden" value="ISR.teammates.test">
-                                  <input name="token" type="hidden" value="${sessionToken}">
-                                </form>
-                                <a class="btn btn-default btn-xs icon-button pull-right show-frc-edit-form" data-frcindex="2" data-giverindex="1" data-original-title="Edit this comment" data-placement="top" data-qnindex="1" data-recipientindex="1" data-toggle="tooltip" data-viewtype="RGQ" id="commentedit-RGQ-1-1-1-2" title="" type="button">
-                                  <span class="glyphicon glyphicon-pencil glyphicon-primary">
-                                  </span>
-                                </a>
+                                </div>
                               </div>
                               <div id="plainCommentText-RGQ-1-1-1-2" style="margin-left: 15px;">
                                 Instructor second comment to Alice about feedback to Benny

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
@@ -273,10 +273,14 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: AHPUiT Instrúctör WithPlusInEmail [Tue, 01 May 2012, 05:36 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: AHPUiT Instrúctör WithPlusInEmail [Tue, 01 May 2012, 05:36 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       <p>
@@ -318,10 +322,14 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: AHPUiT Instrúctör WithPlusInEmail [Tue, 01 May 2012, 05:39 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: AHPUiT Instrúctör WithPlusInEmail [Tue, 01 May 2012, 05:39 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       <p>

--- a/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
@@ -101,20 +101,28 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor first comment to Alice
                     </div>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor second comment to Alice

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -98,20 +98,28 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor first comment to Alice
                     </div>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor second comment to Alice

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -98,20 +98,28 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor first comment to Alice
                     </div>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor second comment to Alice

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -109,20 +109,28 @@
               <td>
                 <ul class="list-group comment-list">
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Mon, 02 Mar 2026, 07:59 AM UTC+0800] (last edited by Teammates Test at Tue, 03 Mar 2026, 07:59 AM UTC+0800)
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor first comment to Alice
                     </div>
                   </li>
                   <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
-                    <div id="commentBar-${comment.id}">
-                      <span class="text-muted">
-                        From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
-                      </span>
+                    <div class="row" id="commentBar-${comment.id}">
+                      <div class="col-xs-10">
+                        <span class="text-muted">
+                          From: Teammates Test [Tue, 03 Mar 2026, 07:59 AM UTC+0800]
+                        </span>
+                      </div>
+                      <div class="col-xs-2">
+                      </div>
                     </div>
                     <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
                       Instructor second comment to Alice


### PR DESCRIPTION
Fixes #7719 

**Outline of solution**

- Used bootstrap to achieve the desired changes.
- Added `row` class to `commentBar` parent div
- Surrounded the comment details and `eye icon` with a `col-xs-10`
- Surrounded the edit and delete buttons with `col-xs-2`


**Screenshot of change:**
(Old behaviour can be seen in issue description)

New behaviour:

**Option 1:** (`10-2`)
<img width="890" alt="screen shot 2017-07-22 at 4 45 08 am" src="https://user-images.githubusercontent.com/18088721/28488085-cff9a222-6ebf-11e7-9fe2-1db4b20de42c.png">


Note: we can also change the distribution of bootstrap columns to 11-1. This would make the comment bar look like this:

**Option 2:** (`11-1`)
<img width="886" alt="screen shot 2017-07-22 at 4 43 56 am" src="https://user-images.githubusercontent.com/18088721/28488094-275a611e-6ec0-11e7-8bc8-4b4b86a7fa49.png">


Depending on whatever looks better according to everyone, we can finalise between `10-2` and `11-1` and then I will go ahead with god mode.
