### PR TITLE
StringHelper: Remove join(String, String…) #7837

### DIFF
--- a/src/main/java/teammates/common/util/ActivityLogEntry.java
+++ b/src/main/java/teammates/common/util/ActivityLogEntry.java
@@ -64,7 +64,7 @@ public final class ActivityLogEntry {
     public String generateLogMessage() {
         // TEAMMATESLOG|||SERVLET_NAME|||ACTION|||TO_SHOW|||ROLE|||NAME|||GOOGLE_ID|||EMAIL|||MESSAGE(IN HTML)|||URL|||ID
         String userRoleSuffix = isMasqueradeUserRole ? Const.ActivityLog.ROLE_MASQUERADE_POSTFIX : "";
-        return StringHelper.join(Const.ActivityLog.FIELD_SEPARATOR, Const.ActivityLog.TEAMMATESLOG,
+        return String.join(Const.ActivityLog.FIELD_SEPARATOR, Const.ActivityLog.TEAMMATESLOG,
                 actionName, actionResponse, Boolean.toString(shouldShowLog), userRole + userRoleSuffix,
                 userName, userGoogleId, userEmail, logMessage, actionUrl, logId);
     }

--- a/src/main/java/teammates/common/util/EmailLogEntry.java
+++ b/src/main/java/teammates/common/util/EmailLogEntry.java
@@ -46,7 +46,7 @@ public class EmailLogEntry {
      */
     public String generateLogMessage() {
         // TEAMMATESEMAILSLOG|||RECEIVER|||SUBJECT|||CONTENT
-        return StringHelper.join(Const.EmailLog.FIELD_SEPARATOR, Const.EmailLog.TEAMMATES_EMAIL_LOG,
+        return String.join(Const.EmailLog.FIELD_SEPARATOR, Const.EmailLog.TEAMMATES_EMAIL_LOG,
                 receiver, subject, content);
     }
 

--- a/src/main/java/teammates/common/util/LogMessageGenerator.java
+++ b/src/main/java/teammates/common/util/LogMessageGenerator.java
@@ -191,7 +191,7 @@ public class LogMessageGenerator {
     }
 
     private String generateLogIdForAutomatedAction(long time) {
-        return StringHelper.join(Const.ActivityLog.FIELD_CONNECTOR,
+        return String.join(Const.ActivityLog.FIELD_CONNECTOR,
                 Const.ActivityLog.ROLE_AUTO, formatTimeForId(new Date(time)));
     }
 
@@ -199,15 +199,15 @@ public class LogMessageGenerator {
         String courseId = HttpRequestHelper.getValueFromParamMap(params, Const.ParamsNames.COURSE_ID);
         String studentEmail = HttpRequestHelper.getValueFromParamMap(params, Const.ParamsNames.STUDENT_EMAIL);
         if (courseId != null && studentEmail != null) {
-            return StringHelper.join(Const.ActivityLog.FIELD_CONNECTOR,
+            return String.join(Const.ActivityLog.FIELD_CONNECTOR,
                     studentEmail, courseId, formatTimeForId(new Date(time)));
         }
-        return StringHelper.join(Const.ActivityLog.FIELD_CONNECTOR,
+        return String.join(Const.ActivityLog.FIELD_CONNECTOR,
                 Const.ActivityLog.AUTH_NOT_LOGIN, formatTimeForId(new Date(time)));
     }
 
     private String generateLogIdWithGoogleId(String googleId, long time) {
-        return StringHelper.join(Const.ActivityLog.FIELD_CONNECTOR, googleId, formatTimeForId(new Date(time)));
+        return String.join(Const.ActivityLog.FIELD_CONNECTOR, googleId, formatTimeForId(new Date(time)));
     }
 
     private String formatTimeForId(Date date) {

--- a/src/main/java/teammates/common/util/StringHelper.java
+++ b/src/main/java/teammates/common/util/StringHelper.java
@@ -544,27 +544,8 @@ public final class StringHelper {
      * Returns a new String composed of copies of the String elements joined together
      * with a copy of the specified delimiter.
      */
-    public static String join(String delimiter, String... elements) {
-        if (delimiter == null || elements == null) {
-            throw new IllegalArgumentException("Provided arguments cannot be null");
-        }
-
-        StringBuilder result = new StringBuilder();
-        for (String element : elements) {
-            result.append(element).append(delimiter);
-        }
-        if (result.length() > 0 && delimiter.length() > 0) {
-            result.delete(result.length() - delimiter.length(), result.length());
-        }
-        return result.toString();
-    }
-
-    /**
-     * Returns a new String composed of copies of the String elements joined together
-     * with a copy of the specified delimiter.
-     */
     public static String join(String delimiter, List<Integer> elements) {
-        return join(delimiter, toStringArray(elements));
+        return String.join(delimiter, toStringArray(elements));
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -384,7 +384,7 @@ public class AdminActivityLogPageData extends PageData {
             return "";
         }
 
-        return StringHelper.join(",", q.infoValues);
+        return String.join(",", q.infoValues);
     }
 
     /**

--- a/src/main/java/teammates/ui/pagedata/AdminEmailLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminEmailLogPageData.java
@@ -88,7 +88,7 @@ public class AdminEmailLogPageData extends PageData {
             return "";
         }
 
-        return StringHelper.join(",", q.receiverValues);
+        return String.join(",", q.receiverValues);
     }
 
     public String getQueryKeywordsForSubject() {
@@ -96,7 +96,7 @@ public class AdminEmailLogPageData extends PageData {
             return "";
         }
 
-        return StringHelper.join(",", q.subjectValues);
+        return String.join(",", q.subjectValues);
     }
 
     public String getQueryKeywordsForContent() {
@@ -104,7 +104,7 @@ public class AdminEmailLogPageData extends PageData {
             return "";
         }
 
-        return StringHelper.join(",", q.infoValues);
+        return String.join(",", q.infoValues);
     }
 
     // Setter methods

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -67,7 +67,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         AdminEmailAttributes savedEmail = adminEmailsLogic.getAdminEmailBySubject(subject);
         assertNotNull("Email should be saved and should exists.", savedEmail);
         assertEquals(SanitizationHelper.sanitizeForRichText(content), savedEmail.getContentValue());
-        assertEquals(receiver, StringHelper.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
+        assertEquals(receiver, String.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
 
         ______TS("save new email : invalid subject : failure");
         content = "<p>Email Content</p>";
@@ -143,7 +143,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         savedEmail = adminEmailsLogic.getAdminEmailBySubject(subject);
         assertNotNull("Email should be saved and should exists.", savedEmail);
         assertEquals(SanitizationHelper.sanitizeForRichText(content), savedEmail.getContentValue());
-        assertEquals(receiver, StringHelper.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
+        assertEquals(receiver, String.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
 
         ______TS("save existing email : values require sanitization : success");
         emailId = email.emailId;
@@ -172,7 +172,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         savedEmail = adminEmailsLogic.getAdminEmailBySubject(subject);
         assertNotNull("Email should be saved and should exists.", savedEmail);
         assertEquals(SanitizationHelper.sanitizeForRichText(content), savedEmail.getContentValue());
-        assertEquals(receiver, StringHelper.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
+        assertEquals(receiver, String.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
 
         ______TS("save existing email : invalid subject : failure");
         content = "valid content";
@@ -250,7 +250,7 @@ public class AdminEmailComposeSaveActionTest extends BaseActionTest {
         savedEmail = adminEmailsLogic.getAdminEmailBySubject(subject);
         assertNotNull("Email should be saved and should exists.", savedEmail);
         assertEquals(SanitizationHelper.sanitizeForRichText(content), savedEmail.getContentValue());
-        assertEquals(receiver, StringHelper.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
+        assertEquals(receiver, String.join(", ", savedEmail.getAddressReceiver().toArray(new String[0])));
 
         ______TS("save non-existing email : invalid subject : failure");
         emailId = "nonExisitingId";

--- a/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminEmailComposeSaveActionTest.java
@@ -5,7 +5,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.attributes.AdminEmailAttributes;
 import teammates.common.util.Const;
 import teammates.common.util.SanitizationHelper;
-import teammates.common.util.StringHelper;
 import teammates.logic.core.AdminEmailsLogic;
 import teammates.test.driver.AssertHelper;
 import teammates.ui.controller.AdminEmailComposeSaveAction;

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -418,19 +418,19 @@ public class StringHelperTest extends BaseTestCase {
 
     @Test
     public void testJoin() {
-        assertEquals("", StringHelper.join(""));
-        assertEquals("", StringHelper.join(","));
-        assertEquals("", StringHelper.join("||"));
+        assertEquals("", String.join(""));
+        assertEquals("", String.join(","));
+        assertEquals("", String.join("||"));
 
-        assertEquals("test", StringHelper.join("", "test"));
-        assertEquals("test", StringHelper.join(",", "test"));
-        assertEquals("test", StringHelper.join("||", "test"));
-        assertEquals("testdata", StringHelper.join("", "test", "data"));
+        assertEquals("test", String.join("", "test"));
+        assertEquals("test", String.join(",", "test"));
+        assertEquals("test", String.join("||", "test"));
+        assertEquals("testdata", String.join("", "test", "data"));
 
-        assertEquals("test,data", StringHelper.join(",", "test", "data"));
-        assertEquals("test||data", StringHelper.join("||", "test", "data"));
+        assertEquals("test,data", String.join(",", "test", "data"));
+        assertEquals("test||data", String.join("||", "test", "data"));
         assertEquals("test|||data|||testdata",
-                StringHelper.join("|||", "test", "data", "testdata"));
+                String.join("|||", "test", "data", "testdata"));
     }
 
     @Test
@@ -443,7 +443,7 @@ public class StringHelperTest extends BaseTestCase {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testJoinWithNullDelimiter() {
-        StringHelper.join(null, "test", "data");
+        String.join(null, "test", "data");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -441,7 +441,7 @@ public class StringHelperTest extends BaseTestCase {
         assertEquals("5||14", StringHelper.join("||", Arrays.asList(5, 14)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test(expectedExceptions = NullPointerException.class)
     public void testJoinWithNullDelimiter() {
         String.join(null, "test", "data");
     }

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -417,33 +417,11 @@ public class StringHelperTest extends BaseTestCase {
     }
 
     @Test
-    public void testJoin() {
-        assertEquals("", String.join(""));
-        assertEquals("", String.join(","));
-        assertEquals("", String.join("||"));
-
-        assertEquals("test", String.join("", "test"));
-        assertEquals("test", String.join(",", "test"));
-        assertEquals("test", String.join("||", "test"));
-        assertEquals("testdata", String.join("", "test", "data"));
-
-        assertEquals("test,data", String.join(",", "test", "data"));
-        assertEquals("test||data", String.join("||", "test", "data"));
-        assertEquals("test|||data|||testdata",
-                String.join("|||", "test", "data", "testdata"));
-    }
-
-    @Test
     public void testJoinWithListOfIntegers() {
         assertEquals("", StringHelper.join(",", new ArrayList<Integer>()));
         assertEquals("5", StringHelper.join(",", Collections.singletonList(5)));
         assertEquals("5,14", StringHelper.join(",", Arrays.asList(5, 14)));
         assertEquals("5||14", StringHelper.join("||", Arrays.asList(5, 14)));
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void testJoinWithNullDelimiter() {
-        String.join(null, "test", "data");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -179,7 +179,7 @@ public final class AssertHelper {
             String expected, String actual, String studentEmail, String courseId) {
         assertLogMessageEqualsIgnoreLogId(expected, actual);
         assertLogIdContainsUserId(actual,
-                StringHelper.join(Const.ActivityLog.FIELD_CONNECTOR, studentEmail, courseId));
+                String.join(Const.ActivityLog.FIELD_CONNECTOR, studentEmail, courseId));
     }
 
     /**

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -13,7 +13,6 @@ import java.util.regex.Pattern;
 import com.google.common.base.Joiner;
 
 import teammates.common.util.Const;
-import teammates.common.util.StringHelper;
 import teammates.common.util.TimeHelper;
 
 /**


### PR DESCRIPTION
Fixes #7837 

**Outline of Solution**
I replaced instances using `StringHelper.join(String delimiter, String... elements)` with the native [`String.join(CharSequence delimiter, CharSequence... elements)` method](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#join-java.lang.CharSequence-java.lang.CharSequence...-).

One key behavior change is that the original `StringHelper.join` throws an `IllegalArgumentException` if `delimiter == null` but `String.join` throws a `NullPointerException` in the same situation.
I updated the test `testJoinWithNullDelimiter` in `teammates.test.cases.util.StringHelperTest` to reflect this change.