### PR TITLE
Instructor: home page: show response published status separate from submission status #4536

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -279,7 +279,9 @@ public final class Const {
         public static final String STUDENT_FEEDBACK_SESSION_STATUS_CLOSED =
                 "<br>The session is now closed for submissions.";
         public static final String STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED =
-                "<br>The responses for the session can now be viewed.";
+                "The responses for the session have been published and can now be viewed.";
+        public static final String STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED =
+                "The responses for the session have not yet been published and cannot be viewed.";
 
         public static final String FEEDBACK_CONTRIBUTION_DIFF = "Perceived Contribution - Claimed Contribution";
         public static final String FEEDBACK_CONTRIBUTION_POINTS_RECEIVED =
@@ -347,7 +349,10 @@ public final class Const {
         public static final String FEEDBACK_SESSION_STATUS_AWAITING = ", and is waiting to open";
         public static final String FEEDBACK_SESSION_STATUS_OPEN = ", and is open for submissions";
         public static final String FEEDBACK_SESSION_STATUS_CLOSED = ", and has ended";
-        public static final String FEEDBACK_SESSION_STATUS_PUBLISHED = ".<br>The responses for this session are visible";
+        public static final String FEEDBACK_SESSION_STATUS_PUBLISHED = "The responses for this session are visible.";
+        public static final String FEEDBACK_SESSION_STATUS_NOT_PUBLISHED = "The responses for this session are not visible.";
+        public static final String FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION = 
+                "This feedback session is not published as it is private and only visible to you.";
 
         public static final String FEEDBACK_SESSION_INPUT_TIMEZONE =
                 "You should not need to change this as your timezone is auto-detected. <br><br>"

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -351,7 +351,7 @@ public final class Const {
         public static final String FEEDBACK_SESSION_STATUS_CLOSED = ", and has ended";
         public static final String FEEDBACK_SESSION_STATUS_PUBLISHED = "The responses for this session are visible.";
         public static final String FEEDBACK_SESSION_STATUS_NOT_PUBLISHED = "The responses for this session are not visible.";
-        public static final String FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION = 
+        public static final String FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION =
                 "This feedback session is not published as it is private and only visible to you.";
 
         public static final String FEEDBACK_SESSION_INPUT_TIMEZONE =

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -282,6 +282,8 @@ public final class Const {
                 "The responses for the session have been published and can now be viewed.";
         public static final String STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED =
                 "The responses for the session have not yet been published and cannot be viewed.";
+        public static final String STUDENT_FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED =
+                "The instructor has set the results for this feedback session to not be published.";
 
         public static final String FEEDBACK_CONTRIBUTION_DIFF = "Perceived Contribution - Claimed Contribution";
         public static final String FEEDBACK_CONTRIBUTION_POINTS_RECEIVED =
@@ -353,6 +355,8 @@ public final class Const {
         public static final String FEEDBACK_SESSION_STATUS_NOT_PUBLISHED = "The responses for this session are not visible.";
         public static final String FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION =
                 "This feedback session is not published as it is private and only visible to you.";
+        public static final String FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED =
+                "The responses for this feedback session have been set to never get published.";
 
         public static final String FEEDBACK_SESSION_INPUT_TIMEZONE =
                 "You should not need to change this as your timezone is auto-detected. <br><br>"

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackSessionsPageData.java
@@ -178,7 +178,8 @@ public class InstructorFeedbackSessionsPageData extends PageData {
             String courseId = session.getCourseId();
             String name = sanitizeForHtml(session.getFeedbackSessionName());
             String tooltip = getInstructorHoverMessageForFeedbackSession(session);
-            String status = getInstructorStatusForFeedbackSession(session);
+            String submissionStatus = getInstructorSubmissionStatusForFeedbackSession(session);
+            String publishedStatus = getInstructorPublishedStatusForFeedbackSession(session);
             String href = getInstructorFeedbackStatsLink(session.getCourseId(), session.getFeedbackSessionName());
 
             InstructorFeedbackSessionActions actions =
@@ -193,7 +194,7 @@ public class InstructorFeedbackSessionsPageData extends PageData {
                 elementAttributes = new ElementTag("class", "sessionsRow");
             }
 
-            rows.add(new FeedbackSessionsTableRow(courseId, name, tooltip, status, href,
+            rows.add(new FeedbackSessionsTableRow(courseId, name, tooltip, submissionStatus, publishedStatus, href,
                                                   actions, elementAttributes));
         }
 

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackSessionsPageData.java
@@ -177,7 +177,8 @@ public class InstructorFeedbackSessionsPageData extends PageData {
         for (FeedbackSessionAttributes session : sessions) {
             String courseId = session.getCourseId();
             String name = sanitizeForHtml(session.getFeedbackSessionName());
-            String tooltip = getInstructorHoverMessageForFeedbackSession(session);
+            String submissionsTooltip = getInstructorSubmissionsTooltipForFeedbackSession(session);
+            String publishedTooltip = getInstructorPublishedTooltipForFeedbackSession(session);
             String submissionStatus = getInstructorSubmissionStatusForFeedbackSession(session);
             String publishedStatus = getInstructorPublishedStatusForFeedbackSession(session);
             String href = getInstructorFeedbackStatsLink(session.getCourseId(), session.getFeedbackSessionName());
@@ -194,8 +195,8 @@ public class InstructorFeedbackSessionsPageData extends PageData {
                 elementAttributes = new ElementTag("class", "sessionsRow");
             }
 
-            rows.add(new FeedbackSessionsTableRow(courseId, name, tooltip, submissionStatus, publishedStatus, href,
-                                                  actions, elementAttributes));
+            rows.add(new FeedbackSessionsTableRow(courseId, name, submissionsTooltip, publishedTooltip, submissionStatus,
+                                                  publishedStatus, href, actions, elementAttributes));
         }
 
         return rows;

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -124,7 +124,8 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
             InstructorHomeFeedbackSessionRow row = new InstructorHomeFeedbackSessionRow(
                     sanitizeForHtml(session.getFeedbackSessionName()),
                     getInstructorHoverMessageForFeedbackSession(session),
-                    getInstructorStatusForFeedbackSession(session),
+                    getInstructorSubmissionStatusForFeedbackSession(session),
+                    getInstructorPublishedStatusForFeedbackSession(session),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getStartTime()),
                     session.getStartTimeString(),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getEndTime()),

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -123,7 +123,8 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
         for (FeedbackSessionAttributes session : sessions) {
             InstructorHomeFeedbackSessionRow row = new InstructorHomeFeedbackSessionRow(
                     sanitizeForHtml(session.getFeedbackSessionName()),
-                    getInstructorHoverMessageForFeedbackSession(session),
+                    getInstructorSubmissionsTooltipForFeedbackSession(session),
+                    getInstructorPublishedTooltipForFeedbackSession(session),
                     getInstructorSubmissionStatusForFeedbackSession(session),
                     getInstructorPublishedStatusForFeedbackSession(session),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getStartTime()),

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -633,9 +633,9 @@ public class PageData {
 
     public static String getInstructorPublishedStatusForFeedbackSession(FeedbackSessionAttributes session) {
         if (session.isPublished()) {
-            return "Yes";
+            return "Published";
         } else {
-            return "No";
+            return "Not Published";
         }
     }
 

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -671,7 +671,7 @@ public class PageData {
         if (session.isPrivateSession()) {
             return Const.Tooltips.FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION;
         } else if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
-          return Const.Tooltips.FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;  
+            return Const.Tooltips.FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;  
         } else if (session.isPublished()) {
             return Const.Tooltips.FEEDBACK_SESSION_STATUS_PUBLISHED;
         } else {

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -639,7 +639,7 @@ public class PageData {
         }
     }
 
-    public static String getInstructorHoverMessageForFeedbackSession(FeedbackSessionAttributes session) {
+    public static String getInstructorSubmissionsTooltipForFeedbackSession(FeedbackSessionAttributes session) {
 
         if (session.isPrivateSession()) {
             return Const.Tooltips.FEEDBACK_SESSION_STATUS_PRIVATE;
@@ -660,13 +660,19 @@ public class PageData {
             msg.append(Const.Tooltips.FEEDBACK_SESSION_STATUS_CLOSED);
         }
 
-        if (session.isPublished()) {
-            msg.append(Const.Tooltips.FEEDBACK_SESSION_STATUS_PUBLISHED);
-        }
-
         msg.append('.');
 
         return msg.toString();
+    }
+
+    public static String getInstructorPublishedTooltipForFeedbackSession(FeedbackSessionAttributes session) {
+        if (session.isPrivateSession()) {
+            return Const.Tooltips.FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION;
+        } else if (session.isPublished()) {
+            return Const.Tooltips.FEEDBACK_SESSION_STATUS_PUBLISHED;
+        } else {
+            return Const.Tooltips.FEEDBACK_SESSION_STATUS_NOT_PUBLISHED;
+        }
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -632,14 +632,10 @@ public class PageData {
     }
 
     public static String getInstructorPublishedStatusForFeedbackSession(FeedbackSessionAttributes session) {
-        if (session.isPrivateSession()) {
-            return "NA for Private Session";
-        } else if (session.isWaitingToOpen()) {
-            return "NA for not-yet-open Session";
-        } else if (session.isPublished()) {
-            return "Published";
+        if (session.isPublished()) {
+            return "Yes";
         } else {
-            return "Not Published";
+            return "No";
         }
     }
 

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -671,7 +671,7 @@ public class PageData {
         if (session.isPrivateSession()) {
             return Const.Tooltips.FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION;
         } else if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
-            return Const.Tooltips.FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;  
+            return Const.Tooltips.FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;
         } else if (session.isPublished()) {
             return Const.Tooltips.FEEDBACK_SESSION_STATUS_PUBLISHED;
         } else {

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -632,7 +632,9 @@ public class PageData {
     }
 
     public static String getInstructorPublishedStatusForFeedbackSession(FeedbackSessionAttributes session) {
-        if (session.isPublished()) {
+        if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
+            return "-";
+        } else if (session.isPublished()) {
             return "Published";
         } else {
             return "Not Published";

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -670,6 +670,8 @@ public class PageData {
     public static String getInstructorPublishedTooltipForFeedbackSession(FeedbackSessionAttributes session) {
         if (session.isPrivateSession()) {
             return Const.Tooltips.FEEDBACK_SESSION_PUBLISHED_STATUS_PRIVATE_SESSION;
+        } else if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
+          return Const.Tooltips.FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;  
         } else if (session.isPublished()) {
             return Const.Tooltips.FEEDBACK_SESSION_STATUS_PUBLISHED;
         } else {

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -619,17 +619,27 @@ public class PageData {
         return link;
     }
 
-    public static String getInstructorStatusForFeedbackSession(FeedbackSessionAttributes session) {
+    public static String getInstructorSubmissionStatusForFeedbackSession(FeedbackSessionAttributes session) {
         if (session.isPrivateSession()) {
             return "Private";
         } else if (session.isOpened()) {
             return "Open";
         } else if (session.isWaitingToOpen()) {
             return "Awaiting";
+        } else {
+            return "Closed";
+        }
+    }
+
+    public static String getInstructorPublishedStatusForFeedbackSession(FeedbackSessionAttributes session) {
+        if (session.isPrivateSession()) {
+            return "NA for Private Session";
+        } else if (session.isWaitingToOpen()) {
+            return "NA for not-yet-open Session";
         } else if (session.isPublished()) {
             return "Published";
         } else {
-            return "Closed";
+            return "Not Published";
         }
     }
 

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -66,7 +66,8 @@ public class StudentHomePageData extends PageData {
 
             rows.add(new StudentHomeFeedbackSessionRow(
                     PageData.sanitizeForHtml(sessionName),
-                    getStudentHoverMessageForSession(feedbackSession, hasSubmitted),
+                    getStudentSubmissionsTooltipForSession(feedbackSession, hasSubmitted),
+                    getStudentPublishedTooltipForSession(feedbackSession),
                     getStudentSubmissionStatusForSession(feedbackSession, hasSubmitted),
                     getStudentPublishedStatusForSession(feedbackSession),
                     TimeHelper.formatTime12H(feedbackSession.getEndTime()),
@@ -111,7 +112,7 @@ public class StudentHomePageData extends PageData {
      * @param session The feedback session in question.
      * @param hasSubmitted Whether the student had submitted the session or not.
      */
-    private String getStudentHoverMessageForSession(FeedbackSessionAttributes session, boolean hasSubmitted) {
+    private String getStudentSubmissionsTooltipForSession(FeedbackSessionAttributes session, boolean hasSubmitted) {
         StringBuilder msg = new StringBuilder();
 
         Boolean isAwaiting = session.isWaitingToOpen();
@@ -126,10 +127,15 @@ public class StudentHomePageData extends PageData {
         if (session.isClosed()) {
             msg.append(Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED);
         }
-        if (session.isPublished()) {
-            msg.append(Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED);
-        }
         return msg.toString();
+    }
+
+    private String getStudentPublishedTooltipForSession(FeedbackSessionAttributes session) {
+        if (session.isPublished()) {
+            return Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED;
+        } else {
+            return Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED;
+        }
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -104,10 +104,10 @@ public class StudentHomePageData extends PageData {
         }
 
         if (session.isPublished()) {
-            return "Yes";
+            return "Published";
         }
 
-        return "No";
+        return "Not Published";
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -135,7 +135,9 @@ public class StudentHomePageData extends PageData {
     }
 
     private String getStudentPublishedTooltipForSession(FeedbackSessionAttributes session) {
-        if (session.isPublished()) {
+        if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
+            return Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NEVER_PUBLISHED;
+        } else if (session.isPublished()) {
             return Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED;
         } else {
             return Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED;

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -99,10 +99,10 @@ public class StudentHomePageData extends PageData {
 
     private String getStudentPublishedStatusForSession(FeedbackSessionAttributes session) {
         if (session.isPublished()) {
-            return "Published";
+            return "Yes";
         }
 
-        return "Not Published";
+        return "No";
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -67,7 +67,8 @@ public class StudentHomePageData extends PageData {
             rows.add(new StudentHomeFeedbackSessionRow(
                     PageData.sanitizeForHtml(sessionName),
                     getStudentHoverMessageForSession(feedbackSession, hasSubmitted),
-                    getStudentStatusForSession(feedbackSession, hasSubmitted),
+                    getStudentSubmissionStatusForSession(feedbackSession, hasSubmitted),
+                    getStudentPublishedStatusForSession(feedbackSession),
                     TimeHelper.formatTime12H(feedbackSession.getEndTime()),
                     getStudentFeedbackSessionActions(feedbackSession, hasSubmitted),
                     sessionIdx));
@@ -84,7 +85,7 @@ public class StudentHomePageData extends PageData {
      * @param session The feedback session in question.
      * @param hasSubmitted Whether the student had submitted the session or not.
      */
-    private String getStudentStatusForSession(FeedbackSessionAttributes session, boolean hasSubmitted) {
+    private String getStudentSubmissionStatusForSession(FeedbackSessionAttributes session, boolean hasSubmitted) {
         if (session.isOpened()) {
             return hasSubmitted ? "Submitted" : "Pending";
         }
@@ -93,11 +94,15 @@ public class StudentHomePageData extends PageData {
             return "Awaiting";
         }
 
+        return "Closed";
+    }
+
+    private String getStudentPublishedStatusForSession(FeedbackSessionAttributes session) {
         if (session.isPublished()) {
             return "Published";
         }
 
-        return "Closed";
+        return "Not Published";
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -99,6 +99,10 @@ public class StudentHomePageData extends PageData {
     }
 
     private String getStudentPublishedStatusForSession(FeedbackSessionAttributes session) {
+        if (session.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_NEVER)) {
+            return "-";
+        }
+
         if (session.isPublished()) {
             return "Yes";
         }

--- a/src/main/java/teammates/ui/template/FeedbackSessionsTableRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackSessionsTableRow.java
@@ -3,7 +3,8 @@ package teammates.ui.template;
 public class FeedbackSessionsTableRow {
     private String courseId;
     private String name;
-    private String tooltip;
+    private String submissionsTooltip;
+    private String publishedTooltip;
     private String href;
     private String submissionStatus;
     private String publishedStatus;
@@ -19,12 +20,13 @@ public class FeedbackSessionsTableRow {
      * @param href link for the session under response rate
      * @param actions possible actions to do on the session, a block of HTML representing the formatted actions
      */
-    public FeedbackSessionsTableRow(String courseId, String name, String tooltip, String submissionStatus,
-                                    String publishedStatus, String href, InstructorFeedbackSessionActions actions,
-                                    ElementTag attributes) {
+    public FeedbackSessionsTableRow(String courseId, String name, String submissionsTooltip, String publishedTooltip,
+                                    String submissionStatus, String publishedStatus, String href,
+                                    InstructorFeedbackSessionActions actions, ElementTag attributes) {
         this.courseId = courseId;
         this.name = name;
-        this.tooltip = tooltip;
+        this.submissionsTooltip = submissionsTooltip;
+        this.publishedTooltip = publishedTooltip;
         this.href = href;
         this.submissionStatus = submissionStatus;
         this.publishedStatus = publishedStatus;
@@ -48,8 +50,12 @@ public class FeedbackSessionsTableRow {
         return publishedStatus;
     }
 
-    public String getTooltip() {
-        return tooltip;
+    public String getSubmissionsTooltip() {
+        return submissionsTooltip;
+    }
+
+    public String getPublishedTooltip() {
+        return publishedTooltip;
     }
 
     public String getHref() {

--- a/src/main/java/teammates/ui/template/FeedbackSessionsTableRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackSessionsTableRow.java
@@ -5,7 +5,8 @@ public class FeedbackSessionsTableRow {
     private String name;
     private String tooltip;
     private String href;
-    private String status;
+    private String submissionStatus;
+    private String publishedStatus;
     private InstructorFeedbackSessionActions actions;
 
     private ElementTag rowAttributes;
@@ -18,13 +19,15 @@ public class FeedbackSessionsTableRow {
      * @param href link for the session under response rate
      * @param actions possible actions to do on the session, a block of HTML representing the formatted actions
      */
-    public FeedbackSessionsTableRow(String courseId, String name, String tooltip, String status, String href,
-                                    InstructorFeedbackSessionActions actions, ElementTag attributes) {
+    public FeedbackSessionsTableRow(String courseId, String name, String tooltip, String submissionStatus,
+                                    String publishedStatus, String href, InstructorFeedbackSessionActions actions,
+                                    ElementTag attributes) {
         this.courseId = courseId;
         this.name = name;
         this.tooltip = tooltip;
         this.href = href;
-        this.status = status;
+        this.submissionStatus = submissionStatus;
+        this.publishedStatus = publishedStatus;
         this.actions = actions;
         this.rowAttributes = attributes;
     }
@@ -37,8 +40,12 @@ public class FeedbackSessionsTableRow {
         return name;
     }
 
-    public String getStatus() {
-        return status;
+    public String getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public String getPublishedStatus() {
+        return publishedStatus;
     }
 
     public String getTooltip() {

--- a/src/main/java/teammates/ui/template/HomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/HomeFeedbackSessionRow.java
@@ -2,13 +2,16 @@ package teammates.ui.template;
 
 public class HomeFeedbackSessionRow {
     private String name;
-    private String tooltip;
+    private String submissionsTooltip;
+    private String publishedTooltip;
     private String submissionStatus;
     private String publishedStatus;
 
-    public HomeFeedbackSessionRow(String name, String tooltip, String submissionStatus, String publishedStatus) {
+    public HomeFeedbackSessionRow(String name, String submissionsTooltip, String publishedTooltip,
+                                  String submissionStatus, String publishedStatus) {
         this.name = name;
-        this.tooltip = tooltip;
+        this.submissionsTooltip = submissionsTooltip;
+        this.publishedTooltip = publishedTooltip;
         this.submissionStatus = submissionStatus;
         this.publishedStatus = publishedStatus;
     }
@@ -17,8 +20,12 @@ public class HomeFeedbackSessionRow {
         return name;
     }
 
-    public String getTooltip() {
-        return tooltip;
+    public String getSubmissionsTooltip() {
+        return submissionsTooltip;
+    }
+
+    public String getPublishedTooltip() {
+        return publishedTooltip;
     }
 
     public String getSubmissionStatus() {

--- a/src/main/java/teammates/ui/template/HomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/HomeFeedbackSessionRow.java
@@ -3,12 +3,14 @@ package teammates.ui.template;
 public class HomeFeedbackSessionRow {
     private String name;
     private String tooltip;
-    private String status;
+    private String submissionStatus;
+    private String publishedStatus;
 
-    public HomeFeedbackSessionRow(String name, String tooltip, String status) {
+    public HomeFeedbackSessionRow(String name, String tooltip, String submissionStatus, String publishedStatus) {
         this.name = name;
         this.tooltip = tooltip;
-        this.status = status;
+        this.submissionStatus = submissionStatus;
+        this.publishedStatus = publishedStatus;
     }
 
     public String getName() {
@@ -19,7 +21,11 @@ public class HomeFeedbackSessionRow {
         return tooltip;
     }
 
-    public String getStatus() {
-        return status;
+    public String getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public String getPublishedStatus() {
+        return publishedStatus;
     }
 }

--- a/src/main/java/teammates/ui/template/InstructorHomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/InstructorHomeFeedbackSessionRow.java
@@ -8,10 +8,10 @@ public class InstructorHomeFeedbackSessionRow extends HomeFeedbackSessionRow {
     private String href;
     private InstructorFeedbackSessionActions actions;
 
-    public InstructorHomeFeedbackSessionRow(String name, String tooltip, String submissionStatus,
-            String publishedStatus, String startTime, String startTimeToolTip, String endTime,
-            String endTimeToolTip, String href, InstructorFeedbackSessionActions actions) {
-        super(name, tooltip, submissionStatus, publishedStatus);
+    public InstructorHomeFeedbackSessionRow(String name, String submissionsTooltip, String publishedTooltip,
+            String submissionStatus, String publishedStatus, String startTime, String startTimeToolTip,
+            String endTime, String endTimeToolTip, String href, InstructorFeedbackSessionActions actions) {
+        super(name, submissionsTooltip, publishedTooltip, submissionStatus, publishedStatus);
         this.startTime = startTime;
         this.startTimeToolTip = startTimeToolTip;
         this.endTime = endTime;

--- a/src/main/java/teammates/ui/template/InstructorHomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/InstructorHomeFeedbackSessionRow.java
@@ -8,10 +8,10 @@ public class InstructorHomeFeedbackSessionRow extends HomeFeedbackSessionRow {
     private String href;
     private InstructorFeedbackSessionActions actions;
 
-    public InstructorHomeFeedbackSessionRow(String name, String tooltip, String status,
-            String startTime, String startTimeToolTip, String endTime, String endTimeToolTip,
-            String href, InstructorFeedbackSessionActions actions) {
-        super(name, tooltip, status);
+    public InstructorHomeFeedbackSessionRow(String name, String tooltip, String submissionStatus,
+            String publishedStatus, String startTime, String startTimeToolTip, String endTime,
+            String endTimeToolTip, String href, InstructorFeedbackSessionActions actions) {
+        super(name, tooltip, submissionStatus, publishedStatus);
         this.startTime = startTime;
         this.startTimeToolTip = startTimeToolTip;
         this.endTime = endTime;

--- a/src/main/java/teammates/ui/template/StudentHomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/StudentHomeFeedbackSessionRow.java
@@ -5,9 +5,10 @@ public class StudentHomeFeedbackSessionRow extends HomeFeedbackSessionRow {
     private StudentFeedbackSessionActions actions;
     private int index;
 
-    public StudentHomeFeedbackSessionRow(String name, String tooltip, String submissionStatus,
-            String publishedStatus, String endTime, StudentFeedbackSessionActions actions, int index) {
-        super(name, tooltip, submissionStatus, publishedStatus);
+    public StudentHomeFeedbackSessionRow(String name, String submissionsTooltip, String publishedTooltip,
+            String submissionStatus, String publishedStatus, String endTime, StudentFeedbackSessionActions actions,
+            int index) {
+        super(name, submissionsTooltip, publishedTooltip, submissionStatus, publishedStatus);
         this.endTime = endTime;
         this.actions = actions;
         this.index = index;

--- a/src/main/java/teammates/ui/template/StudentHomeFeedbackSessionRow.java
+++ b/src/main/java/teammates/ui/template/StudentHomeFeedbackSessionRow.java
@@ -5,9 +5,9 @@ public class StudentHomeFeedbackSessionRow extends HomeFeedbackSessionRow {
     private StudentFeedbackSessionActions actions;
     private int index;
 
-    public StudentHomeFeedbackSessionRow(String name, String tooltip, String status,
-            String endTime, StudentFeedbackSessionActions actions, int index) {
-        super(name, tooltip, status);
+    public StudentHomeFeedbackSessionRow(String name, String tooltip, String submissionStatus,
+            String publishedStatus, String endTime, StudentFeedbackSessionActions actions, int index) {
+        super(name, tooltip, submissionStatus, publishedStatus);
         this.endTime = endTime;
         this.actions = actions;
         this.index = index;

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
@@ -32,12 +32,14 @@
           <td>${sessionRow.courseId}</td>
           <td>${sessionRow.name}</td>
           <td>
-            <span title="${sessionRow.tooltip}" data-toggle="tooltip" data-placement="top">
+            <span title="${sessionRow.submissionsTooltip}" data-toggle="tooltip" data-placement="top">
               ${sessionRow.submissionStatus}
             </span>
           </td>
           <td>
-            ${sessionRow.publishedStatus}          
+            <span title="${sessionRow.publishedTooltip}" data-toggle="tooltip" data-placement="top">
+              ${sessionRow.publishedStatus}
+            </span>
           </td>
           <td class="session-response-for-test">
             <a oncontextmenu="return false;" href="${sessionRow.href}">Show</a>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
@@ -15,8 +15,8 @@
       <th id="button_sortname" class="button-sort-none session-name-table-width toggle-sort">
         Session Name <span class="icon-sort unsorted"></span>
       </th>
-      <th>Submission Status</th>
-      <th>Published Status</th>
+      <th>Submissions</th>
+      <th>Published?</th>
       <th>
         <span title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>" data-toggle="tooltip" data-placement="top">
           Response Rate

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
@@ -15,7 +15,8 @@
       <th id="button_sortname" class="button-sort-none session-name-table-width toggle-sort">
         Session Name <span class="icon-sort unsorted"></span>
       </th>
-      <th>Status</th>
+      <th>Submission Status</th>
+      <th>Published Status</th>
       <th>
         <span title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>" data-toggle="tooltip" data-placement="top">
           Response Rate
@@ -32,8 +33,11 @@
           <td>${sessionRow.name}</td>
           <td>
             <span title="${sessionRow.tooltip}" data-toggle="tooltip" data-placement="top">
-              ${sessionRow.status}
+              ${sessionRow.submissionStatus}
             </span>
+          </td>
+          <td>
+            ${sessionRow.publishedStatus}          
           </td>
           <td class="session-response-for-test">
             <a oncontextmenu="return false;" href="${sessionRow.href}">Show</a>

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsTable.tag
@@ -16,7 +16,7 @@
         Session Name <span class="icon-sort unsorted"></span>
       </th>
       <th>Submissions</th>
-      <th>Published?</th>
+      <th>Responses</th>
       <th>
         <span title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>" data-toggle="tooltip" data-placement="top">
           Response Rate

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -17,8 +17,8 @@
                     <th  class="button_sortenddate button-sort-none toggle-sort"
                          data-toggle-sort-comparator="sortDate"
                          data-toggle-sort-extractor="tooltipExtractor">End Date<span class="icon-sort unsorted"></span></th>
-                    <th>Submission Status</th>
-                    <th>Published Status</th>
+                    <th>Submissions</th>
+                    <th>Published?</th>
                     <th>
                         <span class="text-nowrap" title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>"
                                 data-toggle="tooltip" data-placement="top">Response Rate</span>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -18,7 +18,7 @@
                          data-toggle-sort-comparator="sortDate"
                          data-toggle-sort-extractor="tooltipExtractor">End Date<span class="icon-sort unsorted"></span></th>
                     <th>Submissions</th>
-                    <th>Published?</th>
+                    <th>Responses</th>
                     <th>
                         <span class="text-nowrap" title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>"
                                 data-toggle="tooltip" data-placement="top">Response Rate</span>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -51,12 +51,14 @@
                         <span title="${sessionRow.endTimeToolTip}" data-toggle="tooltip">${sessionRow.endTime}</span>
                     </td>
                     <td>
-                        <span title="${sessionRow.tooltip}" data-toggle="tooltip" data-placement="top">
+                        <span title="${sessionRow.submissionsTooltip}" data-toggle="tooltip" data-placement="top">
                             ${sessionRow.submissionStatus}
                         </span>
                     </td>
                     <td>
-                      ${sessionRow.publishedStatus}
+                      <span title="${sessionRow.publishedTooltip}" data-toggle="tooltip" data-placement="top">
+                        ${sessionRow.publishedStatus}
+                      </span>
                     </td>
                     <td class="session-response-for-test">
                         <a oncontextmenu="return false;" href="${sessionRow.href}">Show</a>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -17,7 +17,8 @@
                     <th  class="button_sortenddate button-sort-none toggle-sort"
                          data-toggle-sort-comparator="sortDate"
                          data-toggle-sort-extractor="tooltipExtractor">End Date<span class="icon-sort unsorted"></span></th>
-                    <th>Status</th>
+                    <th>Submission Status</th>
+                    <th>Published Status</th>
                     <th>
                         <span class="text-nowrap" title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>"
                                 data-toggle="tooltip" data-placement="top">Response Rate</span>
@@ -51,8 +52,11 @@
                     </td>
                     <td>
                         <span title="${sessionRow.tooltip}" data-toggle="tooltip" data-placement="top">
-                            ${sessionRow.status}
+                            ${sessionRow.submissionStatus}
                         </span>
+                    </td>
+                    <td>
+                      ${sessionRow.publishedStatus}
                     </td>
                     <td class="session-response-for-test">
                         <a oncontextmenu="return false;" href="${sessionRow.href}">Show</a>

--- a/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
@@ -20,12 +20,14 @@
           <td>${sessionRow.name}</td>
           <td>${sessionRow.endTime}</td>
           <td>
-            <span data-toggle="tooltip" data-placement="top" title="${sessionRow.tooltip}">
+            <span data-toggle="tooltip" data-placement="top" title="${sessionRow.submissionsTooltip}">
               ${sessionRow.submissionStatus}
             </span>
           </td>
           <td>
-            ${sessionRow.publishedStatus}
+            <span data-toggle="tooltip" data-placement="top" title="${sessionRow.publishedTooltip}">
+              ${sessionRow.publishedStatus}
+            </span>
           </td>
           <td class="studentHomeActions">
             <home:rowActions actions="${sessionRow.actions}" index="${sessionRow.index}" />

--- a/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
@@ -10,8 +10,8 @@
         <tr>
           <th>Session Name</th>
           <th>Deadline</th>
-          <th>Submission Status</th>
-          <th>Published Status</th>
+          <th>Submissions</th>
+          <th>Published?</th>
           <th class="studentHomeActions">Action(s)</th>
         </tr>
       </thead>

--- a/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
@@ -11,7 +11,7 @@
           <th>Session Name</th>
           <th>Deadline</th>
           <th>Submissions</th>
-          <th>Published?</th>
+          <th>Responses</th>
           <th class="studentHomeActions">Action(s)</th>
         </tr>
       </thead>

--- a/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/student/home/courseTable.tag
@@ -10,7 +10,8 @@
         <tr>
           <th>Session Name</th>
           <th>Deadline</th>
-          <th>Status</th>
+          <th>Submission Status</th>
+          <th>Published Status</th>
           <th class="studentHomeActions">Action(s)</th>
         </tr>
       </thead>
@@ -20,8 +21,11 @@
           <td>${sessionRow.endTime}</td>
           <td>
             <span data-toggle="tooltip" data-placement="top" title="${sessionRow.tooltip}">
-              ${sessionRow.status}
+              ${sessionRow.submissionStatus}
             </span>
+          </td>
+          <td>
+            ${sessionRow.publishedStatus}
           </td>
           <td class="studentHomeActions">
             <home:rowActions actions="${sessionRow.actions}" index="${sessionRow.index}" />

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -87,11 +87,14 @@ public class StudentHomePageDataTest extends BaseTestCase {
         int index = 0;
 
         testFeedbackSession(index++, submittedRow, submittedSession,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_SUBMITTED, "Submitted");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_SUBMITTED,
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Submitted", "No");
         testFeedbackSession(index++, pendingRow, pendingSession,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING, "Pending");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING,
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Pending", "No");
         testFeedbackSession(index++, awaitingRow, awaitingSession,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_AWAITING, "Awaiting");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_AWAITING,
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Awaiting", "No");
     }
 
     private void testOldCourseTable(CourseDetailsBundle oldCourse, CourseTable courseTable) {
@@ -107,26 +110,31 @@ public class StudentHomePageDataTest extends BaseTestCase {
 
         testFeedbackSession(index++, publishedRow, publishedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING
-                                + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED
-                                + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED,
-                            "Published");
+                                + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED,
+                            "Closed", "Yes");
         testFeedbackSession(index++, closedRow, closedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING
                                 + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
-                            "Closed");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED,
+                            "Closed", "No");
         testFeedbackSession(index++, submittedClosedRow, submittedClosedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_SUBMITTED
                                 + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
-                            "Closed");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED,
+                            "Closed", "No");
     }
 
     private void testFeedbackSession(int index, HomeFeedbackSessionRow row, FeedbackSessionAttributes session,
-            String expectedTooltip, String expectedStatus) {
+            String expectedSubmissionsTooltip, String expectedPublishedTooltip, String expectedSubmissionStatus,
+            String expectedPublishedStatus) {
         StudentHomeFeedbackSessionRow studentRow = (StudentHomeFeedbackSessionRow) row;
         assertEquals(session.getFeedbackSessionName(), studentRow.getName());
         assertEquals(TimeHelper.formatTime12H(session.getEndTime()), studentRow.getEndTime());
-        assertEquals(expectedTooltip, studentRow.getTooltip());
-        assertEquals(expectedStatus, studentRow.getStatus());
+        assertEquals(expectedSubmissionsTooltip, studentRow.getSubmissionsTooltip());
+        assertEquals(expectedPublishedTooltip, studentRow.getPublishedTooltip());
+        assertEquals(expectedSubmissionStatus, studentRow.getSubmissionStatus());
+        assertEquals(expectedPublishedStatus, studentRow.getPublishedStatus());
         assertEquals(index, studentRow.getIndex());
         testActions(studentRow.getActions(), session);
     }

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -88,13 +88,13 @@ public class StudentHomePageDataTest extends BaseTestCase {
 
         testFeedbackSession(index++, submittedRow, submittedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_SUBMITTED,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Submitted", "No");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Submitted", "Not Published");
         testFeedbackSession(index++, pendingRow, pendingSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Pending", "No");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Pending", "Not Published");
         testFeedbackSession(index++, awaitingRow, awaitingSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_AWAITING,
-                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Awaiting", "No");
+                            Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED, "Awaiting", "Not Published");
     }
 
     private void testOldCourseTable(CourseDetailsBundle oldCourse, CourseTable courseTable) {
@@ -112,17 +112,17 @@ public class StudentHomePageDataTest extends BaseTestCase {
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING
                                 + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PUBLISHED,
-                            "Closed", "Yes");
+                            "Closed", "Published");
         testFeedbackSession(index++, closedRow, closedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_PENDING
                                 + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED,
-                            "Closed", "No");
+                            "Closed", "Not Published");
         testFeedbackSession(index++, submittedClosedRow, submittedClosedSession,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_SUBMITTED
                                 + Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_CLOSED,
                             Const.Tooltips.STUDENT_FEEDBACK_SESSION_STATUS_NOT_PUBLISHED,
-                            "Closed", "No");
+                            "Closed", "Not Published");
     }
 
     private void testFeedbackSession(int index, HomeFeedbackSessionRow row, FeedbackSessionAttributes session,

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -782,7 +782,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -805,6 +808,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
               Awaiting
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -889,6 +897,11 @@
               Private
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -971,6 +984,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1049,8 +1067,13 @@
             First Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1133,6 +1156,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
               Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -785,7 +785,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -812,7 +812,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -899,7 +899,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
-              No
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -986,7 +986,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1073,7 +1073,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1160,7 +1160,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -779,7 +779,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -802,6 +805,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
               Awaiting
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -886,6 +894,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.helper" oncontextmenu="return false;">
               Show
@@ -964,8 +977,13 @@
             First Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1048,6 +1066,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
               Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -782,7 +782,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -809,7 +809,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -896,7 +896,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -983,7 +983,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1070,7 +1070,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -787,7 +787,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -810,6 +813,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
               Open
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -890,8 +898,13 @@
             Allow Early Viewing Session #
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -976,6 +989,11 @@
               Private
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS2104&fsname=private+session+of+characters1234567+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1056,6 +1074,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
               Awaiting
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1140,6 +1163,11 @@
               Awaiting
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS2104&fsname=Awaiting+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1220,6 +1248,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="This is a private session. Nobody can see it but you." data-placement="top" data-toggle="tooltip" title="">
               Private
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1304,6 +1337,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1382,8 +1420,13 @@
             First Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1466,6 +1509,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
               Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -790,7 +790,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -816,8 +816,8 @@
             </span>
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+            <span class="tool-tip-decorate" data-original-title="The responses for this feedback session have been set to never get published." data-placement="top" data-toggle="tooltip" title="">
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -904,7 +904,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -991,7 +991,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
-              No
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1078,7 +1078,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1165,7 +1165,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1252,7 +1252,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
-              No
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1339,7 +1339,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1426,7 +1426,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1513,7 +1513,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -793,7 +793,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -820,7 +820,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -907,7 +907,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -994,7 +994,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1081,7 +1081,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -790,7 +790,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -813,6 +816,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
               Open
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -897,6 +905,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=FeedbackEditCopy.CS2105&fsname=New+name%21&user=FeedbackEditCopyinstructor" oncontextmenu="return false;">
               Show
@@ -979,6 +992,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=FeedbackEditCopy.CS2103&fsname=New+name%21&user=FeedbackEditCopyinstructor" oncontextmenu="return false;">
               Show
@@ -1059,6 +1077,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
               Open
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -876,7 +876,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -879,7 +879,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -779,7 +779,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -782,7 +782,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -787,7 +787,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -810,6 +813,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
               Awaiting
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -894,6 +902,11 @@
               Private
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -976,6 +989,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1054,8 +1072,13 @@
             First Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1136,8 +1159,13 @@
             Manual Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -790,7 +790,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -817,7 +817,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -904,7 +904,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
-              No
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -991,7 +991,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1078,7 +1078,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1165,7 +1165,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -787,7 +787,10 @@
             </span>
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -810,6 +813,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
               Awaiting
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">
@@ -894,6 +902,11 @@
               Private
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS2104&fsname=Private+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -976,6 +989,11 @@
               Open
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="session-response-for-test">
             <a href="/page/feedbackSessionStatsPage?courseid=CFeedbackUiT.CS1101&fsname=Open+Session+%23&user=CFeedbackUiT.instructor" oncontextmenu="return false;">
               Show
@@ -1054,8 +1072,13 @@
             First Session #1
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1138,6 +1161,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
               Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -790,7 +790,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th>
             <span class="tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -817,7 +817,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -904,7 +904,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="This feedback session is not published as it is private and only visible to you." data-placement="top" data-toggle="tooltip" title="">
-              No
+              -
             </span>
           </td>
           <td class="session-response-for-test">
@@ -991,7 +991,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1078,7 +1078,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="session-response-for-test">
@@ -1165,7 +1165,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -206,7 +206,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -240,7 +240,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -334,7 +334,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -428,7 +428,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -522,7 +522,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -203,7 +203,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -233,6 +236,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -324,6 +332,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -413,6 +426,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -498,8 +516,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -226,6 +229,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -317,6 +325,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -406,6 +419,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -491,8 +509,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -678,7 +701,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -233,7 +233,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -327,7 +327,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -421,7 +421,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -515,7 +515,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -704,7 +704,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -367,8 +373,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -636,6 +657,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -456,8 +467,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -549,6 +565,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -636,6 +657,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
                   Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -456,8 +467,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -636,6 +657,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is waiting to open." data-placement="top" data-toggle="tooltip" title="">
                   Awaiting
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -369,6 +375,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -460,6 +471,11 @@
                   Awaiting
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Second+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -549,6 +565,11 @@
                   Closed
                 </span>
               </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
+                </span>
+              </td>
               <td class="session-response-for-test">
                 <a href="/page/feedbackSessionStatsPage?courseid=CHomeUiT.CS2104&fsname=Third+Feedback+Session&user=CHomeUiT.instructor.tmms" oncontextmenu="return false;">
                   Show
@@ -634,8 +655,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -379,7 +379,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -473,7 +473,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -567,7 +567,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -661,7 +661,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -345,7 +345,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -491,7 +491,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -339,7 +342,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -482,7 +488,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -211,7 +211,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -214,7 +214,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -196,7 +196,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -199,7 +199,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">

--- a/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
+++ b/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
@@ -56,7 +56,7 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <strong>
-            [course2]
+            [course3]
           </strong>
         </div>
         <div class="panel-body padding-0">
@@ -66,7 +66,7 @@
                 <th>
                   Photo
                 </th>
-                <th class="toggle-sort button-sort-none" id="button_sortsection-0">
+                <th class="toggle-sort button-sort-none hidden" id="button_sortsection-0">
                   Section
                   <span class="icon-sort unsorted">
                   </span>
@@ -106,8 +106,8 @@
                     <img alt="No Image Given" class="hidden" src="">
                   </div>
                 </td>
-                <td id="studentsection-c0.0">
-                  Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
+                <td class="hidden" id="studentsection-c0.0">
+                  None
                 </td>
                 <td id="studentteam-c0.0.0">
                   Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
@@ -122,100 +122,6 @@
                   Joined
                 </td>
                 <td id="studentemail-c0.0">
-                  CCSDetailsUiT.
-                  <span class="highlight">
-                    alice
-                  </span>
-                  .tmms@gmail.tmt
-                </td>
-                <td class="no-print align-center">
-                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
-                    View
-                  </a>
-                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
-                    Edit
-                  </a>
-                  <a class="course-student-delete-link btn btn-default btn-xs margin-bottom-7px" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
-                    Delete
-                  </a>
-                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
-                    All Records
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div class="panel panel-info">
-        <div class="panel-heading">
-          <strong>
-            [course3]
-          </strong>
-        </div>
-        <div class="panel-body padding-0">
-          <table class="table table-bordered table-striped table-responsive margin-0">
-            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
-              <tr id="resultsHeader-1">
-                <th>
-                  Photo
-                </th>
-                <th class="toggle-sort button-sort-none hidden" id="button_sortsection-1">
-                  Section
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="button_sortteam-1">
-                  Team
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="button_sortstudentname-1">
-                  Student Name
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="button_sortstudentstatus">
-                  Status
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="button_sortemail-1">
-                  Email
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th>
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="student_row" id="student-c1.0">
-                <td id="studentphoto-c1.0">
-                  <div class="profile-pic-icon-click align-center" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=instructorWith2Courses">
-                    <a class="student-profile-pic-view-link btn-link">
-                      View Photo
-                    </a>
-                    <img alt="No Image Given" class="hidden" src="">
-                  </div>
-                </td>
-                <td class="hidden" id="studentsection-c1.0">
-                  None
-                </td>
-                <td id="studentteam-c1.0.0">
-                  Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
-                </td>
-                <td id="studentname-c1.0">
-                  <span class="highlight">
-                    Alice
-                  </span>
-                  &lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
-                </td>
-                <td class="align-center">
-                  Joined
-                </td>
-                <td id="studentemail-c1.0">
                   CCSDetailsUiT.
                   <span class="highlight">
                     alice

--- a/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
+++ b/src/test/resources/pages/instructorStudentListPageSearchStudentMultiple.html
@@ -56,7 +56,7 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <strong>
-            [course3]
+            [course2]
           </strong>
         </div>
         <div class="panel-body padding-0">
@@ -66,7 +66,7 @@
                 <th>
                   Photo
                 </th>
-                <th class="toggle-sort button-sort-none hidden" id="button_sortsection-0">
+                <th class="toggle-sort button-sort-none" id="button_sortsection-0">
                   Section
                   <span class="icon-sort unsorted">
                   </span>
@@ -106,8 +106,8 @@
                     <img alt="No Image Given" class="hidden" src="">
                   </div>
                 </td>
-                <td class="hidden" id="studentsection-c0.0">
-                  None
+                <td id="studentsection-c0.0">
+                  Section A&lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
                 </td>
                 <td id="studentteam-c0.0.0">
                   Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
@@ -122,6 +122,100 @@
                   Joined
                 </td>
                 <td id="studentemail-c0.0">
+                  CCSDetailsUiT.
+                  <span class="highlight">
+                    alice
+                  </span>
+                  .tmms@gmail.tmt
+                </td>
+                <td class="no-print align-center">
+                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="View the details of the student" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
+                    View
+                  </a>
+                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="Use this to edit the details of this student. <br>To edit multiple students in one go, you can use the enroll page: <br>Simply enroll students using the updated data and existing data will be updated accordingly" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseStudentDetailsEdit?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
+                    Edit
+                  </a>
+                  <a class="course-student-delete-link btn btn-default btn-xs margin-bottom-7px" data-course-id="course2" data-original-title="Delete the student and the corresponding submissions from the course" data-placement="top" data-student-name="Alice</option></td>tags and char here</div>&\'\&quot;" data-toggle="tooltip" href="/page/instructorCourseStudentDelete?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" title="">
+                    Delete
+                  </a>
+                  <a class="btn btn-default btn-xs margin-bottom-7px" data-original-title="View all data about this student" data-placement="top" data-toggle="tooltip" href="/page/instructorStudentRecordsPage?courseid=course2&studentemail=CCSDetailsUiT.alice.tmms%40gmail.tmt&user=instructorWith2Courses&token=${sessionToken}" rel="noopener noreferrer" target="_blank" title="">
+                    All Records
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="panel panel-info">
+        <div class="panel-heading">
+          <strong>
+            [course3]
+          </strong>
+        </div>
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped table-responsive margin-0">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr id="resultsHeader-1">
+                <th>
+                  Photo
+                </th>
+                <th class="toggle-sort button-sort-none hidden" id="button_sortsection-1">
+                  Section
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="button_sortteam-1">
+                  Team
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="button_sortstudentname-1">
+                  Student Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="button_sortstudentstatus">
+                  Status
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="button_sortemail-1">
+                  Email
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th>
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="student_row" id="student-c1.0">
+                <td id="studentphoto-c1.0">
+                  <div class="profile-pic-icon-click align-center" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=instructorWith2Courses">
+                    <a class="student-profile-pic-view-link btn-link">
+                      View Photo
+                    </a>
+                    <img alt="No Image Given" class="hidden" src="">
+                  </div>
+                </td>
+                <td class="hidden" id="studentsection-c1.0">
+                  None
+                </td>
+                <td id="studentteam-c1.0.0">
+                  Team 1&lt;/td&gt;tags and char here&lt;/div&gt;&'"
+                </td>
+                <td id="studentname-c1.0">
+                  <span class="highlight">
+                    Alice
+                  </span>
+                  &lt;/option&gt;&lt;/td&gt;tags and char here&lt;/div&gt;&'"
+                </td>
+                <td class="align-center">
+                  Joined
+                </td>
+                <td id="studentemail-c1.0">
                   CCSDetailsUiT.
                   <span class="highlight">
                     alice

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -214,7 +214,7 @@
                 Submissions
               </th>
               <th>
-                Published?
+                Responses
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -248,7 +248,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
-                  No
+                  Not Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -342,7 +342,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -436,7 +436,7 @@
               </td>
               <td>
                 <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Yes
+                  Published
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -211,7 +211,10 @@
                 </span>
               </th>
               <th>
-                Status
+                Submissions
+              </th>
+              <th>
+                Published?
               </th>
               <th>
                 <span class="text-nowrap tool-tip-decorate" data-original-title="Number of students submitted / Class size" data-placement="top" data-toggle="tooltip" title="">
@@ -241,6 +244,11 @@
               <td>
                 <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and is open for submissions." data-placement="top" data-toggle="tooltip" title="">
                   Open
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are not visible." data-placement="top" data-toggle="tooltip" title="">
+                  No
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -328,8 +336,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">
@@ -417,8 +430,13 @@
                 </span>
               </td>
               <td>
-                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended.<br>The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
-                  Published
+                <span class="tool-tip-decorate" data-original-title="The feedback session has been created, is visible, and has ended." data-placement="top" data-toggle="tooltip" title="">
+                  Closed
+                </span>
+              </td>
+              <td>
+                <span class="tool-tip-decorate" data-original-title="The responses for this session are visible." data-placement="top" data-toggle="tooltip" title="">
+                  Yes
                 </span>
               </td>
               <td class="session-response-for-test">

--- a/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
+++ b/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
@@ -60,7 +60,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -82,7 +82,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="studentHomeActions">
@@ -108,7 +108,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="studentHomeActions">

--- a/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
+++ b/src/test/resources/pages/studentHomeFeedbackDeletedHTML.html
@@ -57,7 +57,10 @@
             Deadline
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -73,8 +76,13 @@
             Mon, 30 Apr 2012, 11:59 PM
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you.<br>The session is now closed for submissions.<br>The responses for the session can now be viewed." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you.<br>The session is now closed for submissions." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="studentHomeActions">
@@ -96,6 +104,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you." data-placement="top" data-toggle="tooltip" title="">
               Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="studentHomeActions">

--- a/src/test/resources/pages/studentHomeHTML.html
+++ b/src/test/resources/pages/studentHomeHTML.html
@@ -75,7 +75,10 @@
             Deadline
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -91,8 +94,13 @@
             Mon, 30 Apr 2035, 11:59 PM
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="You have submitted your feedback for this session.<br>The responses for the session can now be viewed." data-placement="top" data-toggle="tooltip" title="">
+            <span class="tool-tip-decorate" data-original-title="You have submitted your feedback for this session." data-placement="top" data-toggle="tooltip" title="">
               Submitted
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="studentHomeActions">

--- a/src/test/resources/pages/studentHomeHTML.html
+++ b/src/test/resources/pages/studentHomeHTML.html
@@ -78,7 +78,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -100,7 +100,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="studentHomeActions">

--- a/src/test/resources/pages/studentHomeTypicalHTML.html
+++ b/src/test/resources/pages/studentHomeTypicalHTML.html
@@ -55,7 +55,7 @@
             Submissions
           </th>
           <th>
-            Published?
+            Responses
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -77,7 +77,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
-              Yes
+              Published
             </span>
           </td>
           <td class="studentHomeActions">
@@ -103,7 +103,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="studentHomeActions">
@@ -129,7 +129,7 @@
           </td>
           <td>
             <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
-              No
+              Not Published
             </span>
           </td>
           <td class="studentHomeActions">

--- a/src/test/resources/pages/studentHomeTypicalHTML.html
+++ b/src/test/resources/pages/studentHomeTypicalHTML.html
@@ -52,7 +52,10 @@
             Deadline
           </th>
           <th>
-            Status
+            Submissions
+          </th>
+          <th>
+            Published?
           </th>
           <th class="studentHomeActions">
             Action(s)
@@ -68,8 +71,13 @@
             Mon, 30 Apr 2012, 11:59 PM
           </td>
           <td>
-            <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you.<br>The session is now closed for submissions.<br>The responses for the session can now be viewed." data-placement="top" data-toggle="tooltip" title="">
-              Published
+            <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you.<br>The session is now closed for submissions." data-placement="top" data-toggle="tooltip" title="">
+              Closed
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have been published and can now be viewed." data-placement="top" data-toggle="tooltip" title="">
+              Yes
             </span>
           </td>
           <td class="studentHomeActions">
@@ -93,6 +101,11 @@
               Closed
             </span>
           </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
+              No
+            </span>
+          </td>
           <td class="studentHomeActions">
             <a class="btn btn-default btn-xs btn-tm-actions" data-original-title="View the submitted responses for this feedback session" data-placement="top" data-toggle="tooltip" disabled="" href="javascript:;" id="viewFeedbackResults1" name="viewFeedbackResults1" role="button" title="">
               View Responses
@@ -112,6 +125,11 @@
           <td>
             <span class="tool-tip-decorate" data-original-title="The feedback session is yet to be completed by you." data-placement="top" data-toggle="tooltip" title="">
               Pending
+            </span>
+          </td>
+          <td>
+            <span class="tool-tip-decorate" data-original-title="The responses for the session have not yet been published and cannot be viewed." data-placement="top" data-toggle="tooltip" title="">
+              No
             </span>
           </td>
           <td class="studentHomeActions">


### PR DESCRIPTION
Fixes #4536

This one turned out to be bigger than expected!

Note: I have updated the InstructorHomePage, StudentHomePage, and InstructorFeedbackSessionsPage in this PR with the new table columns.

### Outline of the solution:

**To add the new status columns (`Submissions` and `Published?`) to the various tables:**

- Added the `publishedStatus` data attribute (private data field, initialization via constructor and getter method) to the required classes, FeedbackSessionsTableRow (for the Instructor Sessions Page) and HomeFeedbackSessionRow (for the Instructor and Student home pages). Modified the original `status` variables in these classes to `submissionStatus`.
- Update the constructor calls for these classes (Which are in the *PageData classes).
    - In order to so, I first had to write utility methods to get the correct value that I wanted to inject into the cell. This involved editing the present method to remove any `publishedStatus` related checks from it (renamed accordingly) and adding a new method that returns either "yes/no" for the `Published?` column.
    - Then called these utility methods in the constructors as required.
- Finally, update the `instructor/feedbacks/feedbackSessionsTable.tag`, `instructor/home/courseTable.tag` and `student/home/courseTable.tag` tag files to add in the new data attributes.

**To Update the Tooltips:**
- Followed a similar process as above for the tooltips that involved adding the new `publishedTooltip` data attribute and editing the current 'tooltip' attribute to `submissionsTooltip` ==> writing new methods to populate the new tooltip and editing the existing one to remove any `published` data from it ==> and then adding the new tooltips to the required tag files.
    - The only difference here was that I had to add in the new tooltips in `Const.Tooltips`

**Testing:**
- Updated the `StudentHomePageDataTest` (see 2aa06ff). Managed to locate this test as I had changed the method names of some of the methods it called. Proceeded to not only fix the compilation errors but also add checks for tooltip and table cell content. 
    - Was unable to find a similar testing method for the Instructor Home Page and the `InstructorFeedbackSessionsPageDataTest` did not seem to test the cell contents and tooltips as the `StudentHomePageDataTest` did. Anyway, the test I added in `StudentHomePageDataTest` seemed to cover most of the permutation and combinations.
- Updated all the expected HTML using god mode. I feel this expected HTML change is enough verification for this change and that this combined with the test I added above should suffice as testing for this PR. Let me know if you disagree.

@damithc Sir if you could please review the following portion of the PR description and see if anything is different from the behavior you intended:

### The new behavior:

**Instructors:**

- `Submissions` Column:
    - Possible Values: `Open`, `Closed`, `Awaiting`, `Private`
    - Tooltips: Unchanged from the original tooltips associated with these statusses, except that they no longer contain  `published?` data.
- `Published?` Column:
    - Possible Values: `Yes`, `No`
    - Tooltips: `The responses for this session are visible.`, `The responses for this session are not visible.` And a **special case** wherein if the session is private, the `No` is explained with the following tooltip: `This feedback session is not published as it is private and only visible to you.` @damithc let me know if this sounds acceptable to you.

**Students:**
- `Submissions` Column:
    - Possible Values: `Submitted`, `Pending`, `Awaiting`, `Closed`.
    - Tooltips: Unchanged from the original tooltips associated with these statusses, except that they no longer contain  `published?` data.
- `Published?` Column:
    - Possible Values: `Yes`, `No`
    - Tooltips: `The responses for the session have been published and can now be viewed.`, `The responses for the session have not yet been published and cannot be viewed.`