### PR TITLE
instructorFeedbackEdit.es6: Remove unwanted space #7621

### DIFF
--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.es6
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.es6
@@ -127,7 +127,7 @@ import {
     matchVisibilityOptionToFeedbackPath,
     showVisibilityCheckboxesIfCustomOptionSelected,
     tallyCheckboxes,
- } from '../common/visibilityOptions.es6';
+} from '../common/visibilityOptions.es6';
 
 const NEW_QUESTION = -1;
 


### PR DESCRIPTION
Near line 130 of instructorFeedbackEdit.es6, a line began with a space -

 } from '../common/visibilityOptions.es6';
Changed this to -

} from '../common/visibilityOptions.es6';
(Removed space in the beginning)

Fixes #7621 
(ready for review)