### PR TITLE
Fix AppVeyor failure due to Guava version #8324

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ def jsoupVersion = "1.10.3"
 def checkstyleVersion = "8.7"
 def pmdVersion = "5.8.1"
 def findbugsVersion = "3.0.1"
+def guavaVersion = "22.0"
 
 buildscript {
     repositories {
@@ -45,7 +46,7 @@ configurations.all {
             // not been released as of the time of writing. Once the new version (>1.23.0) is released,
             // we can update the `google-api-client` dependency and remove this block of code.
             if (details.requested.group == 'com.google.guava' && details.requested.name == 'guava-jdk5') {
-                details.useTarget 'com.google.guava:guava:23.5-jre'
+                details.useTarget 'com.google.guava:guava:${guavaVersion}'
             }
         }
     }
@@ -64,7 +65,7 @@ dependencies {
     compile         "com.google.appengine:appengine-api-1.0-sdk:${appengineVersion}",
                     "com.google.appengine.tools:appengine-gcs-client:0.7",
                     "com.google.code.gson:gson:2.8.2",
-                    "com.google.guava:guava:23.5-jre",
+                    "com.google.guava:guava:${guavaVersion}",
                     "com.googlecode.objectify:objectify:5.1.21",
                     "com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20171016.1",
                     "com.mailjet:mailjet-client:4.1.1",


### PR DESCRIPTION
Fixes #8324 

- [Guava 22.0 works](https://ci.appveyor.com/project/wkurniawan07/repo/build/1.0.184). It still fails but the failures are those from months back.
- [Guava 23.0 does not work](https://ci.appveyor.com/project/wkurniawan07/repo/build/1.0.183).