### PR TITLE
Migrate development tools to Google Cloud SDK - CLI/Gradle #7648

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ before_script:
 install: true
 script:
   - npm run build
-  - ./gradlew appengineRun ciTests
+  - ./gradlew appengineStart
+  - ./gradlew ciTests
 
 after_failure:
   - gem install gist

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,15 @@ before_install:
 before_script:
   - export DISPLAY=:99.0
   - tar -xjf /tmp/firefox-46.0.tar.bz2 --directory $TRAVIS_BUILD_DIR/
-  - export PATH="$TRAVIS_BUILD_DIR/firefox:$PATH"
-  - export PATH="./node_modules/.bin":$PATH
+  - export PATH=$TRAVIS_BUILD_DIR/firefox:./node_modules/.bin:$HOME/google-cloud-sdk/bin:$PATH
+
+  - curl -fsS -o $HOME/google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-173.0.0-linux-x86_64.tar.gz
+  - cd $HOME
+  - tar -xzf google-cloud-sdk.tar.gz
+  - ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false
+  - cd $TRAVIS_BUILD_DIR
+  - gcloud -q components install app-engine-java
+
   - ./gradlew createConfigs testClasses
   - ./gradlew downloadStaticAnalysisTools
   - ./gradlew lint --continue

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,4 +38,5 @@ build_script:
 
 test_script:
   - npm run build
-  - gradlew.bat appengineRun ciTests
+  - gradlew.bat appengineStart
+  - gradlew.bat ciTests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,15 @@ install:
   - npm install
 
 build_script:
+  - set PATH=C:\google-cloud-sdk\bin;%PATH%
+
+  - curl -fsS -o C:\google-cloud-sdk.zip https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-173.0.0-windows-x86_64.zip
+  - cd C:\
+  - 7z x google-cloud-sdk.zip
+  - google-cloud-sdk/install.bat --usage-reporting false --path-update false --command-completion false
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - gcloud -q components install app-engine-java
+
   - gradlew.bat createConfigs testClasses
 
 test_script:

--- a/build.gradle
+++ b/build.gradle
@@ -361,6 +361,13 @@ appengine {
                 "-Ddatastore.backing_store=appengine-generated/local_db.bin",
                 "-Dblobstore.backing_store=appengine-generated"]
     }
+    deploy {
+        Node appengineWebXml = new XmlParser().parse('src/main/webapp/WEB-INF/appengine-web.xml')
+        project = appengineWebXml.application.text()
+        version = appengineWebXml.version.text()
+        stopPreviousVersion = false
+        promote = false
+    }
 }
 
 // STATIC ANALYSIS TASKS

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,6 @@ buildscript {
 
 configurations {
     staticAnalysis
-    exclude
-    testExclude
 }
 
 configurations.all {
@@ -56,7 +54,6 @@ dependencies {
                     "de.andrena.tools.macker:macker:1.0.1"
 
     compile         "com.google.appengine.tools:appengine-gcs-client:0.6",
-                    "com.google.appengine:appengine-api-labs:${appengineVersion}",
                     "com.google.code.gson:gson:2.8.0",
                     "com.googlecode.objectify:objectify:5.1.17",
                     "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20160924.1",
@@ -69,13 +66,7 @@ dependencies {
                     "org.apache.taglibs:taglibs-standard-impl:1.2.5",
                     "org.jsoup:jsoup:${jsoupVersion}"
 
-    exclude         "com.google.appengine:appengine-api-1.0-sdk:${appengineVersion}",
-                    "com.google.appengine:appengine-endpoints-deps:${appengineVersion}",
-                    "com.google.appengine:appengine-endpoints:${appengineVersion}",
-                    "com.google.appengine:appengine-jsr107cache:${appengineVersion}",
-                    "net.sf.jsr107cache:jsr107cache:1.1"
-
-    runtime         configurations.exclude
+    runtime         "com.google.appengine:appengine-api-1.0-sdk:${appengineVersion}"
 
     testCompile     "com.google.appengine:appengine-api-stubs:${appengineVersion}",
                     "com.google.appengine:appengine-remote-api:${appengineVersion}",
@@ -90,10 +81,6 @@ dependencies {
                     "com.google.oauth-client:google-oauth-client-jetty:1.22.0",
                     // For using Gmail API
                     "com.google.apis:google-api-services-gmail:v1-rev67-1.22.0"
-
-    testExclude     "com.google.appengine:appengine-tools-sdk:${appengineVersion}"
-
-    testRuntime     configurations.testExclude
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ sourceSets {
 
 // SETUP TASKS
 
+/*
 import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 eclipse {
@@ -172,6 +173,7 @@ eclipseClasspath {
         !(new File(".classpath")).exists()
     }
 }
+*/
 
 task createConfigs {
     description "Sets up the project by obtaining necessary files and configurations points."
@@ -193,6 +195,7 @@ task createConfigs {
     }
 }
 
+/*
 task createEclipseLaunches {
     doLast {
         def templatesToCopy = [
@@ -343,6 +346,7 @@ task setupEclipse {
     group "Setup"
     dependsOn eclipseProject, createEclipseLaunches, resetEclipseDeps
 }
+*/
 
 // RUN SERVER TASKS
 

--- a/build.gradle
+++ b/build.gradle
@@ -353,34 +353,15 @@ compileJava.options.encoding = "UTF-8"
 compileTestJava.options.encoding = "UTF-8"
 
 appengine {
-    httpPort = 8888
-    downloadSdk = true
-    jvmFlags = ["-Xss2m", "-Dfile.encoding=UTF-8",
-                // absolute paths are not supported, the following is relative to the exploded war directory
-                // this only specifies the datastore path, but the indexes are still generated in
-                // WEB-INF/appengine-generated.
-                "-Ddatastore.backing_store=../../local_db.bin"]
-    appcfg {
-        oauth2 = true
+    run {
+        port = 8888
+        jvmFlags = ["-Xss2m", "-Dfile.encoding=UTF-8",
+                // Absolute paths are not supported, the following is relative to the project directory
+                // These only specify the datastore/blobstore paths, but search indexes are still generated in WEB-INF/appengine-generated
+                "-Ddatastore.backing_store=appengine-generated/local_db.bin",
+                "-Dblobstore.backing_store=appengine-generated"]
     }
 }
-
-appengineRun {
-    if (project.hasProperty("disable_daemon")) {
-        daemon = false
-    } else {
-        daemon = true
-    }
-}
-
-task removeDuplicateLibs(type: Delete) {
-    delete  "${buildDir}/exploded-app/WEB-INF/lib/datanucleus-appengine-1.0.10.final.jar",
-            "${buildDir}/exploded-app/WEB-INF/lib/appengine-endpoints-deps.jar",
-            "${buildDir}/exploded-app/WEB-INF/lib/appengine-endpoints.jar",
-            "${buildDir}/exploded-app/WEB-INF/lib/appengine-api-labs.jar"
-}
-
-appengineExplodeApp.finalizedBy removeDuplicateLibs
 
 // STATIC ANALYSIS TASKS
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,26 +8,27 @@ apply plugin: "war"
 if (System.properties['ide'] == 'idea') {
     buildDir = new File(projectDir, 'buildIdea')
 }
-apply plugin: "appengine"
+// apply plugin: "com.google.cloud.tools.appengine"
+// see https://github.com/GoogleCloudPlatform/app-gradle-plugin/issues/125
+project.pluginManager.apply com.google.cloud.tools.gradle.appengine.standard.AppEngineStandardPlugin
 
 apply plugin: "checkstyle"
 apply plugin: "pmd"
 apply plugin: "findbugs"
 apply plugin: "jacoco"
 
+def appengineVersion = "1.9.56"
+def jsoupVersion = "1.10.2"
+def checkstyleVersion = "8.0"
+def pmdVersion = "5.5.4"
+def findbugsVersion = "3.0.1"
+
 buildscript {
-    ext {
-        appengineVersion = "1.9.54"
-        jsoupVersion = "1.10.2"
-        checkstyleVersion = "8.0"
-        pmdVersion = "5.5.4"
-        findbugsVersion = "3.0.1"
-    }
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath "com.google.appengine:gradle-appengine-plugin:${appengineVersion}"
+        classpath "com.google.cloud.tools:appengine-gradle-plugin:1.3.3"
     }
 }
 
@@ -53,8 +54,6 @@ dependencies {
                     "net.sourceforge.pmd:pmd-java:${pmdVersion}",
                     "com.google.code.findbugs:findbugs:${findbugsVersion}",
                     "de.andrena.tools.macker:macker:1.0.1"
-
-    appengineSdk    "com.google.appengine:appengine-java-sdk:${appengineVersion}"
 
     compile         "com.google.appengine.tools:appengine-gcs-client:0.6",
                     "com.google.appengine:appengine-api-labs:${appengineVersion}",

--- a/docs/development.md
+++ b/docs/development.md
@@ -245,6 +245,12 @@ This instruction set assumes that the app identifier is `teammates-john`.
    Suggested app identifier: `teammates-yourname` (e.g `teammates-john`).<br>
    The URL of the app will be like this: `https://teammates-john.appspot.com`.
 
+1. [Authorize your Google account to be used by the Google Cloud SDK](https://cloud.google.com/sdk/docs/authorizing) if you have not done so.
+   ```sh
+   gcloud auth login
+   ```
+   Follow the steps until you see `You are now logged in as [...]` on the console.
+
 1. Modify configuration files.
    * `src/main/resources/build.properties`<br>
      Edit the file as instructed in its comments.
@@ -256,9 +262,9 @@ This instruction set assumes that the app identifier is `teammates-john`.
      * Run the following command:
 
        ```sh
-       ./gradlew appengineUpdate
+       ./gradlew appengineDeploy
        ```
-     * Follow the steps and wait until the command ends with a `BUILD SUCCESSFUL`.
+     * Wait until you see `Deployed service [default] to [https://4-18-dot-teammates-john.appspot.com]` or similar on the console.
    * With Eclipse
      * Choose `Deploy to App Engine...` from Eclipse (under the `Google` menu item) and follow the steps.
      * Wait until you see this message (or similar) in Eclipse console: `Deployment completed successfully`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,13 +42,13 @@ In addition, the command will also *minify* the JavaScript files to reduce the s
 To start the server in the background, run the following command
 and wait until the task exits with a `BUILD SUCCESSFUL`:
 ```sh
-./gradlew appengineRun
+./gradlew appengineStart
 ```
 
 To start the server in the foreground (e.g. if you want the console output to be visible),
 run the following command instead:
 ```sh
-./gradlew appengineRun -Pdisable_daemon
+./gradlew appengineRun
 ```
 
 The dev server URL will be `http://localhost:8888` as specified in `build.gradle`.
@@ -60,7 +60,7 @@ If you started the server in the background, run the following command to stop i
 ./gradlew appengineStop
 ```
 
-If the server is running in the foreground, press `Ctrl + C` to stop it.
+If the server is running in the foreground, press `Ctrl + C` to stop it or run the above command in a new console.
 
 ### With Eclipse
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -316,12 +316,15 @@ therefore delivery of emails is not tested when testing against the dev server.
 
 > Client scripts are scripts that remotely manipulate data on GAE via its Remote API. They are run as standard Java applications.
 
-Most of developers may not need to write and/or run client scripts but if you are to do so *in a production environment*, additional steps are required:
+Most of developers may not need to write and/or run client scripts but if you are to do so, take note of the following:
 
-1. Download and install Google Cloud SDK from [here](https://cloud.google.com/sdk/downloads).
-1. Run `gcloud auth login` and choose your Google account for authentication.
+* In order to run any script *in a production environment*, you need to authorize your account for [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+  ```sh
+  gcloud auth application-default login
+  ```
+  Follow the steps until you see `Credentials saved to file: [...].` printed on the console.
 
-You are now ready to run your scripts.
+* It is not encouraged to compile and run any script via command line; use any of the supported IDEs to significantly ease this task.
 
 ## Config points
 

--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -14,6 +14,7 @@ The instructions in all parts of this document work for Linux, OS X, and Windows
 
 1. Install Source Tree or other similar Git Client, or at least Git.
 1. Install JDK 1.8.
+1. Install Python 2.7.
 1. Install Node.js (minimum version 4.x).
 
 ## Step 2: Obtain your own repository copy
@@ -40,11 +41,23 @@ More information can be found at [this documentation](https://help.github.com/ar
 
 ## Step 3: Set up project-specific settings and dependencies
 
-1. Run this command to download the correct version Google App Engine SDK as used in the project:
+1. Install Google Cloud SDK version 173.0.0. Follow the directions given [here](https://cloud.google.com/sdk/downloads).
+   Note that you *do not* need to [initialize the SDK](https://cloud.google.com/sdk/docs/initializing).
    ```sh
-   ./gradlew appengineDownloadSdk
+   # This command is to be run at the Google Cloud SDK directory
+
+   # Linux/OS X
+   ./install.sh --path-update true
+   # Windows
+   install.bat --path-update true
    ```
-   **Verification:** Check your Gradle folder (the directory can be found with the command `./gradlew printUserHomeDir`). A folder named appengine-sdk` should be present.
+   **Verification**: Run a `gcloud` command (e.g. `gcloud version`) in order to verify that you can access the SDK from the command line.
+
+1. Run this command to install App Engine Java SDK bundled with the Cloud SDK:
+   ```sh
+   gcloud -q components install app-engine-java
+   ```
+   **Verification:** Run `gcloud version` and there should be an entry on `app-engine-java`.
 
 1. Run this command to download the necessary tools for JavaScript development:
    ```sh

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -15,6 +15,13 @@ Note that some of the screenshots might be outdated, but the instructions will r
 
 ### Common setup errors and solutions
 
+* **ERROR**: After downloading and installing Google Cloud SDK, running any `gcloud` command results in `gcloud: command not found` or alike.
+
+  **REASON**: You did not choose to update the `PATH` variable when installing the SDK.
+
+  **SOLUTION**: You can re-run the install command again without any side effect. Make sure to choose to update the `PATH` variable this time. Alternatively, you can use other appropriate methods to update your `PATH` variable to include the `/bin` sub-folder of the SDK folder.<br>
+  To verify this, try running any `gcloud` command and it should now give you access to the SDK.
+
 * **ERROR**: Eclipse complains "...your project must be configured to use a JDK in order to use JSP".
 
   **REASON**: This happens because Eclipse is only aware of JRE, not JDK (Compiling JSP requires the JDK).

--- a/src/client/java/teammates/client/remoteapi/RemoteApiClient.java
+++ b/src/client/java/teammates/client/remoteapi/RemoteApiClient.java
@@ -32,10 +32,9 @@ public abstract class RemoteApiClient {
             // Dev Server doesn't require credential.
             options.useDevelopmentServerCredential();
         } else {
-            // If you are trying to run script on Staging Server:
-            // Step 1: Install Google Cloud SDK in your local PC first, https://cloud.google.com/sdk/downloads
-            // Step 2: Run `gcloud auth login` in the terminal and choose your google account
-            // Step 3: Run the script again.
+            // Your Google Cloud SDK needs to be authenticated for Application Default Credentials
+            // in order to run any script in production server.
+            // Refer to https://developers.google.com/identity/protocols/application-default-credentials.
             options.useApplicationDefaultCredential();
         }
 


### PR DESCRIPTION
Part of #7648.
<!-- Fixes #7468 -->

This is the first part of Cloud SDK migration. This has been worked on since as early as July but can only finalize for the past week due to a blocker issue on Cloud SDK.

**Notes**

- Routine has been tested on Travis CI (Linux-based), AppVeyor (Windows-based), and my own Mac OS-based environment.
- The App Engine version to be used is coupled to the Cloud SDK version. The latest SDK (~~172~~ 173.0.0) has support for Java SDK 1.9.56 which is ~~also~~ *unfortunately not* the latest. (P.S. Cloud SDK releases much more frequently than Java SDK which may or may not be helpful for us)
- Python 2.7 is needed, but only to run the Cloud SDK and not needed for development at all. Unfortunately not supported for Python 3, but [at least we're not Python 3 GAE developers](https://issuetracker.google.com/issues/35876441).

**Caveats**

- There are two different places to configure app ID and app version; `build.gradle` and `appengine-web.xml`. Deployment makes use of the former while dev server makes use of the latter. ~~Not a loss of function; just some inconvenience.~~ It has been worked such that it does not affect us, but hopefully it will be converted back to single configuration point some time in the future.
- Support for both IDEs are totally removed here; they need to be restored (independently) as the follow-ups of this PR.
