### PR TITLE
Java: Use Java 8 map.forEach to iterate through map entries #8216

### DIFF
--- a/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
+++ b/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -41,12 +40,8 @@ public final class DataBundleRegenerator {
             }
             String jsonString = FileHelper.readFile(file.getCanonicalPath());
             DataBundle db = JsonUtils.fromJson(jsonString, DataBundle.class);
-            for (Map.Entry<String, FeedbackResponseAttributes> responseMap : db.feedbackResponses.entrySet()) {
-                fixResponse(responseMap.getValue());
-            }
-            for (Map.Entry<String, FeedbackQuestionAttributes> questionMap : db.feedbackQuestions.entrySet()) {
-                fixQuestion(questionMap.getValue());
-            }
+            db.feedbackResponses.forEach((key, feedbackResponseAttributes) -> fixResponse(feedbackResponseAttributes));
+            db.feedbackQuestions.forEach((key, feedbackQuestionAttributes) -> fixQuestion(feedbackQuestionAttributes));
             String regeneratedJsonString = JsonUtils.toJson(db).replace("+0000", "UTC");
             saveFile(file.getCanonicalPath(), regeneratedJsonString);
         }

--- a/src/client/java/teammates/client/scripts/DataGenerator.java
+++ b/src/client/java/teammates/client/scripts/DataGenerator.java
@@ -198,6 +198,7 @@ public final class DataGenerator {
     /**
      * Returns Json string presentation for all instructors.
      */
+    @SuppressWarnings("PMD.ConsecutiveLiteralAppends") // Seems like a bug in PMD
     private static String allInstructors() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"instructors\":{\n");

--- a/src/client/java/teammates/client/scripts/DataGenerator.java
+++ b/src/client/java/teammates/client/scripts/DataGenerator.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -202,15 +201,15 @@ public final class DataGenerator {
     private static String allInstructors() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"instructors\":{\n");
-        for (Map.Entry<String, String> entry : instructors.entrySet()) {
-            String course = PREFIX + instructors.get(entry.getValue());
-            String instructorWithPrefix = PREFIX + entry.getKey();
+        instructors.forEach((key, value) -> {
+            String course = PREFIX + instructors.get(value);
+            String instructorWithPrefix = PREFIX + key;
             outputBuilder.append('\t')
                          .append(instructor(instructorWithPrefix, "googleIdOf_" + instructorWithPrefix,
                                             "courseIdOf_" + course, "nameOf_" + instructorWithPrefix,
                                             "emailOf_" + instructorWithPrefix + "@gmail.com"))
                          .append(",\n");
-        }
+        });
         String output = outputBuilder.substring(0, outputBuilder.length() - 2);
         return output + "\n},";
 

--- a/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
+++ b/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
@@ -253,11 +253,11 @@ public class StatisticsPerInstitute extends RemoteApiClient {
     private List<InstituteStats> convertToList(
             HashMap<String, HashMap<Integer, HashSet<String>>> institutes) {
         List<InstituteStats> list = new ArrayList<>();
-        institutes.forEach((insStatName, inStatStudents) -> {
+        institutes.forEach((insName, insStudents) -> {
             InstituteStats insStat = new InstituteStats();
-            insStat.name = insStatName;
-            insStat.studentTotal = inStatStudents.get(STUDENT_INDEX).size();
-            insStat.instructorTotal = inStatStudents.get(INSTRUCTOR_INDEX).size();
+            insStat.name = insName;
+            insStat.studentTotal = insStudents.get(STUDENT_INDEX).size();
+            insStat.instructorTotal = insStudents.get(INSTRUCTOR_INDEX).size();
             list.add(insStat);
         });
         return list;

--- a/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
+++ b/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
@@ -7,7 +7,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 
 import teammates.client.remoteapi.RemoteApiClient;
 import teammates.storage.entity.Account;
@@ -254,13 +253,13 @@ public class StatisticsPerInstitute extends RemoteApiClient {
     private List<InstituteStats> convertToList(
             HashMap<String, HashMap<Integer, HashSet<String>>> institutes) {
         List<InstituteStats> list = new ArrayList<>();
-        for (Map.Entry<String, HashMap<Integer, HashSet<String>>> entry : institutes.entrySet()) {
+        institutes.forEach((insStatName, inStatStudents) -> {
             InstituteStats insStat = new InstituteStats();
-            insStat.name = entry.getKey();
-            insStat.studentTotal = entry.getValue().get(STUDENT_INDEX).size();
-            insStat.instructorTotal = entry.getValue().get(INSTRUCTOR_INDEX).size();
+            insStat.name = insStatName;
+            insStat.studentTotal = inStatStudents.get(STUDENT_INDEX).size();
+            insStat.instructorTotal = inStatStudents.get(INSTRUCTOR_INDEX).size();
             list.add(insStat);
-        }
+        });
         return list;
     }
 

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -161,9 +161,7 @@ public final class InstructorPrivileges {
     }
 
     private void setDefaultPrivileges(Map<String, Boolean> defaultPrivileges) {
-        for (Map.Entry<String, Boolean> entry : defaultPrivileges.entrySet()) {
-            courseLevel.put(entry.getKey(), entry.getValue());
-        }
+        defaultPrivileges.forEach((key, value) -> courseLevel.put(key, value));
     }
 
     public Map<String, Boolean> getOverallPrivilegesForSections() {
@@ -490,23 +488,20 @@ public final class InstructorPrivileges {
 
     public Map<String, Map<String, Boolean>> getSectionLevelPrivileges() {
         Map<String, Map<String, Boolean>> copy = new LinkedHashMap<>();
-        for (Map.Entry<String, Map<String, Boolean>> sectionPrivileges : sectionLevel.entrySet()) {
-            copy.put(sectionPrivileges.getKey(), new LinkedHashMap<>(sectionPrivileges.getValue()));
-        }
+        sectionLevel.forEach((key, value) -> copy.put(key, new LinkedHashMap<>(value)));
         return copy;
     }
 
     public Map<String, Map<String, Map<String, Boolean>>> getSessionLevelPrivileges() {
         Map<String, Map<String, Map<String, Boolean>>> copy = new LinkedHashMap<>();
-        for (Map.Entry<String, Map<String, Map<String, Boolean>>> sectionPrivileges : sessionLevel.entrySet()) {
+        sessionLevel.forEach((sessionLevelKey, sessionLevelValue) -> {
 
             Map<String, Map<String, Boolean>> sectionCopy = new LinkedHashMap<>();
-            for (Map.Entry<String, Map<String, Boolean>> sessionPrivileges : sectionPrivileges.getValue().entrySet()) {
-                sectionCopy.put(sessionPrivileges.getKey(), new LinkedHashMap<>(sessionPrivileges.getValue()));
-            }
+            sessionLevelValue.forEach((key, value) ->
+                    sectionCopy.put(key, new LinkedHashMap<>(value)));
 
-            copy.put(sectionPrivileges.getKey(), sectionCopy);
-        }
+            copy.put(sessionLevelKey, sectionCopy);
+        });
         return copy;
     }
 

--- a/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivileges.java
@@ -495,10 +495,8 @@ public final class InstructorPrivileges {
     public Map<String, Map<String, Map<String, Boolean>>> getSessionLevelPrivileges() {
         Map<String, Map<String, Map<String, Boolean>>> copy = new LinkedHashMap<>();
         sessionLevel.forEach((sessionLevelKey, sessionLevelValue) -> {
-
             Map<String, Map<String, Boolean>> sectionCopy = new LinkedHashMap<>();
-            sessionLevelValue.forEach((key, value) ->
-                    sectionCopy.put(key, new LinkedHashMap<>(value)));
+            sessionLevelValue.forEach((key, value) -> sectionCopy.put(key, new LinkedHashMap<>(value)));
 
             copy.put(sessionLevelKey, sectionCopy);
         });

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -409,15 +408,14 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             putOptionsInSortedMap(optionPoints, options, sortedOptionPoints);
         }
 
-        for (Entry<String, List<Integer>> entry : sortedOptionPoints.entrySet()) {
+        sortedOptionPoints.forEach((option, points) -> {
 
-            List<Integer> points = entry.getValue();
             double average = computeAverage(points);
             int total = computeTotal(points);
             String pointsReceived = getListOfPointsAsString(points);
 
             if (distributeToRecipients) {
-                String participantIdentifier = identifierMap.get(entry.getKey());
+                String participantIdentifier = identifierMap.get(option);
                 String name = bundle.getNameForEmail(participantIdentifier);
                 String teamName = bundle.getTeamNameForEmail(participantIdentifier);
 
@@ -428,7 +426,6 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
                         Slots.CONSTSUM_TOTAL_POINTS, Integer.toString(total),
                         Slots.CONSTSUM_AVERAGE_POINTS, df.format(average)));
             } else {
-                String option = entry.getKey();
 
                 fragments.append(Templates.populateTemplate(FormTemplates.CONSTSUM_RESULT_STATS_OPTIONFRAGMENT,
                         Slots.CONSTSUM_OPTION_VALUE, SanitizationHelper.sanitizeForHtml(option),
@@ -436,7 +433,7 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
                         Slots.CONSTSUM_TOTAL_POINTS, Integer.toString(total),
                         Slots.CONSTSUM_AVERAGE_POINTS, df.format(average)));
             }
-        }
+        });
 
         if (distributeToRecipients) {
             return Templates.populateTemplate(FormTemplates.CONSTSUM_RESULT_RECIPIENT_STATS,
@@ -473,20 +470,19 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             putOptionsInSortedMap(optionPoints, options, sortedOptionPoints);
         }
 
-        for (Entry<String, List<Integer>> entry : sortedOptionPoints.entrySet()) {
+        sortedOptionPoints.forEach((key, points) -> {
             String option;
             if (distributeToRecipients) {
-                String participantIdentifier = identifierMap.get(entry.getKey());
+                String participantIdentifier = identifierMap.get(key);
                 String teamName = bundle.getTeamNameForEmail(participantIdentifier);
                 String recipientName = bundle.getNameForEmail(participantIdentifier);
 
                 option = SanitizationHelper.sanitizeForCsv(teamName)
                          + "," + SanitizationHelper.sanitizeForCsv(recipientName);
             } else {
-                option = SanitizationHelper.sanitizeForCsv(entry.getKey());
+                option = SanitizationHelper.sanitizeForCsv(key);
             }
 
-            List<Integer> points = entry.getValue();
             double average = computeAverage(points);
             double total = computeTotal(points);
 
@@ -496,7 +492,7 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
                     .append(',').append(StringHelper.join(",", points))
                     .append(Const.EOL);
 
-        }
+        });
 
         return (distributeToRecipients ? "Team, Recipient" : "Option")
                + ", Average Points, Total Points, Received Points" + Const.EOL
@@ -514,14 +510,13 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             Map<String, List<Integer>> recipientMapping, Map<String, String> identifierMap,
             Map<String, List<Integer>> sortedOptionPoints, FeedbackSessionResultsBundle bundle) {
 
-        for (Entry<String, List<Integer>> entry : recipientMapping.entrySet()) {
-            String participantIdentifier = entry.getKey();
+        recipientMapping.forEach((participantIdentifier, value) -> {
             String name = bundle.getNameForEmail(participantIdentifier);
             String nameEmail = name + participantIdentifier;
 
             identifierMap.put(nameEmail, participantIdentifier);
-            sortedOptionPoints.put(nameEmail, entry.getValue());
-        }
+            sortedOptionPoints.put(nameEmail, value);
+        });
     }
 
     /**
@@ -535,11 +530,11 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             Map<String, List<Integer>> optionPoints, List<String> optionList,
             Map<String, List<Integer>> sortedOptionPoints) {
 
-        for (Entry<String, List<Integer>> entry : optionPoints.entrySet()) {
-            String option = optionList.get(Integer.parseInt(entry.getKey()));
+        optionPoints.forEach((key, value) -> {
+            String option = optionList.get(Integer.parseInt(key));
 
-            sortedOptionPoints.put(option, entry.getValue());
-        }
+            sortedOptionPoints.put(option, value);
+        });
     }
 
     /**

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -411,9 +411,9 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
         }
 
-        for (Map.Entry<String, String> entry : sortedMap.entrySet()) {
-            contribFragments.append(entry.getValue());
-        }
+        sortedMap.forEach((key, value) -> {
+            contribFragments.append(value);
+        });
 
         String csvPointsExplanation =
                 "In the points given below, an equal share is equal to 100 points. "
@@ -482,9 +482,8 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
             Map<String, List<String>> teamMembersEmail,
             Map<String, TeamEvalResult> teamResults) {
         Map<String, StudentResultSummary> studentResults = new LinkedHashMap<>();
-        for (Map.Entry<String, TeamEvalResult> entry : teamResults.entrySet()) {
-            TeamEvalResult teamResult = entry.getValue();
-            List<String> teamEmails = teamMembersEmail.get(entry.getKey());
+        teamResults.forEach((key, teamResult) -> {
+            List<String> teamEmails = teamMembersEmail.get(key);
             int i = 0;
             for (String studentEmail : teamEmails) {
                 StudentResultSummary summary = new StudentResultSummary();
@@ -495,7 +494,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
                 i++;
             }
-        }
+        });
         return studentResults;
     }
 

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -411,9 +411,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
 
         }
 
-        sortedMap.forEach((key, value) -> {
-            contribFragments.append(value);
-        });
+        sortedMap.forEach((key, value) -> contribFragments.append(value));
 
         String csvPointsExplanation =
                 "In the points given below, an equal share is equal to 100 points. "

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -191,10 +191,8 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
 
             //Convert email to anonEmail and add stats.
             Map<String, StudentResultSummary> anonContribQnStats = new HashMap<>();
-            for (Map.Entry<String, StudentResultSummary> entry : contribQnStats.entrySet()) {
-                anonContribQnStats.put(
-                        feedbackSessionResultsBundle.getAnonEmailFromStudentEmail(entry.getKey()), entry.getValue());
-            }
+            contribQnStats.forEach((key, studentResultSummary) -> anonContribQnStats.put(
+                        feedbackSessionResultsBundle.getAnonEmailFromStudentEmail(key), studentResultSummary));
             for (Map.Entry<String, StudentResultSummary> entry : anonContribQnStats.entrySet()) {
                 if (contribQnStats.get(entry.getKey()) == null) {
                     contribQnStats.put(entry.getKey(), entry.getValue());

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionResponseDetails.java
@@ -184,18 +184,20 @@ public class FeedbackContributionResponseDetails extends FeedbackResponseDetails
     public static Map<String, StudentResultSummary> getContribQnStudentResultSummary(FeedbackQuestionAttributes question,
             FeedbackSessionResultsBundle feedbackSessionResultsBundle) {
 
-        feedbackSessionResultsBundle.contributionQuestionStudentResultSummary.computeIfAbsent(question.getId(), key -> {
-            FeedbackContributionQuestionDetails fqcd = (FeedbackContributionQuestionDetails) question.getQuestionDetails();
-            Map<String, StudentResultSummary> contribQnStats =
-                    fqcd.getStudentResults(feedbackSessionResultsBundle, question);
+        return feedbackSessionResultsBundle.contributionQuestionStudentResultSummary.computeIfAbsent(
+                question.getId(), key -> {
+                    FeedbackContributionQuestionDetails fqcd =
+                            (FeedbackContributionQuestionDetails) question.getQuestionDetails();
+                    Map<String, StudentResultSummary> contribQnStats =
+                            fqcd.getStudentResults(feedbackSessionResultsBundle, question);
 
-            new HashMap<>(contribQnStats).forEach((contribQnStatsKey, value) -> contribQnStats.putIfAbsent(
-                    feedbackSessionResultsBundle.getAnonEmailFromStudentEmail(contribQnStatsKey), value));
+                    new HashMap<>(contribQnStats).forEach((contribQnStatsKey, value) -> contribQnStats.putIfAbsent(
+                            feedbackSessionResultsBundle.getAnonEmailFromStudentEmail(contribQnStatsKey), value));
 
-            return contribQnStats;
-        });
+                    return contribQnStats;
+                }
+        );
 
-        return feedbackSessionResultsBundle.contributionQuestionStudentResultSummary.get(question.getId());
     }
 
     public Map<String, TeamEvalResult> getContribQnTeamEvalResult(FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -414,15 +413,13 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, Integer> entry : answerFrequency.entrySet()) {
-            fragments.append(Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS_OPTIONFRAGMENT,
-                    Slots.MCQ_CHOICE_VALUE, SanitizationHelper.sanitizeForHtml(entry.getKey()),
-                    Slots.COUNT, entry.getValue().toString(),
-                    Slots.PERCENTAGE, df.format(100 * (double) entry.getValue() / responses.size())));
-        }
+        answerFrequency.forEach((key, value) ->
+                fragments.append(Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS_OPTIONFRAGMENT,
+                        Slots.MCQ_CHOICE_VALUE, SanitizationHelper.sanitizeForHtml(key),
+                        Slots.COUNT, value.toString(),
+                        Slots.PERCENTAGE, df.format(100 * (double) value / responses.size()))));
 
-        return Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS,
-                Slots.FRAGMENTS, fragments.toString());
+        return Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS, Slots.FRAGMENTS, fragments.toString());
     }
 
     @Override
@@ -465,11 +462,9 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, Integer> entry : answerFrequency.entrySet()) {
-            fragments.append(SanitizationHelper.sanitizeForCsv(entry.getKey())).append(',')
-                     .append(entry.getValue().toString()).append(',')
-                     .append(df.format(100 * (double) entry.getValue() / responses.size())).append(Const.EOL);
-        }
+        answerFrequency.forEach((key, value) -> fragments.append(SanitizationHelper.sanitizeForCsv(key)).append(',')
+                     .append(value.toString()).append(',')
+                     .append(df.format(100 * (double) value / responses.size())).append(Const.EOL));
 
         return "Choice, Response Count, Percentage" + Const.EOL
                + fragments.toString();

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -506,14 +505,13 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
         DecimalFormat df = new DecimalFormat("#.##");
 
         StringBuilder fragments = new StringBuilder();
-        for (Entry<String, Integer> entry : answerFrequency.entrySet()) {
-            fragments.append(Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS_OPTIONFRAGMENT,
-                                Slots.MCQ_CHOICE_VALUE, entry.getKey(),
-                                Slots.COUNT, entry.getValue().toString(),
+        answerFrequency.forEach((key, value) ->
+                fragments.append(Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS_OPTIONFRAGMENT,
+                                Slots.MCQ_CHOICE_VALUE, key,
+                                Slots.COUNT, value.toString(),
                                 Slots.PERCENTAGE,
-                                df.format(100 * divideOrReturnZero(entry.getValue(), numChoicesSelected))));
+                                df.format(100 * divideOrReturnZero(value, numChoicesSelected)))));
 
-        }
         //Use same template as MCQ for now, until they need to be different.
         return Templates.populateTemplate(FormTemplates.MCQ_RESULT_STATS, Slots.FRAGMENTS, fragments.toString());
     }
@@ -535,12 +533,10 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
 
         DecimalFormat df = new DecimalFormat("#.##");
         StringBuilder fragments = new StringBuilder();
-        for (Entry<String, Integer> entry : answerFrequency.entrySet()) {
-            fragments.append(SanitizationHelper.sanitizeForCsv(entry.getKey()) + ','
-                             + entry.getValue().toString() + ','
-                             + df.format(100 * divideOrReturnZero(entry.getValue(), numChoicesSelected))
-                             + Const.EOL);
-        }
+        answerFrequency.forEach((key, value) -> fragments.append(SanitizationHelper.sanitizeForCsv(key) + ','
+                + value.toString() + ','
+                + df.format(100 * divideOrReturnZero(value, numChoicesSelected))
+                + Const.EOL));
 
         return "Choice, Response Count, Percentage" + Const.EOL
                + fragments + Const.EOL;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -320,20 +319,17 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, List<Integer>> entry : optionRanks.entrySet()) {
+        optionRanks.forEach((option, ranks) -> {
 
-            List<Integer> ranks = entry.getValue();
             double average = computeAverage(ranks);
             String ranksReceived = getListOfRanksReceivedAsString(ranks);
-
-            String option = entry.getKey();
 
             fragments.append(Templates.populateTemplate(FormTemplates.RANK_RESULT_STATS_OPTIONFRAGMENT,
                     Slots.RANK_OPTION_VALUE, SanitizationHelper.sanitizeForHtml(option),
                     Slots.RANK_RECIEVED, ranksReceived,
                     Slots.RANK_AVERAGE, df.format(average)));
 
-        }
+        });
 
         return Templates.populateTemplate(FormTemplates.RANK_RESULT_OPTION_STATS,
                 Slots.OPTION_RECIPIENT_DISPLAY_NAME, "Option",
@@ -354,15 +350,14 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, List<Integer>> entry : optionRanks.entrySet()) {
-            String option = SanitizationHelper.sanitizeForCsv(entry.getKey());
+        optionRanks.forEach((key, ranksAssigned) -> {
+            String option = SanitizationHelper.sanitizeForCsv(key);
 
-            List<Integer> ranksAssigned = entry.getValue();
             double average = computeAverage(ranksAssigned);
             String fragment = option + "," + df.format(average) + ","
                     + StringHelper.join(",", ranksAssigned) + Const.EOL;
             fragments.append(fragment);
-        }
+        });
 
         return "Option, Average Rank, Ranks Received" + Const.EOL + fragments.toString() + Const.EOL;
     }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -263,17 +262,15 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, List<Integer>> entry : recipientRanks.entrySet()) {
+        recipientRanks.forEach((participantIdentifier, ranks) -> {
 
-            List<Integer> ranks = entry.getValue();
             double average = computeAverage(ranks);
             String ranksReceived = getListOfRanksReceivedAsString(ranks);
 
-            String participantIdentifier = entry.getKey();
             String name = bundle.getNameForEmail(participantIdentifier);
             String teamName = bundle.getTeamNameForEmail(participantIdentifier);
             String userAverageExcludingSelfText =
-                    getAverageExcludingSelfText(df, recipientRanksExcludingSelf, entry.getKey());
+                    getAverageExcludingSelfText(df, recipientRanksExcludingSelf, participantIdentifier);
             String selfRank = recipientSelfRanks.containsKey(participantIdentifier)
                     ? Integer.toString(recipientSelfRanks.get(participantIdentifier)) : "-";
 
@@ -285,7 +282,7 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
                     Slots.RANK_AVERAGE, df.format(average),
                     Slots.RANK_EXCLUDING_SELF_AVERAGE, userAverageExcludingSelfText));
 
-        }
+        });
 
         return Templates.populateTemplate(templateToUse,
                 Slots.RANK_OPTION_RECIPIENT_DISPLAY_NAME, "Recipient",
@@ -310,20 +307,19 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
 
         DecimalFormat df = new DecimalFormat("#.##");
 
-        for (Entry<String, List<Integer>> entry : recipientRanks.entrySet()) {
+        recipientRanks.forEach((key, ranks) -> {
 
-            String teamName = bundle.getTeamNameForEmail(entry.getKey());
-            String recipientName = bundle.getNameForEmail(entry.getKey());
+            String teamName = bundle.getTeamNameForEmail(key);
+            String recipientName = bundle.getNameForEmail(key);
             String option = SanitizationHelper.sanitizeForCsv(teamName)
                             + ","
                             + SanitizationHelper.sanitizeForCsv(recipientName);
 
             String userAverageExcludingSelfText =
-                    getAverageExcludingSelfText(df, recipientRanksExcludingSelf, entry.getKey());
-            List<Integer> ranks = entry.getValue();
+                    getAverageExcludingSelfText(df, recipientRanksExcludingSelf, key);
             double average = computeAverage(ranks);
-            String selfRank = recipientSelfRanks.containsKey(entry.getKey())
-                    ? Integer.toString(recipientSelfRanks.get(entry.getKey())) : "-";
+            String selfRank = recipientSelfRanks.containsKey(key)
+                    ? Integer.toString(recipientSelfRanks.get(key)) : "-";
 
             fragments.append(option);
             fragments.append(',').append(selfRank);
@@ -332,7 +328,7 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
             fragments.append(',');
             fragments.append(StringHelper.join(",", ranks));
             fragments.append(Const.EOL);
-        }
+        });
 
         return "Team, Recipient, Self Rank, Average Rank, Average Rank Excluding Self, Ranks Received" + Const.EOL
                 + fragments + Const.EOL;

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -394,15 +394,16 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
 
         // resolve ties for each giver's responses
         Map<FeedbackResponseAttributes, Integer> normalisedRankOfResponse = new HashMap<>();
-        for (Map.Entry<String, List<FeedbackResponseAttributes>> entry : responsesGivenByPerson.entrySet()) {
+        responsesGivenByPerson.forEach((key, feedbackResponseAttributesList) -> {
             Map<FeedbackResponseAttributes, Integer> rankOfResponse = new HashMap<>();
             for (FeedbackResponseAttributes res : responses) {
                 FeedbackRankRecipientsResponseDetails frd = (FeedbackRankRecipientsResponseDetails) res.getResponseDetails();
                 rankOfResponse.put(res, frd.answer);
             }
 
-            normalisedRankOfResponse.putAll(obtainMappingToNormalisedRanksForRanking(rankOfResponse, entry.getValue()));
-        }
+            normalisedRankOfResponse.putAll(obtainMappingToNormalisedRanksForRanking(rankOfResponse,
+                    feedbackResponseAttributesList));
+        });
 
         return normalisedRankOfResponse;
     }

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -26,9 +26,7 @@ public class TaskQueuer {
 
     protected void addTask(String queueName, String workerUrl, Map<String, String> paramMap) {
         Map<String, String[]> multisetParamMap = new HashMap<>();
-        for (Map.Entry<String, String> entry : paramMap.entrySet()) {
-            multisetParamMap.put(entry.getKey(), new String[] { entry.getValue() });
-        }
+        paramMap.forEach((key, value) -> multisetParamMap.put(key, new String[] { value }));
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, multisetParamMap);
         new TaskQueuesLogic().addTask(task);
     }
@@ -36,9 +34,7 @@ public class TaskQueuer {
     protected void addDeferredTask(String queueName, String workerUrl, Map<String, String> paramMap,
                                    long countdownTime) {
         Map<String, String[]> multisetParamMap = new HashMap<>();
-        for (Map.Entry<String, String> entry : paramMap.entrySet()) {
-            multisetParamMap.put(entry.getKey(), new String[] { entry.getValue() });
-        }
+        paramMap.forEach((key, value) -> multisetParamMap.put(key, new String[] { value }));
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, multisetParamMap);
         new TaskQueuesLogic().addDeferredTask(task, countdownTime);
     }

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -229,12 +229,12 @@ public class AdminSessionsPageAction extends Action {
     }
 
     private void constructSessionToInstructorIdMap() {
-        for (Map.Entry<String, List<FeedbackSessionAttributes>> entry : this.map.entrySet()) {
-            for (FeedbackSessionAttributes fs : entry.getValue()) {
+        this.map.forEach((key, feedbackSessionAttributesList) -> {
+            for (FeedbackSessionAttributes fs : feedbackSessionAttributesList) {
                 String googleId = findAvailableInstructorGoogleIdForCourse(fs.getCourseId());
                 this.sessionToInstructorIdMap.put(fs.getIdentificationString(), googleId);
             }
-        }
+        });
     }
 
     /**

--- a/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
@@ -41,10 +41,7 @@ public abstract class InstructorCourseInstructorAbstractAction extends Action {
         Map<String, List<String>> sectionNamesMap = getSectionsWithSpecialPrivilegesFromParameters(
                                                                 instructor, sectionNames,
                                                                 isSectionSpecialMappings);
-        for (Entry<String, List<String>> entry : sectionNamesMap.entrySet()) {
-            String sectionGroupName = entry.getKey();
-            List<String> specialSectionsInSectionGroup = entry.getValue();
-
+        sectionNamesMap.forEach((sectionGroupName, specialSectionsInSectionGroup) -> {
             updateInstructorPrivilegesForSectionInSectionLevel(sectionGroupName,
                     specialSectionsInSectionGroup, instructor);
 
@@ -57,7 +54,7 @@ public abstract class InstructorCourseInstructorAbstractAction extends Action {
             } else {
                 removeSessionLevelPrivileges(instructor, specialSectionsInSectionGroup);
             }
-        }
+        });
         for (Entry<String, Boolean> entry : isSectionSpecialMappings.entrySet()) {
             String sectionNameToBeChecked = entry.getKey();
             boolean isSectionSpecial = entry.getValue().booleanValue();

--- a/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
@@ -54,8 +54,7 @@ public abstract class InstructorCourseInstructorAbstractAction extends Action {
                 removeSessionLevelPrivileges(instructor, specialSectionsInSectionGroup);
             }
         });
-        isSectionSpecialMappings.forEach((sectionNameToBeChecked, value) -> {
-            boolean isSectionSpecial = value.booleanValue();
+        isSectionSpecialMappings.forEach((sectionNameToBeChecked, isSectionSpecial) -> {
             if (!isSectionSpecial) {
                 instructor.privileges.removeSectionLevelPrivileges(sectionNameToBeChecked);
             }

--- a/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseInstructorAbstractAction.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -55,13 +54,12 @@ public abstract class InstructorCourseInstructorAbstractAction extends Action {
                 removeSessionLevelPrivileges(instructor, specialSectionsInSectionGroup);
             }
         });
-        for (Entry<String, Boolean> entry : isSectionSpecialMappings.entrySet()) {
-            String sectionNameToBeChecked = entry.getKey();
-            boolean isSectionSpecial = entry.getValue().booleanValue();
+        isSectionSpecialMappings.forEach((sectionNameToBeChecked, value) -> {
+            boolean isSectionSpecial = value.booleanValue();
             if (!isSectionSpecial) {
                 instructor.privileges.removeSectionLevelPrivileges(sectionNameToBeChecked);
             }
-        }
+        });
     }
 
     /**

--- a/src/main/java/teammates/ui/controller/InstructorCourseRemindAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseRemindAction.java
@@ -2,8 +2,6 @@ package teammates.ui.controller;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import java.util.TreeMap;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -113,17 +111,9 @@ public class InstructorCourseRemindAction extends Action {
                      .append(courseId)
                      .append("]</span>:<br>");
 
-        Set<Entry<String, JoinEmailData>> entries = emailDataMap.entrySet();
-
-        for (Entry<String, JoinEmailData> entry : entries) {
-
-            String userEmail = entry.getKey();
-            JoinEmailData joinEmailData = entry.getValue();
-
-            statusToAdmin.append(joinEmailData.userName)
+        emailDataMap.forEach((userEmail, joinEmailData) -> statusToAdmin.append(joinEmailData.userName)
                          .append("<span class=\"bold\"> (").append(userEmail).append(")</span>.<br>")
-                         .append(joinEmailData.regKey).append("<br>");
-        }
+                         .append(joinEmailData.regKey).append("<br>"));
 
         return statusToAdmin.toString();
     }

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -194,10 +194,8 @@ public class AdminSessionsPageData extends PageData {
     public void setInstitutionPanels(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap) {
         institutionPanels = new ArrayList<>();
-        for (Map.Entry<String, List<FeedbackSessionAttributes>> entry : map.entrySet()) {
-            institutionPanels.add(
-                    new InstitutionPanel(
-                            entry.getKey(), getFeedbackSessionRows(entry.getValue(), sessionToInstructorIdMap)));
-        }
+        map.forEach((key, feedbackSessionAttributesList) -> institutionPanels.add(
+                new InstitutionPanel(
+                        key, getFeedbackSessionRows(feedbackSessionAttributesList, sessionToInstructorIdMap))));
     }
 }

--- a/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
@@ -178,14 +178,14 @@ public class FeedbackSubmissionEditPageData extends PageData {
         result.add("<option value=\"\" " + (currentlySelectedOption == null ? "selected>" : ">")
                    + "</option>");
 
-        for (Map.Entry<String, String> pair : emailNamePair.entrySet()) {
-            boolean isSelected = SanitizationHelper.desanitizeFromHtml(pair.getKey())
+        emailNamePair.forEach((key, value) -> {
+            boolean isSelected = SanitizationHelper.desanitizeFromHtml(key)
                                              .equals(currentlySelectedOption);
-            result.add("<option value=\"" + sanitizeForHtml(pair.getKey()) + "\"" + (isSelected ? " selected" : "") + ">"
-                           + sanitizeForHtml(pair.getValue())
+            result.add("<option value=\"" + sanitizeForHtml(key) + "\"" + (isSelected ? " selected" : "") + ">"
+                           + sanitizeForHtml(value)
                        + "</option>"
             );
-        }
+        });
 
         return result;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResultsPageData.java
@@ -115,11 +115,7 @@ public class InstructorFeedbackResultsPageData extends PageData {
         // and load them by ajax question by question
         boolean isLoadingStructureOnly = questionToResponseMap.size() > 1;
 
-        for (Map.Entry<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>
-                     entry : questionToResponseMap.entrySet()) {
-            FeedbackQuestionAttributes question = entry.getKey();
-            List<FeedbackResponseAttributes> responses = entry.getValue();
-
+        questionToResponseMap.forEach((question, responses) -> {
             InstructorFeedbackResultsQuestionTable questionPanel;
             if (isLoadingStructureOnly) {
                 questionPanel = buildQuestionTableWithoutResponseRows(question, responses, "");
@@ -129,8 +125,7 @@ public class InstructorFeedbackResultsPageData extends PageData {
             }
 
             questionPanels.add(questionPanel);
-        }
-
+        });
     }
 
     private void initCommonVariables(InstructorAttributes instructor, String selectedSection,

--- a/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
@@ -209,11 +209,11 @@ public class InstructorSearchPageData extends PageData {
             }
         }
         List<SectionDetailsBundle> sections = new ArrayList<>();
-        for (Map.Entry<String, List<String>> entry : sectionNameToTeamNameMap.entrySet()) {
+        sectionNameToTeamNameMap.forEach((sdbName, teamNameList) -> {
             SectionDetailsBundle sdb = new SectionDetailsBundle();
-            sdb.name = entry.getKey();
+            sdb.name = sdbName;
             ArrayList<TeamDetailsBundle> teams = new ArrayList<>();
-            for (String teamName : entry.getValue()) {
+            for (String teamName : teamNameList) {
                 TeamDetailsBundle tdb = new TeamDetailsBundle();
                 tdb.name = teamName;
                 tdb.students = teamNameToStudentsMap.get(teamName);
@@ -221,7 +221,7 @@ public class InstructorSearchPageData extends PageData {
             }
             sdb.teams = teams;
             sections.add(sdb);
-        }
+        });
         for (SectionDetailsBundle section : sections) {
             InstructorAttributes instructor = studentSearchResultBundle.courseIdInstructorMap.get(courseId);
             boolean isAllowedToViewStudentInSection =

--- a/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
@@ -209,9 +209,9 @@ public class InstructorSearchPageData extends PageData {
             }
         }
         List<SectionDetailsBundle> sections = new ArrayList<>();
-        sectionNameToTeamNameMap.forEach((sdbName, teamNameList) -> {
+        sectionNameToTeamNameMap.forEach((sectionName, teamNameList) -> {
             SectionDetailsBundle sdb = new SectionDetailsBundle();
-            sdb.name = sdbName;
+            sdb.name = sectionName;
             ArrayList<TeamDetailsBundle> teams = new ArrayList<>();
             for (String teamName : teamNameList) {
                 TeamDetailsBundle tdb = new TeamDetailsBundle();

--- a/src/main/java/teammates/ui/template/ElementTag.java
+++ b/src/main/java/teammates/ui/template/ElementTag.java
@@ -86,12 +86,12 @@ public class ElementTag {
         }
 
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> attribute : attributes.entrySet()) {
-            sb.append(' ').append(attribute.getKey());
-            if (attribute.getValue() != null) {
-                sb.append("=\"" + attribute.getValue() + "\"");
+        attributes.forEach((key, value) -> {
+            sb.append(' ').append(key);
+            if (value != null) {
+                sb.append("=\"" + value + "\"");
             }
-        }
+        });
         return sb.toString();
     }
 }

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -2151,11 +2151,11 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     // Stringifies the visibility table for easy testing/comparison.
     private String tableToString(Map<String, boolean[]> table) {
         StringBuilder tableStringBuilder = new StringBuilder();
-        for (Map.Entry<String, boolean[]> entry : table.entrySet()) {
-            tableStringBuilder.append('{' + entry.getKey() + "={"
-                                      + entry.getValue()[0] + ','
-                                      + entry.getValue()[1] + "}},");
-        }
+        table.forEach((key, value) -> {
+            tableStringBuilder.append('{' + key + "={"
+                                      + value[0] + ','
+                                      + value[1] + "}},");
+        });
         String tableString = tableStringBuilder.toString();
         if (!tableString.isEmpty()) {
             tableString = tableString.substring(0, tableString.length() - 1);

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -2151,11 +2151,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     // Stringifies the visibility table for easy testing/comparison.
     private String tableToString(Map<String, boolean[]> table) {
         StringBuilder tableStringBuilder = new StringBuilder();
-        table.forEach((key, value) -> {
-            tableStringBuilder.append('{' + key + "={"
-                                      + value[0] + ','
-                                      + value[1] + "}},");
-        });
+        table.forEach((key, value) -> tableStringBuilder.append('{' + key + "={" + value[0] + ',' + value[1] + "}},"));
         String tableString = tableStringBuilder.toString();
         if (!tableString.isEmpty()) {
             tableString = tableString.substring(0, tableString.length() - 1);

--- a/src/test/java/teammates/test/cases/pagedata/StudentFeedbackResultsPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentFeedbackResultsPageDataTest.java
@@ -140,16 +140,11 @@ public class StudentFeedbackResultsPageDataTest extends BaseComponentTestCase {
             Logic logic, Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponses) {
         Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> actualQuestionsWithResponses =
                 new LinkedHashMap<>();
-        for (Map.Entry<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>
-                     entry : questionsWithResponses.entrySet()) {
-            FeedbackQuestionAttributes dataBundleQuestion = entry.getKey();
-
+        questionsWithResponses.forEach((dataBundleQuestion, dataBundleResponses) -> {
             FeedbackQuestionAttributes actualQuestion = logic.getFeedbackQuestion(
                                                                     dataBundleQuestion.feedbackSessionName,
                                                                     dataBundleQuestion.courseId,
                                                                     dataBundleQuestion.questionNumber);
-
-            List<FeedbackResponseAttributes> dataBundleResponses = entry.getValue();
 
             List<FeedbackResponseAttributes> actualResponses = new ArrayList<>();
             for (FeedbackResponseAttributes dataBundleResponse : dataBundleResponses) {
@@ -158,10 +153,9 @@ public class StudentFeedbackResultsPageDataTest extends BaseComponentTestCase {
                                                                     dataBundleResponse.giver,
                                                                     dataBundleResponse.recipient);
                 actualResponses.add(actualResponse);
-
             }
             actualQuestionsWithResponses.put(actualQuestion, actualResponses);
-        }
+        });
         return actualQuestionsWithResponses;
     }
 }

--- a/src/test/java/teammates/test/cases/testdriver/TestNgTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/TestNgTest.java
@@ -3,7 +3,6 @@ package teammates.test.cases.testdriver;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Map.Entry;
 
 import org.testng.annotations.Test;
 
@@ -34,9 +33,7 @@ public class TestNgTest extends BaseTestCase {
                                             "GodModeTest"
                                             );
 
-        for (Entry<String, String> testFileName : testFiles.entrySet()) {
-            assertTrue(isTestFileIncluded(testNgXml, testFileName.getValue(), testFileName.getKey()));
-        }
+        testFiles.forEach((key, value) -> assertTrue(isTestFileIncluded(testNgXml, value, key)));
     }
 
     /**

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -466,9 +466,7 @@ public final class BackDoor {
 
     private static String encodeParameters(Map<String, String> map) {
         StringBuilder dataStringBuilder = new StringBuilder();
-        map.forEach((key, value) -> {
-            dataStringBuilder.append(key + "=" + SanitizationHelper.sanitizeForUri(value) + "&");
-        });
+        map.forEach((key, value) -> dataStringBuilder.append(key + "=" + SanitizationHelper.sanitizeForUri(value) + "&"));
         return dataStringBuilder.toString();
     }
 

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -466,9 +466,9 @@ public final class BackDoor {
 
     private static String encodeParameters(Map<String, String> map) {
         StringBuilder dataStringBuilder = new StringBuilder();
-        for (Map.Entry<String, String> e : map.entrySet()) {
-            dataStringBuilder.append(e.getKey() + "=" + SanitizationHelper.sanitizeForUri(e.getValue()) + "&");
-        }
+        map.forEach((key, value) -> {
+            dataStringBuilder.append(key + "=" + SanitizationHelper.sanitizeForUri(value) + "&");
+        });
         return dataStringBuilder.toString();
     }
 

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -220,10 +220,10 @@ public class GaeSimulation {
             paramMultiMap.get(key).add(parameters[i + 1]);
         }
 
-        for (Map.Entry<String, List<String>> entry : paramMultiMap.entrySet()) {
-            List<String> values = entry.getValue();
-            request.setParameter(entry.getKey(), values.toArray(new String[values.size()]));
-        }
+        paramMultiMap.forEach((key, value) -> {
+            List<String> values = value;
+            request.setParameter(key, values.toArray(new String[values.size()]));
+        });
 
         try {
             InvocationContext ic = sc.newInvocation(request);

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -220,10 +220,7 @@ public class GaeSimulation {
             paramMultiMap.get(key).add(parameters[i + 1]);
         }
 
-        paramMultiMap.forEach((key, value) -> {
-            List<String> values = value;
-            request.setParameter(key, values.toArray(new String[values.size()]));
-        });
+        paramMultiMap.forEach((key, values) -> request.setParameter(key, values.toArray(new String[values.size()])));
 
         try {
             InvocationContext ic = sc.newInvocation(request);

--- a/src/test/java/teammates/test/driver/MockTaskQueuer.java
+++ b/src/test/java/teammates/test/driver/MockTaskQueuer.java
@@ -21,9 +21,9 @@ public class MockTaskQueuer extends TaskQueuer {
     @Override
     protected void addTask(String queueName, String workerUrl, Map<String, String> paramMap) {
         Map<String, String[]> multisetParamMap = new HashMap<>();
-        for (Map.Entry<String, String> entrySet : paramMap.entrySet()) {
-            multisetParamMap.put(entrySet.getKey(), new String[] { entrySet.getValue() });
-        }
+        paramMap.forEach((key, value) -> {
+            multisetParamMap.put(key, new String[] { value });
+        });
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, multisetParamMap);
         tasksAdded.add(task);
     }

--- a/src/test/java/teammates/test/driver/MockTaskQueuer.java
+++ b/src/test/java/teammates/test/driver/MockTaskQueuer.java
@@ -21,9 +21,7 @@ public class MockTaskQueuer extends TaskQueuer {
     @Override
     protected void addTask(String queueName, String workerUrl, Map<String, String> paramMap) {
         Map<String, String[]> multisetParamMap = new HashMap<>();
-        paramMap.forEach((key, value) -> {
-            multisetParamMap.put(key, new String[] { value });
-        });
+        paramMap.forEach((key, value) -> multisetParamMap.put(key, new String[] { value }));
         TaskWrapper task = new TaskWrapper(queueName, workerUrl, multisetParamMap);
         tasksAdded.add(task);
     }


### PR DESCRIPTION
Fixes #8216 

**Outline of Solution**
I have replaced instances of `Map.Entry<String, String> entry : map.entrySet()` with `map.forEach(key, value)` across different files in the project.

To keep the naming for `key` and `value` consistent while still being descriptive as far as possible, I have named the `key` and `value` according to the following (in order of decreasing priority):

1. If the key and value of `Map.Entry` are named later in the same function, use these names.
e.g.
```
for (Map.Entry<String, HashMap<Integer, HashSet<String>>> entry : institutes.entrySet()) { 
    insStat.name = entry.getKey();
    insStat.studentTotal = entry.getValue().get(STUDENT_INDEX).size();
    ...
}
```
becomes `institutes.forEach((insStatName, inStatStudents) -> ...`

2. Otherwise, if the types of the `key` and `value` are specified, use the types as names.
e.g.
```
for (Map.Entry<String, FeedbackResponseAttributes> responseMap : db.feedbackResponses.entrySet())
```
becomes `db.feedbackResponses.forEach((key, feedbackResponseAttributes) -> ...`

3. Otherwise, use `key` and `value` as names.

**Note**
Not every single instance of `for (Map.Entry<TypeOne, TypeTwo> entry : map.entryset())` has been modified. In particular, I did not modify the `Map.Entry` if there is at least one variable in the lambda expression that is not final/effectively final.

Redundant imports after the changes made have also been removed.