### PR TITLE
ide-setup.md: Typo under text encoding: change HTML to XML #8397

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -58,7 +58,7 @@ Supported Eclipse versions: [Eclipse IDE for Java EE Developers version Neon or 
      * HTML: `Web → HTML Files → Encoding`. Alternatively, tick `Use workspace encoding`.
      * CSS: `Web → CSS Files → Encoding`.
      * JSP: `Web → JSP Files → Encoding`.
-     * HTML: `XML → XML Files → Encoding`.
+     * XML: `XML → XML Files → Encoding`.
 
    * JDK: `Java Build Path → Libraries` → ensure that the system library used is JDK 8.
 


### PR DESCRIPTION
Fixes #8397

Fix typo, changing HTML tag for XML.
