### PR TITLE
Admin: recent activity log: show correct 'time stamp in instructor timezone' #8594

### DIFF
--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -370,6 +370,10 @@ public final class TimeHelper {
 
     /**
      * Formats {@code instant} in admin's activity log page.
+     *
+     * @param instant   the instant to be formatted
+     * @param zoneId    the time zone to calculate local date and time
+     * @return          the formatted string
      */
     public static String formatActivityLogTime(Instant instant, ZoneId zoneId) {
         return formatInstant(instant, zoneId, "dd/MM/yyyy HH:mm:ss.SSS");
@@ -476,6 +480,10 @@ public final class TimeHelper {
     /**
      * Parses a {@code LocalDateTime} object from a date time string according to a pattern.
      * Returns {@code null} on error.
+     *
+     * @param dateTimeString    the string containing the date and time
+     * @param pattern           the pattern of the date and time string
+     * @return                  the parsed {@code LocalDateTime} object, or {@code null} if there are errors.
      */
     public static LocalDateTime parseLocalDateTime(String dateTimeString, String pattern) {
         if (dateTimeString == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -381,17 +381,6 @@ public final class TimeHelper {
     }
 
     /**
-     * Converts the date string to a Date object.
-     *
-     * @param dateInStringFormat should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
-     * @deprecated Use {@link TimeHelper#parseInstant(String)} instead
-     */
-    @Deprecated
-    public static Date convertToDate(String dateInStringFormat) {
-        return convertInstantToDate(parseInstant(dateInStringFormat));
-    }
-
-    /**
      * Converts the datetime string to an Instant object.
      *
      * @param dateTimeString should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
@@ -404,17 +393,6 @@ public final class TimeHelper {
             Assumption.fail("Date in String is in wrong format.");
             return null;
         }
-    }
-
-    // TODO: both Date and Calendar will become Instant so this should be removed totally
-    @Deprecated
-    public static Calendar dateToCalendar(Date date) {
-        Calendar c = Calendar.getInstance(SystemParams.TIME_ZONE);
-        if (date == null) {
-            return c;
-        }
-        c.setTime(date);
-        return c;
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -486,7 +486,6 @@ public final class TimeHelper {
         try {
             return LocalDateTime.parse(dateTimeString, formatter);
         } catch (DateTimeParseException e) {
-            Assumption.fail("Date in String is in wrong format.");
             return null;
         }
     }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -166,18 +166,13 @@ public final class TimeHelper {
             return null;
         }
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM, yyyy H.mm");
         String dateTimeString;
         if ("24".equals(inputTimeHours)) {
             dateTimeString = inputDate + " 23.59";
         } else {
             dateTimeString = inputDate + " " + inputTimeHours + ".00";
         }
-        try {
-            return LocalDateTime.parse(dateTimeString, formatter);
-        } catch (DateTimeParseException e) {
-            return null;
-        }
+        return parseLocalDateTime(dateTimeString, "EEE, dd MMM, yyyy H.mm");
     }
 
     /**
@@ -243,7 +238,7 @@ public final class TimeHelper {
      * PM is especially formatted as NOON if it's 12:00 PM, if present
      */
     private static String formatLocalDateTime(LocalDateTime localDateTime, String pattern) {
-        if (localDateTime == null) {
+        if (localDateTime == null || pattern == null) {
             return "";
         }
         String processedPattern = pattern;
@@ -306,7 +301,7 @@ public final class TimeHelper {
      * PM is especially formatted as NOON if it's 12:00 PM, if present.
      */
     private static String formatInstant(Instant instant, ZoneId timeZone, String pattern) {
-        if (instant == null || timeZone == null) {
+        if (instant == null || timeZone == null || pattern == null) {
             return "";
         }
         ZonedDateTime zonedDateTime = instant.atZone(timeZone);
@@ -479,7 +474,25 @@ public final class TimeHelper {
     }
 
     /**
-     * Parse a `LocalDateTime` object from separated date, hour and minute strings.
+     * Parses a {@code LocalDateTime} object from a date time string according to a pattern.
+     * Returns {@code null} on error.
+     */
+    public static LocalDateTime parseLocalDateTime(String dateTimeString, String pattern) {
+        if (dateTimeString == null || pattern == null) {
+            return null;
+        }
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        try {
+            return LocalDateTime.parse(dateTimeString, formatter);
+        } catch (DateTimeParseException e) {
+            Assumption.fail("Date in String is in wrong format.");
+            return null;
+        }
+    }
+
+    /**
+     * Parses a `LocalDateTime` object from separated date, hour and minute strings.
      *
      * <p>required parameter format:
      * date: dd/MM/yyyy  hour: H   min:m
@@ -489,13 +502,7 @@ public final class TimeHelper {
         if (date == null || hour == null || min == null) {
             return null;
         }
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy H m");
-        try {
-            return LocalDateTime.parse(date + " " + hour + " " + min, formatter);
-        } catch (DateTimeParseException e) {
-            Assumption.fail("Date in String is in wrong format.");
-            return null;
-        }
+        return parseLocalDateTime(date + " " + hour + " " + min, "dd/MM/yyyy H m");
     }
 
 }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -483,7 +483,7 @@ public final class TimeHelper {
      *
      * @param dateTimeString    the string containing the date and time
      * @param pattern           the pattern of the date and time string
-     * @return                  the parsed {@code LocalDateTime} object, or {@code null} if there are errors.
+     * @return                  the parsed {@code LocalDateTime} object, or {@code null} if there are errors
      */
     public static LocalDateTime parseLocalDateTime(String dateTimeString, String pattern) {
         if (dateTimeString == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -306,7 +306,7 @@ public final class TimeHelper {
      * PM is especially formatted as NOON if it's 12:00 PM, if present.
      */
     private static String formatInstant(Instant instant, ZoneId timeZone, String pattern) {
-        if (instant == null) {
+        if (instant == null || timeZone == null) {
             return "";
         }
         ZonedDateTime zonedDateTime = instant.atZone(timeZone);
@@ -373,8 +373,11 @@ public final class TimeHelper {
         return instant == null ? null : DateTimeFormatter.ISO_INSTANT.format(instant);
     }
 
-    public static String formatActivityLogTime(Instant instant, ZoneId adminTimeZone) {
-        return formatInstant(instant, adminTimeZone, "MM/dd/yyyy HH:mm:ss SSS");
+    /**
+     * Formats {@code instant} in admin's activity log page.
+     */
+    public static String formatActivityLogTime(Instant instant, ZoneId zoneId) {
+        return formatInstant(instant, zoneId, "dd/MM/yyyy HH:mm:ss.SSS");
     }
 
     /**

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -54,6 +54,7 @@ public class AdminActivityLogPageAction extends Action {
 
         String logRoleFromAjax = getRequestParamValue("logRole");
         String logGoogleIdFromAjax = getRequestParamValue("logGoogleId");
+        // logUnixTimeMillis is the number of milliseconds from the Unix epoch, i.e. independent of time zone
         String logUnixTimeMillis = getRequestParamValue("logUnixTimeMillis");
 
         boolean isLoadingLocalTimeAjax = logRoleFromAjax != null
@@ -158,14 +159,14 @@ public class AdminActivityLogPageAction extends Action {
             targetTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_ID;
         }
 
-        ZoneId adminTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_ID;
         String timeInAdminTimeZone =
-                TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime), adminTimeZone);
+                TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime),
+                        Const.SystemParams.ADMIN_TIME_ZONE_ID);
         String timeInUserTimeZone =
                 TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime), targetTimeZone);
 
         status.append("The earliest log entry checked on <b>" + timeInAdminTimeZone + "</b> in Admin Time Zone ("
-                      + adminTimeZone + ") and ");
+                      + Const.SystemParams.ADMIN_TIME_ZONE_ID.getId() + ") and ");
         if (targetTimeZone == null) {
             status.append(timeInUserTimeZone).append(".<br>");
         } else {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -53,16 +53,16 @@ public class AdminActivityLogPageAction extends Action {
 
         String logRoleFromAjax = getRequestParamValue("logRole");
         String logGoogleIdFromAjax = getRequestParamValue("logGoogleId");
-        String logTimeInAdminTimeZoneFromAjax = getRequestParamValue("logTimeInAdminTimeZone");
+        String logUnixTimeMillis = getRequestParamValue("logUnixTimeMillis");
 
         boolean isLoadingLocalTimeAjax = logRoleFromAjax != null
                                          && logGoogleIdFromAjax != null
-                                         && logTimeInAdminTimeZoneFromAjax != null;
+                                         && logUnixTimeMillis != null;
 
         if (isLoadingLocalTimeAjax) {
             data.setLogLocalTime(getLocalTimeInfo(logGoogleIdFromAjax,
                                                   logRoleFromAjax,
-                                                  logTimeInAdminTimeZoneFromAjax));
+                                                  logUnixTimeMillis));
             return createAjaxResult(data);
         }
 
@@ -342,13 +342,13 @@ public class AdminActivityLogPageAction extends Action {
         return Const.DOUBLE_UNINITIALIZED;
     }
 
-    private String getLocalTimeInfo(String logGoogleId, String logRole, String logTimeInAdminTimeZone) {
+    private String getLocalTimeInfo(String logGoogleId, String logRole, String logUnixTimeMillis) {
         double timeZone = getLocalTimeZoneInfo(logGoogleId, logRole);
         if (timeZone == Const.DOUBLE_UNINITIALIZED) {
             return "Local Time Unavailable";
         }
         double timeZoneOffset = timeZone - Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE;
-        return computeTimeWithOffset(timeZoneOffset, Long.parseLong(logTimeInAdminTimeZone));
+        return computeTimeWithOffset(timeZoneOffset, Long.parseLong(logUnixTimeMillis));
     }
 
     private String computeTimeWithOffset(double timeZoneOffset, long logTime) {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -1,7 +1,8 @@
 package teammates.ui.controller;
 
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -144,26 +145,28 @@ public class AdminActivityLogPageAction extends Action {
             earliestSearchTime = earliestLogChecked.getLogTime();
         }
 
-        double targetTimeZone = Const.DOUBLE_UNINITIALIZED;
+        ZoneId targetTimeZone = null;
         if (data.isPersonSpecified()) {
             String targetUserGoogleId = data.getPersonSpecified();
             targetTimeZone = getLocalTimeZoneForRequest(targetUserGoogleId, "");
 
-            if (targetTimeZone == Const.DOUBLE_UNINITIALIZED && courseId != null && !courseId.isEmpty()) {
+            if (targetTimeZone == null && courseId != null && !courseId.isEmpty()) {
                 // if the user is unregistered, try finding the timezone by course id passed from Search page
                 targetTimeZone = getLocalTimeZoneForUnregisteredUserRequest(courseId);
             }
         } else {
-            targetTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE;
+            targetTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_ID;
         }
 
-        double adminTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE;
-        String timeInAdminTimeZone = computeTimeWithOffset(adminTimeZone, earliestSearchTime);
-        String timeInUserTimeZone = computeTimeWithOffset(targetTimeZone, earliestSearchTime);
+        ZoneId adminTimeZone = Const.SystemParams.ADMIN_TIME_ZONE_ID;
+        String timeInAdminTimeZone =
+                TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime), adminTimeZone);
+        String timeInUserTimeZone =
+                TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime), targetTimeZone);
 
         status.append("The earliest log entry checked on <b>" + timeInAdminTimeZone + "</b> in Admin Time Zone ("
                       + adminTimeZone + ") and ");
-        if (targetTimeZone == Const.DOUBLE_UNINITIALIZED) {
+        if (targetTimeZone == null) {
             status.append(timeInUserTimeZone).append(".<br>");
         } else {
             status.append("on <b>" + timeInUserTimeZone + "</b> in Local Time Zone (" + targetTimeZone + ").<br>");
@@ -270,67 +273,66 @@ public class AdminActivityLogPageAction extends Action {
         return appLogs;
     }
 
-    private double getLocalTimeZoneForRequest(String userGoogleId, String userRole) {
+    private ZoneId getLocalTimeZoneForRequest(String userGoogleId, String userRole) {
 
         if (userRole != null && (userRole.contentEquals("Admin") || userRole.contains("(M)"))) {
-            return Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE;
+            return Const.SystemParams.ADMIN_TIME_ZONE_ID;
         }
 
-        double localTimeZone = Const.DOUBLE_UNINITIALIZED;
-        if (userGoogleId != null && !userGoogleId.isEmpty()) {
-            localTimeZone = findAvailableTimeZoneFromCourses(logic.getCoursesForInstructor(userGoogleId));
-
-            if (localTimeZone != Const.DOUBLE_UNINITIALIZED) {
-                return localTimeZone;
-            }
-
-            try {
-                localTimeZone = findAvailableTimeZoneFromCourses(logic.getCoursesForStudentAccount(userGoogleId));
-            } catch (EntityDoesNotExistException e) {
-                localTimeZone = Const.DOUBLE_UNINITIALIZED;
-            }
-
-            if (localTimeZone != Const.DOUBLE_UNINITIALIZED) {
-                return localTimeZone;
-            }
+        if (userGoogleId == null || userGoogleId.isEmpty()) {
+            return null;
         }
 
-        return localTimeZone;
+        ZoneId localTimeZone = findAvailableTimeZoneFromCourses(logic.getCoursesForInstructor(userGoogleId));
+        if (localTimeZone != null) {
+            return localTimeZone;
+        }
+
+        try {
+            return findAvailableTimeZoneFromCourses(logic.getCoursesForStudentAccount(userGoogleId));
+        } catch (EntityDoesNotExistException e) {
+            return null;
+        }
     }
 
-    private double findAvailableTimeZoneFromCourses(List<CourseAttributes> courses) {
-        double localTimeZone = Const.DOUBLE_UNINITIALIZED;
-
-        if (courses == null) {
-            return localTimeZone;
+    private ZoneId findAvailableTimeZoneFromCourses(List<CourseAttributes> courses) {
+        if (courses == null || courses.isEmpty()) {
+            return null;
         }
 
         for (CourseAttributes course : courses) {
-            List<FeedbackSessionAttributes> fsl = logic.getFeedbackSessionsForCourse(course.getId());
-            if (!fsl.isEmpty()) {
-                return TimeHelper.convertToOffset(fsl.get(0).getTimeZone());
+            if (!course.getTimeZone().equals(Const.DEFAULT_TIME_ZONE)) {
+                // non default time zone must be set by user, i.e. reliable
+                return course.getTimeZone();
             }
         }
 
-        return localTimeZone;
+        // course time zones are all default values, look up in the course's session
+        for (CourseAttributes course : courses) {
+            List<FeedbackSessionAttributes> fsl = logic.getFeedbackSessionsForCourse(course.getId());
+            if (!fsl.isEmpty()) {
+                return fsl.get(0).getTimeZone();
+            }
+        }
+
+        // use course's default time zone
+        return Const.DEFAULT_TIME_ZONE;
     }
 
-    private double getLocalTimeZoneForUnregisteredUserRequest(String courseId) {
-        double localTimeZone = Const.DOUBLE_UNINITIALIZED;
-
+    private ZoneId getLocalTimeZoneForUnregisteredUserRequest(String courseId) {
         if (courseId == null || courseId.isEmpty()) {
-            return localTimeZone;
+            return null;
         }
 
-        List<FeedbackSessionAttributes> fsl = logic.getFeedbackSessionsForCourse(courseId);
-        if (!fsl.isEmpty()) {
-            return TimeHelper.convertToOffset(fsl.get(0).getTimeZone());
+        CourseAttributes course = logic.getCourse(courseId);
+        if (course == null) {
+            return null;
         }
 
-        return localTimeZone;
+        return findAvailableTimeZoneFromCourses(Arrays.asList(course));
     }
 
-    private double getLocalTimeZoneInfo(String logGoogleId, String logRole) {
+    private ZoneId getLocalTimeZoneInfo(String logGoogleId, String logRole) {
         if (!logGoogleId.contentEquals("Unknown") && !logGoogleId.contentEquals("Unregistered")) {
             return getLocalTimeZoneForRequest(logGoogleId, logRole);
         }
@@ -339,24 +341,16 @@ public class AdminActivityLogPageAction extends Action {
             return getLocalTimeZoneForUnregisteredUserRequest(courseId);
         }
 
-        return Const.DOUBLE_UNINITIALIZED;
+        return null;
     }
 
     private String getLocalTimeInfo(String logGoogleId, String logRole, String logUnixTimeMillis) {
-        double timeZone = getLocalTimeZoneInfo(logGoogleId, logRole);
-        if (timeZone == Const.DOUBLE_UNINITIALIZED) {
+        ZoneId timeZone = getLocalTimeZoneInfo(logGoogleId, logRole);
+        if (timeZone == null) {
             return "Local Time Unavailable";
         }
-        double timeZoneOffset = timeZone - Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE;
-        return computeTimeWithOffset(timeZoneOffset, Long.parseLong(logUnixTimeMillis));
-    }
-
-    private String computeTimeWithOffset(double timeZoneOffset, long logTime) {
-        Calendar appCal = Calendar.getInstance();
-        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
-        appCal.setTimeInMillis(logTime);
-        appCal = TimeHelper.convertToUserTimeZone(appCal, timeZoneOffset);
-        return sdf.format(appCal.getTime());
+        Instant logInstant = Instant.ofEpochMilli(Long.parseLong(logUnixTimeMillis));
+        return TimeHelper.formatActivityLogTime(logInstant, timeZone) + " [" + timeZone.getId() + "]";
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -2,12 +2,11 @@ package teammates.ui.pagedata;
 
 import java.lang.reflect.Field;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.exception.InvalidParametersException;
@@ -68,11 +67,8 @@ public class AdminActivityLogPageData extends PageData {
     }
 
     private void setDefaultLogSearchPeriod() {
-        Calendar fromCalendarDate = TimeHelper.now(0.0);
-        fromCalendarDate.add(Calendar.DAY_OF_MONTH, -1);
-
-        fromDateValue = fromCalendarDate.getTimeInMillis();
-        toDateValue = TimeHelper.now(0.0).getTimeInMillis();
+        fromDateValue = TimeHelper.getInstantDaysOffsetFromNow(-1).toEpochMilli();
+        toDateValue = Instant.now().toEpochMilli();
     }
 
     public void init(List<ActivityLogEntry> logList) {
@@ -264,22 +260,15 @@ public class AdminActivityLogPageData extends PageData {
                 }
 
             } else if ("from".equals(label)) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy HH:mm");
-                sdf.setTimeZone(TimeZone.getTimeZone(Const.SystemParams.ADMIN_TIME_ZONE));
-                Date d = sdf.parse(values[0] + " 00:00");
-                Calendar cal = TimeHelper.now(0.0);
-                cal.setTime(d);
-                fromDateValue = cal.getTime().getTime();
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy");
+                fromDateValue = LocalDate.parse(values[0], formatter)
+                        .atStartOfDay(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant().toEpochMilli();
                 isFromDateSpecifiedInQuery = true;
 
             } else if ("to".equals(label)) {
-                SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy HH:mm");
-
-                sdf.setTimeZone(TimeZone.getTimeZone(Const.SystemParams.ADMIN_TIME_ZONE));
-                Date d = sdf.parse(values[0] + " 23:59");
-                Calendar cal = TimeHelper.now(0.0);
-                cal.setTime(d);
-                toDateValue = cal.getTime().getTime();
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy");
+                toDateValue = LocalDate.parse(values[0], formatter).atTime(23, 59)
+                        .atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant().toEpochMilli();
             } else {
                 q.add(label, values);
             }

--- a/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminActivityLogPageData.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -260,15 +261,13 @@ public class AdminActivityLogPageData extends PageData {
                 }
 
             } else if ("from".equals(label)) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy");
-                fromDateValue = LocalDate.parse(values[0], formatter)
+                fromDateValue = LocalDate.parse(values[0], DateTimeFormatter.ofPattern("dd/MM/yy"))
                         .atStartOfDay(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant().toEpochMilli();
                 isFromDateSpecifiedInQuery = true;
 
             } else if ("to".equals(label)) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy");
-                toDateValue = LocalDate.parse(values[0], formatter).atTime(23, 59)
-                        .atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant().toEpochMilli();
+                toDateValue = LocalDate.parse(values[0], DateTimeFormatter.ofPattern("dd/MM/yy"))
+                        .atTime(LocalTime.MAX).atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant().toEpochMilli();
             } else {
                 q.add(label, values);
             }

--- a/src/main/webapp/dev/js/main/adminActivityLog.js
+++ b/src/main/webapp/dev/js/main/adminActivityLog.js
@@ -30,7 +30,7 @@ function toggleReference() {
 }
 
 function submitLocalTimeAjaxRequest(time, googleId, role, entry) {
-    const params = `logTimeInAdminTimeZone=${time}&logRole=${role}&logGoogleId=${googleId}`;
+    const params = `logUnixTimeMillis=${time}&logRole=${role}&logGoogleId=${googleId}`;
 
     const link = $(entry);
     const localTimeDisplay = $(entry).parent().children()[1];

--- a/src/main/webapp/dev/js/main/adminActivityLog.js
+++ b/src/main/webapp/dev/js/main/adminActivityLog.js
@@ -32,10 +32,7 @@ function toggleReference() {
 function submitLocalTimeAjaxRequest(time, googleId, role, entry) {
     const params = `logUnixTimeMillis=${time}&logRole=${role}&logGoogleId=${googleId}`;
 
-    const link = $(entry);
     const localTimeDisplay = $(entry).parent().children()[1];
-
-    const originalTime = $(link).html();
 
     $.ajax({
         type: 'POST',

--- a/src/main/webapp/dev/js/main/adminActivityLog.js
+++ b/src/main/webapp/dev/js/main/adminActivityLog.js
@@ -51,7 +51,7 @@ function submitLocalTimeAjaxRequest(time, googleId, role, entry) {
                 if (data.isError) {
                     $(localTimeDisplay).html('Loading error, please retry');
                 } else {
-                    $(link).parent().html(`${originalTime}<mark><br>${data.logLocalTime}</mark>`);
+                    $(localTimeDisplay).html(`<mark>${data.logLocalTime}</mark>`);
                 }
 
                 setStatusMessage(data.statusForAjax, BootstrapContextualColors.INFO);

--- a/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
@@ -70,9 +70,7 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
 
         ______TS("content: ensure default search period is not more than one day");
         Instant yesterday = TimeHelper.getInstantDaysOffsetFromNow(-1);
-
-        assertTrue(logPage.getDateOfEarliestLog()
-                                        .isAfter(yesterday));
+        assertTrue(logPage.getDateOfEarliestLog().isAfter(yesterday));
 
         ______TS("content: show the earliest log's date in both Admin Time Zone and local Time Zone");
         String statusMessageText = logPage.getTextsForAllStatusMessagesToUser().get(0);

--- a/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
@@ -1,6 +1,6 @@
 package teammates.test.cases.browsertests;
 
-import java.util.Calendar;
+import java.time.Instant;
 
 import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchElementException;
@@ -69,11 +69,10 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
         assertEquals(2, logPage.getNumberOfTableHeaders());
 
         ______TS("content: ensure default search period is not more than one day");
-        Calendar yesterday = TimeHelper.now(Const.SystemParams.ADMIN_TIME_ZONE_DOUBLE);
-        yesterday.add(Calendar.DAY_OF_MONTH, -1);
+        Instant yesterday = TimeHelper.getInstantDaysOffsetFromNow(-1);
 
         assertTrue(logPage.getDateOfEarliestLog()
-                                        .after(yesterday.getTime()));
+                                        .isAfter(yesterday));
 
         ______TS("content: show the earliest log's date in both Admin Time Zone and local Time Zone");
         String statusMessageText = logPage.getTextsForAllStatusMessagesToUser().get(0);

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -3,15 +3,13 @@ package teammates.test.pageobjects;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
 
 public class AdminActivityLogPage extends AppPage {
 
@@ -122,11 +120,11 @@ public class AdminActivityLogPage extends AppPage {
         return !elements.isEmpty();
     }
 
-    public Instant getDateOfEarliestLog() throws DateTimeParseException {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss.SSS");
+    public Instant getDateOfEarliestLog() {
         String dateTimeString = getLogsTable().findElement(By.cssSelector("tr:last-child > td > a")).getText();
 
-        return LocalDateTime.parse(dateTimeString, formatter).atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant();
+        return TimeHelper.parseLocalDateTime(dateTimeString, "dd/MM/yyyy HH:mm:ss.SSS")
+                .atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant();
 
     }
 }

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -2,14 +2,16 @@ package teammates.test.pageobjects;
 
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+
+import teammates.common.util.Const;
 
 public class AdminActivityLogPage extends AppPage {
 
@@ -120,12 +122,11 @@ public class AdminActivityLogPage extends AppPage {
         return !elements.isEmpty();
     }
 
-    public Date getDateOfEarliestLog() throws ParseException {
-        String dateFormat = "MM/dd/yyyy HH:mm:ss SSS";
-        DateFormat sdf = new SimpleDateFormat(dateFormat);
+    public Instant getDateOfEarliestLog() throws DateTimeParseException {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss.SSS");
         String dateTimeString = getLogsTable().findElement(By.cssSelector("tr:last-child > td > a")).getText();
 
-        return sdf.parse(dateTimeString);
+        return LocalDateTime.parse(dateTimeString, formatter).atZone(Const.SystemParams.ADMIN_TIME_ZONE_ID).toInstant();
 
     }
 }

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -118,7 +118,7 @@ public class AdminActivityLogPage extends AppPage {
 
     public boolean isUserTimezoneAtFirstRowClicked() {
         List<WebElement> elements = browser.driver
-                .findElements(By.cssSelector("#activity-logs-table td > mark"));
+                .findElements(By.cssSelector("#activity-logs-table td > .localTime > mark"));
         return !elements.isEmpty();
     }
 

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -138,7 +138,7 @@
       "createdAt": "2012-04-01T23:58:00Z",
       "id": "idOfTypicalCourse1",
       "name": "Typical Course 1 with 2 Evals",
-      "timeZone": "UTC"
+      "timeZone": "UTC+02:00"
     },
     "typicalCourse2": {
       "createdAt": "2012-04-01T23:59:00Z",


### PR DESCRIPTION
Fixes #8594

Times in activity log page now always uses the same format. User's local time is attached with the timezone's name to avoid confusion in case our user timezone detection is wrong.
![image](https://user-images.githubusercontent.com/8559368/37479288-41749f4a-28b7-11e8-9bca-00f45814e679.png)

Also refactor `AdminActivityLogPageAction` and its test to use `java.time`.


