### PR TITLE
Instructor: download results: don't display header if no responses #7823

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -582,6 +582,9 @@ public final class Const {
         public static final String RGQ_SORT_TYPE = "recipient-giver-question";
         public static final String GQR_SORT_TYPE = "giver-question-recipient";
         public static final String RQG_SORT_TYPE = "recipient-question-giver";
+
+        public static final String QUESTION_NO_RESPONSES_MSG = "There are no responses for this question " +
+                "or you may not have the permission to see the response";
     }
 
     public static class InstructorPermissionRoleNames {

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -891,8 +891,13 @@ public final class FeedbackSessionsLogic {
         List<String> possibleRecipientsForGiver = new ArrayList<>();
         String prevGiver = "";
 
-        int maxNumOfResponseComments = getMaxNumberOfResponseComments(allResponses, fsrBundle.getResponseComments());
-        exportBuilder.append(questionDetails.getCsvDetailedResponsesHeader(maxNumOfResponseComments));
+        if (!allResponses.isEmpty()) {
+            int maxNumOfResponseComments = getMaxNumberOfResponseComments(allResponses,
+                    fsrBundle.getResponseComments());
+            exportBuilder.append(questionDetails.getCsvDetailedResponsesHeader(maxNumOfResponseComments));
+        } else {
+            exportBuilder.append(Const.FeedbackSessionResults.QUESTION_NO_RESPONSES_MSG).append(Const.EOL);
+        }
 
         for (FeedbackResponseAttributes response : allResponses) {
 

--- a/src/main/webapp/WEB-INF/tags/instructor/results/questionPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/questionPanel.tag
@@ -63,7 +63,7 @@
 
             <c:if test="${!questionPanel.hasResponses}">
                 <div class="col-sm-12 no-response">
-                    <i class="text-muted">There are no responses for this question or you may not have the permission to see the response</i>
+                    <i class="text-muted"><%=Const.FeedbackSessionResults.QUESTION_NO_RESPONSES_MSG%></i>
                 </div>
             </c:if>
 


### PR DESCRIPTION
Fixes #7823 

Before:
![image](https://user-images.githubusercontent.com/8873908/28503699-75d3dee2-7014-11e7-90d9-9c3673bcec7b.png)

After:
![image](https://user-images.githubusercontent.com/8873908/28503701-84e9c4a0-7014-11e7-8100-6a24bb5a75c7.png)

