### PR TITLE
MSQ and MCQ results: make table occupy full width #7962

### DIFF
--- a/src/main/resources/feedbackQuestionMcqResultStatsTemplate.html
+++ b/src/main/resources/feedbackQuestionMcqResultStatsTemplate.html
@@ -7,7 +7,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-6 col-lg-4">
+        <div class="col-sm-12">
             <table class="table margin-0">
                 <thead>
                     <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -608,7 +608,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -766,7 +766,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -919,7 +919,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1032,7 +1032,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1959,7 +1959,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -2105,7 +2105,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -607,7 +607,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -777,7 +777,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -942,7 +942,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1067,7 +1067,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1974,7 +1974,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -2132,7 +2132,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -1493,7 +1493,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>
@@ -1939,7 +1939,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>
@@ -2379,7 +2379,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>
@@ -2782,7 +2782,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -608,7 +608,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -766,7 +766,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -919,7 +919,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1032,7 +1032,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1959,7 +1959,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -2105,7 +2105,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -472,7 +472,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -597,7 +597,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -710,7 +710,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -790,7 +790,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -1051,7 +1051,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1209,7 +1209,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1362,7 +1362,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1475,7 +1475,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -2127,7 +2127,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -2240,7 +2240,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -2643,7 +2643,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -2789,7 +2789,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -607,7 +607,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -777,7 +777,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -942,7 +942,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1067,7 +1067,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -1974,7 +1974,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -2132,7 +2132,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -472,7 +472,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -597,7 +597,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -710,7 +710,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -790,7 +790,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -1050,7 +1050,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1220,7 +1220,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1385,7 +1385,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1510,7 +1510,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -2106,7 +2106,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -2219,7 +2219,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -2658,7 +2658,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -2816,7 +2816,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
@@ -429,7 +429,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>
@@ -802,7 +802,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -455,7 +455,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -572,7 +572,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -460,7 +460,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -540,7 +540,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -1139,7 +1139,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1256,7 +1256,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
@@ -429,7 +429,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -449,7 +449,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>
@@ -578,7 +578,7 @@
                           </div>
                         </div>
                         <div class="row">
-                          <div class="col-sm-6 col-lg-4">
+                          <div class="col-sm-12">
                             <table class="table margin-0">
                               <thead>
                                 <tr>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -460,7 +460,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -540,7 +540,7 @@
                             </div>
                           </div>
                           <div class="row">
-                            <div class="col-sm-6 col-lg-4">
+                            <div class="col-sm-12">
                               <table class="table margin-0">
                                 <thead>
                                   <tr>
@@ -991,7 +991,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>
@@ -1120,7 +1120,7 @@
                                 </div>
                               </div>
                               <div class="row">
-                                <div class="col-sm-6 col-lg-4">
+                                <div class="col-sm-12">
                                   <table class="table margin-0">
                                     <thead>
                                       <tr>

--- a/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
@@ -1285,7 +1285,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>
@@ -1989,7 +1989,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-6 col-lg-4">
+              <div class="col-sm-12">
                 <table class="table margin-0">
                   <thead>
                     <tr>


### PR DESCRIPTION
Fixes #7962 

Made table `col-sm-12` so that it occupies full width for all resolutions. UI changes -

![1](https://user-images.githubusercontent.com/11662001/29486306-535a52f0-8500-11e7-8d5a-e91a144062eb.JPG)

![2](https://user-images.githubusercontent.com/11662001/29486309-55763522-8500-11e7-99d9-38e0716dd370.JPG)

