### PR TITLE
StudentProfilePageUiTest failing on live server #8393

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/BaseUiTestCase.java
+++ b/src/test/java/teammates/test/cases/browsertests/BaseUiTestCase.java
@@ -132,7 +132,7 @@ public abstract class BaseUiTestCase extends BaseTestCaseWithBackDoorApiAccess {
     /**
      * Logs in a page as an instructor.
      */
-    protected <T extends AppPage> T loginInstructorToPage(String instructorId, AppUrl url, Class<T> typeOfPage) {
+    protected <T extends AppPage> T loginInstructorToPage(String instructorGoogleId, String password, AppUrl url, Class<T> typeOfPage) {
         //logout
         logout();
 
@@ -141,7 +141,7 @@ public abstract class BaseUiTestCase extends BaseTestCaseWithBackDoorApiAccess {
 
         //login based on the login page type
         LoginPage loginPage = AppPage.createCorrectLoginPageType(browser);
-        loginPage.loginAsInstructor(instructorId, TestProperties.TEST_INSTRUCTOR_PASSWORD, typeOfPage);
+        loginPage.loginAsInstructor(instructorGoogleId, password, typeOfPage);
 
         //After login, the browser will redirect to the original page requested
         return AppPage.getNewPageInstance(browser, typeOfPage);

--- a/src/test/java/teammates/test/cases/browsertests/BaseUiTestCase.java
+++ b/src/test/java/teammates/test/cases/browsertests/BaseUiTestCase.java
@@ -132,7 +132,8 @@ public abstract class BaseUiTestCase extends BaseTestCaseWithBackDoorApiAccess {
     /**
      * Logs in a page as an instructor.
      */
-    protected <T extends AppPage> T loginInstructorToPage(String instructorGoogleId, String password, AppUrl url, Class<T> typeOfPage) {
+    protected <T extends AppPage> T loginInstructorToPage(String instructorGoogleId, String password,
+            AppUrl url, Class<T> typeOfPage) {
         //logout
         logout();
 

--- a/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
@@ -30,6 +30,15 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
     protected void prepareTestData() {
         testData = loadDataBundle("/StudentProfilePageUiTest.json");
 
+        // inject the 1st student account as student of the course where instructor is only the helper
+        String student1GoogleId = TestProperties.TEST_STUDENT1_ACCOUNT;
+        String student1Email = student1GoogleId + "@gmail.com";
+        testData.accounts.get("studentForHelperCourse").googleId = student1GoogleId;
+        testData.accounts.get("studentForHelperCourse").email = student1Email;
+        testData.accounts.get("studentForHelperCourse").studentProfile.googleId = student1GoogleId;
+        testData.students.get("studentForHelperCourse").googleId = student1GoogleId;
+        testData.students.get("studentForHelperCourse").email = student1Email;
+
         // use the 2nd student account injected for this test
 
         String student2GoogleId = TestProperties.TEST_STUDENT2_ACCOUNT;
@@ -39,6 +48,16 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
         testData.accounts.get("studentWithExistingProfile").studentProfile.googleId = student2GoogleId;
         testData.students.get("studentWithExistingProfile").googleId = student2GoogleId;
         testData.students.get("studentWithExistingProfile").email = student2Email;
+
+        // also inject instructor account for this test
+        String instructorGoogleId = TestProperties.TEST_INSTRUCTOR_ACCOUNT;
+        String instructorEmail = instructorGoogleId + "@gmail.com";
+        testData.accounts.get("SHomeUiT.instr").googleId = instructorGoogleId;
+        testData.accounts.get("SHomeUiT.instr").email = instructorEmail;
+        testData.instructors.get("SHomeUiT.instr.CS2104").googleId = instructorGoogleId;
+        testData.instructors.get("SHomeUiT.instr.CS2104").email = instructorEmail;
+        testData.instructors.get("SHomeUiT.instr.CS2103").googleId = instructorGoogleId;
+        testData.instructors.get("SHomeUiT.instr.CS2103").email = instructorEmail;
 
         removeAndRestoreDataBundle(testData);
     }
@@ -244,7 +263,7 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
     private void testAjaxPictureUrl() {
         String studentId = "studentWithExistingProfile";
         String instructorId = "SHomeUiT.instr";
-        String helperId = "SHomeUiT.helper";
+        String instructorGoogleId = testData.accounts.get(instructorId).googleId;
         String studentGoogleId = testData.accounts.get("studentWithExistingProfile").googleId;
         String currentPictureKey = BackDoor.getStudentProfile(studentGoogleId).pictureKey;
         String email = testData.students.get("studentWithExistingProfile").email;
@@ -270,23 +289,31 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
 
         ______TS("Typical case: with email and course");
 
-        getProfilePicturePage(instructorId, email, courseId, StudentProfilePicturePage.class).verifyHasPicture();
+        getProfilePicturePage(instructorGoogleId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
+                email, courseId, StudentProfilePicturePage.class).verifyHasPicture();
 
         ______TS("Failure case: instructor does not have privilege");
 
-        getProfilePicturePage(helperId, email, courseId, NotAuthorizedPage.class);
+        String emailStudentForHelperCourse = testData.students.get("studentForHelperCourse").email;
+        String courseIdHelperCourse = testData.students.get("studentForHelperCourse").course;
+
+        emailStudentForHelperCourse = StringHelper.encrypt(emailStudentForHelperCourse);
+        courseIdHelperCourse = StringHelper.encrypt(courseIdHelperCourse);
+        getProfilePicturePage(instructorGoogleId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
+                emailStudentForHelperCourse, courseIdHelperCourse, NotAuthorizedPage.class);
 
         ______TS("Failure case: non-existent student");
 
-        getProfilePicturePage(instructorId, invalidEmail, courseId, EntityNotFoundPage.class);
+        getProfilePicturePage(instructorId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
+                invalidEmail, courseId, EntityNotFoundPage.class);
     }
 
-    private <T extends AppPage> T getProfilePicturePage(String instructorId, String email, String courseId,
-                                                        Class<T> typeOfPage) {
+    private <T extends AppPage> T getProfilePicturePage(String instructorGoogleId, String password, String email, String courseId,
+            Class<T> typeOfPage) {
         AppUrl profileUrl = createUrl(Const.ActionURIs.STUDENT_PROFILE_PICTURE)
                                    .withParam(Const.ParamsNames.STUDENT_EMAIL, email)
                                    .withParam(Const.ParamsNames.COURSE_ID, courseId);
-        return loginInstructorToPage(instructorId, profileUrl, typeOfPage);
+        return loginInstructorToPage(instructorGoogleId, password, profileUrl, typeOfPage);
     }
 
     private <T extends AppPage> T getProfilePicturePage(String studentId, String pictureKey, Class<T> typeOfPage) {

--- a/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
@@ -294,13 +294,13 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
 
         ______TS("Failure case: instructor does not have privilege");
 
-        String emailStudentForHelperCourse = testData.students.get("studentForHelperCourse").email;
-        String courseIdHelperCourse = testData.students.get("studentForHelperCourse").course;
+        String studentForHelperCourseEmail = testData.students.get("studentForHelperCourse").email;
+        String helperCourseId = testData.students.get("studentForHelperCourse").course;
 
-        emailStudentForHelperCourse = StringHelper.encrypt(emailStudentForHelperCourse);
-        courseIdHelperCourse = StringHelper.encrypt(courseIdHelperCourse);
+        studentForHelperCourseEmail = StringHelper.encrypt(studentForHelperCourseEmail);
+        helperCourseId = StringHelper.encrypt(helperCourseId);
         getProfilePicturePage(instructorGoogleId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
-                emailStudentForHelperCourse, courseIdHelperCourse, NotAuthorizedPage.class);
+                studentForHelperCourseEmail, helperCourseId, NotAuthorizedPage.class);
 
         ______TS("Failure case: non-existent student");
 

--- a/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
@@ -308,8 +308,8 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
                 invalidEmail, courseId, EntityNotFoundPage.class);
     }
 
-    private <T extends AppPage> T getProfilePicturePage(String instructorGoogleId, String password, String email, String courseId,
-            Class<T> typeOfPage) {
+    private <T extends AppPage> T getProfilePicturePage(String instructorGoogleId, String password,
+            String email, String courseId, Class<T> typeOfPage) {
         AppUrl profileUrl = createUrl(Const.ActionURIs.STUDENT_PROFILE_PICTURE)
                                    .withParam(Const.ParamsNames.STUDENT_EMAIL, email)
                                    .withParam(Const.ParamsNames.COURSE_ID, courseId);

--- a/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentProfilePageUiTest.java
@@ -304,7 +304,7 @@ public class StudentProfilePageUiTest extends BaseUiTestCase {
 
         ______TS("Failure case: non-existent student");
 
-        getProfilePicturePage(instructorId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
+        getProfilePicturePage(instructorGoogleId, TestProperties.TEST_INSTRUCTOR_PASSWORD,
                 invalidEmail, courseId, EntityNotFoundPage.class);
     }
 

--- a/src/test/resources/data/StudentProfilePageUiTest.json
+++ b/src/test/resources/data/StudentProfilePageUiTest.json
@@ -1,10 +1,10 @@
 {
   "accounts": {
     "SHomeUiT.instr": {
-      "googleId": "SHomeUiT.instr",
+      "googleId": "${value.injected.in.testfile}",
       "name": "Teammates Test",
       "isInstructor": true,
-      "email": "SHomeUiT.instr@gmail.tmt",
+      "email": "${value.injected.in.testfile}",
       "institute": "TEAMMATES Test Institute 1"
     },
     "SHomeUiT.helper": {
@@ -28,6 +28,23 @@
         "nationality": "Singaporean",
         "gender": "male",
         "moreInfo": "I am just another student :P",
+        "pictureKey": ""
+      }
+    },
+    "studentForHelperCourse": {
+      "googleId": "${value.injected.in.testfile}",
+      "name": "Ash Ketchum",
+      "isInstructor": false,
+      "email": "${value.injected.in.testfile}",
+      "institute": "TEAMMATES Test Institute 7",
+      "studentProfile": {
+        "googleId": "${value.injected.in.testfile}",
+        "shortName": "Ash",
+        "email": "ash.ketchum@pokemon.com",
+        "institute": "TEAMMATES Test Institute 4",
+        "nationality": "Singaporean",
+        "gender": "male",
+        "moreInfo": "Gotta catch 'em all!",
         "pictureKey": ""
       }
     },
@@ -69,6 +86,11 @@
       "name": "Programming Language Concepts",
       "timeZone": "UTC"
     },
+    "SHomeUiT.CS2103": {
+      "id": "SHomeUiT.CS2103",
+      "name": "Software Engineering",
+      "timeZone": "UTC"
+    },
     "testingSanitizationCourse": {
       "createdAt": "2012-04-01 11:58 PM UTC",
       "id": "SHomeUiT.sanitizationCourse",
@@ -78,17 +100,17 @@
   },
   "instructors": {
     "SHomeUiT.instr.CS2104": {
-      "googleId": "SHomeUiT.instr",
+      "googleId": "${value.injected.in.testfile}",
       "courseId": "SHomeUiT.CS2104",
       "name": "Teammates Test",
-      "email": "SHomeUiT.instr@gmail.tmt",
+      "email": "${value.injected.in.testfile}",
       "isDisplayedToStudents": false
     },
-    "SHomeUiT.helper.CS2104": {
-      "googleId": "SHomeUiT.helper",
-      "courseId": "SHomeUiT.CS2104",
+    "SHomeUiT.instr.CS2103": {
+      "googleId": "${value.injected.in.testfile}",
+      "courseId": "SHomeUiT.CS2103",
       "name": "Teammates Test Helper",
-      "email": "SHomeUiT.helper@gmail.tmt",
+      "email": "${value.injected.in.testfile}",
       "isDisplayedToStudents": false,
       "privileges": {
         "courseLevel": {
@@ -137,6 +159,14 @@
       "course": "SHomeUiT.CS2104",
       "name": "Benny C",
       "comments": "This student's name is BC",
+      "team": "Team 1"
+    },
+    "studentForHelperCourse": {
+      "googleId": "${value.injected.in.testfile}",
+      "email": "${value.injected.in.testfile}",
+      "course": "SHomeUiT.CS2103",
+      "name": "Ash Ketchum",
+      "comments": "This student's name is AK",
       "team": "Team 1"
     },
     "SHomeUiT.benny.c@SHomeUiT.CS2104": {


### PR DESCRIPTION
Fixes #8393

**Outline of Solution**

As discussed in #8323, this PR fixes the `StudentProfilePageUiTest` class to use the instructor account with Google-Id correctly. Additionally, the test logic is also modified. To test the case when instructor does not have view-student-picture privilege (instructor is just a helper), a new course is created and the instructor lacks the privilege in this course.
