### PR TITLE
InstructorSearchPage: Add tests for links displayed with search results #8685

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
@@ -129,7 +129,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         String studentEmail = testData.students.get("student2.2InCourse1").email;
         String courseId = testData.courses.get("typicalCourse1").getId();
 
-        searchPage.clickView(courseId, studentName);
+        searchPage.clickViewStudent(courseId, studentName);
         InstructorCourseStudentDetailsViewPage studentDetailsViewPage = searchPage
                 .changePageType(InstructorCourseStudentDetailsViewPage.class);
         studentDetailsViewPage.verifyIsCorrectPage(studentEmail);
@@ -149,7 +149,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         String studentEmail = testData.students.get("student2.2InCourse1").email;
         String courseId = testData.courses.get("typicalCourse1").getId();
 
-        searchPage.clickEdit(courseId, studentName);
+        searchPage.clickEditStudent(courseId, studentName);
         InstructorCourseStudentDetailsEditPage studentDetailsEditPage = searchPage
                 .changePageType(InstructorCourseStudentDetailsEditPage.class);
         studentDetailsEditPage.verifyIsCorrectPage(studentEmail);
@@ -168,7 +168,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         String studentName = testData.students.get("student2.2InCourse1").name;
         String courseId = testData.courses.get("typicalCourse1").getId();
 
-        searchPage.clickAllRecords(courseId, studentName);
+        searchPage.clickAllRecordsLink(courseId, studentName);
         InstructorStudentRecordsPage studentRecordsPage = searchPage
                 .changePageType(InstructorStudentRecordsPage.class);
         studentRecordsPage.verifyIsCorrectPage(studentName);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
@@ -11,6 +11,7 @@ import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.FileHelper;
+import teammates.test.pageobjects.InstructorCourseStudentDetailsViewPage;
 import teammates.test.pageobjects.InstructorSearchPage;
 
 /**
@@ -38,6 +39,10 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
 
         testContent();
         testSearch();
+
+        testViewAction();
+//        testEditAction();
+//        testAllRecordsAction();
 
         testSanitization();
 
@@ -107,6 +112,25 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         searchPage.clickSearchButton();
         searchPage.clickAndHoverPicture("studentphoto-c0.1");
         searchPage.verifyHtmlMainContent("/instructorSearchPageSearchStudentsForStudent2.html");
+    }
+
+    private void testViewAction() throws Exception {
+
+        ______TS("action: view");
+
+        searchPage.clearSearchBox();
+        String searchContent = "\"student2 2 In Course1\"";
+        searchPage.inputSearchContent(searchContent);
+        searchPage.clickSearchButton();
+
+        String studentName = testData.students.get("student2.2InCourse1").name;
+        String studentEmail = testData.students.get("student2.2InCourse1").email;
+        String courseId = testData.courses.get("typicalCourse1").getId();
+
+        searchPage.clickView(courseId, studentName);
+        InstructorCourseStudentDetailsViewPage studentDetailsViewPage = searchPage
+                .changePageType(InstructorCourseStudentDetailsViewPage.class);
+        studentDetailsViewPage.verifyIsCorrectPage(studentEmail);
     }
 
     private void testSanitization() throws IOException {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
@@ -131,6 +131,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         InstructorCourseStudentDetailsViewPage studentDetailsViewPage = searchPage
                 .changePageType(InstructorCourseStudentDetailsViewPage.class);
         studentDetailsViewPage.verifyIsCorrectPage(studentEmail);
+        studentDetailsViewPage.closeCurrentWindowAndSwitchToParentWindow();
     }
 
     private void testSanitization() throws IOException {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
@@ -14,6 +14,7 @@ import teammates.test.driver.FileHelper;
 import teammates.test.pageobjects.InstructorCourseStudentDetailsEditPage;
 import teammates.test.pageobjects.InstructorCourseStudentDetailsViewPage;
 import teammates.test.pageobjects.InstructorSearchPage;
+import teammates.test.pageobjects.InstructorStudentRecordsPage;
 
 /**
  * SUT: {@link Const.ActionURIs#INSTRUCTOR_SEARCH_PAGE}.
@@ -43,7 +44,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
 
         testViewAction();
         testEditAction();
-//        testAllRecordsAction();
+        testAllRecordsAction();
 
         testSanitization();
 
@@ -153,6 +154,25 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
                 .changePageType(InstructorCourseStudentDetailsEditPage.class);
         studentDetailsEditPage.verifyIsCorrectPage(studentEmail);
         studentDetailsEditPage.closeCurrentWindowAndSwitchToParentWindow();
+    }
+
+    private void testAllRecordsAction() throws Exception {
+
+        ______TS("action: all records");
+
+        searchPage.clearSearchBox();
+        String searchContent = "\"student2 2 In Course1\"";
+        searchPage.inputSearchContent(searchContent);
+        searchPage.clickSearchButton();
+
+        String studentName = testData.students.get("student2.2InCourse1").name;
+        String courseId = testData.courses.get("typicalCourse1").getId();
+
+        searchPage.clickAllRecords(courseId, studentName);
+        InstructorStudentRecordsPage studentRecordsPage = searchPage
+                .changePageType(InstructorStudentRecordsPage.class);
+        studentRecordsPage.verifyIsCorrectPage(studentName);
+        studentRecordsPage.closeCurrentWindowAndSwitchToParentWindow();
     }
 
     private void testSanitization() throws IOException {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorSearchPageUiTest.java
@@ -11,6 +11,7 @@ import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.FileHelper;
+import teammates.test.pageobjects.InstructorCourseStudentDetailsEditPage;
 import teammates.test.pageobjects.InstructorCourseStudentDetailsViewPage;
 import teammates.test.pageobjects.InstructorSearchPage;
 
@@ -41,7 +42,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         testSearch();
 
         testViewAction();
-//        testEditAction();
+        testEditAction();
 //        testAllRecordsAction();
 
         testSanitization();
@@ -132,6 +133,26 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
                 .changePageType(InstructorCourseStudentDetailsViewPage.class);
         studentDetailsViewPage.verifyIsCorrectPage(studentEmail);
         studentDetailsViewPage.closeCurrentWindowAndSwitchToParentWindow();
+    }
+
+    private void testEditAction() throws Exception {
+
+        ______TS("action: edit");
+
+        searchPage.clearSearchBox();
+        String searchContent = "\"student2 2 In Course1\"";
+        searchPage.inputSearchContent(searchContent);
+        searchPage.clickSearchButton();
+
+        String studentName = testData.students.get("student2.2InCourse1").name;
+        String studentEmail = testData.students.get("student2.2InCourse1").email;
+        String courseId = testData.courses.get("typicalCourse1").getId();
+
+        searchPage.clickEdit(courseId, studentName);
+        InstructorCourseStudentDetailsEditPage studentDetailsEditPage = searchPage
+                .changePageType(InstructorCourseStudentDetailsEditPage.class);
+        studentDetailsEditPage.verifyIsCorrectPage(studentEmail);
+        studentDetailsEditPage.closeCurrentWindowAndSwitchToParentWindow();
     }
 
     private void testSanitization() throws IOException {

--- a/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
@@ -1,7 +1,11 @@
 package teammates.test.pageobjects;
 
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+
+import teammates.common.util.Const;
 
 public class InstructorSearchPage extends AppPage {
 
@@ -37,6 +41,14 @@ public class InstructorSearchPage extends AppPage {
         click(getStudentCheckBox());
     }
 
+    public InstructorSearchPage clickView(String courseId, String studentName) {
+        String rowId = getStudentRowId(courseId, studentName);
+        click(getViewLink(rowId));
+        waitForPageToLoad();
+        switchToNewWindow();
+        return this;
+    }
+
     private WebElement getSearchBox() {
         return browser.driver.findElement(By.id("searchBox"));
     }
@@ -51,6 +63,42 @@ public class InstructorSearchPage extends AppPage {
 
     private WebElement getStudentCheckBox() {
         return browser.driver.findElement(By.id("students-check"));
+    }
+
+    private int getCourseNumber(String courseId) {
+        int id = -1;
+        List<WebElement> panels = browser.driver.findElements(By.className("panel-heading"));
+        for (WebElement panel : panels) {
+            if (panel.getText().startsWith("[" + courseId + "]")) {
+                break;
+            }
+            id++;
+        }
+        return id;
+    }
+
+    private String getStudentRowId(String courseId, String studentName) {
+        int courseNumber = getCourseNumber(courseId);
+        int studentCount = browser.driver.findElements(By.cssSelector("tr[id^='student-c" + courseNumber + "']"))
+                .size();
+        for (int i = 0; i < studentCount; i++) {
+            String studentNameInRow = getStudentNameInRow(courseNumber, i);
+            if (studentNameInRow.equals(studentName)) {
+                return courseNumber + "." + i;
+            }
+        }
+        return "";
+    }
+
+    private String getStudentNameInRow(int courseNumber, int rowId) {
+        String xpath = "//tr[@id='student-c" + courseNumber + "." + rowId + "']"
+                + "//td[@id='" + Const.ParamsNames.STUDENT_NAME + "-c" + courseNumber + "." + rowId + "']";
+        return browser.driver.findElement(By.xpath(xpath)).getText();
+    }
+
+    private WebElement getViewLink(String rowId) {
+        WebElement studentRow = browser.driver.findElement(By.id("student-c" + rowId));
+        return studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(1)"));
     }
 
     public void clickAndHoverPicture(String cellId) {

--- a/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
@@ -49,6 +49,14 @@ public class InstructorSearchPage extends AppPage {
         return this;
     }
 
+    public InstructorSearchPage clickEdit(String courseId, String studentName) {
+        String rowId = getStudentRowId(courseId, studentName);
+        click(getEditLink(rowId));
+        waitForPageToLoad();
+        switchToNewWindow();
+        return this;
+    }
+
     private WebElement getSearchBox() {
         return browser.driver.findElement(By.id("searchBox"));
     }
@@ -99,6 +107,11 @@ public class InstructorSearchPage extends AppPage {
     private WebElement getViewLink(String rowId) {
         WebElement studentRow = browser.driver.findElement(By.id("student-c" + rowId));
         return studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(1)"));
+    }
+
+    private WebElement getEditLink(String rowId) {
+        WebElement studentRow = browser.driver.findElement(By.id("student-c" + rowId));
+        return studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(2)"));
     }
 
     public void clickAndHoverPicture(String cellId) {

--- a/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
@@ -41,7 +41,7 @@ public class InstructorSearchPage extends AppPage {
         click(getStudentCheckBox());
     }
 
-    public InstructorSearchPage clickView(String courseId, String studentName) {
+    public InstructorSearchPage clickViewStudent(String courseId, String studentName) {
         String rowId = getStudentRowId(courseId, studentName);
         click(getViewLink(rowId));
         waitForPageToLoad();
@@ -49,7 +49,7 @@ public class InstructorSearchPage extends AppPage {
         return this;
     }
 
-    public InstructorSearchPage clickEdit(String courseId, String studentName) {
+    public InstructorSearchPage clickEditStudent(String courseId, String studentName) {
         String rowId = getStudentRowId(courseId, studentName);
         click(getEditLink(rowId));
         waitForPageToLoad();
@@ -57,7 +57,7 @@ public class InstructorSearchPage extends AppPage {
         return this;
     }
 
-    public InstructorSearchPage clickAllRecords(String courseId, String studentName) {
+    public InstructorSearchPage clickAllRecordsLink(String courseId, String studentName) {
         String rowId = getStudentRowId(courseId, studentName);
         click(getAllRecordsLink(rowId));
         waitForPageToLoad();

--- a/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorSearchPage.java
@@ -57,6 +57,14 @@ public class InstructorSearchPage extends AppPage {
         return this;
     }
 
+    public InstructorSearchPage clickAllRecords(String courseId, String studentName) {
+        String rowId = getStudentRowId(courseId, studentName);
+        click(getAllRecordsLink(rowId));
+        waitForPageToLoad();
+        switchToNewWindow();
+        return this;
+    }
+
     private WebElement getSearchBox() {
         return browser.driver.findElement(By.id("searchBox"));
     }
@@ -112,6 +120,16 @@ public class InstructorSearchPage extends AppPage {
     private WebElement getEditLink(String rowId) {
         WebElement studentRow = browser.driver.findElement(By.id("student-c" + rowId));
         return studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(2)"));
+    }
+
+    private WebElement getAllRecordsLink(String rowId) {
+        WebElement studentRow = browser.driver.findElement(By.id("student-c" + rowId));
+        WebElement fourthLink = studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(4)"));
+
+        if ("All Records".equals(fourthLink.getText())) {
+            return fourthLink;
+        }
+        return studentRow.findElement(By.cssSelector("td.no-print.align-center > a:nth-child(5)"));
     }
 
     public void clickAndHoverPicture(String cellId) {


### PR DESCRIPTION
Fixes #8685 

**Outline of Solution**
- Add tests for `View`, `Edit` and `All Records` button displayed on instructor search result page
- For the test checking on each button, it opens the expected page and compares it with the actual page by using attributes (i.e. `studentName` or `studentEmail`)