### PR TITLE
Instructor: courses page: show creation time in active/archived courses #1297

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -66,7 +66,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     public String getCreatedAtDateString() {
-        return TimeHelper.formatDateTimeForInstructorHomePage(createdAt);
+        return TimeHelper.formatDateTimeForInstructorCoursesPage(createdAt);
     }
 
     public void setTimeZone(String timeZone) {

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -66,7 +66,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     public String getCreatedAtDateString() {
-        return TimeHelper.formatDate(createdAt);
+        return TimeHelper.formatDateTimeForInstructorHomePage(createdAt);
     }
 
     public void setTimeZone(String timeZone) {

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -69,6 +69,10 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         return TimeHelper.formatDateTimeForInstructorCoursesPage(createdAt);
     }
 
+    public String getCreatedAtDateTimeString() {
+        return TimeHelper.formatDateToIso8601Utc(createdAt);
+    }
+
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -69,7 +69,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         return TimeHelper.formatDateTimeForInstructorCoursesPage(createdAt);
     }
 
-    public String getCreatedAtDateTimeString() {
+    public String getCreatedAtDateStamp() {
         return TimeHelper.formatDateToIso8601Utc(createdAt);
     }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -73,6 +73,10 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         return TimeHelper.formatDateToIso8601Utc(createdAt);
     }
 
+    public String getCreatedAtFullDateTimeString() {
+        return TimeHelper.formatTime12H(createdAt);
+    }
+
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -10,6 +10,7 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.JsonUtils;
 import teammates.common.util.SanitizationHelper;
+import teammates.common.util.TimeHelper;
 import teammates.storage.entity.Course;
 
 /**
@@ -62,6 +63,10 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     public String getTimeZone() {
         return timeZone;
+    }
+
+    public String getCreatedAtDateString() {
+        return TimeHelper.formatDate(createdAt);
     }
 
     public void setTimeZone(String timeZone) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -267,6 +267,21 @@ public final class TimeHelper {
     }
 
     /**
+     * Formats a date in the format d MMM yyyy. Example: 5 May 2017
+     */
+    public static String formatDateTimeForInstructorCoursesPage(Date date) {
+        if (date == null) {
+            return "";
+        }
+        SimpleDateFormat sdf = null;
+        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
+        c.setTime(date);
+        sdf = new SimpleDateFormat("d MMM yyyy");
+        sdf.setTimeZone(SystemParams.TIME_ZONE);
+        return sdf.format(date);
+    }
+
+    /**
      * Formats {@code dateInUtc} according to the ISO8601 format.
      */
     public static String formatDateToIso8601Utc(Date dateInUtc) {

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -102,6 +102,8 @@ public class InstructorCoursesPageData extends PageData {
                                                                       SanitizationHelper.sanitizeForHtml(course.getName()),
                                                                       SanitizationHelper.sanitizeForHtml(
                                                                               course.getCreatedAtDateString()),
+                                                                      SanitizationHelper.sanitizeForHtml(
+                                                                              course.getCreatedAtDateTimeString()),
                                                                                                 actionsParam);
             archivedCoursesTable.getRows().add(row);
 
@@ -156,6 +158,8 @@ public class InstructorCoursesPageData extends PageData {
                                                                   SanitizationHelper.sanitizeForHtml(course.getName()),
                                                                   SanitizationHelper.sanitizeForHtml(
                                                                           course.getCreatedAtDateString()),
+                                                                  SanitizationHelper.sanitizeForHtml(
+                                                                          course.getCreatedAtDateTimeString()),
                                                                   this.getInstructorCourseStatsLink(course.getId()),
                                                                   actionsParam);
             activeCourses.getRows().add(row);

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -100,13 +100,10 @@ public class InstructorCoursesPageData extends PageData {
 
             ArchivedCoursesTableRow row = new ArchivedCoursesTableRow(SanitizationHelper.sanitizeForHtml(course.getId()),
                                                                       SanitizationHelper.sanitizeForHtml(course.getName()),
-                                                                      SanitizationHelper.sanitizeForHtml(
-                                                                              course.getCreatedAtDateString()),
-                                                                      SanitizationHelper.sanitizeForHtml(
-                                                                              course.getCreatedAtDateStamp()),
-                                                                      SanitizationHelper.sanitizeForHtml(
-                                                                              course.getCreatedAtFullDateTimeString()),
-                                                                                                actionsParam);
+                                                                      course.getCreatedAtDateString(),
+                                                                      course.getCreatedAtDateStamp(),
+                                                                      course.getCreatedAtFullDateTimeString(),
+                                                                      actionsParam);
             archivedCoursesTable.getRows().add(row);
 
         }
@@ -158,12 +155,9 @@ public class InstructorCoursesPageData extends PageData {
 
             ActiveCoursesTableRow row = new ActiveCoursesTableRow(SanitizationHelper.sanitizeForHtml(course.getId()),
                                                                   SanitizationHelper.sanitizeForHtml(course.getName()),
-                                                                  SanitizationHelper.sanitizeForHtml(
-                                                                          course.getCreatedAtDateString()),
-                                                                  SanitizationHelper.sanitizeForHtml(
-                                                                          course.getCreatedAtDateStamp()),
-                                                                  SanitizationHelper.sanitizeForHtml(
-                                                                          course.getCreatedAtFullDateTimeString()),
+                                                                  course.getCreatedAtDateString(),
+                                                                  course.getCreatedAtDateStamp(),
+                                                                  course.getCreatedAtFullDateTimeString(),
                                                                   this.getInstructorCourseStatsLink(course.getId()),
                                                                   actionsParam);
             activeCourses.getRows().add(row);

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -104,6 +104,8 @@ public class InstructorCoursesPageData extends PageData {
                                                                               course.getCreatedAtDateString()),
                                                                       SanitizationHelper.sanitizeForHtml(
                                                                               course.getCreatedAtDateStamp()),
+                                                                      SanitizationHelper.sanitizeForHtml(
+                                                                              course.getCreatedAtFullDateTimeString()),
                                                                                                 actionsParam);
             archivedCoursesTable.getRows().add(row);
 
@@ -160,6 +162,8 @@ public class InstructorCoursesPageData extends PageData {
                                                                           course.getCreatedAtDateString()),
                                                                   SanitizationHelper.sanitizeForHtml(
                                                                           course.getCreatedAtDateStamp()),
+                                                                  SanitizationHelper.sanitizeForHtml(
+                                                                          course.getCreatedAtFullDateTimeString()),
                                                                   this.getInstructorCourseStatsLink(course.getId()),
                                                                   actionsParam);
             activeCourses.getRows().add(row);

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -100,6 +100,8 @@ public class InstructorCoursesPageData extends PageData {
 
             ArchivedCoursesTableRow row = new ArchivedCoursesTableRow(SanitizationHelper.sanitizeForHtml(course.getId()),
                                                                       SanitizationHelper.sanitizeForHtml(course.getName()),
+                                                                      SanitizationHelper.sanitizeForHtml(
+                                                                              course.getCreatedAtDateString()),
                                                                                                 actionsParam);
             archivedCoursesTable.getRows().add(row);
 
@@ -152,6 +154,8 @@ public class InstructorCoursesPageData extends PageData {
 
             ActiveCoursesTableRow row = new ActiveCoursesTableRow(SanitizationHelper.sanitizeForHtml(course.getId()),
                                                                   SanitizationHelper.sanitizeForHtml(course.getName()),
+                                                                  SanitizationHelper.sanitizeForHtml(
+                                                                          course.getCreatedAtDateString()),
                                                                   this.getInstructorCourseStatsLink(course.getId()),
                                                                   actionsParam);
             activeCourses.getRows().add(row);

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -103,7 +103,7 @@ public class InstructorCoursesPageData extends PageData {
                                                                       SanitizationHelper.sanitizeForHtml(
                                                                               course.getCreatedAtDateString()),
                                                                       SanitizationHelper.sanitizeForHtml(
-                                                                              course.getCreatedAtDateTimeString()),
+                                                                              course.getCreatedAtDateStamp()),
                                                                                                 actionsParam);
             archivedCoursesTable.getRows().add(row);
 
@@ -159,7 +159,7 @@ public class InstructorCoursesPageData extends PageData {
                                                                   SanitizationHelper.sanitizeForHtml(
                                                                           course.getCreatedAtDateString()),
                                                                   SanitizationHelper.sanitizeForHtml(
-                                                                          course.getCreatedAtDateTimeString()),
+                                                                          course.getCreatedAtDateStamp()),
                                                                   this.getInstructorCourseStatsLink(course.getId()),
                                                                   actionsParam);
             activeCourses.getRows().add(row);

--- a/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
@@ -6,15 +6,17 @@ public class ActiveCoursesTableRow {
     private String courseId;
     private String courseName;
     private String createdAtDateString;
+    private String createdAtDateTimeString;
     private String href;
     private List<ElementTag> actions;
 
     public ActiveCoursesTableRow(String courseIdParam, String courseNameParam,
-                                 String createdAtStringParam, String href,
-                                 List<ElementTag> actionsParam) {
+                                 String createdAtStringParam, String createdAtDateTimeStringParam,
+                                 String href, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtStringParam;
+        this.createdAtDateTimeString = createdAtDateTimeStringParam;
         this.href = href;
         this.actions = actionsParam;
     }
@@ -29,6 +31,10 @@ public class ActiveCoursesTableRow {
 
     public String getCreatedAtDateString() {
         return createdAtDateString;
+    }
+
+    public String getCreatedAtDateTimeString() {
+        return createdAtDateTimeString;
     }
 
     public String getHref() {

--- a/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
@@ -6,17 +6,17 @@ public class ActiveCoursesTableRow {
     private String courseId;
     private String courseName;
     private String createdAtDateString;
-    private String createdAtDateTimeString;
+    private String createdAtDateStamp;
     private String href;
     private List<ElementTag> actions;
 
     public ActiveCoursesTableRow(String courseIdParam, String courseNameParam,
-                                 String createdAtDateStringParam, String createdAtDateTimeStringParam,
+                                 String createdAtDateStringParam, String createdAtDateStampParam,
                                  String href, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;
-        this.createdAtDateTimeString = createdAtDateTimeStringParam;
+        this.createdAtDateStamp = createdAtDateStampParam;
         this.href = href;
         this.actions = actionsParam;
     }
@@ -33,8 +33,8 @@ public class ActiveCoursesTableRow {
         return createdAtDateString;
     }
 
-    public String getCreatedAtDateTimeString() {
-        return createdAtDateTimeString;
+    public String getCreatedAtDateStamp() {
+        return createdAtDateStamp;
     }
 
     public String getHref() {

--- a/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
@@ -11,11 +11,11 @@ public class ActiveCoursesTableRow {
     private List<ElementTag> actions;
 
     public ActiveCoursesTableRow(String courseIdParam, String courseNameParam,
-                                 String createdAtStringParam, String createdAtDateTimeStringParam,
+                                 String createdAtDateStringParam, String createdAtDateTimeStringParam,
                                  String href, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
-        this.createdAtDateString = createdAtStringParam;
+        this.createdAtDateString = createdAtDateStringParam;
         this.createdAtDateTimeString = createdAtDateTimeStringParam;
         this.href = href;
         this.actions = actionsParam;

--- a/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
@@ -7,16 +7,18 @@ public class ActiveCoursesTableRow {
     private String courseName;
     private String createdAtDateString;
     private String createdAtDateStamp;
+    private String createdAtFullDateTimeString;
     private String href;
     private List<ElementTag> actions;
 
     public ActiveCoursesTableRow(String courseIdParam, String courseNameParam,
                                  String createdAtDateStringParam, String createdAtDateStampParam,
-                                 String href, List<ElementTag> actionsParam) {
+                                 String createdAtFullDateTimeStringParam, String href, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;
         this.createdAtDateStamp = createdAtDateStampParam;
+        this.createdAtFullDateTimeString = createdAtFullDateTimeStringParam;
         this.href = href;
         this.actions = actionsParam;
     }
@@ -35,6 +37,10 @@ public class ActiveCoursesTableRow {
 
     public String getCreatedAtDateStamp() {
         return createdAtDateStamp;
+    }
+
+    public String getCreatedAtFullDateTimeString() {
+        return createdAtFullDateTimeString;
     }
 
     public String getHref() {

--- a/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ActiveCoursesTableRow.java
@@ -5,13 +5,16 @@ import java.util.List;
 public class ActiveCoursesTableRow {
     private String courseId;
     private String courseName;
+    private String createdAtDateString;
     private String href;
     private List<ElementTag> actions;
 
-    public ActiveCoursesTableRow(String courseIdParam, String courseNameParam, String href,
+    public ActiveCoursesTableRow(String courseIdParam, String courseNameParam,
+                                 String createdAtStringParam, String href,
                                  List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
+        this.createdAtDateString = createdAtStringParam;
         this.href = href;
         this.actions = actionsParam;
     }
@@ -22,6 +25,10 @@ public class ActiveCoursesTableRow {
 
     public String getCourseName() {
         return courseName;
+    }
+
+    public String getCreatedAtDateString() {
+        return createdAtDateString;
     }
 
     public String getHref() {

--- a/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
@@ -11,7 +11,7 @@ public class ArchivedCoursesTableRow {
 
     public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam,
             String createdAtDateStringParam, String createdAtDateStampParam,
-            List<ElementTag> actionsParam) {
+            String createdAtFullDateTimeStringParam, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;

--- a/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
@@ -7,6 +7,7 @@ public class ArchivedCoursesTableRow {
     private String courseName;
     private String createdAtDateString;
     private String createdAtDateStamp;
+    private String createdAtFullDateTimeString;
     private List<ElementTag> actions;
 
     public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam,
@@ -16,6 +17,7 @@ public class ArchivedCoursesTableRow {
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;
         this.createdAtDateStamp = createdAtDateStampParam;
+        this.createdAtFullDateTimeString = createdAtFullDateTimeStringParam;
         this.actions = actionsParam;
     }
 
@@ -33,6 +35,10 @@ public class ArchivedCoursesTableRow {
 
     public String getCreatedAtDateStamp() {
         return createdAtDateStamp;
+    }
+
+    public String getCreatedAtFullDateTimeString() {
+        return createdAtFullDateTimeString;
     }
 
     public List<ElementTag> getActions() {

--- a/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
@@ -5,11 +5,14 @@ import java.util.List;
 public class ArchivedCoursesTableRow {
     private String courseId;
     private String courseName;
+    private String createdAtDateString;
     private List<ElementTag> actions;
 
-    public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam, List<ElementTag> actionsParam) {
+    public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam,
+            String createdAtDateStringParam, List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
+        this.createdAtDateString = createdAtDateStringParam;
         this.actions = actionsParam;
     }
 
@@ -19,6 +22,10 @@ public class ArchivedCoursesTableRow {
 
     public String getCourseName() {
         return courseName;
+    }
+
+    public String getCreatedAtDateString() {
+        return createdAtDateString;
     }
 
     public List<ElementTag> getActions() {

--- a/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
@@ -6,13 +6,16 @@ public class ArchivedCoursesTableRow {
     private String courseId;
     private String courseName;
     private String createdAtDateString;
+    private String createdAtDateTimeString;
     private List<ElementTag> actions;
 
     public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam,
-            String createdAtDateStringParam, List<ElementTag> actionsParam) {
+            String createdAtDateStringParam, String createdAtDateTimeStringParam,
+            List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;
+        this.createdAtDateTimeString = createdAtDateTimeStringParam;
         this.actions = actionsParam;
     }
 
@@ -26,6 +29,10 @@ public class ArchivedCoursesTableRow {
 
     public String getCreatedAtDateString() {
         return createdAtDateString;
+    }
+
+    public String getCreatedAtDateTimeString() {
+        return createdAtDateTimeString;
     }
 
     public List<ElementTag> getActions() {

--- a/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/ArchivedCoursesTableRow.java
@@ -6,16 +6,16 @@ public class ArchivedCoursesTableRow {
     private String courseId;
     private String courseName;
     private String createdAtDateString;
-    private String createdAtDateTimeString;
+    private String createdAtDateStamp;
     private List<ElementTag> actions;
 
     public ArchivedCoursesTableRow(String courseIdParam, String courseNameParam,
-            String createdAtDateStringParam, String createdAtDateTimeStringParam,
+            String createdAtDateStringParam, String createdAtDateStampParam,
             List<ElementTag> actionsParam) {
         this.courseId = courseIdParam;
         this.courseName = courseNameParam;
         this.createdAtDateString = createdAtDateStringParam;
-        this.createdAtDateTimeString = createdAtDateTimeStringParam;
+        this.createdAtDateStamp = createdAtDateStampParam;
         this.actions = actionsParam;
     }
 
@@ -31,8 +31,8 @@ public class ArchivedCoursesTableRow {
         return createdAtDateString;
     }
 
-    public String getCreatedAtDateTimeString() {
-        return createdAtDateTimeString;
+    public String getCreatedAtDateStamp() {
+        return createdAtDateStamp;
     }
 
     public List<ElementTag> getActions() {

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -12,7 +12,7 @@
       <th id="button_sortcoursename" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
-      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" class="button-sort-none toggle-sort">
+      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
         Course Created At<span class="icon-sort unsorted"></span>
       </th>
       <th>
@@ -36,7 +36,7 @@
     <tr>
       <td id="courseid${i.index}">${activeCourse.courseId}</td>
       <td id="coursename${i.index}">${activeCourse.courseName}</td>
-      <td id="coursecreateddate${i.index}">${activeCourse.createdAtDateString}</td>
+      <td id="coursecreateddate${i.index}" data-date-stamp="${activeCourse.createdAtDateTimeString}">${activeCourse.createdAtDateString}</td>
       <td id="course-stats-sectionNum-${i.index}">
         <a class="course-stats-link-${i.index}" oncontextmenu="return false;" href="${activeCourse.href}">Show</a>
       </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -36,7 +36,7 @@
     <tr>
       <td id="courseid${i.index}">${activeCourse.courseId}</td>
       <td id="coursename${i.index}">${activeCourse.courseName}</td>
-      <td id="coursecreateddate${i.index}" data-date-stamp="${activeCourse.createdAtDateTimeString}">${activeCourse.createdAtDateString}</td>
+      <td id="coursecreateddate${i.index}" data-date-stamp="${activeCourse.createdAtDateStamp}">${activeCourse.createdAtDateString}</td>
       <td id="course-stats-sectionNum-${i.index}">
         <a class="course-stats-link-${i.index}" oncontextmenu="return false;" href="${activeCourse.href}">Show</a>
       </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -13,7 +13,7 @@
         Course Name<span class="icon-sort unsorted"></span>
       </th>
       <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
-        Course Created At<span class="icon-sort unsorted"></span>
+        Creation Date<span class="icon-sort unsorted"></span>
       </th>
       <th>
         Sections

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -12,6 +12,9 @@
       <th id="button_sortcoursename" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
+      <th id="button_sortcoursecreateddate" class="button-sort-none toggle-sort">
+        Course Created At<span class="icon-sort unsorted"></span>
+      </th>
       <th>
         Sections
       </th>
@@ -33,6 +36,7 @@
     <tr>
       <td id="courseid${i.index}">${activeCourse.courseId}</td>
       <td id="coursename${i.index}">${activeCourse.courseName}</td>
+      <td id="coursecreateddate${i.index}">${activeCourse.createdAtDateString}</td>
       <td id="course-stats-sectionNum-${i.index}">
         <a class="course-stats-link-${i.index}" oncontextmenu="return false;" href="${activeCourse.href}">Show</a>
       </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -36,7 +36,13 @@
     <tr>
       <td id="courseid${i.index}">${activeCourse.courseId}</td>
       <td id="coursename${i.index}">${activeCourse.courseName}</td>
-      <td id="coursecreateddate${i.index}" data-date-stamp="${activeCourse.createdAtDateStamp}">${activeCourse.createdAtDateString}</td>
+      <td
+        id="coursecreateddate${i.index}"
+        data-date-stamp="${activeCourse.createdAtDateStamp}"
+        data-toggle="tooltip"
+        data-original-title="${activeCourse.createdAtFullDateTimeString}">
+          ${activeCourse.createdAtDateString}
+      </td>
       <td id="course-stats-sectionNum-${i.index}">
         <a class="course-stats-link-${i.index}" oncontextmenu="return false;" href="${activeCourse.href}">Show</a>
       </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -12,7 +12,7 @@
       <th id="button_sortcoursename" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
-      <th id="button_sortcoursecreateddate" class="button-sort-none toggle-sort">
+      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" class="button-sort-none toggle-sort">
         Course Created At<span class="icon-sort unsorted"></span>
       </th>
       <th>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -24,7 +24,7 @@
     <tr>
       <td id="courseid${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseId}</td>
       <td id="coursename${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseName}</td>
-      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}">${archivedCourse.createdAtDateString}</td>
+      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}" data-date-stamp="${archivedCourse.createdAtDateTimeString}">${archivedCourse.createdAtDateString}</td>
       <td class="align-center no-print">
         <c:forEach items="${archivedCourse.actions}" var="button">
           <a ${button.attributesToString}>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -14,6 +14,9 @@
       <th id="button_sortid" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
+      <th id="button_sortcoursecreateddate" class="button-sort-none toggle-sort">
+        Course Created At<span class="icon-sort unsorted"></span>
+      </th>
       <th class="align-center no-print">Action(s)</th>
     </tr>
   </thead>
@@ -21,6 +24,7 @@
     <tr>
       <td id="courseid${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseId}</td>
       <td id="coursename${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseName}</td>
+      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}">${archivedCourse.createdAtDateString}</td>
       <td class="align-center no-print">
         <c:forEach items="${archivedCourse.actions}" var="button">
           <a ${button.attributesToString}>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -24,7 +24,7 @@
     <tr>
       <td id="courseid${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseId}</td>
       <td id="coursename${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseName}</td>
-      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}" data-date-stamp="${archivedCourse.createdAtDateTimeString}">${archivedCourse.createdAtDateString}</td>
+      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}" data-date-stamp="${archivedCourse.createdAtDateStamp}">${archivedCourse.createdAtDateString}</td>
       <td class="align-center no-print">
         <c:forEach items="${archivedCourse.actions}" var="button">
           <a ${button.attributesToString}>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -24,7 +24,13 @@
     <tr>
       <td id="courseid${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseId}</td>
       <td id="coursename${i.index + fn:length(activeCourses.rows)}">${archivedCourse.courseName}</td>
-      <td id="coursecreateddate${i.index + fn:length(activeCourses.rows)}" data-date-stamp="${archivedCourse.createdAtDateStamp}">${archivedCourse.createdAtDateString}</td>
+      <td
+        id="coursecreateddate${i.index + fn:length(activeCourses.rows)}"
+        data-date-stamp="${archivedCourse.createdAtDateStamp}"
+        data-toggle="tooltip"
+        data-original-title="${archivedCourse.createdAtFullDateTimeString}">
+          ${archivedCourse.createdAtDateString}
+        </td>
       <td class="align-center no-print">
         <c:forEach items="${archivedCourse.actions}" var="button">
           <a ${button.attributesToString}>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -14,7 +14,7 @@
       <th id="button_sortid" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
-      <th id="button_sortcoursecreateddate" class="button-sort-none toggle-sort">
+      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" class="button-sort-none toggle-sort">
         Course Created At<span class="icon-sort unsorted"></span>
       </th>
       <th class="align-center no-print">Action(s)</th>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -14,7 +14,7 @@
       <th id="button_sortid" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
-      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" class="button-sort-none toggle-sort">
+      <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
         Course Created At<span class="icon-sort unsorted"></span>
       </th>
       <th class="align-center no-print">Action(s)</th>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -15,7 +15,7 @@
         Course Name<span class="icon-sort unsorted"></span>
       </th>
       <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
-        Course Created At<span class="icon-sort unsorted"></span>
+        Creation Date<span class="icon-sort unsorted"></span>
       </th>
       <th class="align-center no-print">Action(s)</th>
     </tr>

--- a/src/main/webapp/dev/js/common/sortBy.es6
+++ b/src/main/webapp/dev/js/common/sortBy.es6
@@ -142,6 +142,10 @@ class Extractors {
         return $tableCell.find('span').attr('data-original-title');
     }
 
+    static dateStampExtractor($tableCell) {
+        return $tableCell.data('dateStamp');
+    }
+
     static getDefaultExtractor() {
         return Extractors.textExtractor;
     }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -397,6 +397,8 @@ public final class HtmlHelper {
         String dateTimeNow = sdf.format(now);
         SimpleDateFormat sdfForIso8601 = new SimpleDateFormat("yyyy-MM-dd'T'");
         String dateTimeNowInIso8601 = sdfForIso8601.format(now);
+        SimpleDateFormat sdfForCoursesPage = new SimpleDateFormat("d MMM yyyy");
+        String dateTimeNowInCoursesPageFormat = sdfForCoursesPage.format(now);
         String dateOfNextHour = TimeHelper.formatDate(TimeHelper.getNextHour());
         return content // dev server admin absolute URLs (${teammates.url}/_ah/...)
                       .replace("\"" + TestProperties.TEAMMATES_URL + "/_ah", "\"/_ah")
@@ -450,6 +452,7 @@ public final class HtmlHelper {
                       // date/time now e.g [Thu, 07 May 2015, 07:52 PM]
                       .replaceAll(dateTimeNow + REGEX_DISPLAY_TIME, "\\${datetime\\.now}")
                       .replaceAll(dateTimeNowInIso8601 + REGEX_DISPLAY_TIME_ISO_8601_UTC, "\\${datetime\\.now\\.iso8601utc}")
+                      .replaceAll(dateTimeNowInCoursesPageFormat, "\\${datetime\\.now\\.courses}")
                       // admin footer, test institute section
                       .replaceAll("(?s)<div( class=\"col-md-8\"| id=\"adminInstitute\"){2}>"
                                               + REGEX_ADMIN_INSTITUTE_FOOTER + "</div>",
@@ -505,7 +508,8 @@ public final class HtmlHelper {
                       .replace("<!-- nexthour.date -->", TimeHelper.formatDate(TimeHelper.getNextHour()))
                       .replace("<!-- now.datetime -->", TimeHelper.formatTime12H(now))
                       .replace("<!-- now.datetime.sessions -->", TimeHelper.formatDateTimeForSessions(now, 0))
-                      .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateToIso8601Utc(now));
+                      .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateToIso8601Utc(now))
+                      .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateTimeForInstructorCoursesPage(now));
     }
 
     private static TimeZone getTimeZone(String content) {

--- a/src/test/resources/pages/godmode.html
+++ b/src/test/resources/pages/godmode.html
@@ -43,6 +43,7 @@
                 <li><!-- now.datetime --></li>
                 <li><!-- now.datetime.sessions --></li>
                 <li><!-- now.datetime.iso8601utc --></li>
+                <li><!-- now.datetime.courses --></li>
                 <li><div class="col-md-8" id="adminInstitute">
                 </div></li>
                 <li><div id="adminInstitute" class="col-md-8">

--- a/src/test/resources/pages/godmodeExpectedOutput.html
+++ b/src/test/resources/pages/godmodeExpectedOutput.html
@@ -40,6 +40,7 @@
                 <li>${datetime.now}</li>
                 <li>${datetime.now} UTC+0000</li>
                 <li>${datetime.now.iso8601utc}</li>
+                <li>${datetime.now.courses}</li>
                 <li>${admin.institute}</li>
                 <li>${admin.institute}</li>
                 <li><input name="token" type="hidden" value="${sessionToken}"></li>

--- a/src/test/resources/pages/godmodeExpectedPartOutput.html
+++ b/src/test/resources/pages/godmodeExpectedPartOutput.html
@@ -38,6 +38,7 @@
         <li>${datetime.now}</li>
         <li>${datetime.now} UTC+0000</li>
         <li>${datetime.now.iso8601utc}</li>
+        <li>${datetime.now.courses}</li>
         <li>${admin.institute}</li>
         <li>${admin.institute}</li>
         <li><input name="token" type="hidden" value="${sessionToken}"></li>

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -104,7 +104,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instr3" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -74,7 +74,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -73,7 +73,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -103,7 +103,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -73,6 +73,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -97,6 +102,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instr3" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename2">
             Software Engineering $^&*()
           </td>
-          <td id="coursecreateddate2">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
@@ -156,7 +156,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -204,7 +204,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename2">
             Software Engineering $^&*()
+          </td>
+          <td id="coursecreateddate2">
+            9 Aug 11:27 AM
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -148,6 +156,9 @@
           <td id="coursename0">
             Programming Methodology
           </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
+          </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
@@ -192,6 +203,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -109,7 +109,7 @@
             Software Engineering $^&*()
           </td>
           <td id="coursecreateddate2">
-            9 Aug 11:27 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -157,7 +157,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -205,7 +205,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename2">
             Software Engineering $^&*()
           </td>
-          <td id="coursecreateddate2">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
@@ -156,7 +156,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -204,7 +204,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename2">
             Software Engineering $^&*()
+          </td>
+          <td id="coursecreateddate2">
+            9 Aug 11:27 AM
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -148,6 +156,9 @@
           <td id="coursename0">
             Programming Methodology
           </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
+          </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
@@ -192,6 +203,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -109,7 +109,7 @@
             Software Engineering $^&*()
           </td>
           <td id="coursecreateddate2">
-            9 Aug 11:27 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -157,7 +157,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -205,7 +205,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename2">
             Software Engineering $^&*()
           </td>
-          <td id="coursecreateddate2">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
@@ -156,7 +156,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -204,7 +204,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename2">
             Software Engineering $^&*()
+          </td>
+          <td id="coursecreateddate2">
+            9 Aug 11:27 AM
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -148,6 +156,9 @@
           <td id="coursename0">
             Programming Methodology
           </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
+          </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
@@ -192,6 +203,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -109,7 +109,7 @@
             Software Engineering $^&*()
           </td>
           <td id="coursecreateddate2">
-            9 Aug 11:27 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -157,7 +157,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -205,7 +205,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -88,7 +88,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -118,7 +118,7 @@
           <td id="coursename2">
             Software Engineering $^&*()
           </td>
-          <td id="coursecreateddate2">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
@@ -166,7 +166,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -214,7 +214,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -89,7 +89,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -88,6 +88,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -112,6 +117,9 @@
           </td>
           <td id="coursename2">
             Software Engineering $^&*()
+          </td>
+          <td id="coursecreateddate2">
+            9 Aug 11:27 AM
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -158,6 +166,9 @@
           <td id="coursename0">
             Programming Methodology
           </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
+          </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
@@ -202,6 +213,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -119,7 +119,7 @@
             Software Engineering $^&*()
           </td>
           <td id="coursecreateddate2">
-            9 Aug 11:27 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-2">
             <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -167,7 +167,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -215,7 +215,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename0">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -171,7 +171,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -189,7 +189,7 @@
           <td id="coursename1">
             Programming Methodology
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td class="align-center no-print">

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -109,7 +109,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -190,7 +190,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td class="align-center no-print">
             <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive1">

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>
@@ -172,7 +172,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename0">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -163,6 +171,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th class="align-center no-print">
             Action(s)
           </th>
@@ -175,6 +188,9 @@
           </td>
           <td id="coursename1">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td class="align-center no-print">
             <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive1">

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -156,7 +156,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -109,7 +109,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -157,7 +157,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -147,6 +155,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -73,6 +73,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -97,6 +102,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -142,6 +150,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -74,7 +74,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -73,7 +73,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -103,7 +103,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -151,7 +151,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -104,7 +104,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -152,7 +152,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -155,7 +155,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -154,6 +154,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -154,7 +154,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -74,7 +74,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -104,7 +104,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="invalidLink" oncontextmenu="return false;">
@@ -152,7 +152,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             Failed.

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -73,6 +73,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -97,6 +102,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="invalidLink" oncontextmenu="return false;">
@@ -142,6 +150,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             Failed.

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -73,7 +73,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -103,7 +103,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -151,7 +151,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -74,7 +74,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -73,6 +73,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -97,6 +102,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -142,6 +150,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             0

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -104,7 +104,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -152,7 +152,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             0

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -73,7 +73,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -103,7 +103,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -151,7 +151,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -78,7 +78,7 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
             Course Created At
             <span class="icon-sort unsorted">
             </span>
@@ -108,7 +108,7 @@
           <td id="coursename0">
             Programming Methodology
           </td>
-          <td id="coursecreateddate0">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate0">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
@@ -156,7 +156,7 @@
           <td id="coursename1">
             Programming Language Concept
           </td>
-          <td id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
             ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -79,7 +79,7 @@
             </span>
           </th>
           <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
-            Course Created At
+            Creation Date
             <span class="icon-sort unsorted">
             </span>
           </th>

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -109,7 +109,7 @@
             Programming Methodology
           </td>
           <td id="coursecreateddate0">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -157,7 +157,7 @@
             Programming Language Concept
           </td>
           <td id="coursecreateddate1">
-            9 Aug 11:26 AM
+            ${datetime.now.courses}
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -78,6 +78,11 @@
             <span class="icon-sort unsorted">
             </span>
           </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" id="button_sortcoursecreateddate">
+            Course Created At
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
           <th>
             Sections
           </th>
@@ -102,6 +107,9 @@
           </td>
           <td id="coursename0">
             Programming Methodology
+          </td>
+          <td id="coursecreateddate0">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-0">
             <a class="course-stats-link-0" href="/page/courseStatsPage?courseid=CCAddUiTest.CS1101&user=CCAddUiTest.instructor" oncontextmenu="return false;">
@@ -147,6 +155,9 @@
           </td>
           <td id="coursename1">
             Programming Language Concept
+          </td>
+          <td id="coursecreateddate1">
+            9 Aug 11:26 AM
           </td>
           <td id="course-stats-sectionNum-1">
             <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2104&user=CCAddUiTest.instructor" oncontextmenu="return false;">


### PR DESCRIPTION
Fixes #1297 

**Outline of solution:**
- Added a method in CourseAttributes to get createdAt date field as a formatted String.
- Added this string as data to active and archived row classes
- Added this new data to the HTML tags.
- Used the `sort-comparator` from `toggle-sort` to sort by date.

Note: I have formatted the date using the `TimeHelper.formatDateTimeForInstructorHomePage` method. I had originally simply used the `formatDate` method but that was neither as user-readable and universally understood as this nor was it being parsed by JS as a date object (for `sortDate` comparator to work). Let me know if I should change the method name to `formatDateTimeForInstructorHomePageAndCoursesPage`.

**TODO:**
- ~~Run god mode.~~