### PR TITLE
Instructor: edit student data: fix typo in error message for team/section name #3436

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -131,7 +131,7 @@ public class FieldValidator {
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES =
             "It cannot be longer than ${maxLength} characters, cannot be empty and cannot contain spaces.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_INVALID_NAME =
-            "A ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar "
+            "A/An ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar "
             + "(|) or percent sign (%).";
 
     // generic (i.e., not specific to any field) error messages

--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -131,7 +131,7 @@ public class FieldValidator {
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY_NO_SPACES =
             "It cannot be longer than ${maxLength} characters, cannot be empty and cannot contain spaces.";
     public static final String HINT_FOR_CORRECT_FORMAT_FOR_INVALID_NAME =
-            "All ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar "
+            "A ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar "
             + "(|) or percent sign (%).";
 
     // generic (i.e., not specific to any field) error messages

--- a/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
@@ -90,7 +90,7 @@ public class AdminInstructorAccountAddActionTest extends BaseActionTest {
 
         String expectedError =
                 "\"" + invalidName + "\" is not acceptable to TEAMMATES as a/an person name because "
-                + "it contains invalid characters. All person name must start with an "
+                + "it contains invalid characters. A person name must start with an "
                 + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).";
 
         AjaxResult rInvalidParam = getAjaxResult(a);

--- a/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminInstructorAccountAddActionTest.java
@@ -90,7 +90,7 @@ public class AdminInstructorAccountAddActionTest extends BaseActionTest {
 
         String expectedError =
                 "\"" + invalidName + "\" is not acceptable to TEAMMATES as a/an person name because "
-                + "it contains invalid characters. A person name must start with an "
+                + "it contains invalid characters. A/An person name must start with an "
                 + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).";
 
         AjaxResult rInvalidParam = getAjaxResult(a);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
@@ -75,7 +75,7 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         feedbackEditPage.getFsCopyToModal().verifyStatusMessage(
                 "\"" + invalidNameforFs + "\" is not acceptable to TEAMMATES as a/an "
                 + "feedback session name because it contains invalid characters. "
-                + "All feedback session name must start with an alphanumeric character, "
+                + "A feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackEditPage.getFsCopyToModal().clickCloseButton();

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditCopyUiTest.java
@@ -75,7 +75,7 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         feedbackEditPage.getFsCopyToModal().verifyStatusMessage(
                 "\"" + invalidNameforFs + "\" is not acceptable to TEAMMATES as a/an "
                 + "feedback session name because it contains invalid characters. "
-                + "A feedback session name must start with an alphanumeric character, "
+                + "A/An feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackEditPage.getFsCopyToModal().clickCloseButton();

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -485,7 +485,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.verifyStatus(
                 "\"(New Session ##)\" is not acceptable to TEAMMATES as a/an feedback session name because "
                 + "it starts with a non-alphanumeric character. "
-                + "A feedback session name must start with an alphanumeric character, "
+                + "A/An feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackPage.goToPreviousPage(InstructorFeedbackSessionsPage.class);
@@ -537,7 +537,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.getFsCopyToModal().verifyStatusMessage(
                 "\"Invalid name | for feedback session\" is not acceptable to TEAMMATES as a/an "
                 + "feedback session name because it contains invalid characters. "
-                + "A feedback session name must start with an alphanumeric character, "
+                + "A/An feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackPage.getFsCopyToModal().clickCloseButton();

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -485,7 +485,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.verifyStatus(
                 "\"(New Session ##)\" is not acceptable to TEAMMATES as a/an feedback session name because "
                 + "it starts with a non-alphanumeric character. "
-                + "All feedback session name must start with an alphanumeric character, "
+                + "A feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackPage.goToPreviousPage(InstructorFeedbackSessionsPage.class);
@@ -537,7 +537,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         feedbackPage.getFsCopyToModal().verifyStatusMessage(
                 "\"Invalid name | for feedback session\" is not acceptable to TEAMMATES as a/an "
                 + "feedback session name because it contains invalid characters. "
-                + "All feedback session name must start with an alphanumeric character, "
+                + "A feedback session name must start with an alphanumeric character, "
                 + "and cannot contain any vertical bar (|) or percent sign (%).");
 
         feedbackPage.getFsCopyToModal().clickCloseButton();

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -273,7 +273,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             signalFailureToDetectException();
         } catch (Exception e) {
             assertEquals("\"test %| test\" is not acceptable to TEAMMATES as a/an feedback session name "
-                             + "because it contains invalid characters. A feedback session name "
+                             + "because it contains invalid characters. A/An feedback session name "
                              + "must start with an alphanumeric character, and cannot contain "
                              + "any vertical bar (|) or percent sign (%).",
                          e.getMessage());

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -273,7 +273,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             signalFailureToDetectException();
         } catch (Exception e) {
             assertEquals("\"test %| test\" is not acceptable to TEAMMATES as a/an feedback session name "
-                             + "because it contains invalid characters. All feedback session name "
+                             + "because it contains invalid characters. A feedback session name "
                              + "must start with an alphanumeric character, and cannot contain "
                              + "any vertical bar (|) or percent sign (%).",
                          e.getMessage());

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -191,7 +191,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"Dr. Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is "
                          + "not acceptable to TEAMMATES as a/an name field because it contains invalid "
-                         + "characters. A name field must start with an alphanumeric character, and cannot "
+                         + "characters. A/An name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameContainInvalidChars));
@@ -202,7 +202,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"!Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
-                         + "non-alphanumeric character. A name field must start with an alphanumeric "
+                         + "non-alphanumeric character. A/An name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithNonAlphaNumChar));
@@ -213,7 +213,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"{Amy} -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it contains invalid "
-                         + "characters. A name field must start with an alphanumeric character, and cannot "
+                         + "characters. A/An name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithBracesButHasInvalidChar));
@@ -224,7 +224,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length started with non-alphanumeric character",
                      "\"{Amy -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
-                         + "non-alphanumeric character. A name field must start with an alphanumeric "
+                         + "non-alphanumeric character. A/An name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithCurlyBracketButHasNoEnd));
@@ -330,7 +330,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = validator.getInvalidityInfoForSectionName(invalidSectionName);
         assertEquals("Invalid section name (invalid char) should return error string that is specific to section name",
                      "\"Percent Symbol % Section\" is not acceptable to TEAMMATES as a/an section name "
-                         + "because it contains invalid characters. A section name must start with an "
+                         + "because it contains invalid characters. A/An section name must start with an "
                          + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }
@@ -341,7 +341,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = validator.getInvalidityInfoForCourseName(invalidCourseName);
         assertEquals("Invalid course name (invalid char) should return error string that is specific to course name",
                      "\"Vertical Bar | Course\" is not acceptable to TEAMMATES as a/an course name because "
-                         + "it contains invalid characters. A course name must start with an alphanumeric "
+                         + "it contains invalid characters. A/An course name must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -191,7 +191,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"Dr. Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is "
                          + "not acceptable to TEAMMATES as a/an name field because it contains invalid "
-                         + "characters. All name field must start with an alphanumeric character, and cannot "
+                         + "characters. A name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameContainInvalidChars));
@@ -202,7 +202,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"!Amy-Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
-                         + "non-alphanumeric character. All name field must start with an alphanumeric "
+                         + "non-alphanumeric character. A name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithNonAlphaNumChar));
@@ -213,7 +213,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length with invalid characters",
                      "\"{Amy} -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={}[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it contains invalid "
-                         + "characters. All name field must start with an alphanumeric character, and cannot "
+                         + "characters. A name field must start with an alphanumeric character, and cannot "
                          + "contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithBracesButHasInvalidChar));
@@ -224,7 +224,7 @@ public class FieldValidatorTest extends BaseTestCase {
         assertEquals("invalid: typical length started with non-alphanumeric character",
                      "\"{Amy -Bén s&#x2f;o O&#39;&amp;|% 2\t\n (~!@#$^*+_={[]\\:;&quot;&lt;&gt;?)\" is not "
                          + "acceptable to TEAMMATES as a/an name field because it starts with a "
-                         + "non-alphanumeric character. All name field must start with an alphanumeric "
+                         + "non-alphanumeric character. A name field must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      validator.getValidityInfoForAllowedName(typicalFieldName, maxLength,
                                                              nameStartedWithCurlyBracketButHasNoEnd));
@@ -330,7 +330,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = validator.getInvalidityInfoForSectionName(invalidSectionName);
         assertEquals("Invalid section name (invalid char) should return error string that is specific to section name",
                      "\"Percent Symbol % Section\" is not acceptable to TEAMMATES as a/an section name "
-                         + "because it contains invalid characters. All section name must start with an "
+                         + "because it contains invalid characters. A section name must start with an "
                          + "alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }
@@ -341,7 +341,7 @@ public class FieldValidatorTest extends BaseTestCase {
         String actual = validator.getInvalidityInfoForCourseName(invalidCourseName);
         assertEquals("Invalid course name (invalid char) should return error string that is specific to course name",
                      "\"Vertical Bar | Course\" is not acceptable to TEAMMATES as a/an course name because "
-                         + "it contains invalid characters. All course name must start with an alphanumeric "
+                         + "it contains invalid characters. A course name must start with an alphanumeric "
                          + "character, and cannot contain any vertical bar (|) or percent sign (%).",
                      actual);
     }


### PR DESCRIPTION
Fixes #3436 

**Outline of Solution**

- Changed the error message for all input fields which contain ( % or | ).

Previous error message: `All ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).`

New error message: `A ${fieldName} must start with an alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).`

