### PR TITLE
Instructor: add options (Rank and Distribute Points) question: add more options inputs not appearing #8463

### DIFF
--- a/src/main/webapp/dev/js/common/questionConstSum.js
+++ b/src/main/webapp/dev/js/common/questionConstSum.js
@@ -45,7 +45,7 @@ function addConstSumOption(questionNum) {
 }
 
 function showConstSumOptionTable(questionNum) {
-    $(`#${ParamsNames.FEEDBACK_QUESTION_CONSTSUMOPTIONTABLE}-${questionNum}`).show();
+    $(`#constSumOptionTable-${questionNum}`).show();
 }
 
 function hideConstSumOptionTable(questionNum) {

--- a/src/main/webapp/dev/js/common/questionConstSum.js
+++ b/src/main/webapp/dev/js/common/questionConstSum.js
@@ -44,6 +44,10 @@ function addConstSumOption(questionNum) {
     }
 }
 
+function showConstSumOptionTable(questionNum) {
+    $(`#${ParamsNames.FEEDBACK_QUESTION_CONSTSUMOPTIONTABLE}-${questionNum}`).show();
+}
+
 function hideConstSumOptionTable(questionNum) {
     $(`#${ParamsNames.FEEDBACK_QUESTION_CONSTSUMOPTIONTABLE}-${questionNum}`).hide();
 }
@@ -70,5 +74,6 @@ export {
     addConstSumOption,
     hideConstSumOptionTable,
     removeConstSumOption,
+    showConstSumOptionTable,
     updateConstSumPointsValue,
 };

--- a/src/main/webapp/dev/js/common/questionRank.js
+++ b/src/main/webapp/dev/js/common/questionRank.js
@@ -173,7 +173,7 @@ function addRankOption(questionNum) {
 }
 
 function showRankOptionTable(questionNum) {
-    $(`#${ParamsNames.FEEDBACK_QUESTION_RANKOPTIONTABLE}-${questionNum}`).show();
+    $(`#rankOptionTable-${questionNum}`).show();
 }
 
 function hideRankOptionTable(questionNum) {

--- a/src/main/webapp/dev/js/common/questionRank.js
+++ b/src/main/webapp/dev/js/common/questionRank.js
@@ -172,6 +172,10 @@ function addRankOption(questionNum) {
     adjustMinMaxOptionsToBeRanked(questionNum);
 }
 
+function showRankOptionTable(questionNum) {
+    $(`#${ParamsNames.FEEDBACK_QUESTION_RANKOPTIONTABLE}-${questionNum}`).show();
+}
+
 function hideRankOptionTable(questionNum) {
     $(`#${ParamsNames.FEEDBACK_QUESTION_RANKOPTIONTABLE}-${questionNum}`).hide();
 }
@@ -237,6 +241,7 @@ export {
     hideInvalidRankRecipientFeedbackPaths,
     hideRankOptionTable,
     removeRankOption,
+    showRankOptionTable,
     toggleMaxOptionsToBeRanked,
     toggleMinOptionsToBeRanked,
 };

--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -43,6 +43,7 @@ import {
     addConstSumOption,
     hideConstSumOptionTable,
     removeConstSumOption,
+    showConstSumOptionTable,
     updateConstSumPointsValue,
 } from '../common/questionConstSum';
 
@@ -726,6 +727,7 @@ function prepareQuestionForm(type) {
         $(`#${ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED}-${NEW_QUESTION}`).val(2);
         $(`#${ParamsNames.FEEDBACK_QUESTION_CONSTSUMTORECIPIENTS}-${NEW_QUESTION}`).val('false');
         $(`#constSumOption_Recipient-${NEW_QUESTION}`).hide();
+        showConstSumOptionTable(NEW_QUESTION);
         $('#questionTypeHeader').html(FEEDBACK_QUESTION_TYPENAME_CONSTSUM_OPTION);
 
         $('#constSumForm').show();

--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -81,6 +81,7 @@ import {
     hideInvalidRankRecipientFeedbackPaths,
     hideRankOptionTable,
     removeRankOption,
+    showRankOptionTable,
     toggleMaxOptionsToBeRanked,
     toggleMinOptionsToBeRanked,
 } from '../common/questionRank';
@@ -761,6 +762,7 @@ function prepareQuestionForm(type) {
         $(`#${ParamsNames.FEEDBACK_QUESTION_NUMBEROFCHOICECREATED}-${NEW_QUESTION}`).val(2);
         $(`#${ParamsNames.FEEDBACK_QUESTION_RANKTORECIPIENTS}-${NEW_QUESTION}`).val('false');
         $(`#rankOption_Recipient-${NEW_QUESTION}`).hide();
+        showRankOptionTable(NEW_QUESTION);
         $('#questionTypeHeader').html(FEEDBACK_QUESTION_TYPENAME_RANK_OPTION);
 
         $('#rankOptionsForm').show();


### PR DESCRIPTION
Fixes #8463

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
`rank-option-table` is hidden every time `rank recipients` is toggled. Call a function so that the element is shown every time `rank options` is selected.