### PR TITLE
Instructor: discard edit question button: sometimes button does not work #8329

### DIFF
--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -1171,7 +1171,7 @@ $(document).ready(() => {
     });
 
     $(document).on('click', '.btn-discard-changes', (e) => {
-        discardChanges($(e.target).data('qnnumber'));
+        discardChanges($(e.currentTarget).data('qnnumber'));
     });
 
     $(document).on('click', '.btn-edit-qn', (e) => {


### PR DESCRIPTION
Fixes #8329 

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

Similar to #8148 `discard` button does not work if user points the mouse to the glyphicon instead of the word `discard`. Fix by replacing `event.target` with `event.currentTarget` to capture the correct element when the event is triggered by a child element.
