### PR TITLE
FeedbackSessionQuestionTypeTest.json: fix malformed question metadata #8418

### DIFF
--- a/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
+++ b/src/test/resources/data/FeedbackSessionQuestionTypeTest.json
@@ -708,7 +708,7 @@
       "courseId": "FSQTT.idOfTypicalCourse1",
       "creatorEmail": "instructor1@course1.tmt",
       "questionMetaData": {
-        "value": "{\"msqChoices\":[\"It's good\",\"It's perfect\"],\"numOfMcqChoices\":2,\"questionText\":\"What do you like best about the class' product?\",\"questionType\":\"MSQ\",\"otherEnabled\":false}"
+        "value": "{\"msqChoices\":[\"It's good\",\"It's perfect\"],\"numOfMsqChoices\":2,\"questionText\":\"What do you like best about the class' product?\",\"questionType\":\"MSQ\",\"otherEnabled\":false}"
       },
       "questionNumber": 2,
       "questionType": "MSQ",


### PR DESCRIPTION
Fixes #8418

Submitting quick fix.
I tried adding tests related to the fix but couldn't as discussed in #8418. Would be happy to add tests (if possible) which check data of `numOfMsqChoices`.