### PR TITLE
Setup docs: Add installation instructions for Debian and Fedora OS #8491

### DIFF
--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -50,14 +50,24 @@ More information can be found at [this documentation](https://help.github.com/ar
 
    # Linux/OS X
    ./install.sh --path-update true
+
    # Windows
    install.bat --path-update true
    ```
+   If you are installing in Red Hat, CentOS, Fedora, Debian or Ubuntu, refer to the quick start of Google Cloud SDK for [Debian/Ubuntu](https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu) or [Red Hat/CentOS/Fedora](https://cloud.google.com/sdk/docs/quickstart-redhat-centos) respectively.
+
    **Verification**: Run a `gcloud` command (e.g. `gcloud version`) in order to verify that you can access the SDK from the command line.
 
 1. Run this command to install App Engine Java SDK bundled with the Cloud SDK:
    ```sh
+   # Linux/OS X/Windows
    gcloud -q components install app-engine-java
+   
+   # Red Hat/CentOS/Fedora
+   sudo yum install google-cloud-sdk-app-engine-java
+   
+   # Debian/Ubuntu
+   sudo apt-get install google-cloud-sdk-app-engine-java
    ```
    **Verification:** Run `gcloud version` and there should be an entry on `app-engine-java`.
 


### PR DESCRIPTION
Sepearte package available for Google cloud Java API plugin. For Linux system, the package can be directly installed.

Signed-off-by: Progyan Bhattacharya <progyanb@acm.org>

Fixes #8491 

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [ ] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr
  - [ ] Added the issue number to the "Fixes" keyword above
  - [ ] Titled the PR as specified in the abovementioned document
- [ ] Made your changes on a branch other than `master` and `release`
- [ ] Gone through all the changes in this PR and ensured that:
  - [ ] They addressed one (and only one) issue
  - [ ] No unintended changes were made
- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [ ] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
