### PR TITLE
Fix Checkstyle configuration

### DIFF
--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -169,11 +169,11 @@
       <property name="illegalPkgs" value="sun,com.google.appengine.repackaged,com.google.appengine.labs.repackaged"/>
     </module>
     <module name="NoLineWrap"/>
-    <module name="SuppressionCommentFilter">
-      <property name="offCommentFormat" value="CHECKSTYLE\.OFF:([A-Za-z\|]+)"/>
-      <property name="onCommentFormat" value="CHECKSTYLE\.ON:([A-Za-z\|]+)"/>
-      <property name="checkFormat" value="$1"/>
-    </module>
+  </module>
+  <module name="SuppressionCommentFilter">
+    <property name="offCommentFormat" value="CHECKSTYLE\.OFF:([A-Za-z\|]+)"/>
+    <property name="onCommentFormat" value="CHECKSTYLE\.ON:([A-Za-z\|]+)"/>
+    <property name="checkFormat" value="$1"/>
   </module>
   <module name="SuppressionFilter">
     <property name="file" value="${basedir}/static-analysis/teammates-checkstyle-suppressions.xml"/>


### PR DESCRIPTION
IntelliJ has been giving me this error message:

```
The Checkstyle rules file could not be parsed.
cannot initialize module TreeWalker - TreeWalker is not allowed as a parent of SuppressionCommentFilter
```

and the Checkstyle plugin does not work at all.

Googling finds [this answer](https://stackoverflow.com/questions/17343018/eclipse-checkstyle-error-cannot-initialize-module-treewalker-treewalker-is-not#17349110), so I correct the Checkstyle configuration file as suggested in there.