### PR TITLE
Java: Use Java 8 Lambda expressions to replace instances of iterators. #8273

### DIFF
--- a/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
+++ b/src/client/java/teammates/client/scripts/DataBundleRegenerator.java
@@ -69,13 +69,9 @@ public final class DataBundleRegenerator {
     private static JSONObject maintainKeyOrder(JSONObject json) {
         JSONObject reprintedJson = new JSONObject();
         List<String> keys = new ArrayList<>();
-        for (Object key : json.keySet()) {
-            keys.add((String) key);
-        }
+        json.keySet().forEach((key) -> keys.add((String) key));
         keys.sort(null);
-        for (String key : keys) {
-            reprintedJson.put(key, json.get(key));
-        }
+        keys.forEach((key) -> reprintedJson.put(key, json.get(key)));
         return reprintedJson;
     }
 
@@ -92,9 +88,7 @@ public final class DataBundleRegenerator {
         String jsonString = FileHelper.readFile(file.getCanonicalPath());
         List<FeedbackQuestionAttributes> template =
                 JsonUtils.fromJson(jsonString, new TypeToken<List<FeedbackQuestionAttributes>>(){}.getType());
-        for (FeedbackQuestionAttributes question : template) {
-            fixQuestion(question);
-        }
+        template.forEach((question) -> fixQuestion(question));
         String regeneratedJsonString = JsonUtils.toJson(template).replace("+0000", "UTC");
         saveFile(file.getCanonicalPath(), regeneratedJsonString);
     }

--- a/src/client/java/teammates/client/scripts/DataGenerator.java
+++ b/src/client/java/teammates/client/scripts/DataGenerator.java
@@ -142,9 +142,7 @@ public final class DataGenerator {
         }
 
         ArrayList<String> studentEmailInCourse = new ArrayList<>();
-        for (Integer integer : studentIndexs) {
-            studentEmailInCourse.add(studentEmails.get(integer));
-        }
+        studentIndexs.forEach((integer) -> studentEmailInCourse.add(studentEmails.get(integer)));
         //=====================================================================
 
         //Add teams
@@ -186,11 +184,11 @@ public final class DataGenerator {
     private static String allAccounts() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"accounts\":{\n");
-        for (String email : studentEmails) {
+        studentEmails.forEach((email) -> {
             email = email.split("@")[0];
             outputBuilder.append('\t').append(account(email));
             outputBuilder.append(",\n");
-        }
+        });
         String output = outputBuilder.substring(0, outputBuilder.length() - 2);
         return output + "\n},";
     }
@@ -220,17 +218,14 @@ public final class DataGenerator {
      * Returns Json string presentation for all courses.
      */
     private static String allCourses() {
-        StringBuilder output = new StringBuilder(100);
-        output.append("\"courses\":{\n");
-        for (int i = 0; i < courses.size(); i++) {
-            String course = PREFIX + courses.get(i);
-
-            output.append('\t').append(course(course, "courseIdOf_" + course, "nameOf_" + course));
-            if (i != courses.size() - 1) {
-                output.append(",\n");
-            }
-        }
-        return output.append("\n},").toString();
+        StringBuilder outputBuilder = new StringBuilder(100);
+        outputBuilder.append("\"courses\":{\n");
+        courses.forEach((course) -> {
+            String newCourse = PREFIX + course;
+            outputBuilder.append('\t').append(course(newCourse, "courseIdOf_" + newCourse, "nameOf_" + newCourse)).append(",\n");
+        });
+        String output = outputBuilder.substring(0, outputBuilder.length() - 2);
+        return output + "\n},";
     }
 
     /**
@@ -239,22 +234,18 @@ public final class DataGenerator {
     private static String allStudents() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"students\":{\n");
-        for (int i = 0; i < students.size(); i++) {
-            String student = students.get(i);
+        students.forEach((student) -> {
             String index = student.split("Stu")[1].split("Team")[0];
             String team = student.split("Team")[1].split("_")[0];
             String course = PREFIX + student.split("_in_")[1];
             String email = studentEmails.get(Integer.parseInt(index));
-
             outputBuilder.append('\t')
                          .append(student(student, email, "Student " + index + " in " + course,
                                         "Team " + team, email.split("@")[0], "comment",
-                                        "courseIdOf_" + course));
-            if (i != students.size() - 1) {
-                outputBuilder.append(",\n");
-            }
-        }
-        return outputBuilder.append("\n},").toString();
+                                        "courseIdOf_" + course)).append(",\n");
+        });
+        String output = outputBuilder.substring(0, outputBuilder.length() - 2);
+        return output + "\n},";
     }
 
     private static String account(String acc) {

--- a/src/client/java/teammates/client/scripts/DataGenerator.java
+++ b/src/client/java/teammates/client/scripts/DataGenerator.java
@@ -184,11 +184,11 @@ public final class DataGenerator {
     private static String allAccounts() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"accounts\":{\n");
-        studentEmails.forEach((email) -> {
+        for (String email : studentEmails) {
             email = email.split("@")[0];
             outputBuilder.append('\t').append(account(email));
             outputBuilder.append(",\n");
-        });
+        }
         String output = outputBuilder.substring(0, outputBuilder.length() - 2);
         return output + "\n},";
     }
@@ -220,10 +220,11 @@ public final class DataGenerator {
     private static String allCourses() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"courses\":{\n");
-        courses.forEach((course) -> {
+        for (String course : courses) {
             String newCourse = PREFIX + course;
-            outputBuilder.append('\t').append(course(newCourse, "courseIdOf_" + newCourse, "nameOf_" + newCourse)).append(",\n");
-        });
+            outputBuilder.append('\t').append(course(newCourse, "courseIdOf_" + newCourse, "nameOf_" + newCourse));
+            outputBuilder.append(",\n");
+        }
         String output = outputBuilder.substring(0, outputBuilder.length() - 2);
         return output + "\n},";
     }
@@ -234,7 +235,7 @@ public final class DataGenerator {
     private static String allStudents() {
         StringBuilder outputBuilder = new StringBuilder(100);
         outputBuilder.append("\"students\":{\n");
-        students.forEach((student) -> {
+        for (String student : students) {
             String index = student.split("Stu")[1].split("Team")[0];
             String team = student.split("Team")[1].split("_")[0];
             String course = PREFIX + student.split("_in_")[1];
@@ -243,7 +244,7 @@ public final class DataGenerator {
                          .append(student(student, email, "Student " + index + " in " + course,
                                         "Team " + team, email.split("@")[0], "comment",
                                         "courseIdOf_" + course)).append(",\n");
-        });
+        }
         String output = outputBuilder.substring(0, outputBuilder.length() - 2);
         return output + "\n},";
     }

--- a/src/client/java/teammates/client/scripts/DataMigrationForResponseRate.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForResponseRate.java
@@ -51,27 +51,18 @@ public class DataMigrationForResponseRate extends RemoteApiClient {
                          ? getFeedbackSessionsWithZeroResponseRate()
                          : fsDb.getAllFeedbackSessions();
 
-        for (FeedbackSessionAttributes session : feedbackSessions) {
-            updateRespondentsForSession(session.getFeedbackSessionName(), session.getCourseId());
-        }
+        feedbackSessions.forEach((session) -> updateRespondentsForSession(
+                session.getFeedbackSessionName(), session.getCourseId()));
     }
 
     private List<FeedbackSessionAttributes> getFeedbackSessionsWithZeroResponseRate() {
         @SuppressWarnings("deprecation")
         List<FeedbackSessionAttributes> feedbackSessions = fsDb.getAllFeedbackSessions();
-
-        List<FeedbackSessionAttributes> feedbackSessionsWithNoRespondents = new ArrayList<>();
-
-        for (FeedbackSessionAttributes feedbackSession : feedbackSessions) {
-            if (feedbackSession.getRespondingStudentList().size() != 0
-                    || feedbackSession.getRespondingInstructorList().size() != 0) {
-                continue;
-            }
-
-            feedbackSessionsWithNoRespondents.add(feedbackSession);
-        }
-
-        return feedbackSessionsWithNoRespondents;
+        
+        feedbackSessions.removeIf((feedbackSession) -> feedbackSession.getRespondingStudentList().size() != 0
+                                                 || feedbackSession.getRespondingInstructorList().size() != 0);
+        
+        return feedbackSessions;
     }
 
     /* Operation for a specific session */

--- a/src/client/java/teammates/client/scripts/DataMigrationForResponseRate.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForResponseRate.java
@@ -1,7 +1,6 @@
 package teammates.client.scripts;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import teammates.client.remoteapi.RemoteApiClient;
@@ -58,10 +57,10 @@ public class DataMigrationForResponseRate extends RemoteApiClient {
     private List<FeedbackSessionAttributes> getFeedbackSessionsWithZeroResponseRate() {
         @SuppressWarnings("deprecation")
         List<FeedbackSessionAttributes> feedbackSessions = fsDb.getAllFeedbackSessions();
-        
+
         feedbackSessions.removeIf((feedbackSession) -> feedbackSession.getRespondingStudentList().size() != 0
                                                  || feedbackSession.getRespondingInstructorList().size() != 0);
-        
+
         return feedbackSessions;
     }
 

--- a/src/client/java/teammates/client/scripts/DataMigrationForSearchableInstructors.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSearchableInstructors.java
@@ -19,9 +19,7 @@ public class DataMigrationForSearchableInstructors extends RemoteApiClient {
     @Override
     protected void doOperation() {
         List<InstructorAttributes> allInstructors = getAllInstructors();
-        for (InstructorAttributes instructor : allInstructors) {
-            updateDocumentForInstructor(instructor);
-        }
+        allInstructors.forEach((instructor) -> updateDocumentForInstructor(instructor));
     }
 
     @SuppressWarnings("deprecation")

--- a/src/client/java/teammates/client/scripts/DataMigrationForSearchableStudents.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSearchableStudents.java
@@ -19,9 +19,7 @@ public class DataMigrationForSearchableStudents extends RemoteApiClient {
     @Override
     protected void doOperation() {
         List<StudentAttributes> allStudents = getAllStudents();
-        for (StudentAttributes student : allStudents) {
-            updateDocumentForStudent(student);
-        }
+        allStudents.forEach((student) -> updateDocumentForStudent(student));
     }
 
     private List<StudentAttributes> getAllStudents() {

--- a/src/client/java/teammates/client/scripts/ModifyInstituteOfStudentsInCourse.java
+++ b/src/client/java/teammates/client/scripts/ModifyInstituteOfStudentsInCourse.java
@@ -28,13 +28,9 @@ public class ModifyInstituteOfStudentsInCourse extends RemoteApiClient {
 
         try {
             List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
-
+            students.removeIf((student) -> student.googleId == null || student.googleId.isEmpty());
+            
             for (StudentAttributes student : students) {
-
-                //Account might be null if student was enrolled but not joined yet
-                if (student.googleId == null || student.googleId.isEmpty()) {
-                    continue;
-                }
 
                 AccountAttributes account = logic.getAccount(student.googleId);
 

--- a/src/client/java/teammates/client/scripts/ModifyInstituteOfStudentsInCourse.java
+++ b/src/client/java/teammates/client/scripts/ModifyInstituteOfStudentsInCourse.java
@@ -29,7 +29,7 @@ public class ModifyInstituteOfStudentsInCourse extends RemoteApiClient {
         try {
             List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
             students.removeIf((student) -> student.googleId == null || student.googleId.isEmpty());
-            
+
             for (StudentAttributes student : students) {
 
                 AccountAttributes account = logic.getAccount(student.googleId);

--- a/src/client/java/teammates/client/scripts/OfflineBackup.java
+++ b/src/client/java/teammates/client/scripts/OfflineBackup.java
@@ -13,7 +13,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -83,14 +82,10 @@ public class OfflineBackup extends RemoteApiClient {
     private Set<String> extractModifiedCourseIds(List<String> modifiedLogs) {
 
         //Extracts the course Ids to be backup from the logs
+        List<String> newModifiedLogs = new ArrayList<>(modifiedLogs);
         Set<String> courses = new HashSet<>();
-        for (String course : modifiedLogs) {
-            course = course.trim();
-            if (!course.isEmpty()) {
-                courses.add(course);
-            }
-
-        }
+        newModifiedLogs.removeIf((course) -> course.trim().isEmpty());
+        newModifiedLogs.forEach((course) -> courses.add(course.trim()));
         return courses;
     }
 
@@ -122,10 +117,7 @@ public class OfflineBackup extends RemoteApiClient {
      */
     protected void retrieveEntitiesByCourse(Set<String> coursesList) {
 
-        Iterator<String> it = coursesList.iterator();
-
-        while (it.hasNext()) {
-            String courseId = it.next();
+        coursesList.forEach((courseId) -> {
             currentFileName = backupFileDirectory + "/" + courseId + ".json";
             appendToFile(currentFileName, "{\n");
 
@@ -140,7 +132,7 @@ public class OfflineBackup extends RemoteApiClient {
             retrieveAndSaveStudentProfilesByCourse(courseId);
 
             appendToFile(currentFileName, "\n}");
-        }
+        });
     }
 
     /**
@@ -154,13 +146,8 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"accounts\":{\n");
 
-        for (StudentAttributes student : students) {
-            saveStudentAccount(student);
-        }
-
-        for (InstructorAttributes instructor : instructors) {
-            saveInstructorAccount(instructor);
-        }
+        students.forEach((student) -> saveStudentAccount(student));
+        instructors.forEach((instructor) -> saveInstructorAccount(instructor));
 
         appendToFile(currentFileName, "\n\t},\n");
         hasPreviousEntity = false;
@@ -194,9 +181,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"feedbackQuestions\":{\n");
 
-        for (FeedbackQuestionAttributes feedbackQuestion : feedbackQuestions) {
-            saveFeedbackQuestion(feedbackQuestion);
-        }
+        feedbackQuestions.forEach((feedbackQuestion) -> saveFeedbackQuestion(feedbackQuestion));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -211,9 +196,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"feedbackResponses\":{\n");
 
-        for (FeedbackResponseAttributes feedbackResponse : feedbackResponses) {
-            saveFeedbackResponse(feedbackResponse);
-        }
+        feedbackResponses.forEach((feedbackResponse) -> saveFeedbackResponse(feedbackResponse));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -229,9 +212,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"feedbackResponseComments\":{\n");
 
-        for (FeedbackResponseCommentAttributes feedbackResponseComment : feedbackResponseComments) {
-            saveFeedbackResponseComment(feedbackResponseComment);
-        }
+        feedbackResponseComments.forEach((feedbackResponseComment) -> saveFeedbackResponseComment(feedbackResponseComment));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -245,9 +226,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"feedbackSessions\":{\n");
 
-        for (FeedbackSessionAttributes feedbackSession : feedbackSessions) {
-            saveFeedbackSession(feedbackSession);
-        }
+        feedbackSessions.forEach((feedbackSession) -> saveFeedbackSession(feedbackSession));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -261,9 +240,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"instructors\":{\n");
 
-        for (InstructorAttributes instructor : instructors) {
-            saveInstructor(instructor);
-        }
+        instructors.forEach((instructor) -> saveInstructor(instructor));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -277,9 +254,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"students\":{\n");
 
-        for (StudentAttributes student : students) {
-            saveStudent(student);
-        }
+        students.forEach((student)-> saveStudent(student));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -293,16 +268,11 @@ public class OfflineBackup extends RemoteApiClient {
         List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
 
         appendToFile(currentFileName, "\t\"profiles\":{\n");
-
-        for (StudentAttributes student : students) {
-            if (student != null && student.googleId != null && !student.googleId.isEmpty()) {
-                StudentProfileAttributes profile = logic.getStudentProfile(student.googleId);
-                if (profile != null) {
-                    saveProfile(profile);
-                }
-            }
-        }
-
+        
+        students.removeIf((student) -> student == null || student.googleId == null ||
+                student.googleId.isEmpty() || logic.getStudentProfile(student.googleId) == null);
+        students.forEach((student) -> saveProfile(logic.getStudentProfile(student.googleId)));
+        
         appendToFile(currentFileName, "\n\t}\n");
         hasPreviousEntity = false;
     }

--- a/src/client/java/teammates/client/scripts/OfflineBackup.java
+++ b/src/client/java/teammates/client/scripts/OfflineBackup.java
@@ -254,7 +254,7 @@ public class OfflineBackup extends RemoteApiClient {
 
         appendToFile(currentFileName, "\t\"students\":{\n");
 
-        students.forEach((student)-> saveStudent(student));
+        students.forEach((student) -> saveStudent(student));
         hasPreviousEntity = false;
         appendToFile(currentFileName, "\n\t},\n");
     }
@@ -268,11 +268,9 @@ public class OfflineBackup extends RemoteApiClient {
         List<StudentAttributes> students = logic.getStudentsForCourse(courseId);
 
         appendToFile(currentFileName, "\t\"profiles\":{\n");
-        
-        students.removeIf((student) -> student == null || student.googleId == null ||
-                student.googleId.isEmpty() || logic.getStudentProfile(student.googleId) == null);
+        students.removeIf((student) -> student == null || student.googleId == null
+                || student.googleId.isEmpty() || logic.getStudentProfile(student.googleId) == null);
         students.forEach((student) -> saveProfile(logic.getStudentProfile(student.googleId)));
-        
         appendToFile(currentFileName, "\n\t}\n");
         hasPreviousEntity = false;
     }

--- a/src/client/java/teammates/client/scripts/PerformanceProfiler.java
+++ b/src/client/java/teammates/client/scripts/PerformanceProfiler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 
 import teammates.common.datatransfer.DataBundle;
-import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.JsonUtils;
@@ -555,7 +554,8 @@ public class PerformanceProfiler extends Thread {
     @PerformanceTest(name = "BD Delete Course")
     public String deleteCourse() {
         StringBuilder status = new StringBuilder();
-        data.courses.keySet().forEach((courseKey) -> status.append(' ').append(BackDoor.deleteCourse(data.courses.get(courseKey).getId())));
+        data.courses.keySet().forEach((courseKey) ->
+                status.append(' ').append(BackDoor.deleteCourse(data.courses.get(courseKey).getId())));
         return status.toString();
     }
 

--- a/src/client/java/teammates/client/scripts/PerformanceProfiler.java
+++ b/src/client/java/teammates/client/scripts/PerformanceProfiler.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,10 +198,7 @@ public class PerformanceProfiler extends Thread {
             String[] durations = strs[2].split("\\,");
 
             ArrayList<Float> arr = new ArrayList<>();
-            for (String str : durations) {
-                Float f = Float.parseFloat(str);
-                arr.add(f);
-            }
+            Arrays.stream(durations).forEach((str) -> arr.add(Float.parseFloat(str)));
             results.put(testName, arr);
         }
         br.close();
@@ -212,9 +210,7 @@ public class PerformanceProfiler extends Thread {
      */
     private void printResult(String filePath) throws IOException {
         List<String> list = new ArrayList<>();
-        for (String str : results.keySet()) {
-            list.add(str);
-        }
+        list.addAll(results.keySet());
         list.sort(null);
         FileWriter fstream = new FileWriter(filePath);
         BufferedWriter out = new BufferedWriter(fstream);
@@ -559,11 +555,7 @@ public class PerformanceProfiler extends Thread {
     @PerformanceTest(name = "BD Delete Course")
     public String deleteCourse() {
         StringBuilder status = new StringBuilder();
-        Set<String> set = data.courses.keySet();
-        for (String courseKey : set) {
-            CourseAttributes course = data.courses.get(courseKey);
-            status.append(' ').append(BackDoor.deleteCourse(course.getId()));
-        }
+        data.courses.keySet().forEach((courseKey) -> status.append(' ').append(BackDoor.deleteCourse(data.courses.get(courseKey).getId())));
         return status.toString();
     }
 

--- a/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
+++ b/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
@@ -206,12 +206,11 @@ public class StatisticsPerInstitute extends RemoteApiClient {
 
     private List<Instructor> getInstructorsOfCourse(List<Instructor> allInstructors, String courseId) {
         List<Instructor> instructorsOfCourse = new ArrayList<>();
-        for (Instructor instructor : allInstructors) {
-            if (instructor.getCourseId().equals(courseId)) {
-                instructorsOfCourse.add(instructor);
-            }
-        }
+        List<Instructor> newAllInstructors = new ArrayList<>(allInstructors);
 
+        newAllInstructors.removeIf((instructor) -> !instructor.getCourseId().equals(courseId));
+        newAllInstructors.forEach((instructor) -> instructorsOfCourse.add(instructor));
+        
         return instructorsOfCourse;
     }
 

--- a/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
+++ b/src/client/java/teammates/client/scripts/StatisticsPerInstitute.java
@@ -210,7 +210,7 @@ public class StatisticsPerInstitute extends RemoteApiClient {
 
         newAllInstructors.removeIf((instructor) -> !instructor.getCourseId().equals(courseId));
         newAllInstructors.forEach((instructor) -> instructorsOfCourse.add(instructor));
-        
+
         return instructorsOfCourse;
     }
 

--- a/src/client/java/teammates/client/scripts/UploadBackupData.java
+++ b/src/client/java/teammates/client/scripts/UploadBackupData.java
@@ -78,11 +78,7 @@ public class UploadBackupData extends RemoteApiClient {
     @Override
     protected void doOperation() {
         String[] folders = getFolders();
-
-        for (String folder : folders) {
-            String[] backupFiles = getBackupFilesInFolder(folder);
-            uploadData(backupFiles, folder);
-        }
+        Arrays.stream(folders).forEach((folder) -> uploadData(getBackupFilesInFolder(folder), folder));
     }
 
     private static String[] getFolders() {
@@ -222,10 +218,7 @@ public class UploadBackupData extends RemoteApiClient {
 
         try {
             fqDb.createFeedbackQuestions(questions.values());
-
-            for (FeedbackQuestionAttributes question : questions.values()) {
-                feedbackQuestionsPersisted.put(question.getId(), question);
-            }
+            questions.values().forEach((question) -> feedbackQuestionsPersisted.put(question.getId(), question));
 
         } catch (InvalidParametersException e) {
             System.out.println("Error in uploading feedback questions: " + e.getMessage());
@@ -236,9 +229,7 @@ public class UploadBackupData extends RemoteApiClient {
         Map<String, FeedbackResponseAttributes> responses = map;
 
         try {
-            for (FeedbackResponseAttributes response : responses.values()) {
-                adjustFeedbackResponseId(response);
-            }
+            responses.values().forEach((response) -> adjustFeedbackResponseId(response));
 
             frDb.createFeedbackResponses(responses.values());
         } catch (InvalidParametersException e) {
@@ -250,9 +241,7 @@ public class UploadBackupData extends RemoteApiClient {
         Map<String, FeedbackResponseCommentAttributes> responseComments = map;
 
         try {
-            for (FeedbackResponseCommentAttributes responseComment : responseComments.values()) {
-                adjustFeedbackResponseCommentId(responseComment);
-            }
+            responseComments.values().forEach((responseComment) -> adjustFeedbackResponseCommentId(responseComment));
 
             fcDb.createFeedbackResponseComments(responseComments.values());
         } catch (InvalidParametersException e) {


### PR DESCRIPTION
Fixes #8273 

I worked on package **teammates.client.scripts** and replaced iterator instances and for loops by Java 8 lambda expressions to reduce dependency on Iterators and to also reduce the written lines of code. I am still working on other packages.