### PR TITLE
build.gradle: fix misleading message when dependencies are not found #8113

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -494,10 +494,11 @@ def afterTestClosure = { descriptor, result ->
 
 import org.gradle.internal.serialize.PlaceholderException
 
-def checkConfigFailureClosure = { descriptor, result ->
+def checkTestNgFailureClosure = { descriptor, result ->
     if (result.exception instanceof PlaceholderException
             && result.exception.toString().startsWith("org.gradle.api.internal.tasks.testing.TestSuiteExecutionException")) {
-        throw new GradleException('Detected TestNG configuration failure - check src/test/testng-ci.xml')
+        result.exception.printStackTrace()
+        throw new GradleException("Detected TestNG failure")
     }
 }
 
@@ -575,7 +576,7 @@ task ciTests {
         if (isLastRetry) {
             afterTest afterTestClosure
         } else if (isFirstTry) {
-            afterSuite checkConfigFailureClosure
+            afterSuite checkTestNgFailureClosure
         }
         finalizedBy "killFirefox${id}"
         onlyIf {


### PR DESCRIPTION
Fixes #8113

Test runs:
- [Malformed XML](https://travis-ci.org/whipermr5/teammates/builds/289819078#L870)
- [Non-existent test](https://travis-ci.org/whipermr5/teammates/builds/289819453#L878)
- [Missing dependency](https://travis-ci.org/whipermr5/teammates/builds/289820300#L900)