### PR TITLE
Student: Feedback Submission Edit: Fix misalignment of Student MOTD #7997

### DIFF
--- a/src/main/webapp/WEB-INF/tags/student/studentMessageOfTheDay.tag
+++ b/src/main/webapp/WEB-INF/tags/student/studentMessageOfTheDay.tag
@@ -6,7 +6,7 @@
   <div id="student-motd-wrapper">
     <input type="hidden" id="motd-url" value="<c:out value="${motdUrl}" />">
     <script type="text/javascript" src="/js/studentMotd.js" defer></script>
-    <div class="container theme-showcase" id="student-motd-container">
+    <div class="theme-showcase" id="student-motd-container">
       <div class="row">
         <div class="col-sm-12">
           <div class="panel panel-default">


### PR DESCRIPTION
Fixes #7997 

**Outline of solution:**

- Simply removed the container class from a div that contained the Student MOTD feature in `studentMessageOfTheDay.tag`
- This `container` was causing the problem as it was a container within the container we already place in all our pages. Container within container is not recommended and leads to problems like these.