### PR TITLE
Add missing label number to instructor help page #8317

### DIFF
--- a/src/main/webapp/partials/instructorHelpGettingStarted.jsp
+++ b/src/main/webapp/partials/instructorHelpGettingStarted.jsp
@@ -65,6 +65,8 @@
         </div>
       </div>
       <br>
+    </li>
+    <li>
       <span class="text-bold">Adding more instructors</span>
       <div class="helpSectionContent">
         More instructors (e.g. tutors) can be added to a course by going to the ‘edit’ link of the course.


### PR DESCRIPTION
Fixes #8317

Added the missing label number in the instructor help page.


![screen shot 2018-01-20 at 11 41 51 am](https://user-images.githubusercontent.com/4986717/35179565-ad9e870e-fdd7-11e7-8c96-1f2364fc45ba.png)
