### PR TITLE
Fix unnecessary map contains key usage

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -274,10 +274,8 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
             String overallRank = Integer.toString(recipientOverallRank.get(participantIdentifier));
             String name = bundle.getNameForEmail(participantIdentifier);
             String teamName = bundle.getTeamNameForEmail(participantIdentifier);
-            String overallRankExceptSelf = recipientOverallRankExceptSelf.containsKey(participantIdentifier)
-                    ? Integer.toString(recipientOverallRankExceptSelf.get(participantIdentifier)) : "-";
-            String selfRank = recipientSelfRanks.containsKey(participantIdentifier)
-                    ? Integer.toString(recipientSelfRanks.get(participantIdentifier)) : "-";
+            String overallRankExceptSelf = getRecipientInfo(recipientOverallRankExceptSelf, participantIdentifier);
+            String selfRank = getRecipientInfo(recipientSelfRanks, participantIdentifier);
 
             fragments.append(Templates.populateTemplate(fragmentTemplateToUse,
                     Slots.RANK_OPTION_VALUE, SanitizationHelper.sanitizeForHtml(name),
@@ -325,13 +323,9 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
                             + ","
                             + SanitizationHelper.sanitizeForCsv(recipientName);
 
-            String selfRank = Optional.ofNullable(recipientSelfRanks.get(participantIdentifier))
-                                      .map(val -> Integer.toString(val))
-                                      .orElse("-");
+            String selfRank = getRecipientInfo(recipientSelfRanks, participantIdentifier);
             String overallRank = Integer.toString(recipientOverallRank.get(participantIdentifier));
-            String overallRankExceptSelf = Optional.ofNullable(recipientOverallRankExceptSelf.get(participantIdentifier))
-                                                   .map(val -> Integer.toString(val))
-                                                   .orElse("-");
+            String overallRankExceptSelf = getRecipientInfo(recipientOverallRankExceptSelf, participantIdentifier);
 
             fragments.append(option)
                     .append(',').append(selfRank)
@@ -438,6 +432,19 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     private Map<String, List<Integer>> getRecipientRanksExcludingSelf(List<FeedbackResponseAttributes> responses) {
         List<FeedbackResponseAttributes> responsesExcludingSelf = getResponsesExcludingSelf(responses);
         return generateOptionRanksMapping(responsesExcludingSelf);
+    }
+
+    /**
+     * Returns value converted to string or dash.
+     *
+     * @param map original map with recipient information
+     * @param key recipient identifier to get from map
+     * @return value converted to string or dash if there is no value associated with key
+     */
+    private String getRecipientInfo(Map<String, Integer> map, String key) {
+        return Optional.ofNullable(map.get(key))
+                       .map(val -> Integer.toString(val))
+                       .orElse("-");
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
@@ -324,19 +325,21 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
                             + ","
                             + SanitizationHelper.sanitizeForCsv(recipientName);
 
-            String overallRankExceptSelf = recipientOverallRankExceptSelf.containsKey(participantIdentifier)
-                    ? Integer.toString(recipientOverallRankExceptSelf.get(participantIdentifier)) : "-";
+            String selfRank = Optional.ofNullable(recipientSelfRanks.get(participantIdentifier))
+                                      .map(val -> Integer.toString(val))
+                                      .orElse("-");
             String overallRank = Integer.toString(recipientOverallRank.get(participantIdentifier));
-            String selfRank = recipientSelfRanks.containsKey(participantIdentifier)
-                    ? Integer.toString(recipientSelfRanks.get(participantIdentifier)) : "-";
+            String overallRankExceptSelf = Optional.ofNullable(recipientOverallRankExceptSelf.get(participantIdentifier))
+                                                   .map(val -> Integer.toString(val))
+                                                   .orElse("-");
 
-            fragments.append(option);
-            fragments.append(',').append(selfRank);
-            fragments.append(',').append(overallRank);
-            fragments.append(',').append(overallRankExceptSelf);
-            fragments.append(',');
-            fragments.append(StringHelper.join(",", ranks));
-            fragments.append(System.lineSeparator());
+            fragments.append(option)
+                    .append(',').append(selfRank)
+                    .append(',').append(overallRank)
+                    .append(',').append(overallRankExceptSelf)
+                    .append(',')
+                    .append(StringHelper.join(",", ranks))
+                    .append(System.lineSeparator());
         });
 
         return "Team, Recipient, Self Rank, Overall Rank, Overall Rank Excluding Self, Ranks Received"

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -505,9 +505,7 @@ public final class FeedbackSessionsLogic {
 
         for (String instructorEmail : hiddenInstructorEmails) {
 
-            if (recipients.containsKey(instructorEmail)) {
-                recipients.remove(instructorEmail);
-            }
+            recipients.remove(instructorEmail);
 
             // Remove responses to the hidden instructors if they have been stored already
             responses.removeIf(response -> response.recipient.equals(instructorEmail));


### PR DESCRIPTION
Fixes #8215

Method Map.remove() removes the mapping for a key from this map if it is present, so there is no need to use containsKey().

Optional.ofNullable allows to NPE check with containsKey().

