### PR TITLE
setting-up.md: IntelliJ IDEA: remove `experimental; limited support` status #8022

### DIFF
--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -68,7 +68,7 @@ More information can be found at [this documentation](https://help.github.com/ar
 
 You are encouraged, but not required, to use an IDE to assist many development tasks.
 
-We currently support two IDEs: Eclipse IDE (full support) and IntelliJ IDEA (experimental; limited support).
+We currently support two IDEs: Eclipse IDE (full support) and IntelliJ IDEA.
 Support requests related to other IDEs will not be entertained.
 
 Refer to [this document](ide-usage.md) if you wish to set up an IDE for developing TEAMMATES.

--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -68,7 +68,7 @@ More information can be found at [this documentation](https://help.github.com/ar
 
 You are encouraged, but not required, to use an IDE to assist many development tasks.
 
-We currently support two IDEs: Eclipse IDE (full support) and IntelliJ IDEA.
+We currently support two IDEs: Eclipse IDE and IntelliJ IDEA.
 Support requests related to other IDEs will not be entertained.
 
 Refer to [this document](ide-usage.md) if you wish to set up an IDE for developing TEAMMATES.


### PR DESCRIPTION
Fixes #8022
Removed the "experimental; limited support" status for intellij, also removed "full support" from eclipse, as it now seemed obsolete.