### PR TITLE
Student submission page: add loading text to submit button #7911

### DIFF
--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.es6
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.es6
@@ -1025,7 +1025,7 @@ $(document).ready(() => {
 
             // disable button to prevent user from clicking submission button again
             const $submissionButton = $('#response_submit_button');
-            addLoadingIndicator($submissionButton, '');
+            addLoadingIndicator($submissionButton, 'Submitting ');
         }
     });
 


### PR DESCRIPTION
Fixes #7911 

**Outline of Solution**

Changed the loading text for the submit button from an empty string to "Submitting ".
