### PR TITLE
Remove method getInstructorsForEmail(String) #8168

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -358,17 +358,7 @@ public class Logic {
         return instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
     }
 
-    /**
-     * Preconditions: <br>
-     * * All parameters are non-null.
-     * @return Empty list if none found.
-     */
-    public List<InstructorAttributes> getInstructorsForEmail(String email) {
 
-        Assumption.assertNotNull(email);
-
-        return instructorsLogic.getInstructorsForEmail(email);
-    }
 
     /**
      * Preconditions: <br>

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -358,8 +358,6 @@ public class Logic {
         return instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
     }
 
-
-
     /**
      * Preconditions: <br>
      * * All parameters are non-null.

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -145,8 +145,6 @@ public final class InstructorsLogic {
         return StringHelper.encrypt(instructor.key);
     }
 
-
-
     /**
      * Gets all instructors in the Datastore.
      *

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -145,10 +145,7 @@ public final class InstructorsLogic {
         return StringHelper.encrypt(instructor.key);
     }
 
-    public List<InstructorAttributes> getInstructorsForEmail(String email) {
 
-        return instructorsDb.getInstructorsForEmail(email);
-    }
 
     /**
      * Gets all instructors in the Datastore.

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -174,16 +174,7 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         return makeAttributesOrNull(getInstructorEntityForRegistrationKey(decryptedKey));
     }
 
-    /**
-     * Preconditions: <br>
-     *  * All parameters are non-null.
-     * @return empty list if no matching objects.
-     */
-    public List<InstructorAttributes> getInstructorsForEmail(String email) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, email);
 
-        return makeAttributes(getInstructorEntitiesForEmail(email));
-    }
 
     /**
      * Preconditions: <br>

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -174,8 +174,6 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         return makeAttributesOrNull(getInstructorEntityForRegistrationKey(decryptedKey));
     }
 
-
-
     /**
      * Preconditions: <br>
      *  * All parameters are non-null.
@@ -373,7 +371,6 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         }
         return getInstructorEntitiesForGoogleId(googleId);
     }
-
 
     private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
         return load().filter("courseId =", courseId).list();

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -374,9 +374,6 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         return getInstructorEntitiesForGoogleId(googleId);
     }
 
-    private List<Instructor> getInstructorEntitiesForEmail(String email) {
-        return load().filter("email =", email).list();
-    }
 
     private List<Instructor> getInstructorEntitiesForCourse(String courseId) {
         return load().filter("courseId =", courseId).list();

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -288,7 +288,6 @@ public class InstructorsLogicTest extends BaseLogicTest {
         }
     }
 
-
     private void testGetKeyForInstructor() throws Exception {
 
         ______TS("success: get encrypted key for instructor");

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -36,7 +36,6 @@ public class InstructorsLogicTest extends BaseLogicTest {
     @Test
     public void testAll() throws Exception {
         testGetInstructorForEmail();
-        testGetInstructorsForEmail();
         testGetInstructorForGoogleId();
         testGetInstructorsForGoogleId();
         testGetInstructorForRegistrationKey();
@@ -289,34 +288,6 @@ public class InstructorsLogicTest extends BaseLogicTest {
         }
     }
 
-    private void testGetInstructorsForEmail() {
-
-        ______TS("success: get all instructors for a google id");
-
-        String email = "instructor3@course1.tmt";
-
-        List<InstructorAttributes> instructors = instructorsLogic.getInstructorsForEmail(email);
-        assertEquals(1, instructors.size());
-
-        InstructorAttributes instructor1 = instructorsDb.getInstructorForEmail("idOfTypicalCourse1", email);
-        verifySameInstructor(instructor1, instructors.get(0));
-
-        ______TS("failure: non-exist email");
-
-        email = "non-exist-email@course1.tmt";
-
-        instructors = instructorsLogic.getInstructorsForEmail(email);
-        assertEquals(0, instructors.size());
-
-        ______TS("failure: null parameter");
-
-        try {
-            instructorsLogic.getInstructorsForEmail(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
-    }
 
     private void testGetKeyForInstructor() throws Exception {
 

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -203,7 +203,6 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         }
     }
 
-
     @Test
     public void testGetInstructorsForGoogleId() throws Exception {
 

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -203,34 +203,6 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         }
     }
 
-    @Test
-    public void testGetInstructorsForEmail() {
-
-        ______TS("Success: get instructors with specific email");
-
-        String email = "instructor1@course1.tmt";
-
-        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForEmail(email);
-        assertEquals(1, retrieved.size());
-
-        InstructorAttributes instructor = retrieved.get(0);
-
-        assertEquals("idOfTypicalCourse1", instructor.courseId);
-
-        ______TS("Failure: instructor does not exist");
-
-        retrieved = instructorsDb.getInstructorsForEmail("non-exist-email");
-        assertEquals(0, retrieved.size());
-
-        ______TS("Failure: null parameters");
-
-        try {
-            instructorsDb.getInstructorsForEmail(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
-    }
 
     @Test
     public void testGetInstructorsForGoogleId() throws Exception {


### PR DESCRIPTION
Fixes #8168 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->

Removed `getInstructorsForEmail (String)` method from from `Logic`, `InstructorsLogic`, `InstructorsDb` and `testGetInstructorsForEmail` method from InstructorsLogicTest and `InstructorsDbTest`.

Also removed the `getInstructorEntitiesForEmail` method from `InstructorsDb` file, as it was causing pmdMain error.
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
