### PR TITLE
FeedbackSession: repurpose legacy timeZone field #8410

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -61,7 +61,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
                 .withEndTime(fs.getEndTime())
                 .withSessionVisibleFromTime(fs.getSessionVisibleFromTime())
                 .withResultsVisibleFromTime(fs.getResultsVisibleFromTime())
-                .withTimeZone(fs.getTimeZone())
+                .withTimeZone(fs.getOffset())
                 .withGracePeriod(fs.getGracePeriod())
                 .withFeedbackSessionType(fs.getFeedbackSessionType())
                 .withSentOpenEmail(fs.isSentOpenEmail())

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -161,7 +161,7 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
         fs.setEndTime(newAttributes.getEndTime());
         fs.setSessionVisibleFromTime(newAttributes.getSessionVisibleFromTime());
         fs.setResultsVisibleFromTime(newAttributes.getResultsVisibleFromTime());
-        fs.setTimeZone(newAttributes.getTimeZone());
+        fs.setOffset(newAttributes.getTimeZone());
         fs.setGracePeriod(newAttributes.getGracePeriod());
         fs.setFeedbackSessionType(newAttributes.getFeedbackSessionType());
         fs.setSentOpenEmail(newAttributes.isSentOpenEmail());

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -101,19 +101,19 @@ public class FeedbackSession extends BaseEntity {
 
     public FeedbackSession(String feedbackSessionName, String courseId,
             String creatorEmail, Text instructions, Date createdTime, Date startTime, Date endTime,
-            Date sessionVisibleFromTime, Date resultsVisibleFromTime, double timeZone, int gracePeriod,
+            Date sessionVisibleFromTime, Date resultsVisibleFromTime, double offset, int gracePeriod,
             FeedbackSessionType feedbackSessionType, boolean sentOpenEmail,
             boolean sentClosingEmail, boolean sentClosedEmail, boolean sentPublishedEmail,
             boolean isOpeningEmailEnabled, boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled) {
         this(feedbackSessionName, courseId, creatorEmail, instructions, createdTime, startTime, endTime,
-             sessionVisibleFromTime, resultsVisibleFromTime, timeZone, gracePeriod, feedbackSessionType,
+             sessionVisibleFromTime, resultsVisibleFromTime, offset, gracePeriod, feedbackSessionType,
              sentOpenEmail, sentClosingEmail, sentClosedEmail, sentPublishedEmail, isOpeningEmailEnabled,
              isClosingEmailEnabled, isPublishedEmailEnabled, new HashSet<String>(), new HashSet<String>());
     }
 
     public FeedbackSession(String feedbackSessionName, String courseId,
             String creatorEmail, Text instructions, Date createdTime, Date startTime, Date endTime,
-            Date sessionVisibleFromTime, Date resultsVisibleFromTime, double timeZone, int gracePeriod,
+            Date sessionVisibleFromTime, Date resultsVisibleFromTime, double offset, int gracePeriod,
             FeedbackSessionType feedbackSessionType, boolean sentOpenEmail, boolean sentClosingEmail,
             boolean sentClosedEmail, boolean sentPublishedEmail,
             boolean isOpeningEmailEnabled, boolean isClosingEmailEnabled, boolean isPublishedEmailEnabled,
@@ -127,7 +127,7 @@ public class FeedbackSession extends BaseEntity {
         this.endTime = endTime;
         this.sessionVisibleFromTime = sessionVisibleFromTime;
         this.resultsVisibleFromTime = resultsVisibleFromTime;
-        this.timeZone = convertOffsetToZoneId(timeZone);
+        this.timeZone = convertOffsetToZoneId(offset);
         this.gracePeriod = gracePeriod;
         this.feedbackSessionType = feedbackSessionType;
         this.sentOpenEmail = sentOpenEmail;
@@ -245,11 +245,11 @@ public class FeedbackSession extends BaseEntity {
         this.resultsVisibleFromTime = resultsVisibleFromTime;
     }
 
-    public double getTimeZone() {
+    public double getOffset() {
         return convertZoneIdToOffset(timeZone);
     }
 
-    public void setTimeZone(double offset) {
+    public void setOffset(double offset) {
         this.timeZone = convertOffsetToZoneId(offset);
     }
 

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -1,5 +1,8 @@
 package teammates.storage.entity;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -7,6 +10,7 @@ import java.util.Set;
 import com.google.appengine.api.datastore.Text;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.IgnoreSave;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnLoad;
 import com.googlecode.objectify.annotation.Unindex;
@@ -64,18 +68,10 @@ public class FeedbackSession extends BaseEntity {
     @Unindex
     private boolean isTimeStoredInUtc;
 
-    /** This is legacy data that is no longer used. <br>
-     * The value is set to Const.INT_UNINITIALIZED if it is already processed or
-     * the old value if it hasn't. <br>
-     * TODO Remove this field
-     */
-    @Unindex
-    private int timeZone;
+    private String timeZone;
 
-    /** This replaces the legacy field timeZone. <br>
-     * The value is null for legacy data. <br>
-     * TODO Rename to timeZone after removing legacy field
-     */
+    // TODO Remove after all legacy data has been converted
+    @IgnoreSave
     private Double timeZoneDouble;
 
     @Unindex
@@ -131,8 +127,7 @@ public class FeedbackSession extends BaseEntity {
         this.endTime = endTime;
         this.sessionVisibleFromTime = sessionVisibleFromTime;
         this.resultsVisibleFromTime = resultsVisibleFromTime;
-        this.timeZone = Const.INT_UNINITIALIZED;
-        this.timeZoneDouble = timeZone;
+        this.timeZone = convertOffsetToZoneId(timeZone);
         this.gracePeriod = gracePeriod;
         this.feedbackSessionType = feedbackSessionType;
         this.sentOpenEmail = sentOpenEmail;
@@ -160,6 +155,22 @@ public class FeedbackSession extends BaseEntity {
         sessionVisibleFromTime = TimeHelper.convertLocalDateToUtc(sessionVisibleFromTime, timeZoneDouble);
         resultsVisibleFromTime = TimeHelper.convertLocalDateToUtc(resultsVisibleFromTime, timeZoneDouble);
         isTimeStoredInUtc = true;
+    }
+
+    @OnLoad
+    @SuppressWarnings("unused") // called by Objectify
+    private void setTimeZoneFromOffsetIfRequired() {
+        if (timeZoneDouble == null) {
+            return;
+        }
+
+        double offset;
+        if (timeZone.equals(String.valueOf(Const.INT_UNINITIALIZED))) {
+            offset = timeZoneDouble;
+        } else {
+            offset = Double.valueOf(timeZone);
+        }
+        timeZone = convertOffsetToZoneId(offset);
     }
 
     public String getFeedbackSessionName() {
@@ -234,23 +245,12 @@ public class FeedbackSession extends BaseEntity {
         this.resultsVisibleFromTime = resultsVisibleFromTime;
     }
 
-    /** This method automatically converts the legacy timeZone field to
-     * the new timeZoneDouble field and returns the value of timeZoneDouble.
-     */
     public double getTimeZone() {
-        if (timeZone != Const.INT_UNINITIALIZED) {
-            timeZoneDouble = Double.valueOf(timeZone);
-            timeZone = Const.INT_UNINITIALIZED;
-        }
-        return timeZoneDouble;
+        return convertZoneIdToOffset(timeZone);
     }
 
-    /** This method automatically marks the timeZone field as legacy
-     * and store the timeZone data to the new timeZoneDouble field.
-     */
-    public void setTimeZone(double timeZone) {
-        this.timeZone = Const.INT_UNINITIALIZED;
-        this.timeZoneDouble = timeZone;
+    public void setTimeZone(double offset) {
+        this.timeZone = convertOffsetToZoneId(offset);
     }
 
     public int getGracePeriod() {
@@ -379,6 +379,14 @@ public class FeedbackSession extends BaseEntity {
                 + ", isOpeningEmailEnabled=" + isOpeningEmailEnabled
                 + ", isClosingEmailEnabled=" + isClosingEmailEnabled
                 + ", isPublishedEmailEnabled=" + isPublishedEmailEnabled + "]";
+    }
+
+    private String convertOffsetToZoneId(double offset) {
+        return ZoneId.ofOffset("UTC", ZoneOffset.ofTotalSeconds((int) (offset * 60 * 60))).getId();
+    }
+
+    private double convertZoneIdToOffset(String zoneId) {
+        return ((double) ZoneId.of(zoneId).getRules().getOffset(Instant.now()).getTotalSeconds()) / 60 / 60;
     }
 
 }


### PR DESCRIPTION
Fixes #8410

**Outline of Solution**
- Store offset in `timeZone` field as `ZoneId` string of the corresponding fixed offset time zone
- Rename getter and setter to indicate that the current implementation is only storing offsets rather than real time zones, to be fixed in #84