### PR TITLE
InstructorCourseJoinConfirmationPageUiTest: Fix broken Javadoc link #7892

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseJoinConfirmationPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseJoinConfirmationPageUiTest.java
@@ -12,7 +12,7 @@ import teammates.test.pageobjects.InstructorCourseJoinConfirmationPage;
 import teammates.test.pageobjects.InstructorHomePage;
 
 /**
- * SUT: {@link Const.ActionURIs#INSTRUCTOR_COURSE_JOIN_CONFIRMATION_PAGE}.
+ * SUT: {@link Const.ActionURIs#INSTRUCTOR_COURSE_JOIN}.
  */
 public class InstructorCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
 


### PR DESCRIPTION
Fixes #7892 

**Outline of Solution**

I copied and pasted the correct javadoc link to replace the broken one. This is ready for review.