### PR TITLE
Use `Strings.isNullOrEmpty` instead of rolling our own `StringHelper.isEmpty` #7765

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
@@ -83,15 +83,15 @@ public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
     public String generateUpdateMessageForStudent() {
         if (isMultipleFieldsEmpty()) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE;
-        } else if (StringHelper.isEmpty(shortName)) {
+        } else if (Strings.isNullOrEmpty(shortName)) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE_SHORTNAME;
-        } else if (StringHelper.isEmpty(email)) {
+        } else if (Strings.isNullOrEmpty(email)) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE_EMAIL;
-        } else if (StringHelper.isEmpty(pictureKey)) {
+        } else if (Strings.isNullOrEmpty(pictureKey)) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE_PICTURE;
-        } else if (StringHelper.isEmpty(moreInfo)) {
+        } else if (Strings.isNullOrEmpty(moreInfo)) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE_MOREINFO;
-        } else if (StringHelper.isEmpty(nationality)) {
+        } else if (Strings.isNullOrEmpty(nationality)) {
             return Const.StatusMessages.STUDENT_UPDATE_PROFILE_NATIONALITY;
         }
         return "";
@@ -111,19 +111,19 @@ public class StudentProfileAttributes extends EntityAttributes<StudentProfile> {
 
         // accept empty string values as it means the user has not specified anything yet.
 
-        if (!StringHelper.isEmpty(shortName)) {
+        if (!Strings.isNullOrEmpty(shortName)) {
             addNonEmptyError(validator.getInvalidityInfoForPersonName(shortName), errors);
         }
 
-        if (!StringHelper.isEmpty(email)) {
+        if (!Strings.isNullOrEmpty(email)) {
             addNonEmptyError(validator.getInvalidityInfoForEmail(email), errors);
         }
 
-        if (!StringHelper.isEmpty(institute)) {
+        if (!Strings.isNullOrEmpty(institute)) {
             addNonEmptyError(validator.getInvalidityInfoForInstituteName(institute), errors);
         }
 
-        if (!StringHelper.isEmpty(nationality)) {
+        if (!Strings.isNullOrEmpty(nationality)) {
             addNonEmptyError(validator.getInvalidityInfoForNationality(nationality), errors);
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentProfileAttributes.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.datastore.Text;
+import com.google.common.base.Strings;
 
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -12,6 +12,8 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.google.common.base.Strings;
+
 import teammates.common.exception.InvalidParametersException;
 
 /**
@@ -475,7 +477,7 @@ public final class StringHelper {
     public static int countEmptyStrings(String... strings) {
         int numOfEmptyStrings = 0;
         for (String s : strings) {
-            if (isEmpty(s)) {
+            if (Strings.isNullOrEmpty(s)) {
                 numOfEmptyStrings += 1;
             }
         }

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -25,14 +25,6 @@ public final class StringHelper {
         // utility class
     }
 
-    /**
-     * Checks whether the input string is empty or equals {@code null}.
-     * @param s The string to be checked
-     */
-    public static boolean isEmpty(String s) {
-        return s == null || s.isEmpty();
-    }
-
     public static String generateStringOfLength(int length, char character) {
         Assumption.assertTrue(length >= 0);
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -283,7 +283,7 @@ public class BackDoorLogic extends Logic {
 
             courseInstructorsMap.put(instructor.courseId, instructor);
 
-            if (StringHelper.isEmpty(instructor.googleId) || googleIdAccountMap.containsKey(instructor.googleId)) {
+            if (Strings.isNullOrEmpty(instructor.googleId) || googleIdAccountMap.containsKey(instructor.googleId)) {
                 // No account, or account already exists in the data bundle
                 continue;
             }
@@ -296,7 +296,7 @@ public class BackDoorLogic extends Logic {
         for (StudentAttributes student : students) {
             populateNullSection(student);
 
-            if (StringHelper.isEmpty(student.googleId) || googleIdAccountMap.containsKey(student.googleId)) {
+            if (Strings.isNullOrEmpty(student.googleId) || googleIdAccountMap.containsKey(student.googleId)) {
                 // No account, account already exists in the data bundle,
                 // or instructor account already exists (i.e. instructor is also a student)
                 continue;

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.appengine.api.blobstore.BlobKey;
+import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
@@ -32,7 +33,6 @@ import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
 import teammates.common.util.JsonUtils;
-import teammates.common.util.StringHelper;
 import teammates.logic.api.Logic;
 import teammates.storage.api.AccountsDb;
 import teammates.storage.api.AdminEmailsDb;

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -25,10 +25,10 @@ public class StringHelperTest extends BaseTestCase {
 
     @Test
     public void testIsEmpty() {
-        assertTrue(StringHelper.isEmpty(null));
-        assertTrue(StringHelper.isEmpty(""));
-        assertFalse(StringHelper.isEmpty("test"));
-        assertFalse(StringHelper.isEmpty("     "));
+        assertTrue(Strings.isNullOrEmpty(null));
+        assertTrue(Strings.isNullOrEmpty(""));
+        assertFalse(Strings.isNullOrEmpty("test"));
+        assertFalse(Strings.isNullOrEmpty("     "));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -10,6 +10,8 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.testng.annotations.Test;
 
+import com.google.common.base.Strings;
+
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.Const;

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -10,8 +10,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.testng.annotations.Test;
 
-import com.google.common.base.Strings;
-
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Config;
 import teammates.common.util.Const;
@@ -24,14 +22,6 @@ import teammates.test.driver.StringHelperExtension;
  * SUT: {@link StringHelper}.
  */
 public class StringHelperTest extends BaseTestCase {
-
-    @Test
-    public void testIsEmpty() {
-        assertTrue(Strings.isNullOrEmpty(null));
-        assertTrue(Strings.isNullOrEmpty(""));
-        assertFalse(Strings.isNullOrEmpty("test"));
-        assertFalse(Strings.isNullOrEmpty("     "));
-    }
 
     @Test
     public void testGenerateStringOfLength() {


### PR DESCRIPTION
Fixes #7765

**Outline of Solution**

I replaced all the calls of StringHelper.isEmpty with Strings.isNullOrEmpty.

I then, removed the StringHelper.isEmpty method and the corresponding test and replaced the calls from within StringHelper that were using it with Strings.isNullOrEmpty.

Question: Should I have tossed all the changes into a single commit, with one commit message? 
