### PR TITLE
BackDoorTest: Remove `@SuppressWarnings("deprecation")` #7901

### DIFF
--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -132,7 +132,6 @@ public class BackDoorTest extends BaseTestCaseWithBackDoorApiAccess {
         String courseId = "tmapitt.tcc.course";
         String name = "Tmapitt testInstr Name";
         String email = "tmapitt@tci.tmt";
-        @SuppressWarnings("deprecation")
         InstructorAttributes instructor = InstructorAttributes.builder(instructorId, courseId, name, email)
                 .build();
 

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -132,7 +132,6 @@ public class BackDoorTest extends BaseTestCaseWithBackDoorApiAccess {
         String courseId = "tmapitt.tcc.course";
         String name = "Tmapitt testInstr Name";
         String email = "tmapitt@tci.tmt";
-        
         InstructorAttributes instructor = InstructorAttributes.builder(instructorId, courseId, name, email)
                 .build();
 

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -132,6 +132,7 @@ public class BackDoorTest extends BaseTestCaseWithBackDoorApiAccess {
         String courseId = "tmapitt.tcc.course";
         String name = "Tmapitt testInstr Name";
         String email = "tmapitt@tci.tmt";
+        
         InstructorAttributes instructor = InstructorAttributes.builder(instructorId, courseId, name, email)
                 .build();
 


### PR DESCRIPTION
Fixes #7901 
```diff 
         String courseId = "tmapitt.tcc.course";
         String name = "Tmapitt testInstr Name";
         String email = "tmapitt@tci.tmt";
-        @SuppressWarnings("deprecation")
+        
         InstructorAttributes instructor = InstructorAttributes.builder(instructorId, courseId, name, email)
                 .build();
```