### PR TITLE
Instructor: home page: fix action buttons going out of table #8025

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -23,7 +23,7 @@
             <span class="text-nowrap" title="<%= Const.Tooltips.FEEDBACK_SESSION_RESPONSE_RATE %>"
                 data-toggle="tooltip" data-placement="top">Response Rate</span>
           </th>
-          <th class="no-print">Action(s)</th>
+          <th class="col-lg-4 no-print">Action(s)</th>
         </tr>
       </thead>
       <c:if test="${empty sessionRows}">

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -213,7 +213,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -711,7 +711,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -352,7 +352,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>
@@ -498,7 +498,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -221,7 +221,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -206,7 +206,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -221,7 +221,7 @@
                   Response Rate
                 </span>
               </th>
-              <th class="no-print">
+              <th class="col-lg-4 no-print">
                 Action(s)
               </th>
             </tr>


### PR DESCRIPTION
Fixes #8025

**Outline of Solution**

Specified fixed grid width (4 columns) for actions column on `lg` resoutions (`col-lg-4`) to ensure sufficient width for all action buttons. The other columns will have less priority and become smaller. On `md` and lower resolutions, the action buttons wrap to multiple lines (no change to current behaviour).

Before:
<img width="1149" alt="screen shot 2017-09-26 at 3 56 25 pm" src="https://user-images.githubusercontent.com/6811428/30849001-75e8b064-a2d3-11e7-9ee9-d5c949acc7fc.png">

After:
<img width="1144" alt="screen shot 2017-09-26 at 3 55 57 pm" src="https://user-images.githubusercontent.com/6811428/30849004-79cee194-a2d3-11e7-87d0-945c2ca4c704.png">