### PR TITLE
Instructor: help page: remove link-style formatting from sub-titles #8190

### DIFF
--- a/src/main/resources/feedbackQuestionContribResultStatsTemplate.html
+++ b/src/main/resources/feedbackQuestionContribResultStatsTemplate.html
@@ -6,7 +6,7 @@
       </strong>
     </div>
     <div class="col-sm-3 pull-right">
-      [<a href="/instructorHelp.jsp#faq7a" target="_blank" rel="noopener noreferrer" id="interpret_help_link">How do I interpret/use these values?</a>]
+      [<a href="/instructorHelp.jsp#faq7" target="_blank" rel="noopener noreferrer" id="interpret_help_link">How do I interpret/use these values?</a>]
     </div>
   </div>
   <div class="row">

--- a/src/main/webapp/instructorHelp.jsp
+++ b/src/main/webapp/instructorHelp.jsp
@@ -27,13 +27,13 @@
               <a href="#faq4">How do I delete students from a course?</a>
             </li>
             <li>
-              <a href="#faq6">How do I change the Google ID associated with a student?</a>
+              <a href="#faq5">How do I change the Google ID associated with a student?</a>
             </li>
             <li>
-              <a href="#faq7">What to do if a student says his/her courses have disappeared from the system?</a>
+              <a href="#faq6">What to do if a student says his/her courses have disappeared from the system?</a>
             </li>
             <li>
-              <a href="#faq7a">How do I interpret/use contribution values in the results of ‘Team contribution’ type questions?</a>
+              <a href="#faq7">How do I interpret/use contribution values in the results of ‘Team contribution’ type questions?</a>
             </li>
             <li>
               <a href="#faq8">What to do if a student says he cannot submit responses due to some technical glitch?</a>

--- a/src/main/webapp/partials/instructorHelpAddEditInstructors.jsp
+++ b/src/main/webapp/partials/instructorHelpAddEditInstructors.jsp
@@ -1,14 +1,10 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="editCourse">Add/Edit instructors</a>
-</h4>
+<h4 class="text-color-primary" id="editCourse">Add/Edit instructors</h4>
 <div id="contentHolder">
   <br>
   <ul>
-    <li>
-      <b>
-        <a name="editCourseAddInstructor" id="question">How do I add instructors to my course?</a>
-      </b>
+    <li id="editCourseAddInstructor">
+      <b>How do I add instructors to my course?</b>
       <div class="helpSectionContent">
         After pressing 'edit' link of the course, you can go to course edit page, where you can add new instructors and edit existing instructors in the course. However, depending on your privilege setting, you may or may not perform certain actions.
         <br> For example, edit/delete instructors, add instructor links will be disabled for those who do not have the privilege.
@@ -180,10 +176,8 @@
       </div>
     </li>
     <br>
-    <li>
-      <b>
-        <a name="editCourseEditInstructor" id="question">How do I edit instructors in my course?</a>
-      </b>
+    <li id="editCourseEditInstructor">
+      <b>How do I edit instructors in my course?</b>
       <div class="helpSectionContent">
         In course edit page, you can edit instructors in this course by pressing the 'edit' link for an instructor. After pressing the link, a form will appear for editing the instructor.
         <br> Fill in the form with the updated information of the instructor and press "Save changes" button to save the changes.
@@ -192,10 +186,8 @@
       </div>
     </li>
     <br>
-    <li>
-      <b>
-        <a name="editCourseSetAccessLevel" id="question">How do I set different access level for an instructor?</a>
-      </b>
+    <li id="editCourseSetAccessLevel">
+      <b>How do I set different access level for an instructor?</b>
       <div class="helpSectionContent">
         When adding/editing an instructor, you can set the access level for an instructor. There are 5 options for you to choose from: Co-owner, Manager, Observer, Tutor and Custom.
         <br>
@@ -210,10 +202,8 @@
       </div>
     </li>
     <br>
-    <li>
-      <b>
-        <a name="editCourseSetCustom" id="question">How do I set custom privileges for an instructor?</a>
-      </b>
+    <li id="editCourseSetCustom">
+      <b>How do I set custom privileges for an instructor?</b>
       <div class="helpSectionContent">
         When setting the access level for an instructor as 'Custom', detailed privilege settings will be available for you.
         <br>
@@ -464,7 +454,6 @@
         <br>
         <br> If a course does have sections, the link 'Give different permissions for a specific section' will be shown for customization for different sections. In the panel for section-level privilege settings, you can choose more than one section to apply the same set of settings. You can also set settings for different sessions for student in that section by click the link 'Give different permissions for sessions in this section'.
         <br>
-
       </div>
     </li>
     <br>

--- a/src/main/webapp/partials/instructorHelpArchiving.jsp
+++ b/src/main/webapp/partials/instructorHelpArchiving.jsp
@@ -1,15 +1,11 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="archiving">Archiving</a>
-</h4>
+<h4 class="text-color-primary" id="archiving">Archiving</h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type: none;">
-    <li>
+    <li id="archivingCourse">
       <span class="text-bold">
-        <a name="archivingCourse">
           <h3>1. Archiving a course</h3>
-        </a>
       </span>
       <div>
         You can archive a course so that it doesn't appear in your home page anymore. You cannot edit, create feedback sessions or enroll students in an archived course.
@@ -62,11 +58,9 @@
         <br>Under 'Active Courses', click on the <b>'Archive'</b> button in the row corresponding to the course you want to archive.
       </div>
     </li>
-    <li>
+    <li id="archivingViewArchivedCourses">
       <span class="text-bold">
-        <a name="archivingViewArchivedCourses">
           <h3>2. Viewing archived courses</h3>
-        </a>
       </span>
       <div>
         You can view all your archived courses in the <b>'Courses'</b> page, under the <b>Archived Courses</b> heading. It will look similar to this:
@@ -94,11 +88,9 @@
         </table>
       </div>
     </li>
-    <li>
+    <li id="archivingUnarchiveCourses">
       <span class="text-bold">
-        <a name="archivingUnarchiveCourses">
           <h3>3. Unarchiving a course</h3>
-        </a>
       </span>
       <div>
         You can unarchive a course by clicking on the <button href="#" class="btn btn-default btn-xs" type="button">Unarchive</button> button in the list of archived courses in the

--- a/src/main/webapp/partials/instructorHelpComments.jsp
+++ b/src/main/webapp/partials/instructorHelpComments.jsp
@@ -1,15 +1,11 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="editComments">Comments</a>
-</h4>
+<h4 class="text-color-primary" id="editComments">Comments</h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type:none;">
-    <li>
+    <li id="addResponseComments">
       <span class="text-bold">
-        <a name="addResponseComments">
           <h3>1. Create comments for response</h3>
-        </a>
       </span>
       <div class="row">
         <br> To create comments for response, go to the
@@ -149,11 +145,9 @@
         </div>
       </div>
     </li>
-    <li>
+    <li id="editDeleteComments">
       <span class="text-bold">
-        <a name="editDeleteComments">
           <h3>2. Edit and delete comments</h3>
-        </a>
       </span>
       <div class="row">
         <br> Go to the same page used for adding a comment, then hover the mouse upon a comment.
@@ -166,11 +160,9 @@
         <br>
       </div>
     </li>
-    <li>
+    <li id="searchComments">
       <span class="text-bold">
-        <a name="searchComments">
           <h3>3. Search for comments</h3>
-        </a>
       </span>
       <div class="row">
         <br> Go to the

--- a/src/main/webapp/partials/instructorHelpFAQ.jsp
+++ b/src/main/webapp/partials/instructorHelpFAQ.jsp
@@ -1,28 +1,20 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="faq">Frequently Asked Questions</a>
+<h4 class="text-color-primary" id="faq">
+  Frequently Asked Questions
 </h4>
 <div id="contentHolder">
   <div class="bulletPointsIndent">
     <ul>
-      <li>
-        <b>
-          <a name="faq1" id="question">
-            How do I view a list of students in a course?
-          </a>
-        </b>
+      <li id="faq1">
+        <b>How do I view a list of students in a course?</b>
         <div class="helpSectionContent">
           Go to the ‘Courses’ page, click ‘View’ for the relevant course.
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq2" id="question">
-            How do I change student details after enrolling?
-          </a>
-        </b>
+      <li id="faq2">
+        <b>How do I change student details after enrolling?</b>
         <div class="helpSectionContent">
           Choose to ‘Edit’ a student from the student list (see ‘How do I view a list of students in a course?’ given above).
           <br>
@@ -31,40 +23,32 @@
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq3" id="question">How do I add more students to a course?</a>
-        </b>
+      <li id="faq3">
+        <b>How do I add more students to a course?</b>
         <div class="helpSectionContent">
           You can use the ‘Enrol’ feature to add more students. If a student you are adding has the same email address as an existing student in the class, they will be considered the same student and the name, team name and the comment will be updated to the new values.
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq4" id="question">How do I delete students from a course?</a>
-        </b>
+      <li id="faq4">
+        <b>How do I delete students from a course?</b>
         <div class="helpSectionContent">
           The ‘Delete’ link is available from the student list (see ‘How do I view a list of students in a course?’ given above).
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq6" id="question">How do I change the Google ID associated with a student?</a>
-        </b>
+      <li id="faq5">
+        <b>How do I change the Google ID associated with a student?</b>
         <div class="helpSectionContent">
           Please contact us for assistance.
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq7" id="question">What to do if a student says his/her courses have disappeared from the system?</a>
-        </b>
+      <li id="faq6">
+        <b>What to do if a student says his/her courses have disappeared from the system?</b>
         <div class="helpSectionContent">
           The most likely reason for this is that the student has changed the primary email address associated with his/her Google ID. Please ask the student to email
           <a href="mailto:teammates@comp.nus.edu.sg">teammates@comp.nus.edu.sg</a> so that we help him to rectify the problem.
@@ -72,11 +56,8 @@
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq7a" id="question">How do I interpret/use contribution values in the results of ‘Team contribution’ type questions?</a>
-        </b>
-        <br>
+      <li id="faq7">
+        <b>How do I interpret/use contribution values in the results of ‘Team contribution’ type questions?</b>
         <div class="helpSectionContent">
           <ul>
             <li>
@@ -105,10 +86,8 @@
         </div>
       </li>
 
-      <li>
-        <b>
-          <a name="faq8" id="question">What to do if a student says he cannot submit an evaluation due to some technical glitch?</a>
-        </b>
+      <li id="faq8">
+        <b>What to do if a student says he cannot submit an evaluation due to some technical glitch?</b>
         <div class="helpSectionContent">
           Please ask the student to contact us with the details.
           <br> The ability for instructors to submit on behalf of a student is coming soon.
@@ -116,11 +95,8 @@
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq9" id="question">How come the actual contribution values entered by the student is different from the values shown in the results?
-          </a>
-        </b>
+      <li id="faq9">
+        <b>How come the actual contribution values entered by the student is different from the values shown in the results?</b>
         <div class="helpSectionContent">
           This is because the system ‘normalizes’ those values so that there is no artificial inflation of contribution. For example, if a student says everyone contributed ‘Equal share + 10%’, the system automatically normalize it to ‘Equal share’ because in reality that is what the student means.
           <br>‘Normalize’ here means scale up/down the values so that the (sum of contributions) = (
@@ -130,10 +106,8 @@
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq10" id="question">Can a student influence his ‘perceived contribution’ value by awarding himself a larger contribution?</a>
-        </b>
+      <li id="faq10">
+        <b>Can a student influence his ‘perceived contribution’ value by awarding himself a larger contribution?</b>
         <div class="helpSectionContent">
           No. The perceived contribution is calculated based on what his team members perceive as his contribution. His own opinion about his own contribution is not considered for the calculation.
           <br>
@@ -151,42 +125,32 @@
         </div>
       </li>
       <br>
-      <li>
-        <b>
-          <a name="faq11" id="question">
-            How are the contribution numbers calculated?
-          </a>
-        </b>
+      <li id="faq11">
+        <b>How are the contribution numbers calculated?</b>
         <div class="helpSectionContent">
           You can find the details of the contribution calculation scheme
           <a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.
         </div>
       </li>
       <br>
-      <li>
-        <b>
-          <a name="faq12" id="question">Is it compulsory for students to use Google accounts?</a>
-        </b>
+      <li id="faq12">
+        <b>Is it compulsory for students to use Google accounts?</b>
         <div class="helpSectionContent">
           Student can submit feedback and view results without Google accounts. TEAMMATES send unique URL for each of those. But it is more convenient for them if they use Google accounts.
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq13" id="question">What if my course doesn’t have teams?</a>
-        </b>
+      <li id="faq13">
+        <b>What if my course doesn’t have teams?</b>
         <div class="helpSectionContent">
           They can use a dummy value for the ‘Team’ column.
           <br>
           <br>
         </div>
       </li>
-      <li>
-        <b>
-          <a name="faq14" id="question">Is there a size limit for a course?</a>
-        </b>
+      <li id="faq14">
+        <b>Is there a size limit for a course?</b>
         <div class="helpSectionContent">
           No. But courses bigger than 100 students need to divide the course into sections so that TEAMMATES know how to paginate reports when the entire report is too big to show in one go.
           <br>

--- a/src/main/webapp/partials/instructorHelpGettingStarted.jsp
+++ b/src/main/webapp/partials/instructorHelpGettingStarted.jsp
@@ -1,7 +1,5 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="gs">Getting Started</a>
-</h4>
+<h4 class="text-color-primary" id="gs">Getting Started</h4>
 <div id="contentHolder">
   <br>
   <ol type="1">
@@ -423,8 +421,8 @@
       <span class="text-bold">When you need help</span>
       <div class="helpSectionContent">
         If you have a doubt or need our help, just
-        <a href="mailto:teammates@comp.nus.edu.sg">email us
-        </a>. We respond within 24 hours.
+        <a href="mailto:teammates@comp.nus.edu.sg">email us</a>.
+        We respond within 24 hours.
         <br>
         <br>
       </div>

--- a/src/main/webapp/partials/instructorHelpProfile.jsp
+++ b/src/main/webapp/partials/instructorHelpProfile.jsp
@@ -1,15 +1,11 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="profiles">Profiles</a>
-</h4>
+<h4 class="text-color-primary" id="profiles">Profiles</h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type: none;">
-    <li>
+    <li id="viewStudentProfile">
       <span class="text-bold">
-        <a name="viewStudentProfile">
           <h3>1. Viewing student profiles</h3>
-        </a>
       </span>
       <div>
         Go to the
@@ -135,11 +131,9 @@
         <br>You can press the <span class="text-muted glyphicon glyphicon-resize-full"></span> button in the top-right corner to display the information in a modal for better readability.
       </div>
     </li>
-    <li>
+    <li id="editStudentProfile">
       <span class="text-bold">
-        <a name="editStudentProfile">
           <h3>2. Editing student profiles</h3>
-        </a>
       </span>
       <div>
         Go to the

--- a/src/main/webapp/partials/instructorHelpSearch.jsp
+++ b/src/main/webapp/partials/instructorHelpSearch.jsp
@@ -1,15 +1,12 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="search">Search</a>
+<h4 class="text-color-primary" id="search">Search</a>
 </h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type: none;">
-    <li>
+    <li id="searchStudents">
       <span class="text-bold">
-        <a name="searchStudents">
           <h3>1. Searching for students</h3>
-        </a>
       </span>
       <div>
         You can search for students by clicking on
@@ -289,11 +286,9 @@
         </div>
       </div>
     </li>
-    <li>
+    <li id="searchCommentForResponses">
       <span class="text-bold">
-        <a name="searchCommentForResponses">
           <h3>2. Searching for comments on responses</h3>
-        </a>
       </span>
       <div>
         You can search for comments on responses given by students. To do this check

--- a/src/main/webapp/partials/instructorHelpSections.jsp
+++ b/src/main/webapp/partials/instructorHelpSections.jsp
@@ -1,26 +1,20 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="sections">Sections</a>
-</h4>
+<h4 class="text-color-primary" id="sections">Sections</h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type: none;">
-    <li>
+    <li id="sectionsWhatIsItMeantFor">
       <span class="text-bold">
-        <a name="sectionsWhatIsItMeantFor">
           <h3>1. What are sections meant for?</h3>
-        </a>
       </span>
       <p>
         Sections are meant for organizing students in courses with significantly large numbers of students. It is mandatory for courses with more than 100 students to organize students into sections.
         You are allowed to have sections for courses with less than 100 students, but it is not mandatory.
       </p>
     </li>
-    <li>
+    <li id="sectionsEnrollingStudents">
       <span class="text-bold">
-        <a name="sectionsEnrollingStudents">
           <h3>2. Enrolling students into sections</h3>
-        </a>
       </span>
       <p>
         You can specify the section of each student at the time of enrollment. You just have to include a
@@ -31,11 +25,9 @@
         <b>'More Info'</b> section.
       </p>
     </li>
-    <li>
+    <li id="sectionsEditing">
       <span class="text-bold">
-        <a name="sectionsEditing">
           <h3>3. Editing a student's section</h3>
-        </a>
       </span>
       <p>
         Go to the

--- a/src/main/webapp/partials/instructorHelpSessions.jsp
+++ b/src/main/webapp/partials/instructorHelpSessions.jsp
@@ -1,15 +1,11 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="sessionTypes">Sessions</a>
-</h4>
+<h4 class="text-color-primary" id="sessionTypes">Sessions</h4>
 <div id="contentHolder">
   <br>
   <ol style="list-style-type: none;">
-    <li>
+    <li id="fbSetupSession">
       <span class="text-bold">
-        <a name="fbSetupSession">
           <h3>1. Setting up a feedback session</h3>
-        </a>
       </span>
       <div class="row">
         <div class="col-lg-6">
@@ -592,11 +588,9 @@
     <br>
     <br>
     <br>
-    <li>
+    <li id="fbSetupQuestions">
       <span class="text-bold">
-        <a name="fbSetupQuestions">
           <h3>2. Setting up questions</h3>
-        </a>
       </span>
       <div>
 
@@ -1402,9 +1396,8 @@
     <br>
     <br>
     <br>
-    <li>
+    <li id="fbPreview">
       <span class="text-bold">
-        <a name="fbPreview">
           <h3>3. Previewing a session</h3>
         </a>
       </span>
@@ -1462,9 +1455,8 @@
     </li>
     <br>
     <br>
-    <li>
+    <li id="fbViewResults">
       <span class="text-bold">
-        <a name="fbViewResults">
           <h3>4. Viewing results</h3>
         </a>
       </span>
@@ -2056,9 +2048,8 @@
       <br>
       <br>
     </li>
-    <li>
+    <li id="fbQuestionTypes">
       <span class="text-bold">
-        <a name="fbQuestionTypes">
           <h3>5. Question Types</h3>
         </a>
       </span> TEAMMATES currently provides the following question types. Click to see details for each question type.
@@ -2097,9 +2088,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbEssay">
-            <h4>Essay Question</h4>
-          </a>
+            <h4 id="fbEssay">Essay Question</h4>
           Essay questions are open ended questions that allow students to give text feedback for a question.
           <br> To setup a question of this type, simply provide the question text, feedback path(giver/recipient) and visibility options.
           <br>
@@ -2416,9 +2405,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbMcq">
-            <h4>Multiple-choice (single answer) question</h4>
-          </a>
+            <h4 id="fbMcq">Multiple-choice (single answer) question</h4>
           Multiple-choice (single answer) questions allows you to specify several options, and lets students select one of them as the answer.
           <br> Other than specifying several options by yourself, TEAMMATES also supports
           <b>generating options</b> based on the list of students, teams and instructors in the course.
@@ -3432,9 +3419,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbMsq">
-            <h4>Multiple-choice (multiple answers) question</h4>
-          </a>
+            <h4 id="fbMsq">Multiple-choice (multiple answers) question</h4>
           Multiple-choice (multiple answers) question are similar to the single answer version, except that students are able to select multiple options as their response.
           <br>
           <br> The setup and result statistics is similar to the single answer version. See
@@ -3444,9 +3429,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbNumscale">
-            <h4>Numerical scale question</h4>
-          </a>
+            <h4 id="fbNumscale">Numerical scale question</h4>
           Numerical scale questions are questions that allow numerical responses from students.
           <br> To set up the question, provide the question text as well as the minimum, maximum values the student can input, as well as the increment, or precision of the number that is required.
           <br> If this sounds confusing, you can fiddle with the numbers and see what the acceptable responses are.
@@ -3977,9 +3960,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbConstSumOptions">
-            <h4>Distribute points (among options) question</h4>
-          </a>
+            <h4 id="fbConstSumOptions">Distribute points (among options) question</h4>
           Distribute points (among options) question allows you to specify some options, and allow the student to split some points among these options.
           <br> To setup the question, specify the options as well as the number of points to split among the options.
           <br>
@@ -4610,9 +4591,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbConstSumRecipients">
-            <h4>Distribute points (among recipients) question</h4>
-          </a>
+            <h4 id="fbConstSumRecipients">Distribute points (among recipients) question</h4>
           Distribute points (among recipients) question is similar to Distribute points (among options) question. For this question type, students split points among the recipients of the question.
           <br> For example, if the question recipient is set to the giver's team members, and points to distribute in total is 100, students are required to split the 100 points among his team members.
           <br>
@@ -5090,9 +5069,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbContrib">
-            <h4>Team contribution question</h4>
-          </a>
+            <h4 id="fbContrib">Team contribution question</h4>
           Team contribution questions are a specialized question type designed for team contribution evaluations.
           <br> They allow estimation of perceived contribution of a student and prevents a student from inflating his own score. To see more details about the calculation of results and other common questions, see the FAQ
           <a href="#Top">here</a>.
@@ -6132,11 +6109,10 @@
           </div>
         </div>
       </div>
+
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbRubric">
-            <h4>Rubric question</h4>
-          </a>
+            <h4 id="fbRubric">Rubric question</h4>
           Rubric questions allow instructors to create multiple sub-questions, with highly customizable choices and descriptions.
           <br>
           <br> To the student, the question looks similar to:
@@ -6930,9 +6906,7 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbRankOptions">
-            <h4>Rank Options question</h4>
-          </a>
+            <h4 id="fbRankOptions">Rank Options question</h4>
           Rank options questions are question where the students rank options that are created by you.
           <br>
 
@@ -7342,11 +7316,10 @@
           </div>
         </div>
       </div>
+
       <div class="row">
         <div class="col-sm-12">
-          <a name="fbRankRecipients">
-            <h4>Rank Recipients question</h4>
-          </a>
+            <h4 id="fbRankRecipients">Rank Recipients question</h4>
           Rank recipients questions are questions where the students are to rank students, teams, or instructors.
           <br>
           <br> The options to rank are determined by the feedback path selected for the question. You can configure if students can give the same rank multiple times.

--- a/src/main/webapp/partials/instructorHelpSessions.jsp
+++ b/src/main/webapp/partials/instructorHelpSessions.jsp
@@ -5470,7 +5470,7 @@
             </form>
           </div>
           <br> The results and statistics are presented as follows. See
-          <a href="#faq7a">here</a> on how to use these results.
+          <a href="#faq7">here</a> on how to use these results.
           <br>
           <div class="bs-example">
             <div class="panel panel-info">
@@ -5500,7 +5500,7 @@
                         </div>
                         <div class="col-sm-3 pull-right">
                           [
-                          <a href="#faq7a" target="_blank" rel="noopener noreferrer" id="interpret_help_link">How do I interpret/use these values?</a>]
+                          <a href="#faq7" target="_blank" rel="noopener noreferrer" id="interpret_help_link">How do I interpret/use these values?</a>]
                         </div>
                       </div>
                       <div class="row">

--- a/src/main/webapp/partials/instructorHelpTips.jsp
+++ b/src/main/webapp/partials/instructorHelpTips.jsp
@@ -1,7 +1,5 @@
 <%@ page pageEncoding="UTF-8" %>
-<h4>
-  <a name="tips">Tips for conducting 'team peer evaluation' sessions</a>
-</h4>
+<h4 class="text-color-primary" id="tips">Tips for conducting 'team peer evaluation' sessions</h4>
 <div id="contentHolder">
   <br>
   <p>Any evaluation system has both positive and negative effects on those being evaluated. As teachers, you are probably keen to maximize the positive effect of this system on your course while minimizing any negative effects. Here are some of the things you could do:</p>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionATeam.html
@@ -4109,7 +4109,7 @@
               </div>
               <div class="col-sm-3 pull-right">
                 [
-                <a href="/instructorHelp.jsp#faq7a" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
+                <a href="/instructorHelp.jsp#faq7" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
                   How do I interpret/use these values?
                 </a>
                 ]
@@ -6033,7 +6033,7 @@
               </div>
               <div class="col-sm-3 pull-right">
                 [
-                <a href="/instructorHelp.jsp#faq7a" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
+                <a href="/instructorHelp.jsp#faq7" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
                   How do I interpret/use these values?
                 </a>
                 ]

--- a/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
@@ -391,7 +391,7 @@
               </div>
               <div class="col-sm-3 pull-right">
                 [
-                <a href="/instructorHelp.jsp#faq7a" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
+                <a href="/instructorHelp.jsp#faq7" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
                   How do I interpret/use these values?
                 </a>
                 ]

--- a/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
@@ -9383,7 +9383,7 @@
               </div>
               <div class="col-sm-3 pull-right">
                 [
-                <a href="/instructorHelp.jsp#faq7a" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
+                <a href="/instructorHelp.jsp#faq7" id="interpret_help_link" rel="noopener noreferrer" target="_blank">
                   How do I interpret/use these values?
                 </a>
                 ]


### PR DESCRIPTION
Fixes #8190

**Outline of Solution**
- Moved link bookmarks from `<a>` tag into `<li>` or `<h>` tags where relevant to match [`studentHelp.jsp`](http://teammatesv4.appspot.com/studentHelp.jsp)

Demo can be seen [here](https://teammates-cara.appspot.com/instructorHelp.jsp)