### PR TITLE
Java: Use Java 7 try-with-resources for AutoCloseable resources #8213

### DIFF
--- a/src/main/java/teammates/common/exception/TeammatesException.java
+++ b/src/main/java/teammates/common/exception/TeammatesException.java
@@ -28,7 +28,9 @@ public class TeammatesException extends Exception {
 
     public static String toStringWithStackTrace(Throwable e) {
         StringWriter sw = new StringWriter();
-        e.printStackTrace(new PrintWriter(sw));
-        return Const.EOL + sw.toString();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            e.printStackTrace(pw);
+            return Const.EOL + sw.toString();
+        }
     }
 }

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -1,6 +1,7 @@
 package teammates.common.util;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 import com.google.appengine.api.utils.SystemProperty;
@@ -63,8 +64,8 @@ public final class Config {
 
     static {
         Properties properties = new Properties();
-        try {
-            properties.load(FileHelper.getResourceAsStream("build.properties"));
+        try (InputStream buildPropStream = FileHelper.getResourceAsStream("build.properties")) {
+            properties.load(buildPropStream);
         } catch (IOException e) {
             Assumption.fail(TeammatesException.toStringWithStackTrace(e));
         }

--- a/src/main/java/teammates/common/util/ThreadHelper.java
+++ b/src/main/java/teammates/common/util/ThreadHelper.java
@@ -34,8 +34,10 @@ public final class ThreadHelper {
 
     public static String getCurrentThreadStack() {
         StringWriter sw = new StringWriter();
-        new Throwable("").printStackTrace(new PrintWriter(sw));
-        return "\n" + sw.toString();
+        try (PrintWriter pw = new PrintWriter(sw)) {
+            new Throwable("").printStackTrace(pw);
+            return "\n" + sw.toString();
+        }
     }
 
 }

--- a/src/main/java/teammates/logic/core/MailgunService.java
+++ b/src/main/java/teammates/logic/core/MailgunService.java
@@ -1,5 +1,7 @@
 package teammates.logic.core;
 
+import java.io.IOException;
+
 import javax.ws.rs.core.MediaType;
 
 import com.sun.jersey.api.client.Client;
@@ -8,6 +10,7 @@ import com.sun.jersey.api.client.WebResource;
 import com.sun.jersey.api.client.filter.HTTPBasicAuthFilter;
 import com.sun.jersey.multipart.FormDataMultiPart;
 
+import teammates.common.exception.TeammatesException;
 import teammates.common.util.Config;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.Logger;
@@ -49,16 +52,20 @@ public class MailgunService extends EmailSenderService {
 
     @Override
     protected void sendEmailWithService(EmailWrapper wrapper) {
-        FormDataMultiPart email = parseToEmail(wrapper);
-        Client client = Client.create();
-        client.addFilter(new HTTPBasicAuthFilter("api", Config.MAILGUN_APIKEY));
-        WebResource webResource =
-                client.resource("https://api.mailgun.net/v3/" + Config.MAILGUN_DOMAINNAME + "/messages");
+        try (FormDataMultiPart email = parseToEmail(wrapper)) {
+            Client client = Client.create();
+            client.addFilter(new HTTPBasicAuthFilter("api", Config.MAILGUN_APIKEY));
+            WebResource webResource =
+                    client.resource("https://api.mailgun.net/v3/" + Config.MAILGUN_DOMAINNAME + "/messages");
 
-        ClientResponse response = webResource.type(MediaType.MULTIPART_FORM_DATA_TYPE)
-                                             .post(ClientResponse.class, email);
-        if (response.getStatus() != SUCCESS_CODE) {
-            log.severe("Email failed to send: " + response.getStatusInfo().getReasonPhrase());
+            ClientResponse response = webResource.type(MediaType.MULTIPART_FORM_DATA_TYPE)
+                    .post(ClientResponse.class, email);
+
+            if (response.getStatus() != SUCCESS_CODE) {
+                log.severe("Email failed to send: " + response.getStatusInfo().getReasonPhrase());
+            }
+        } catch (IOException e) {
+            log.warning("Could not clean up resources after sending email: " + TeammatesException.toStringWithStackTrace(e));
         }
     }
 

--- a/src/test/java/teammates/test/cases/logic/EmailSenderTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailSenderTest.java
@@ -80,17 +80,18 @@ public class EmailSenderTest extends BaseLogicTest {
     }
 
     @Test
-    public void testConvertToMailgun() {
+    public void testConvertToMailgun() throws Exception {
         EmailWrapper wrapper = getTypicalEmailWrapper();
-        FormDataMultiPart formData = new MailgunService().parseToEmail(wrapper);
+        try (FormDataMultiPart formData = new MailgunService().parseToEmail(wrapper)) {
 
-        assertEquals(wrapper.getSenderName() + " <" + wrapper.getSenderEmail() + ">",
-                     formData.getField("from").getValue());
-        assertEquals(wrapper.getRecipient(), formData.getField("to").getValue());
-        assertEquals(wrapper.getBcc(), formData.getField("bcc").getValue());
-        assertEquals(wrapper.getReplyTo(), formData.getField("h:Reply-To").getValue());
-        assertEquals(wrapper.getSubject(), formData.getField("subject").getValue());
-        assertEquals(wrapper.getContent(), formData.getField("html").getValue());
+            assertEquals(wrapper.getSenderName() + " <" + wrapper.getSenderEmail() + ">",
+                    formData.getField("from").getValue());
+            assertEquals(wrapper.getRecipient(), formData.getField("to").getValue());
+            assertEquals(wrapper.getBcc(), formData.getField("bcc").getValue());
+            assertEquals(wrapper.getReplyTo(), formData.getField("h:Reply-To").getValue());
+            assertEquals(wrapper.getSubject(), formData.getField("subject").getValue());
+            assertEquals(wrapper.getContent(), formData.getField("html").getValue());
+        }
     }
 
     @Test

--- a/src/test/java/teammates/test/driver/GmailServiceMaker.java
+++ b/src/test/java/teammates/test/driver/GmailServiceMaker.java
@@ -87,14 +87,12 @@ final class GmailServiceMaker {
     }
 
     private GoogleClientSecrets loadClientSecretFromJson() throws IOException {
-        InputStream in;
-        try {
-            in = new FileInputStream(new File(TestProperties.TEST_GMAIL_API_FOLDER, "client_secret.json"));
+        try (InputStream in = new FileInputStream(new File(TestProperties.TEST_GMAIL_API_FOLDER, "client_secret.json"))) {
+            return GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
         } catch (FileNotFoundException e) {
             throw new RuntimeException("You need to set up your Gmail API credentials." + Const.EOL
                     + "See docs/development.md section \"Deploying to a staging server\".", e);
         }
-        return GoogleClientSecrets.load(JSON_FACTORY, new InputStreamReader(in));
     }
 
     private GoogleAuthorizationCodeFlow buildFlow(GoogleClientSecrets clientSecrets) throws IOException {

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -94,7 +94,9 @@ public final class TestProperties {
             } else {
                 propertiesFilename = "test.properties";
             }
-            prop.load(new FileInputStream("src/test/resources/" + propertiesFilename));
+            try (FileInputStream testPropStream = new FileInputStream("src/test/resources/" + propertiesFilename)) {
+                prop.load(testPropStream);
+            }
 
             TEAMMATES_URL = Url.trimTrailingSlash(prop.getProperty("test.app.url"));
 


### PR DESCRIPTION
Fixes #8213.

**Outline of Solution**

Enhanced the usage of various `AutoCloseable` implementing objects to a `try-with-resources` form.  This will ensure these resources get closed and don't leak.  In keeping with good practice about running in an app server, I didn't close the `HttpServletReponse` output writer instances used to write response objects.