### PR TITLE
Rubric questions: show summary excluding self-evaluation #6887

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -1282,7 +1282,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                         responseFrequency[i][chosenChoice] += 1;
                         responseFrequency[i][responseTotalIndex] += 1;
                     }
-                    if (!response.giver.equals(response.recipient)) {
+                    if (chosenChoice != -1 && !response.giver.equals(response.recipient)) {
                         responseFrequencyExcludingSelf[i][chosenChoice] += 1;
                         responseFrequencyExcludingSelf[i][responseTotalIndex] += 1;
                     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -648,7 +648,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                 String tableBodyExcludingSelfCell = Templates.populateTemplate(tableBodyFragmentTemplate,
                         Slots.RUBRIC_PERCENTAGE_FREQUENCY_OR_AVERAGE,
                         percentageFrequencyExclSelfString + " (" + responseFrequencyExcludingSelf[i][j] + ")");
-                
+
                 tableBodyFragmentHtml.append(tableBodyCell).append(Const.EOL);
                 tableBodyExclSelfFragmentHtml.append(tableBodyExcludingSelfCell).append(Const.EOL);
             }
@@ -1228,7 +1228,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
          * -> is the total number of the responses for the given sub-question.
          */
         int[][] responseFrequency;
-        
+
         int[][] responseFrequencyExcludingSelf;
 
         /**
@@ -1245,7 +1245,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
          * -> is the average weight of the responses for the given sub-question.
          */
         float[][] percentageFrequencyAndAverage;
-        
+
         float[][] percentageFrequencyAndAverageExcludingSelf;
 
         List<FeedbackResponseAttributes> responses;
@@ -1266,7 +1266,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
             calculateResponseFrequency();
             calculatePercentageFrequencyAndAverage(false);
-            
+
             calculatePercentageFrequencyAndAverage(true);
         }
 
@@ -1327,7 +1327,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                     }
                 }
             }
-            
+
             if (isSelfExcluded) {
                 this.percentageFrequencyAndAverageExcludingSelf = percentageFrequencyAndAverage;
             } else {
@@ -1338,7 +1338,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         int[][] getResponseFrequency() {
             return responseFrequency;
         }
-        
+
         int[][] getResponseFrequencyExcludingSelf() {
             return responseFrequencyExcludingSelf;
         }
@@ -1346,7 +1346,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
         float[][] getPercentageFrequencyAndAverage() {
             return percentageFrequencyAndAverage;
         }
-        
+
         float[][] getPercentageFrequencyAndAverageExcludingSelf() {
             return percentageFrequencyAndAverageExcludingSelf;
         }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -591,7 +591,9 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
         RubricStatistics statistics = new RubricStatistics(responsesForStatistics, fqd);
         int[][] responseFrequency = statistics.getResponseFrequency();
+        int[][] responseFrequencyExcludingSelf = statistics.getResponseFrequencyExcludingSelf();
         float[][] rubricStats = statistics.getPercentageFrequencyAndAverage();
+        float[][] rubricStatsExcludingSelf = statistics.getPercentageFrequencyAndAverageExcludingSelf();
 
         DecimalFormat weightFormat = new DecimalFormat("#.##");
 
@@ -620,6 +622,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
         // Create table body
         StringBuilder tableBodyHtml = new StringBuilder();
+        StringBuilder tableBodyExcludingSelfHtml = new StringBuilder();
 
         String tableBodyFragmentTemplate = FormTemplates.RUBRIC_RESULT_STATS_BODY_FRAGMENT;
         String tableBodyTemplate = FormTemplates.RUBRIC_RESULT_STATS_BODY;
@@ -628,16 +631,26 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
 
         for (int i = 0; i < numOfRubricSubQuestions; i++) {
             StringBuilder tableBodyFragmentHtml = new StringBuilder();
+            StringBuilder tableBodyExclSelfFragmentHtml = new StringBuilder();
             boolean isSubQuestionRespondedTo = responseFrequency[i][numOfRubricChoices] > 0;
+            boolean isSubQuestionRespondedToForExcludingSelf = responseFrequencyExcludingSelf[i][numOfRubricChoices] > 0;
 
             for (int j = 0; j < numOfRubricChoices; j++) {
                 String percentageFrequencyString = isSubQuestionRespondedTo
                                                  ? df.format(rubricStats[i][j] * 100) + "%"
                                                  : STATISTICS_NO_VALUE_STRING;
+                String percentageFrequencyExclSelfString = isSubQuestionRespondedToForExcludingSelf
+                                                         ? df.format(rubricStatsExcludingSelf[i][j] * 100) + "%"
+                                                         : STATISTICS_NO_VALUE_STRING;
                 String tableBodyCell = Templates.populateTemplate(tableBodyFragmentTemplate,
                         Slots.RUBRIC_PERCENTAGE_FREQUENCY_OR_AVERAGE,
                         percentageFrequencyString + " (" + responseFrequency[i][j] + ")");
+                String tableBodyExcludingSelfCell = Templates.populateTemplate(tableBodyFragmentTemplate,
+                        Slots.RUBRIC_PERCENTAGE_FREQUENCY_OR_AVERAGE,
+                        percentageFrequencyExclSelfString + " (" + responseFrequencyExcludingSelf[i][j] + ")");
+                
                 tableBodyFragmentHtml.append(tableBodyCell).append(Const.EOL);
+                tableBodyExclSelfFragmentHtml.append(tableBodyExcludingSelfCell).append(Const.EOL);
             }
 
             if (fqd.hasAssignedWeights) {
@@ -654,7 +667,12 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                     Slots.SUB_QUESTION, StringHelper.integerToLowerCaseAlphabeticalIndex(i + 1) + ") "
                             + SanitizationHelper.sanitizeForHtml(rubricSubQuestions.get(i)),
                     Slots.RUBRIC_ROW_BODY_FRAGMENTS, tableBodyFragmentHtml.toString());
+            String tableRowExclSelf = Templates.populateTemplate(tableBodyTemplate,
+                    Slots.SUB_QUESTION, StringHelper.integerToLowerCaseAlphabeticalIndex(i + 1) + ") "
+                            + SanitizationHelper.sanitizeForHtml(rubricSubQuestions.get(i)),
+                    Slots.RUBRIC_ROW_BODY_FRAGMENTS, tableBodyExclSelfFragmentHtml.toString());
             tableBodyHtml.append(tableRow).append(Const.EOL);
+            tableBodyExcludingSelfHtml.append(tableRowExclSelf).append(Const.EOL);
         }
 
         String statsTitle = "Response Summary";
@@ -689,6 +707,7 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                 Slots.STATS_TITLE, statsTitle,
                 Slots.TABLE_HEADER_ROW_FRAGMENT_HTML, tableHeaderFragmentHtml.toString(),
                 Slots.TABLE_BODY_HTML, tableBodyHtml.toString(),
+                Slots.TABLE_BODY_EXCL_SELF_HTML, tableBodyExcludingSelfHtml.toString(),
                 Slots.RUBRIC_RECIPIENT_STATS_HTML, recipientStatsHtml);
     }
 
@@ -1209,6 +1228,8 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
          * -> is the total number of the responses for the given sub-question.
          */
         int[][] responseFrequency;
+        
+        int[][] responseFrequencyExcludingSelf;
 
         /**
          * Stores the percentage value between [0,1] of each choice
@@ -1224,6 +1245,8 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
          * -> is the average weight of the responses for the given sub-question.
          */
         float[][] percentageFrequencyAndAverage;
+        
+        float[][] percentageFrequencyAndAverageExcludingSelf;
 
         List<FeedbackResponseAttributes> responses;
         FeedbackRubricQuestionDetails questionDetails;
@@ -1242,11 +1265,14 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
             this.responseTotalIndex = numOfRubricChoices;
 
             calculateResponseFrequency();
-            calculatePercentageFrequencyAndAverage();
+            calculatePercentageFrequencyAndAverage(false);
+            
+            calculatePercentageFrequencyAndAverage(true);
         }
 
         void calculateResponseFrequency() {
             responseFrequency = new int[numOfRubricSubQuestions][numOfRubricChoices + 1];
+            responseFrequencyExcludingSelf = new int[numOfRubricSubQuestions][numOfRubricChoices + 1];
             // count frequencies
             for (FeedbackResponseAttributes response : responses) {
                 FeedbackRubricResponseDetails frd = (FeedbackRubricResponseDetails) response.getResponseDetails();
@@ -1256,6 +1282,10 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                         responseFrequency[i][chosenChoice] += 1;
                         responseFrequency[i][responseTotalIndex] += 1;
                     }
+                    if (!response.giver.equals(response.recipient)) {
+                        responseFrequencyExcludingSelf[i][chosenChoice] += 1;
+                        responseFrequencyExcludingSelf[i][responseTotalIndex] += 1;
+                    }
                 }
             }
         }
@@ -1264,11 +1294,19 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
          * Calculates the percentage frequencies for each choice and average value for each sub-question.
          * Precondition: responseFrequency has been calculated.
          */
-        void calculatePercentageFrequencyAndAverage() {
+        void calculatePercentageFrequencyAndAverage(boolean isSelfExcluded) {
             Assumption.assertNotNull("Response Frequency should be initialised and calculated first.",
                                      (Object[]) responseFrequency);
+            Assumption.assertNotNull("Response Frequency should be initialised and calculated first.",
+                                     (Object[]) responseFrequencyExcludingSelf);
 
-            percentageFrequencyAndAverage = new float[numOfRubricSubQuestions][numOfRubricChoices + 1];
+            int[][] responseFrequency;
+            if (isSelfExcluded) {
+                responseFrequency = responseFrequencyExcludingSelf;
+            } else {
+                responseFrequency = this.responseFrequency;
+            }
+            float[][] percentageFrequencyAndAverage = new float[numOfRubricSubQuestions][numOfRubricChoices + 1];
             // calculate percentage frequencies and average value
             for (int i = 0; i < percentageFrequencyAndAverage.length; i++) {
                 int totalForSubQuestion = responseFrequency[i][responseTotalIndex];
@@ -1289,14 +1327,28 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
                     }
                 }
             }
+            
+            if (isSelfExcluded) {
+                this.percentageFrequencyAndAverageExcludingSelf = percentageFrequencyAndAverage;
+            } else {
+                this.percentageFrequencyAndAverage = percentageFrequencyAndAverage;
+            }
         }
 
         int[][] getResponseFrequency() {
             return responseFrequency;
         }
+        
+        int[][] getResponseFrequencyExcludingSelf() {
+            return responseFrequencyExcludingSelf;
+        }
 
         float[][] getPercentageFrequencyAndAverage() {
             return percentageFrequencyAndAverage;
+        }
+        
+        float[][] getPercentageFrequencyAndAverageExcludingSelf() {
+            return percentageFrequencyAndAverageExcludingSelf;
         }
 
     }

--- a/src/main/java/teammates/common/util/Templates.java
+++ b/src/main/java/teammates/common/util/Templates.java
@@ -454,6 +454,7 @@ public final class Templates {
             public static final String RUBRIC_ROW_BODY_FRAGMENTS = "${rubricRowBodyFragments}";
             public static final String TABLE_HEADER_ROW_FRAGMENT_HTML = "${tableHeaderRowFragmentHtml}";
             public static final String TABLE_BODY_HTML = "${tableBodyHtml}";
+            public static final String TABLE_BODY_EXCL_SELF_HTML = "${tableBodyExcludingSelfHtml}";
             public static final String SUB_QUESTION = "${subQuestion}";
             public static final String ROW = "${row}";
             public static final String COL = "${col}";

--- a/src/main/resources/feedbackQuestionRubricResultStatsTemplate.html
+++ b/src/main/resources/feedbackQuestionRubricResultStatsTemplate.html
@@ -1,7 +1,8 @@
 <div class="panel-body">
   <div class="row">
     <div class="col-sm-4 text-color-gray">
-      <strong>
+      <input type="checkbox" id="self-excluding-check">
+      <strong class="stats-title">
         ${statsTitle}
       </strong>
     </div>
@@ -15,8 +16,11 @@
             ${tableHeaderRowFragmentHtml}
           </tr>
         </thead>
-        <tbody>
+        <tbody class="body-including-self">
           ${tableBodyHtml}
+        </tbody>
+        <tbody class="body-excluding-self hidden">
+            ${tableBodyExcludingSelfHtml}
         </tbody>
       </table>
     </div>

--- a/src/main/webapp/dev/js/common/instructorFeedbackResults.js
+++ b/src/main/webapp/dev/js/common/instructorFeedbackResults.js
@@ -356,6 +356,21 @@ function prepareInstructorFeedbackResultsPage() {
     });
 }
 
+function bindRubicQuestionSelfExcludingCheck() {
+    $('#self-excluding-check').on('change', (e) => {
+        var responseSummary = $(e.target).next();
+        var includingSelfBody = responseSummary.parent().parent().parent().find('.body-including-self');
+        var excludingSelfBody = responseSummary.parent().parent().parent().find('.body-excluding-self');
+        if (responseSummary.html().trim() === 'Response Summary') {
+            responseSummary.html('Response Summary Excluding Self');
+        } else {
+            responseSummary.html('Response Summary');
+        }
+        includingSelfBody.toggleClass('hidden');
+        excludingSelfBody.toggleClass('hidden');
+    });
+}
+
 export {
     bindCollapseEvents,
     displayAjaxRetryMessageForPanelHeading,
@@ -363,4 +378,5 @@ export {
     prepareInstructorFeedbackResultsPage,
     removeSection,
     showHideStats,
+    bindRubicQuestionSelfExcludingCheck,
 };

--- a/src/main/webapp/dev/js/common/instructorFeedbackResults.js
+++ b/src/main/webapp/dev/js/common/instructorFeedbackResults.js
@@ -358,9 +358,9 @@ function prepareInstructorFeedbackResultsPage() {
 
 function bindRubicQuestionSelfExcludingCheck() {
     $('#self-excluding-check').on('change', (e) => {
-        var responseSummary = $(e.target).next();
-        var includingSelfBody = responseSummary.parent().parent().parent().find('.body-including-self');
-        var excludingSelfBody = responseSummary.parent().parent().parent().find('.body-excluding-self');
+        const responseSummary = $(e.target).next();
+        const includingSelfBody = responseSummary.parent().parent().parent().find('.body-including-self');
+        const excludingSelfBody = responseSummary.parent().parent().parent().find('.body-excluding-self');
         if (responseSummary.html().trim() === 'Response Summary') {
             responseSummary.html('Response Summary Excluding Self');
         } else {

--- a/src/main/webapp/dev/js/main/instructorFeedbackResultsQuestion.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackResultsQuestion.js
@@ -14,6 +14,7 @@ import {
     displayAjaxRetryMessageForPanelHeading,
     prepareInstructorFeedbackResultsPage,
     showHideStats,
+    bindRubicQuestionSelfExcludingCheck,
 } from '../common/instructorFeedbackResults';
 
 import {
@@ -77,6 +78,7 @@ $(document).ready(() => {
                     $panelBody.html(appendedQuestion);
                 }
 
+                bindRubicQuestionSelfExcludingCheck();
                 // bind the show picture onclick events
                 bindStudentPhotoLink($panelBody.find('.profile-pic-icon-click > .student-profile-pic-view-link'));
                 // bind the show picture onhover events

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -393,7 +393,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -428,7 +429,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -459,6 +460,34 @@
                                   </td>
                                   <td>
                                     1.01
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                  <td>
+                                    0% (0)
                                   </td>
                                 </tr>
                               </tbody>
@@ -783,7 +812,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -818,7 +848,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -849,6 +879,34 @@
                                   </td>
                                   <td>
                                     0.01
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                  <td>
+                                    100% (1)
                                   </td>
                                 </tr>
                               </tbody>
@@ -1173,7 +1231,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -1208,7 +1267,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -1239,6 +1298,34 @@
                                   </td>
                                   <td>
                                     1.01
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                  <td>
+                                    - (0)
                                   </td>
                                 </tr>
                               </tbody>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -359,7 +359,8 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-sm-4 text-color-gray">
-                <strong>
+                <input id="self-excluding-check" type="checkbox">
+                <strong class="stats-title">
                   Response Summary
                 </strong>
               </div>
@@ -394,7 +395,7 @@
                       </th>
                     </tr>
                   </thead>
-                  <tbody>
+                  <tbody class="body-including-self">
                     <tr>
                       <td>
                         <p>
@@ -425,6 +426,34 @@
                       </td>
                       <td>
                         0.51
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody class="body-excluding-self hidden">
+                    <tr>
+                      <td>
+                        <p>
+                          a) This student has done a good job.
+                        </p>
+                      </td>
+                      <td>
+                        50% (1)
+                      </td>
+                      <td>
+                        50% (1)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p>
+                          b) This student has tried his/her best.
+                        </p>
+                      </td>
+                      <td>
+                        50% (1)
+                      </td>
+                      <td>
+                        50% (1)
                       </td>
                     </tr>
                   </tbody>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -387,7 +387,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -422,7 +423,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -453,6 +454,34 @@
                                   </td>
                                   <td>
                                     -0.99
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                  <td>
+                                    100% (1)
                                   </td>
                                 </tr>
                               </tbody>
@@ -736,7 +765,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -771,7 +801,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -802,6 +832,34 @@
                                   </td>
                                   <td>
                                     1.01
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    0% (0)
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    100% (1)
+                                  </td>
+                                  <td>
+                                    0% (0)
                                   </td>
                                 </tr>
                               </tbody>
@@ -1084,7 +1142,8 @@
                       <div class="panel-body">
                         <div class="row">
                           <div class="col-sm-4 text-color-gray">
-                            <strong>
+                            <input id="self-excluding-check" type="checkbox">
+                            <strong class="stats-title">
                               Response Summary
                             </strong>
                           </div>
@@ -1119,7 +1178,7 @@
                                   </th>
                                 </tr>
                               </thead>
-                              <tbody>
+                              <tbody class="body-including-self">
                                 <tr>
                                   <td>
                                     <p>
@@ -1150,6 +1209,34 @@
                                   </td>
                                   <td>
                                     1.01
+                                  </td>
+                                </tr>
+                              </tbody>
+                              <tbody class="body-excluding-self hidden">
+                                <tr>
+                                  <td>
+                                    <p>
+                                      a) This student has done a good job.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                </tr>
+                                <tr>
+                                  <td>
+                                    <p>
+                                      b) This student has tried his/her best.
+                                    </p>
+                                  </td>
+                                  <td>
+                                    - (0)
+                                  </td>
+                                  <td>
+                                    - (0)
                                   </td>
                                 </tr>
                               </tbody>

--- a/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
@@ -11027,7 +11027,8 @@
           <div class="panel-body">
             <div class="row">
               <div class="col-sm-4 text-color-gray">
-                <strong>
+                <input id="self-excluding-check" type="checkbox">
+                <strong class="stats-title">
                   Response Summary
                 </strong>
               </div>
@@ -11051,7 +11052,7 @@
                       </th>
                     </tr>
                   </thead>
-                  <tbody>
+                  <tbody class="body-including-self">
                     <tr>
                       <td>
                         <p>
@@ -11076,6 +11077,34 @@
                       </td>
                       <td>
                         25% (1)
+                      </td>
+                    </tr>
+                  </tbody>
+                  <tbody class="body-excluding-self hidden">
+                    <tr>
+                      <td>
+                        <p>
+                          a) This student has done a good job.
+                        </p>
+                      </td>
+                      <td>
+                        100% (2)
+                      </td>
+                      <td>
+                        0% (0)
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p>
+                          b) This student has tried his/her best.
+                        </p>
+                      </td>
+                      <td>
+                        50% (1)
+                      </td>
+                      <td>
+                        50% (1)
                       </td>
                     </tr>
                   </tbody>

--- a/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentExtendedFeedbackResultsPageRubric.html
@@ -88,7 +88,8 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-4 text-color-gray">
-            <strong>
+            <input id="self-excluding-check" type="checkbox">
+            <strong class="stats-title">
               Response Summary (of visible responses)
             </strong>
           </div>
@@ -112,7 +113,35 @@
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody class="body-including-self">
+                <tr>
+                  <td>
+                    <p>
+                      a) You have done a good job.
+                    </p>
+                  </td>
+                  <td>
+                    67% (2)
+                  </td>
+                  <td>
+                    33% (1)
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <p>
+                      b) You have tried your best.
+                    </p>
+                  </td>
+                  <td>
+                    33% (1)
+                  </td>
+                  <td>
+                    67% (2)
+                  </td>
+                </tr>
+              </tbody>
+              <tbody class="body-excluding-self hidden">
                 <tr>
                   <td>
                     <p>
@@ -344,7 +373,8 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-4 text-color-gray">
-            <strong>
+            <input id="self-excluding-check" type="checkbox">
+            <strong class="stats-title">
               Response Summary (of received responses)
             </strong>
           </div>
@@ -379,7 +409,7 @@
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody class="body-including-self">
                 <tr>
                   <td>
                     <p>
@@ -410,6 +440,34 @@
                   </td>
                   <td>
                     0.01
+                  </td>
+                </tr>
+              </tbody>
+              <tbody class="body-excluding-self hidden">
+                <tr>
+                  <td>
+                    <p>
+                      a) This student has done a good job.
+                    </p>
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                  <td>
+                    100% (1)
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <p>
+                      b) This student has tried his/her best.
+                    </p>
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                  <td>
+                    100% (1)
                   </td>
                 </tr>
               </tbody>
@@ -791,7 +849,8 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-4 text-color-gray">
-            <strong>
+            <input id="self-excluding-check" type="checkbox">
+            <strong class="stats-title">
               Response Summary (of received responses)
             </strong>
           </div>
@@ -826,7 +885,7 @@
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody class="body-including-self">
                 <tr>
                   <td>
                     <p>
@@ -857,6 +916,34 @@
                   </td>
                   <td>
                     0.00
+                  </td>
+                </tr>
+              </tbody>
+              <tbody class="body-excluding-self hidden">
+                <tr>
+                  <td>
+                    <p>
+                      a) This student has done a good job.
+                    </p>
+                  </td>
+                  <td>
+                    100% (1)
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <p>
+                      b) This student has tried his/her best.
+                    </p>
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                  <td>
+                    100% (1)
                   </td>
                 </tr>
               </tbody>
@@ -1180,7 +1267,8 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-4 text-color-gray">
-            <strong>
+            <input id="self-excluding-check" type="checkbox">
+            <strong class="stats-title">
               Response Summary (of received responses)
             </strong>
           </div>
@@ -1215,7 +1303,7 @@
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody class="body-including-self">
                 <tr>
                   <td>
                     <p>
@@ -1246,6 +1334,34 @@
                   </td>
                   <td>
                     -
+                  </td>
+                </tr>
+              </tbody>
+              <tbody class="body-excluding-self hidden">
+                <tr>
+                  <td>
+                    <p>
+                      a) This student has done a good job.
+                    </p>
+                  </td>
+                  <td>
+                    - (0)
+                  </td>
+                  <td>
+                    - (0)
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <p>
+                      b) This student has tried his/her best.
+                    </p>
+                  </td>
+                  <td>
+                    - (0)
+                  </td>
+                  <td>
+                    - (0)
                   </td>
                 </tr>
               </tbody>

--- a/src/test/resources/pages/studentFeedbackResultsPageRubric.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageRubric.html
@@ -88,7 +88,8 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-4 text-color-gray">
-            <strong>
+            <input id="self-excluding-check" type="checkbox">
+            <strong class="stats-title">
               Response Summary (of received responses)
             </strong>
           </div>
@@ -123,7 +124,7 @@
                   </th>
                 </tr>
               </thead>
-              <tbody>
+              <tbody class="body-including-self">
                 <tr>
                   <td>
                     <p>
@@ -154,6 +155,34 @@
                   </td>
                   <td>
                     -0.99
+                  </td>
+                </tr>
+              </tbody>
+              <tbody class="body-excluding-self hidden">
+                <tr>
+                  <td>
+                    <p>
+                      a) This student has done a good job.
+                    </p>
+                  </td>
+                  <td>
+                    100% (1)
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <p>
+                      b) This student has tried his/her best.
+                    </p>
+                  </td>
+                  <td>
+                    0% (0)
+                  </td>
+                  <td>
+                    100% (1)
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Fixes #6887 

I just did the changes on my local and haven't pushed the changes. Just want to show this particular approach if this looks nice.

![excluding rubic](https://user-images.githubusercontent.com/10528953/33825703-8678b780-de88-11e7-82c2-583374036fdc.gif)

Please suggest whether to proceed with this approach.