### PR TITLE
Fix missing group for build script task `setupIntellijStaticAnalysis` #8350

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -298,6 +298,7 @@ task copyIntelliJProjectPluginsSettings(type: Copy) {
 
 task setupIntellijStaticAnalysis {
     description 'Sets up the static analysis plugins in the IntelliJ project.'
+    group intellijSetupGroup
     dependsOn copyStylelintConfiguration, copyIntelliJProjectPluginsSettings
 }
 


### PR DESCRIPTION
Fixes #8350