### PR TITLE
Usermap: fix failure on live server #8001

### DIFF
--- a/src/main/java/teammates/common/util/FrontEndLibrary.java
+++ b/src/main/java/teammates/common/util/FrontEndLibrary.java
@@ -63,8 +63,13 @@ public final class FrontEndLibrary {
     }
 
     private static String getLibrarySource(String libraryNameInNpm, String fileDir) {
-        return "https://unpkg.com/" + libraryNameInNpm + "@"
+        return getCdnBaseUrlForLibrary(libraryNameInNpm) + libraryNameInNpm + "@"
                 + DEPENDENCIES_CONFIG.get(libraryNameInNpm).getAsString() + "/" + fileDir;
+    }
+
+    private static String getCdnBaseUrlForLibrary(String libraryNameInNpm) {
+        // jsDelivr is more reliable than unpkg, but doesn't host required large files from the datamaps library
+        return "datamaps".equals(libraryNameInNpm) ? "https://unpkg.com/" : "https://cdn.jsdelivr.net/npm/";
     }
 
 }

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -279,13 +279,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/adminAccountDetails.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/adminHomePage.html
+++ b/src/test/resources/pages/adminHomePage.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -225,13 +225,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/adminHome.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/deadlineExceededErrorPage.html
+++ b/src/test/resources/pages/deadlineExceededErrorPage.html
@@ -6,8 +6,8 @@
 <title>
   TEAMMATES
 </title>
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -130,7 +130,7 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
 <script src="/js/errorPageEmailComposer.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/entityNotFoundPage.html
+++ b/src/test/resources/pages/entityNotFoundPage.html
@@ -6,8 +6,8 @@
 <title>
   TEAMMATES
 </title>
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -156,7 +156,7 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
 <script src="/js/errorPageEmailComposer.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/errorPage.html
+++ b/src/test/resources/pages/errorPage.html
@@ -6,8 +6,8 @@
 <title>
   TEAMMATES
 </title>
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -130,7 +130,7 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
 <script src="/js/errorPageEmailComposer.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -211,13 +211,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseDetails.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -1425,17 +1425,17 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/moment@2.17.1/min/moment.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/moment@2.17.1/min/moment.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/moment-timezone@0.5.11/builds/moment-timezone-with-data-2010-2020.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/moment-timezone@0.5.11/builds/moment-timezone-with-data-2010-2020.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseEdit.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseEnrollPage.html
+++ b/src/test/resources/pages/instructorCourseEnrollPage.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -306,13 +306,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseEnrollPage.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseEnrollPageResult.html
+++ b/src/test/resources/pages/instructorCourseEnrollPageResult.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -321,13 +321,13 @@ Section 1 | Team 1|José Gómez | jose.gomez.tmns@gmail.tmt | This student name 
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseEnrollResult.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseJoinConfirmationHTML.html
+++ b/src/test/resources/pages/instructorCourseJoinConfirmationHTML.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -160,13 +160,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseJoinConfirmation.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -266,13 +266,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseStudentDetails.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCourseStudentEditPage.html
+++ b/src/test/resources/pages/instructorCourseStudentEditPage.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -175,13 +175,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourseStudentEdit.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -239,17 +239,17 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/moment@2.17.1/min/moment.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/moment@2.17.1/min/moment.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/moment-timezone@0.5.11/builds/moment-timezone-with-data-2010-2020.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/moment-timezone@0.5.11/builds/moment-timezone-with-data-2010-2020.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorCourses.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorFeedbackEditEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackEditEmpty.html
@@ -6,11 +6,11 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
 </head>
 <body spellcheck="false">
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -2127,15 +2127,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorFeedbackEdit.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -6,11 +6,11 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
 </head>
 <body spellcheck="false">
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -1084,15 +1084,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorFeedbacks.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -6752,17 +6752,17 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/printthis@0.1.5/printThis.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/printthis@0.1.5/printThis.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorFeedbackResultsQuestion.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -6,11 +6,11 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
 </head>
 <body class="modal-open" spellcheck="false">
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -447,15 +447,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/feedbackSubmissionsEdit.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -171,13 +171,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorHome.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorSearchPageDefault.html
+++ b/src/test/resources/pages/instructorSearchPageDefault.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -177,15 +177,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-highlight@3.4.0/jquery.highlight.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-highlight@3.4.0/jquery.highlight.js" type="text/javascript">
 </script>
 <script src="/js/instructorSearch.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorStudentListWithHelperView.html
+++ b/src/test/resources/pages/instructorStudentListWithHelperView.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -817,13 +817,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorStudentList.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -804,15 +804,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/instructorStudentRecords.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/pageNotFound.html
+++ b/src/test/resources/pages/pageNotFound.html
@@ -6,8 +6,8 @@
 <title>
   TEAMMATES
 </title>
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -128,7 +128,7 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
 <script src="/js/errorPageEmailComposer.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentCourseDetailsWithTeammatesHTML.html
+++ b/src/test/resources/pages/studentCourseDetailsWithTeammatesHTML.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -213,13 +213,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/studentCourseDetails.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentCourseJoinConfirmationHTML.html
+++ b/src/test/resources/pages/studentCourseJoinConfirmationHTML.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -142,13 +142,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/studentCourseJoinConfirmation.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -164,13 +164,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/studentFeedbackResults.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -6,11 +6,11 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
 </head>
 <body class="modal-open" spellcheck="false">
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -318,15 +318,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/feedbackSubmissionsEdit.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/studentHomeHTMLPersistenceCheck.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -125,13 +125,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/studentHome.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/studentProfilePageDefault.html
+++ b/src/test/resources/pages/studentProfilePageDefault.html
@@ -6,10 +6,10 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/guillotine@1.3.1/css/jquery.guillotine.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/guillotine@1.3.1/css/jquery.guillotine.css" rel="stylesheet" type="text/css">
 </head>
 <body>
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -839,15 +839,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/guillotine@1.3.1/js/jquery.guillotine.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/guillotine@1.3.1/js/jquery.guillotine.min.js" type="text/javascript">
 </script>
 <script src="/js/studentProfile.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/unauthorized.html
+++ b/src/test/resources/pages/unauthorized.html
@@ -6,8 +6,8 @@
 <title>
   TEAMMATES
 </title>
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -128,7 +128,7 @@
     </div>
   </div>
 </div>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
 <script src="/js/errorPageEmailComposer.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
@@ -6,8 +6,8 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
 </head>
 <body>
@@ -399,13 +399,13 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
 <script src="/js/studentFeedbackResults.js" type="text/javascript">
 </script>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -6,11 +6,11 @@
 <link href="/favicon.png" rel="shortcut icon">
 <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
 <meta content="width=device-width, initial-scale=1.0" name="viewport">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css" rel="stylesheet" type="text/css">
 <link href="/stylesheets/teammatesCommon.css" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
-<link href="https://unpkg.com/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/skin.min.css" id="u0" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/skins/lightgray/content.inline.min.css" rel="stylesheet">
 </head>
 <body spellcheck="false">
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -4507,15 +4507,15 @@
 </script>
 <script src="/js/googleAnalytics.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery@1.12.4/dist/jquery.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/bootbox@4.4.0/bootbox.min.js" type="text/javascript">
 </script>
-<script src="https://unpkg.com/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
+<script src="https://cdn.jsdelivr.net/npm/tinymce@4.5.5/tinymce.min.js" type="text/javascript">
 </script>
 <script src="/js/feedbackSubmissionsEdit.js" type="text/javascript">
 </script>


### PR DESCRIPTION
Fixes #8001

**Outline of Solution**

Use jsDelivr instead of unpkg as default CDN but fallback to unpkg for datamaps library. Temporary workaround to get the usermap working again until a permanent fix for #7573 is developed.