### PR TITLE
TimeHelper: migrate to Java 8's `java.time` #8362 - migrate course `timeZone` field to `ZoneId`

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -40,6 +40,11 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
      * <ul>
      * <li>{@code createdAt = current date}</li>
      * </ul>
+     *
+     * @param courseId Id of the course.
+     * @param name Name of the course.
+     * @param timeZone Time zone of the course.
+     * @return a {@code Builder} object that can be used to construct a {@code CourseAttributes} object
      */
     public static Builder builder(String courseId, String name, ZoneId timeZone) {
         return new Builder(courseId, name, timeZone);

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -24,9 +24,9 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     public Instant createdAt;
     private String id;
     private String name;
-    private String timeZone;
+    private ZoneId timeZone;
 
-    CourseAttributes(String courseId, String name, String timeZone) {
+    CourseAttributes(String courseId, String name, ZoneId timeZone) {
         this.id = SanitizationHelper.sanitizeTitle(courseId);
         this.name = SanitizationHelper.sanitizeTitle(name);
         this.timeZone = timeZone;
@@ -41,7 +41,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
      * <li>{@code createdAt = current date}</li>
      * </ul>
      */
-    public static Builder builder(String courseId, String name, String timeZone) {
+    public static Builder builder(String courseId, String name, ZoneId timeZone) {
         return new Builder(courseId, name, timeZone);
     }
 
@@ -57,7 +57,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         this.name = name;
     }
 
-    public String getTimeZone() {
+    public ZoneId getTimeZone() {
         return timeZone;
     }
 
@@ -70,11 +70,11 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     public String getCreatedAtFullDateTimeString() {
-        LocalDateTime localDateTime = TimeHelper.convertInstantToLocalDateTime(createdAt, ZoneId.of(timeZone));
+        LocalDateTime localDateTime = TimeHelper.convertInstantToLocalDateTime(createdAt, timeZone);
         return TimeHelper.formatTime12H(localDateTime);
     }
 
-    public void setTimeZone(String timeZone) {
+    public void setTimeZone(ZoneId timeZone) {
         this.timeZone = timeZone;
     }
 
@@ -88,14 +88,12 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
         addNonEmptyError(validator.getInvalidityInfoForCourseName(getName()), errors);
 
-        addNonEmptyError(validator.getInvalidityInfoForCourseTimeZone(getTimeZone()), errors);
-
         return errors;
     }
 
     @Override
     public Course toEntity() {
-        return new Course(getId(), getName(), getTimeZone(), createdAt);
+        return new Course(getId(), getName(), getTimeZone().getId(), createdAt);
     }
 
     @Override
@@ -150,7 +148,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         private static final String REQUIRED_FIELD_CANNOT_BE_NULL = "Non-null value expected";
         private final CourseAttributes courseAttributes;
 
-        public Builder(String courseId, String name, String timeZone) {
+        public Builder(String courseId, String name, ZoneId timeZone) {
             validateRequiredFields(courseId, name, timeZone);
             courseAttributes = new CourseAttributes(courseId, name, timeZone);
         }

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -142,7 +143,7 @@ public final class JsonUtils {
         public synchronized ZoneId deserialize(JsonElement element, Type type, JsonDeserializationContext context) {
             try {
                 return ZoneId.of(element.getAsString());
-            } catch (DateTimeParseException e) {
+            } catch (DateTimeException e) {
                 throw new JsonSyntaxException(element.getAsString(), e);
             }
         }

--- a/src/main/java/teammates/common/util/JsonUtils.java
+++ b/src/main/java/teammates/common/util/JsonUtils.java
@@ -5,6 +5,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
@@ -36,6 +37,7 @@ public final class JsonUtils {
     private static Gson getTeammatesGson() {
         return new GsonBuilder().registerTypeAdapter(Date.class, new TeammatesDateAdapter())
                                 .registerTypeAdapter(Instant.class, new TeammatesInstantAdapter())
+                                .registerTypeAdapter(ZoneId.class, new TeammatesZoneIdAdapter())
                                 .setPrettyPrinting()
                                 .disableHtmlEscaping()
                                 .create();
@@ -123,6 +125,23 @@ public final class JsonUtils {
         public synchronized Instant deserialize(JsonElement element, Type type, JsonDeserializationContext context) {
             try {
                 return Instant.parse(element.getAsString());
+            } catch (DateTimeParseException e) {
+                throw new JsonSyntaxException(element.getAsString(), e);
+            }
+        }
+    }
+
+    private static class TeammatesZoneIdAdapter implements JsonSerializer<ZoneId>, JsonDeserializer<ZoneId> {
+
+        @Override
+        public synchronized JsonElement serialize(ZoneId zoneId, Type type, JsonSerializationContext context) {
+            return new JsonPrimitive(zoneId.getId());
+        }
+
+        @Override
+        public synchronized ZoneId deserialize(JsonElement element, Type type, JsonDeserializationContext context) {
+            try {
+                return ZoneId.of(element.getAsString());
             } catch (DateTimeParseException e) {
                 throw new JsonSyntaxException(element.getAsString(), e);
             }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -370,14 +370,14 @@ public final class TimeHelper {
      */
     @Deprecated
     public static String formatDateTimeForInstructorCoursesPage(Date date, String timeZoneId) {
-        return formatDateTimeForInstructorCoursesPage(convertDateToInstant(date), timeZoneId);
+        return formatDateTimeForInstructorCoursesPage(convertDateToInstant(date), ZoneId.of(timeZoneId));
     }
 
     /**
      * Formats a date in the format d MMM yyyy. Example: 5 May 2017
      */
-    public static String formatDateTimeForInstructorCoursesPage(Instant instant, String timeZoneId) {
-        return formatInstant(instant, ZoneId.of(timeZoneId), "d MMM yyyy");
+    public static String formatDateTimeForInstructorCoursesPage(Instant instant, ZoneId timeZoneId) {
+        return formatInstant(instant, timeZoneId, "d MMM yyyy");
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -665,12 +665,17 @@ public class Logic {
     /**
      * Updates the details of a course.
      *
-     * @see CoursesLogic#updateCourse(CourseAttributes)
+     * @see CoursesLogic#updateCourse(String, String, String)
+     * @param courseId
+     * @param courseName
+     * @param courseTimeZone
      */
-    public void updateCourse(CourseAttributes course) throws InvalidParametersException,
-                                                             EntityDoesNotExistException {
-        Assumption.assertNotNull(course);
-        coursesLogic.updateCourse(course);
+    public void updateCourse(String courseId, String courseName, String courseTimeZone)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        Assumption.assertNotNull(courseId);
+        Assumption.assertNotNull(courseName);
+        Assumption.assertNotNull(courseTimeZone);
+        coursesLogic.updateCourse(courseId, courseName, courseTimeZone);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -666,9 +666,6 @@ public class Logic {
      * Updates the details of a course.
      *
      * @see CoursesLogic#updateCourse(String, String, String)
-     * @param courseId
-     * @param courseName
-     * @param courseTimeZone
      */
     public void updateCourse(String courseId, String courseName, String courseTimeZone)
             throws InvalidParametersException, EntityDoesNotExistException {

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -719,21 +719,33 @@ public final class CoursesLogic {
         return archivedCourseIds;
     }
 
-    private CourseAttributes validateAndCreateCourseAttributes(String courseId,
-                                                               String courseName, String courseTimeZone)
-            throws InvalidParametersException {
+    /**
+     * Check that {@code courseTimeZone} is valid and then return a {@code CourseAttributes}
+     *
+     * Field validation is usually done in {@code CourseDb} by calling {@code CourseAttributes.getInvalidityInfo}.
+     * However, a {@code CourseAttributes} cannot be created with an invalid time zone string.
+     * Hence, validation of this field is carried out here.
+     *
+     * @throws InvalidParametersException containing error messages for all fields if {@code courseTimeZone} is valid
+     */
+    private CourseAttributes validateAndCreateCourseAttributes(
+            String courseId, String courseName, String courseTimeZone) throws InvalidParametersException {
 
+        // Imitate `CourseAttributes.getInvalidityInfo`
         FieldValidator validator = new FieldValidator();
         String timeZoneErrorMessage = validator.getInvalidityInfoForCourseTimeZone(courseTimeZone);
         if (!timeZoneErrorMessage.isEmpty()) {
+            // Leave validation of other fields to `CourseAttributes.getInvalidityInfo`
             CourseAttributes dummyCourse = CourseAttributes
                     .builder(courseId, courseName, ZoneId.of("UTC"))
                     .build();
             List<String> errors = dummyCourse.getInvalidityInfo();
             errors.add(timeZoneErrorMessage);
+            // Imitate exception throwing in `CourseDb`
             throw new InvalidParametersException(errors);
         }
 
+        // If time zone field is valid, leave validation  of other fields to `CourseDb` like usual
         return CourseAttributes
                 .builder(courseId, courseName, ZoneId.of(courseTimeZone))
                 .build();

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -720,10 +720,9 @@ public final class CoursesLogic {
     }
 
     /**
-     * Check that {@code courseTimeZone} is valid and then return a {@code CourseAttributes}
-     *
-     * Field validation is usually done in {@code CourseDb} by calling {@code CourseAttributes.getInvalidityInfo}.
-     * However, a {@code CourseAttributes} cannot be created with an invalid time zone string.
+     * Check that {@code courseTimeZone} is valid and then return a {@link CourseAttributes}
+     * Field validation is usually done in {@link CoursesDb} by calling {@link CourseAttributes#getInvalidityInfo()}.
+     * However, a {@link CourseAttributes} cannot be created with an invalid time zone string.
      * Hence, validation of this field is carried out here.
      *
      * @throws InvalidParametersException containing error messages for all fields if {@code courseTimeZone} is valid
@@ -741,11 +740,11 @@ public final class CoursesLogic {
                     .build();
             List<String> errors = dummyCourse.getInvalidityInfo();
             errors.add(timeZoneErrorMessage);
-            // Imitate exception throwing in `CourseDb`
+            // Imitate exception throwing in `CoursesDb`
             throw new InvalidParametersException(errors);
         }
 
-        // If time zone field is valid, leave validation  of other fields to `CourseDb` like usual
+        // If time zone field is valid, leave validation  of other fields to `CoursesDb` like usual
         return CourseAttributes
                 .builder(courseId, courseName, ZoneId.of(courseTimeZone))
                 .build();

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -594,9 +594,9 @@ public final class CoursesLogic {
 
     /**
      * Updates the course details.
-     * @param courseId
-     * @param courseName
-     * @param courseTimeZone
+     * @param courseId Id of the course to update
+     * @param courseName new name of the course
+     * @param courseTimeZone new time zone of the course
      */
     public void updateCourse(String courseId, String courseName, String courseTimeZone)
             throws InvalidParametersException, EntityDoesNotExistException {
@@ -734,9 +734,8 @@ public final class CoursesLogic {
             throw new InvalidParametersException(errors);
         }
 
-        CourseAttributes courseToAdd = CourseAttributes
+        return CourseAttributes
                 .builder(courseId, courseName, ZoneId.of(courseTimeZone))
                 .build();
-        return courseToAdd;
     }
 }

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -720,12 +720,12 @@ public final class CoursesLogic {
     }
 
     /**
-     * Check that {@code courseTimeZone} is valid and then return a {@link CourseAttributes}
+     * Checks that {@code courseTimeZone} is valid and then returns a {@link CourseAttributes}.
      * Field validation is usually done in {@link CoursesDb} by calling {@link CourseAttributes#getInvalidityInfo()}.
      * However, a {@link CourseAttributes} cannot be created with an invalid time zone string.
      * Hence, validation of this field is carried out here.
      *
-     * @throws InvalidParametersException containing error messages for all fields if {@code courseTimeZone} is valid
+     * @throws InvalidParametersException containing error messages for all fields if {@code courseTimeZone} is invalid
      */
     private CourseAttributes validateAndCreateCourseAttributes(
             String courseId, String courseName, String courseTimeZone) throws InvalidParametersException {

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -2,6 +2,7 @@ package teammates.storage.api;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -95,7 +96,7 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         }
 
         courseEntityToUpdate.setName(courseToUpdate.getName());
-        courseEntityToUpdate.setTimeZone(courseToUpdate.getTimeZone());
+        courseEntityToUpdate.setTimeZone(courseToUpdate.getTimeZone().getId());
 
         saveEntity(courseEntityToUpdate, courseToUpdate);
     }
@@ -111,7 +112,7 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
 
         // only the courseId is important here, everything else are placeholders
         deleteEntity(CourseAttributes
-                .builder(courseId, "Non-existent course", "UTC")
+                .builder(courseId, "Non-existent course", ZoneId.of("UTC"))
                 .build());
     }
 
@@ -148,7 +149,7 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     protected CourseAttributes makeAttributes(Course entity) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entity);
 
-        return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), entity.getTimeZone())
+        return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), ZoneId.of(entity.getTimeZone()))
                 .withCreatedAt(entity.getCreatedAt()).build();
     }
 }

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -2,6 +2,7 @@ package teammates.storage.api;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -149,7 +150,15 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     protected CourseAttributes makeAttributes(Course entity) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entity);
 
-        return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), ZoneId.of(entity.getTimeZone()))
+        ZoneId courseTimeZone;
+        try {
+            courseTimeZone = ZoneId.of(entity.getTimeZone());
+        } catch (DateTimeException e) {
+            log.severe("Timezone '" + entity.getTimeZone() + "' of course '" + entity.getUniqueId()
+                    + "' is no longer supported. UTC will be used instead.");
+            courseTimeZone = ZoneId.of("UTC");
+        }
+        return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), courseTimeZone)
                 .withCreatedAt(entity.getCreatedAt()).build();
     }
 }

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -155,7 +155,7 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
             courseTimeZone = ZoneId.of(entity.getTimeZone());
         } catch (DateTimeException e) {
             log.severe("Timezone '" + entity.getTimeZone() + "' of course '" + entity.getUniqueId()
-                    + "' is no longer supported. UTC will be used instead.");
+                    + "' is not supported. UTC will be used instead.");
             courseTimeZone = ZoneId.of("UTC");
         }
         return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), courseTimeZone)

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -50,7 +50,7 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
     public static final String ERROR_TRYING_TO_MAKE_NON_EXISTENT_ACCOUNT_AN_INSTRUCTOR =
             "Trying to make an non-existent account an Instructor :";
 
-    private static final Logger log = Logger.getLogger();
+    protected static final Logger log = Logger.getLogger();
 
     /**
      * Preconditions:

--- a/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
@@ -37,10 +37,8 @@ public class InstructorCourseAddAction extends Action {
 
         /* Create a new course in the database */
         data = new InstructorCoursesPageData(account, sessionToken);
-        CourseAttributes newCourse = CourseAttributes
-                .builder(newCourseId, newCourseName, newCourseTimeZone)
-                .build();
-        createCourse(newCourse);
+
+        createCourse(newCourseId, newCourseName, newCourseTimeZone);
 
         /* Prepare data for the refreshed page after executing the adding action */
         Map<String, InstructorAttributes> instructorsForCourses = new HashMap<>();
@@ -73,8 +71,8 @@ public class InstructorCourseAddAction extends Action {
         String courseNameToShowParam = "";
 
         if (isError) { // there is error in adding the course
-            courseIdToShowParam = SanitizationHelper.sanitizeForHtml(newCourse.getId());
-            courseNameToShowParam = SanitizationHelper.sanitizeForHtml(newCourse.getName());
+            courseIdToShowParam = SanitizationHelper.sanitizeForHtml(newCourseId);
+            courseNameToShowParam = SanitizationHelper.sanitizeForHtml(newCourseName);
 
             List<String> statusMessageTexts = new ArrayList<>();
 
@@ -84,7 +82,7 @@ public class InstructorCourseAddAction extends Action {
 
             statusToAdmin = StringHelper.toString(statusMessageTexts, "<br>");
         } else {
-            statusToAdmin = "Course added : " + newCourse.getId();
+            statusToAdmin = "Course added : " + newCourseId;
             statusToAdmin += "<br>Total courses: " + allCourses.size();
         }
 
@@ -94,13 +92,12 @@ public class InstructorCourseAddAction extends Action {
                 : createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
     }
 
-    private void createCourse(CourseAttributes course) {
+    private void createCourse(String newCourseId, String newCourseName, String newCourseTimeZone) {
         try {
-            logic.createCourseAndInstructor(data.account.googleId, course.getId(), course.getName(),
-                                            course.getTimeZone());
+            logic.createCourseAndInstructor(data.account.googleId, newCourseId, newCourseName, newCourseTimeZone);
             String statusMessage = Const.StatusMessages.COURSE_ADDED.replace("${courseEnrollLink}",
-                    data.getInstructorCourseEnrollLink(course.getId())).replace("${courseEditLink}",
-                    data.getInstructorCourseEditLink(course.getId()));
+                    data.getInstructorCourseEnrollLink(newCourseId)).replace("${courseEditLink}",
+                    data.getInstructorCourseEditLink(newCourseId));
             statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
             isError = false;
 
@@ -108,10 +105,6 @@ public class InstructorCourseAddAction extends Action {
             setStatusForException(e, Const.StatusMessages.COURSE_EXISTS);
         } catch (InvalidParametersException e) {
             setStatusForException(e);
-        }
-
-        if (isError) {
-            return;
         }
     }
 

--- a/src/main/java/teammates/ui/controller/InstructorCourseEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseEditSaveAction.java
@@ -1,6 +1,5 @@
 package teammates.ui.controller;
 
-import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -25,12 +24,8 @@ public class InstructorCourseEditSaveAction extends Action {
         gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId),
                                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
 
-        CourseAttributes courseToEdit = CourseAttributes
-                .builder(courseId, courseName, courseTimeZone)
-                .build();
-
         try {
-            logic.updateCourse(courseToEdit);
+            logic.updateCourse(courseId, courseName, courseTimeZone);
 
             statusToUser.add(new StatusMessage(Const.StatusMessages.COURSE_EDITED, StatusMessageColor.SUCCESS));
             statusToAdmin = "Course name for Course <span class=\"bold\">[" + courseId + "]</span> edited.<br>"

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.browsertests;
 
+import java.time.ZoneId;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -14,8 +16,6 @@ import teammates.test.pageobjects.InstructorCourseDetailsPage;
 import teammates.test.pageobjects.InstructorCourseEditPage;
 import teammates.test.pageobjects.InstructorCourseEnrollPage;
 import teammates.test.pageobjects.InstructorCoursesPage;
-
-import java.time.ZoneId;
 
 /**
  * SUT: {@link Const.ActionURIs#INSTRUCTOR_COURSES_PAGE}.

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -15,6 +15,8 @@ import teammates.test.pageobjects.InstructorCourseEditPage;
 import teammates.test.pageobjects.InstructorCourseEnrollPage;
 import teammates.test.pageobjects.InstructorCoursesPage;
 
+import java.time.ZoneId;
+
 /**
  * SUT: {@link Const.ActionURIs#INSTRUCTOR_COURSES_PAGE}.
  */
@@ -35,7 +37,7 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
 
     private CourseAttributes validCourse =
             CourseAttributes
-                    .builder(" CCAddUiTest.course1 ", " Software Engineering $^&*() ", "Asia/Singapore")
+                    .builder(" CCAddUiTest.course1 ", " Software Engineering $^&*() ", ZoneId.of("Asia/Singapore"))
                     .build();
 
     @Override

--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.browsertests;
 
+import java.time.ZoneId;
+
 import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 
@@ -17,8 +19,6 @@ import teammates.test.pageobjects.InstructorCourseEnrollPage;
 import teammates.test.pageobjects.InstructorFeedbackSessionsPage;
 import teammates.test.pageobjects.InstructorHelpPage;
 import teammates.test.pageobjects.InstructorHomePage;
-
-import java.time.ZoneId;
 
 /**
  * SUT: {@link Const.ActionURIs#INSTRUCTOR_HOME_PAGE}.

--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -18,6 +18,8 @@ import teammates.test.pageobjects.InstructorFeedbackSessionsPage;
 import teammates.test.pageobjects.InstructorHelpPage;
 import teammates.test.pageobjects.InstructorHomePage;
 
+import java.time.ZoneId;
+
 /**
  * SUT: {@link Const.ActionURIs#INSTRUCTOR_HOME_PAGE}.
  */
@@ -126,7 +128,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         homePage.verifyHtmlMainContent("/instructorHomeNewInstructorWithoutSampleCourse.html");
 
         CourseAttributes newCourse = CourseAttributes
-                .builder("newIns.wit-demo", "Sample Course 101", "UTC")
+                .builder("newIns.wit-demo", "Sample Course 101", ZoneId.of("UTC"))
                 .build();
         BackDoor.createCourse(newCourse);
         @SuppressWarnings("deprecation")

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -1,6 +1,7 @@
 package teammates.test.cases.datatransfer;
 
 import java.time.Instant;
+import java.time.ZoneId;
 
 import org.testng.annotations.Test;
 
@@ -17,7 +18,7 @@ public class CourseAttributesTest extends BaseTestCase {
 
     private String validName = "validName";
     private String validId = "validId";
-    private String validTimeZone = "validTimeZone";
+    private ZoneId validTimeZone = ZoneId.of("UTC");
     private Instant validCreatedAt = Instant.ofEpochMilli(98765);
 
     @Test
@@ -94,9 +95,8 @@ public class CourseAttributesTest extends BaseTestCase {
 
         String veryLongId = StringHelperExtension.generateStringOfLength(FieldValidator.COURSE_ID_MAX_LENGTH + 1);
         String emptyName = "";
-        String invalidTimeZone = "InvalidTimeZone";
         CourseAttributes invalidCourse = CourseAttributes
-                .builder(veryLongId, emptyName, invalidTimeZone)
+                .builder(veryLongId, emptyName, validTimeZone)
                 .build();
 
         assertFalse("invalid value", invalidCourse.isValid());
@@ -107,10 +107,7 @@ public class CourseAttributesTest extends BaseTestCase {
                     FieldValidator.COURSE_ID_MAX_LENGTH) + System.lineSeparator()
                 + getPopulatedEmptyStringErrorMessage(
                       FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH) + System.lineSeparator()
-                + getPopulatedErrorMessage(
-                      FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidCourse.getTimeZone(),
-                      FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+                      FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH);
         assertEquals("invalid value", errorMessage, StringHelper.toString(invalidCourse.getInvalidityInfo()));
     }
 
@@ -131,7 +128,7 @@ public class CourseAttributesTest extends BaseTestCase {
     }
 
     private static CourseAttributes generateValidCourseAttributesObject() {
-        return CourseAttributes.builder("valid-id-$_abc", "valid-name", "UTC").build();
+        return CourseAttributes.builder("valid-id-$_abc", "valid-name", ZoneId.of("UTC")).build();
     }
 
 }

--- a/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
@@ -8,6 +8,8 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 
+import java.time.ZoneId;
+
 /**
  * SUT: {@link teammates.logic.backdoor.BackDoorLogic}.
  */
@@ -45,7 +47,7 @@ public class BackDoorLogicTest extends BaseLogicTest {
 
         ______TS("invalid parameters in an entity");
         CourseAttributes invalidCourse = CourseAttributes
-                .builder("invalid id", "valid course name", "UTC")
+                .builder("invalid id", "valid course name", ZoneId.of("UTC"))
                 .build();
         dataBundle = new DataBundle();
         dataBundle.courses.put("invalid", invalidCourse);

--- a/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.logic;
 
+import java.time.ZoneId;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
@@ -7,8 +9,6 @@ import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
-
-import java.time.ZoneId;
 
 /**
  * SUT: {@link teammates.logic.backdoor.BackDoorLogic}.

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -28,7 +28,6 @@ import teammates.storage.api.AccountsDb;
 import teammates.storage.api.CoursesDb;
 import teammates.storage.api.InstructorsDb;
 import teammates.test.driver.AssertHelper;
-import teammates.test.driver.StringHelperExtension;
 
 /**
  * SUT: {@link CoursesLogic}.

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -1,5 +1,6 @@
 package teammates.test.cases.logic;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +69,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("success: typical case");
 
         CourseAttributes c = CourseAttributes
-                .builder("Computing101-getthis", "Basic Computing Getting", "UTC")
+                .builder("Computing101-getthis", "Basic Computing Getting", ZoneId.of("UTC"))
                 .build();
         coursesDb.createEntity(c);
 
@@ -133,7 +134,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: not a sample course");
 
         CourseAttributes notSampleCourse = CourseAttributes
-                .builder("course.id", "not sample course", "UTC")
+                .builder("course.id", "not sample course", ZoneId.of("UTC"))
                 .build();
 
         assertFalse(coursesLogic.isSampleCourse(notSampleCourse.getId()));
@@ -141,14 +142,14 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: is a sample course");
 
         CourseAttributes sampleCourse = CourseAttributes
-                .builder("course.id-demo3", "sample course", "UTC")
+                .builder("course.id-demo3", "sample course", ZoneId.of("UTC"))
                 .build();
         assertTrue(coursesLogic.isSampleCourse(sampleCourse.getId()));
 
         ______TS("typical case: is a sample course with '-demo' in the middle of its id");
 
         CourseAttributes sampleCourse2 = CourseAttributes
-                .builder("course.id-demo3-demo33", "sample course with additional -demo", "UTC")
+                .builder("course.id-demo3-demo33", "sample course with additional -demo", ZoneId.of("UTC"))
                 .build();
         assertTrue(coursesLogic.isSampleCourse(sampleCourse2.getId()));
 
@@ -167,7 +168,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: not an existent course");
 
         CourseAttributes nonExistentCourse = CourseAttributes
-                .builder("non-existent-course", "non existent course", "UTC")
+                .builder("non-existent-course", "non existent course", ZoneId.of("UTC"))
                 .build();
 
         assertFalse(coursesLogic.isCoursePresent(nonExistentCourse.getId()));
@@ -175,7 +176,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: an existent course");
 
         CourseAttributes existingCourse = CourseAttributes
-                .builder("idOfTypicalCourse1", "existing course", "UTC")
+                .builder("idOfTypicalCourse1", "existing course", ZoneId.of("UTC"))
                 .build();
 
         assertTrue(coursesLogic.isCoursePresent(existingCourse.getId()));
@@ -195,7 +196,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: verify a non-existent course");
 
         CourseAttributes nonExistentCourse = CourseAttributes
-                .builder("non-existent-course", "non existent course", "UTC")
+                .builder("non-existent-course", "non existent course", ZoneId.of("UTC"))
                 .build();
 
         try {
@@ -208,7 +209,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case: verify an existent course");
 
         CourseAttributes existingCourse = CourseAttributes
-                .builder("idOfTypicalCourse1", "existing course", "UTC")
+                .builder("idOfTypicalCourse1", "existing course", ZoneId.of("UTC"))
                 .build();
         coursesLogic.verifyCourseIsPresent(existingCourse.getId());
 
@@ -253,7 +254,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         courseSummary = coursesLogic.getCourseSummary("course1");
         assertEquals("course1", courseSummary.course.getId());
         assertEquals("course 1", courseSummary.course.getName());
-        assertEquals("Asia/Singapore", courseSummary.course.getTimeZone());
+        assertEquals("Asia/Singapore", courseSummary.course.getTimeZone().getId());
 
         assertEquals(0, courseSummary.stats.teamsTotal);
         assertEquals(0, courseSummary.stats.studentsTotal);
@@ -315,7 +316,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         courseSummary = coursesLogic.getCourseSummaryWithoutStats("course1");
         assertEquals("course1", courseSummary.course.getId());
         assertEquals("course 1", courseSummary.course.getName());
-        assertEquals("America/Los_Angeles", courseSummary.course.getTimeZone());
+        assertEquals("America/Los_Angeles", courseSummary.course.getTimeZone().getId());
 
         coursesLogic.deleteCourseCascade("course1");
         accountsDb.deleteAccount("instructor1");
@@ -380,7 +381,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         courseDetails = coursesLogic.getCourseSummary("course1");
         assertEquals("course1", courseDetails.course.getId());
         assertEquals("course 1", courseDetails.course.getName());
-        assertEquals("Australia/Adelaide", courseDetails.course.getTimeZone());
+        assertEquals("Australia/Adelaide", courseDetails.course.getTimeZone().getId());
 
         assertEquals(0, courseDetails.stats.teamsTotal);
         assertEquals(0, courseDetails.stats.studentsTotal);
@@ -782,15 +783,15 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("typical case");
 
         CourseAttributes c = CourseAttributes
-                .builder("Computing101-fresh", "Basic Computing", "Asia/Singapore")
+                .builder("Computing101-fresh", "Basic Computing", ZoneId.of("Asia/Singapore"))
                 .build();
-        coursesLogic.createCourse(c.getId(), c.getName(), c.getTimeZone());
+        coursesLogic.createCourse(c.getId(), c.getName(), c.getTimeZone().getId());
         verifyPresentInDatastore(c);
         coursesLogic.deleteCourseCascade(c.getId());
         ______TS("Null parameter");
 
         try {
-            coursesLogic.createCourse(null, c.getName(), c.getTimeZone());
+            coursesLogic.createCourse(null, c.getName(), c.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Non-null value expected", e.getMessage());
@@ -811,7 +812,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("fails: account doesn't exist");
 
         CourseAttributes c = CourseAttributes
-                .builder("fresh-course-tccai", "Fresh course for tccai", "America/Los Angeles")
+                .builder("fresh-course-tccai", "Fresh course for tccai", ZoneId.of("America/Los_Angeles"))
                 .build();
 
         @SuppressWarnings("deprecation")
@@ -820,7 +821,7 @@ public class CoursesLogicTest extends BaseLogicTest {
                 .build();
 
         try {
-            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone());
+            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             AssertHelper.assertContains("for a non-existent instructor", e.getMessage());
@@ -841,7 +842,7 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         accountsDb.createAccount(a);
         try {
-            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone());
+            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             AssertHelper.assertContains("doesn't have instructor privileges", e.getMessage());
@@ -855,21 +856,18 @@ public class CoursesLogicTest extends BaseLogicTest {
         accountsDb.updateAccount(a);
 
         CourseAttributes invalidCourse = CourseAttributes
-                .builder("invalid id", "Fresh course for tccai", "InvalidTimeZone")
+                .builder("invalid id", "Fresh course for tccai", ZoneId.of("UTC"))
                 .build();
 
         String expectedError =
                 "\"" + invalidCourse.getId() + "\" is not acceptable to TEAMMATES as a/an course ID because"
                 + " it is not in the correct format. "
                 + "A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
-                + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces."
-                + System.lineSeparator()
-                + "\"InvalidTimeZone\" is not acceptable to TEAMMATES as a/an course time zone because it not available "
-                + "as a choice. The value must be one of the values from the time zone dropdown selector.";
+                + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.";
 
         try {
             coursesLogic.createCourseAndInstructor(i.googleId, invalidCourse.getId(), invalidCourse.getName(),
-                                                   invalidCourse.getTimeZone());
+                                                   invalidCourse.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
             assertEquals(expectedError, e.getMessage());
@@ -880,14 +878,14 @@ public class CoursesLogicTest extends BaseLogicTest {
         ______TS("fails: error during instructor creation due to duplicate instructor");
 
         CourseAttributes courseWithDuplicateInstructor = CourseAttributes
-                .builder("fresh-course-tccai", "Fresh course for tccai", "UTC")
+                .builder("fresh-course-tccai", "Fresh course for tccai", ZoneId.of("UTC"))
                 .build();
         instructorsDb.createEntity(i); //create a duplicate instructor
 
         try {
             coursesLogic.createCourseAndInstructor(i.googleId, courseWithDuplicateInstructor.getId(),
                                                    courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone());
+                                                   courseWithDuplicateInstructor.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             AssertHelper.assertContains("Unexpected exception while trying to create instructor for a new course",
@@ -902,7 +900,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         try {
             coursesLogic.createCourseAndInstructor(i.googleId, courseWithDuplicateInstructor.getId(),
                                                    courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone());
+                                                   courseWithDuplicateInstructor.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             AssertHelper.assertContains("Unexpected exception while trying to create instructor for a new course",
@@ -919,7 +917,7 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         coursesLogic.createCourseAndInstructor(i.googleId, courseWithDuplicateInstructor.getId(),
                                                courseWithDuplicateInstructor.getName(),
-                                               courseWithDuplicateInstructor.getTimeZone());
+                                               courseWithDuplicateInstructor.getTimeZone().getId());
         verifyPresentInDatastore(courseWithDuplicateInstructor);
         verifyPresentInDatastore(i);
 
@@ -928,7 +926,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         try {
             coursesLogic.createCourseAndInstructor(null, courseWithDuplicateInstructor.getId(),
                                                    courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone());
+                                                   courseWithDuplicateInstructor.getTimeZone().getId());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -19,6 +19,7 @@ import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.FieldValidator;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.CoursesLogic;
 import teammates.logic.core.InstructorsLogic;
@@ -58,6 +59,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         testCreateCourse();
         testCreateCourseAndInstructor();
         testDeleteCourse();
+        testUpdateCourse();
     }
 
     private void testGetCourse() throws Exception {
@@ -776,10 +778,6 @@ public class CoursesLogicTest extends BaseLogicTest {
 
     private void testCreateCourse() throws Exception {
 
-        /*Explanation:
-         * The SUT (i.e. CoursesLogic::createCourse) has only 1 path. Therefore, we
-         * should typically have 1 test cases here.
-         */
         ______TS("typical case");
 
         CourseAttributes c = CourseAttributes
@@ -795,6 +793,18 @@ public class CoursesLogicTest extends BaseLogicTest {
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Non-null value expected", e.getMessage());
+        }
+        ______TS("Invalid time zone");
+
+        String invalidTimeZone = "Invalid Timezone";
+        try {
+            coursesLogic.createCourse(c.getId(), c.getName(), invalidTimeZone);
+            signalFailureToDetectException();
+        } catch (InvalidParametersException e) {
+            String expectedErrorMessage = getPopulatedErrorMessage(
+                    FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
+                    FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+            assertEquals(expectedErrorMessage, e.getMessage());
         }
     }
 
@@ -979,4 +989,24 @@ public class CoursesLogicTest extends BaseLogicTest {
             assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
         }
     }
+
+    private void testUpdateCourse() throws Exception {
+        ______TS("Invalid time zone");
+
+        CourseAttributes c = CourseAttributes
+                .builder("Computing101-getthis", "Basic Computing Getting", ZoneId.of("UTC"))
+                .build();
+        coursesDb.createEntity(c);
+        String invalidTimeZone = "Invalid Timezone";
+        try {
+            coursesLogic.updateCourse(c.getId(), c.getName(), invalidTimeZone);
+            signalFailureToDetectException();
+        } catch (InvalidParametersException e) {
+            String expectedErrorMessage = getPopulatedErrorMessage(
+                    FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
+                    FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+            assertEquals(expectedErrorMessage, e.getMessage());
+        }
+    }
+
 }

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -28,6 +28,7 @@ import teammates.storage.api.AccountsDb;
 import teammates.storage.api.CoursesDb;
 import teammates.storage.api.InstructorsDb;
 import teammates.test.driver.AssertHelper;
+import teammates.test.driver.StringHelperExtension;
 
 /**
  * SUT: {@link CoursesLogic}.
@@ -1004,16 +1005,22 @@ public class CoursesLogicTest extends BaseLogicTest {
         c.setTimeZone(ZoneId.of(validTimeZone));
         verifyPresentInDatastore(c);
 
-        ______TS("Invalid time zone");
+        ______TS("Invalid time zone and name");
 
+        String emptyName = "";
         String invalidTimeZone = "Invalid Timezone";
         try {
-            coursesLogic.updateCourse(c.getId(), c.getName(), invalidTimeZone);
+            coursesLogic.updateCourse(c.getId(), emptyName, invalidTimeZone);
             signalFailureToDetectException();
         } catch (InvalidParametersException e) {
-            String expectedErrorMessage = getPopulatedErrorMessage(
-                    FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
-                    FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+            String expectedErrorMessage =
+                    getPopulatedEmptyStringErrorMessage(
+                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                            FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH)
+                    + System.lineSeparator()
+                    + getPopulatedErrorMessage(
+                            FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
+                            FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
             assertEquals(expectedErrorMessage, e.getMessage());
             verifyPresentInDatastore(c);
         }

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -991,12 +991,21 @@ public class CoursesLogicTest extends BaseLogicTest {
     }
 
     private void testUpdateCourse() throws Exception {
-        ______TS("Invalid time zone");
-
         CourseAttributes c = CourseAttributes
                 .builder("Computing101-getthis", "Basic Computing Getting", ZoneId.of("UTC"))
                 .build();
         coursesDb.createEntity(c);
+
+        ______TS("Typical case");
+        String newName = "New Course Name";
+        String validTimeZone = "Asia/Singapore";
+        coursesLogic.updateCourse(c.getId(), newName, validTimeZone);
+        c.setName(newName);
+        c.setTimeZone(ZoneId.of(validTimeZone));
+        verifyPresentInDatastore(c);
+
+        ______TS("Invalid time zone");
+
         String invalidTimeZone = "Invalid Timezone";
         try {
             coursesLogic.updateCourse(c.getId(), c.getName(), invalidTimeZone);
@@ -1006,6 +1015,7 @@ public class CoursesLogicTest extends BaseLogicTest {
                     FieldValidator.COURSE_TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
                     FieldValidator.COURSE_TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
             assertEquals(expectedErrorMessage, e.getMessage());
+            verifyPresentInDatastore(c);
         }
     }
 

--- a/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
@@ -1,6 +1,7 @@
 package teammates.test.cases.logic;
 
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -286,7 +287,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("instructor course join email");
 
         CourseAttributes course = CourseAttributes
-                .builder("course-id", "Course Name", "UTC")
+                .builder("course-id", "Course Name", ZoneId.of("UTC"))
                 .build();
 
         email = new EmailGenerator().generateInstructorCourseJoinEmail(inviter, instructor, course);
@@ -334,7 +335,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("student course join email");
 
         CourseAttributes course = CourseAttributes
-                .builder("idOfTypicalCourse1", "Course Name", "UTC")
+                .builder("idOfTypicalCourse1", "Course Name", ZoneId.of("UTC"))
                 .build();
 
         StudentAttributes student = StudentAttributes
@@ -357,7 +358,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("student course (without co-owners) join email");
 
-        course = CourseAttributes.builder("course-id", "Course Name", "UTC").build();
+        course = CourseAttributes.builder("course-id", "Course Name", ZoneId.of("UTC")).build();
 
         email = new EmailGenerator().generateStudentCourseJoinEmail(course, student);
         subject = String.format(EmailType.STUDENT_COURSE_JOIN.getSubject(), course.getName(), course.getId());
@@ -401,7 +402,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("student course register email");
 
         CourseAttributes course = CourseAttributes
-                .builder("idOfTypicalCourse1", "Course Name", "UTC")
+                .builder("idOfTypicalCourse1", "Course Name", ZoneId.of("UTC"))
                 .build();
         String name = "User Name";
         String emailAddress = "user@email.tmt";

--- a/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorStudentListPageDataTest.java
@@ -1,5 +1,6 @@
 package teammates.test.cases.pagedata;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class InstructorStudentListPageDataTest extends BaseTestCase {
 
         // only course ID and name are used
         sampleCourse = CourseAttributes
-                .builder("validCourseId", "Sample course name", "UTC")
+                .builder("validCourseId", "Sample course name", ZoneId.of("UTC"))
                 .build();
 
         isCourseArchived = false;

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -1,5 +1,6 @@
 package teammates.test.cases.pagedata;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -149,10 +150,10 @@ public class StudentHomePageDataTest extends BaseTestCase {
     private StudentHomePageData createData() {
         // Courses
         CourseAttributes course1 = CourseAttributes
-                .builder("course-id-1", "old-course", "UTC")
+                .builder("course-id-1", "old-course", ZoneId.of("UTC"))
                 .build();
         CourseAttributes course2 = CourseAttributes
-                .builder("course-id-2", "new-course", "UTC")
+                .builder("course-id-2", "new-course", ZoneId.of("UTC"))
                 .build();
 
         // Feedback sessions

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.storage;
 
+import java.time.ZoneId;
+
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -33,7 +35,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
         ______TS("Success: typical case");
 
         CourseAttributes c = CourseAttributes
-                .builder("CDbT.tCC.newCourse", "Basic Computing", "UTC")
+                .builder("CDbT.tCC.newCourse", "Basic Computing", ZoneId.of("UTC"))
                 .build();
         coursesDb.createEntity(c);
         verifyPresentInDatastore(c);
@@ -51,7 +53,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
         ______TS("Failure: create a course with invalid parameter");
 
         CourseAttributes invalidIdCourse = CourseAttributes
-                .builder("Invalid id", "Basic Computing", "UTC")
+                .builder("Invalid id", "Basic Computing", ZoneId.of("UTC"))
                 .build();
         try {
             coursesDb.createEntity(invalidIdCourse);
@@ -64,7 +66,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         String longCourseName = StringHelperExtension.generateStringOfLength(FieldValidator.COURSE_NAME_MAX_LENGTH + 1);
         CourseAttributes invalidNameCourse = CourseAttributes
-                .builder("CDbT.tCC.newCourse", longCourseName, "UTC")
+                .builder("CDbT.tCC.newCourse", longCourseName, ZoneId.of("UTC"))
                 .build();
         try {
             coursesDb.createEntity(invalidNameCourse);
@@ -72,18 +74,6 @@ public class CoursesDbTest extends BaseComponentTestCase {
         } catch (InvalidParametersException e) {
             AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is too long",
                                         e.getMessage());
-        }
-
-        CourseAttributes invalidTimeZoneCourse = CourseAttributes
-                .builder("CDbT.tCC.newCourse", "Basic Computing", "InvalidTimeZone")
-                .build();
-
-        try {
-            coursesDb.createEntity(invalidTimeZoneCourse);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
-                                         e.getMessage());
         }
 
         ______TS("Failure: null parameter");
@@ -136,7 +126,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
         ______TS("Failure: update course with invalid parameters");
 
         CourseAttributes invalidCourse = CourseAttributes
-                .builder("", "", "")
+                .builder("", "", ZoneId.of("UTC"))
                 .build();
 
         try {
@@ -147,14 +137,12 @@ public class CoursesDbTest extends BaseComponentTestCase {
                                         e.getMessage());
             AssertHelper.assertContains("The field 'course name' is empty",
                                         e.getMessage());
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course time zone",
-                                        e.getMessage());
         }
 
         ______TS("fail: non-exisitng course");
 
         CourseAttributes nonExistentCourse = CourseAttributes
-                .builder("CDbT.non-exist-course", "Non existing course", "UTC")
+                .builder("CDbT.non-exist-course", "Non existing course", ZoneId.of("UTC"))
                 .build();
 
         try {
@@ -168,7 +156,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         CourseAttributes c = createNewCourse();
         CourseAttributes updatedCourse = CourseAttributes
-                .builder(c.getId(), c.getName() + " updated", "UTC")
+                .builder(c.getId(), c.getName() + " updated", ZoneId.of("UTC"))
                 .build();
 
         coursesDb.updateCourse(updatedCourse);
@@ -205,7 +193,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
     private CourseAttributes createNewCourse() throws InvalidParametersException {
 
         CourseAttributes c = CourseAttributes
-                .builder("Computing101", "Basic Computing", "UTC")
+                .builder("Computing101", "Basic Computing", ZoneId.of("UTC"))
                 .build();
 
         try {

--- a/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.storage;
 
+import java.time.ZoneId;
+
 import static teammates.common.util.FieldValidator.COURSE_ID_ERROR_MESSAGE;
 import static teammates.common.util.FieldValidator.REASON_INCORRECT_FORMAT;
 
@@ -13,8 +15,6 @@ import teammates.common.util.FieldValidator;
 import teammates.storage.api.CoursesDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
-
-import java.time.ZoneId;
 
 /**
  * SUT: {@link teammates.storage.api.EntitiesDb}.

--- a/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
@@ -1,9 +1,9 @@
 package teammates.test.cases.storage;
 
-import java.time.ZoneId;
-
 import static teammates.common.util.FieldValidator.COURSE_ID_ERROR_MESSAGE;
 import static teammates.common.util.FieldValidator.REASON_INCORRECT_FORMAT;
+
+import java.time.ZoneId;
 
 import org.testng.annotations.Test;
 

--- a/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
@@ -14,6 +14,8 @@ import teammates.storage.api.CoursesDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
 
+import java.time.ZoneId;
+
 /**
  * SUT: {@link teammates.storage.api.EntitiesDb}.
  */
@@ -31,7 +33,7 @@ public class EntitiesDbTest extends BaseComponentTestCase {
 
         ______TS("success: typical case");
         CourseAttributes c = CourseAttributes
-                .builder("Computing101-fresh", "Basic Computing", "UTC")
+                .builder("Computing101-fresh", "Basic Computing", ZoneId.of("UTC"))
                 .build();
         coursesDb.deleteCourse(c.getId());
         verifyAbsentInDatastore(c);
@@ -52,7 +54,7 @@ public class EntitiesDbTest extends BaseComponentTestCase {
 
         ______TS("fails: invalid parameters");
         CourseAttributes invalidCourse = CourseAttributes
-                .builder("invalid id spaces", "Basic Computing", "UTC")
+                .builder("invalid id spaces", "Basic Computing", ZoneId.of("UTC"))
                 .build();
         try {
             coursesDb.createEntity(invalidCourse);

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -18,6 +18,8 @@ import teammates.test.cases.BaseTestCaseWithBackDoorApiAccess;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.Priority;
 
+import java.time.ZoneId;
+
 /**
  * SUT: {@link BackDoor}.
  */
@@ -156,7 +158,7 @@ public class BackDoorTest extends BaseTestCaseWithBackDoorApiAccess {
 
         String courseId = "tmapitt.tcc.course";
         CourseAttributes course = CourseAttributes
-                .builder(courseId, "Name of tmapitt.tcc.instructor", "UTC")
+                .builder(courseId, "Name of tmapitt.tcc.instructor", ZoneId.of("UTC"))
                 .build();
 
         // Make sure not already inside

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.testdriver;
 
+import java.time.ZoneId;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -17,8 +19,6 @@ import teammates.common.util.StringHelper;
 import teammates.test.cases.BaseTestCaseWithBackDoorApiAccess;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.Priority;
-
-import java.time.ZoneId;
 
 /**
  * SUT: {@link BackDoor}.


### PR DESCRIPTION
<!-- Fixes #8362 -->
Part of #8362

This PR changes the `timeZone` field in`CourseAttributes` to `ZoneId` so that other classes that need time zone information can use it directly. Since `CourseAttributes` now always contains valid time zone, validation of the user supplied time zone field is done in `CourseLogic`. This comes after the Action level so usage of `CourseAttributes` in the Action level is removed.
