### PR TITLE
FeedbackRubricQuestionUiTest: fix cannot focus element error on Chrome #7861

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
@@ -1,7 +1,5 @@
 package teammates.test.cases.browsertests;
 
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
@@ -375,7 +375,6 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.fillRubricDescriptionBox("New Row 2, Col 1 Text", 1, 2, 1);
         feedbackEditPage.fillRubricDescriptionBox("New Row 2, Col 0 Text", 1, 2, 0);
 
-        // move column buttons must be visible, otherwise test fails
         // move last column to first
         assertTrue(feedbackEditPage.moveRubricColLeft(1, 5));
         assertTrue(feedbackEditPage.moveRubricColLeft(1, 3));

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRubricQuestionUiTest.java
@@ -378,8 +378,6 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.fillRubricDescriptionBox("New Row 2, Col 0 Text", 1, 2, 0);
 
         // move column buttons must be visible, otherwise test fails
-        browser.driver.findElement(By.id(Const.ParamsNames.FEEDBACK_QUESTION_RUBRIC_EDIT_TABLE + "-" + 1))
-                .sendKeys(Keys.ARROW_DOWN);
         // move last column to first
         assertTrue(feedbackEditPage.moveRubricColLeft(1, 5));
         assertTrue(feedbackEditPage.moveRubricColLeft(1, 3));

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -398,7 +398,6 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement moveColButton = browser.driver.findElement(By.id(elemId));
 
         if (moveColButton.getAttribute("disabled") == null) {
-            waitForElementToBeClickable(moveColButton);
             click(moveColButton);
 
             return true;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -397,7 +397,7 @@ public class InstructorFeedbackEditPage extends AppPage {
 
         WebElement moveColButton = browser.driver.findElement(By.id(elemId));
 
-        if (moveColButton.getAttribute("disabled") == null) {
+        if (moveColButton.isEnabled()) {
             click(moveColButton);
 
             return true;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -398,7 +398,8 @@ public class InstructorFeedbackEditPage extends AppPage {
         WebElement moveColButton = browser.driver.findElement(By.id(elemId));
 
         if (moveColButton.getAttribute("disabled") == null) {
-            moveColButton.click();
+            waitForElementToBeClickable(moveColButton);
+            click(moveColButton);
 
             return true;
         }


### PR DESCRIPTION
Fixes #7861 

The issue had two parts:

1. **Test failing locally using Firefox**: fixed in daa701b by adding a `waitForElementToBeClickable()` and changing the click method from `WebElement.click()` to our own `AppPage.click(WebElement)`
2. **Test failing both locally and on AppVeyor using Chrome:** fixed by removing the unnecessary `sendKeys()` call in 6d5494b. @VamsiSangam commented  _"move column buttons must be visible, otherwise, the test fails"_ before the line in question. I have left this comment in on purpose so that we can discuss whether or not the line I removed was actually necessary (as that comment implies), but the test passed on both chrome and firefox without this line and the "move column" buttons seemed to be visible anyway when I tried it out using `Thread.sleep()`.