### PR TITLE
AdminSessions*: migrate to java.time #8645

### DIFF
--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -13,7 +13,7 @@ import java.time.zone.ZoneRulesProvider;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -28,8 +28,7 @@ public final class TimeHelper {
 
     private static final Logger log = Logger.getLogger();
 
-    private static final Map<ZoneId, String> TIME_ZONE_CITIES_MAP = new HashMap<>();
-    private static final List<ZoneId> TIME_ZONE_VALUES = new ArrayList<>();
+    private static final Map<ZoneId, String> TIME_ZONE_CITIES_MAP = new LinkedHashMap<>();
 
     /*
      *This time zone - city map was created by selecting major cities from each time zone.
@@ -56,8 +55,7 @@ public final class TimeHelper {
         map("UTC-01:00", "Cape Verde, Greenland, Azores islands");
         map("UTC", "Accra, Abidjan, Casablanca, Dakar, Dublin, Lisbon, London");
         map("UTC+01:00", "Belgrade, Berlin, Brussels, Lagos, Madrid, Paris, Rome, Tunis, Vienna, Warsaw");
-        map("UTC+02:00",
-                "Athens, Sofia, Cairo, Kiev, Istanbul, Beirut, Helsinki, Jerusalem, Johannesburg, Bucharest");
+        map("UTC+02:00", "Athens, Sofia, Cairo, Kiev, Istanbul, Beirut, Helsinki, Jerusalem, Johannesburg, Bucharest");
         map("UTC+03:00", "Nairobi, Baghdad, Doha, Khartoum, Minsk, Riyadh");
         map("UTC+03:30", "Tehran");
         map("UTC+04:00", "Baku, Dubai, Moscow");
@@ -129,9 +127,7 @@ public final class TimeHelper {
     }
 
     private static void map(String timeZone, String cities) {
-        ZoneId zone = ZoneId.of(timeZone);
-        TIME_ZONE_CITIES_MAP.put(zone, cities);
-        TIME_ZONE_VALUES.add(zone);
+        TIME_ZONE_CITIES_MAP.put(ZoneId.of(timeZone), cities);
     }
 
     /**
@@ -186,7 +182,7 @@ public final class TimeHelper {
     }
 
     public static List<ZoneId> getTimeZoneValues() {
-        return new ArrayList<>(TIME_ZONE_VALUES);
+        return new ArrayList<>(TIME_ZONE_CITIES_MAP.keySet());
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -39,46 +39,46 @@ public final class TimeHelper {
      */
 
     static {
-        map(ZoneId.of("UTC-12:00"), "Baker Island, Howland Island");
-        map(ZoneId.of("UTC-11:00"), "American Samoa, Niue");
-        map(ZoneId.of("UTC-10:00"), "Hawaii, Cook Islands");
-        map(ZoneId.of("UTC-09:30"), "Marquesas Islands");
-        map(ZoneId.of("UTC-09:00"), "Gambier Islands, Alaska");
-        map(ZoneId.of("UTC-08:00"), "Los Angeles, Vancouver, Tijuana");
-        map(ZoneId.of("UTC-07:00"), "Phoenix, Calgary, Ciudad Juárez");
-        map(ZoneId.of("UTC-06:00"), "Chicago, Guatemala City, Mexico City, San José, San Salvador, Tegucigalpa, Winnipeg");
-        map(ZoneId.of("UTC-05:00"), "New York, Lima, Toronto, Bogotá, Havana, Kingston");
-        map(ZoneId.of("UTC-04:30"), "Caracas");
-        map(ZoneId.of("UTC-04:00"), "Santiago, La Paz, San Juan de Puerto Rico, Manaus, Halifax");
-        map(ZoneId.of("UTC-03:30"), "St. John's");
-        map(ZoneId.of("UTC-03:00"), "Buenos Aires, Montevideo, São Paulo");
-        map(ZoneId.of("UTC-02:00"), "Fernando de Noronha, South Georgia and the South Sandwich Islands");
-        map(ZoneId.of("UTC-01:00"), "Cape Verde, Greenland, Azores islands");
-        map(ZoneId.of("UTC"), "Accra, Abidjan, Casablanca, Dakar, Dublin, Lisbon, London");
-        map(ZoneId.of("UTC+01:00"), "Belgrade, Berlin, Brussels, Lagos, Madrid, Paris, Rome, Tunis, Vienna, Warsaw");
-        map(ZoneId.of("UTC+02:00"),
+        map("UTC-12:00", "Baker Island, Howland Island");
+        map("UTC-11:00", "American Samoa, Niue");
+        map("UTC-10:00", "Hawaii, Cook Islands");
+        map("UTC-09:30", "Marquesas Islands");
+        map("UTC-09:00", "Gambier Islands, Alaska");
+        map("UTC-08:00", "Los Angeles, Vancouver, Tijuana");
+        map("UTC-07:00", "Phoenix, Calgary, Ciudad Juárez");
+        map("UTC-06:00", "Chicago, Guatemala City, Mexico City, San José, San Salvador, Tegucigalpa, Winnipeg");
+        map("UTC-05:00", "New York, Lima, Toronto, Bogotá, Havana, Kingston");
+        map("UTC-04:30", "Caracas");
+        map("UTC-04:00", "Santiago, La Paz, San Juan de Puerto Rico, Manaus, Halifax");
+        map("UTC-03:30", "St. John's");
+        map("UTC-03:00", "Buenos Aires, Montevideo, São Paulo");
+        map("UTC-02:00", "Fernando de Noronha, South Georgia and the South Sandwich Islands");
+        map("UTC-01:00", "Cape Verde, Greenland, Azores islands");
+        map("UTC", "Accra, Abidjan, Casablanca, Dakar, Dublin, Lisbon, London");
+        map("UTC+01:00", "Belgrade, Berlin, Brussels, Lagos, Madrid, Paris, Rome, Tunis, Vienna, Warsaw");
+        map("UTC+02:00",
                 "Athens, Sofia, Cairo, Kiev, Istanbul, Beirut, Helsinki, Jerusalem, Johannesburg, Bucharest");
-        map(ZoneId.of("UTC+03:00"), "Nairobi, Baghdad, Doha, Khartoum, Minsk, Riyadh");
-        map(ZoneId.of("UTC+03:30"), "Tehran");
-        map(ZoneId.of("UTC+04:00"), "Baku, Dubai, Moscow");
-        map(ZoneId.of("UTC+04:30"), "Kabul");
-        map(ZoneId.of("UTC+05:00"), "Karachi, Tashkent");
-        map(ZoneId.of("UTC+05:30"), "Colombo, Delhi");
-        map(ZoneId.of("UTC+05:45"), "Kathmandu");
-        map(ZoneId.of("UTC+06:00"), "Almaty, Dhaka, Yekaterinburg");
-        map(ZoneId.of("UTC+06:30"), "Yangon");
-        map(ZoneId.of("UTC+07:00"), "Jakarta, Bangkok, Novosibirsk, Hanoi");
-        map(ZoneId.of("UTC+08:00"), "Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk");
-        map(ZoneId.of("UTC+08:45"), "Eucla");
-        map(ZoneId.of("UTC+09:00"), "Seoul, Tokyo, Pyongyang, Ambon, Irkutsk");
-        map(ZoneId.of("UTC+09:30"), "Adelaide");
-        map(ZoneId.of("UTC+10:00"), "Canberra, Yakutsk, Port Moresby");
-        map(ZoneId.of("UTC+10:30"), "Lord Howe Islands");
-        map(ZoneId.of("UTC+11:00"), "Vladivostok, Noumea");
-        map(ZoneId.of("UTC+12:00"), "Auckland, Suva");
-        map(ZoneId.of("UTC+12:45"), "Chatham Islands");
-        map(ZoneId.of("UTC+13:00"), "Phoenix Islands, Tokelau, Tonga");
-        map(ZoneId.of("UTC+14:00"), "Line Islands");
+        map("UTC+03:00", "Nairobi, Baghdad, Doha, Khartoum, Minsk, Riyadh");
+        map("UTC+03:30", "Tehran");
+        map("UTC+04:00", "Baku, Dubai, Moscow");
+        map("UTC+04:30", "Kabul");
+        map("UTC+05:00", "Karachi, Tashkent");
+        map("UTC+05:30", "Colombo, Delhi");
+        map("UTC+05:45", "Kathmandu");
+        map("UTC+06:00", "Almaty, Dhaka, Yekaterinburg");
+        map("UTC+06:30", "Yangon");
+        map("UTC+07:00", "Jakarta, Bangkok, Novosibirsk, Hanoi");
+        map("UTC+08:00", "Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk");
+        map("UTC+08:45", "Eucla");
+        map("UTC+09:00", "Seoul, Tokyo, Pyongyang, Ambon, Irkutsk");
+        map("UTC+09:30", "Adelaide");
+        map("UTC+10:00", "Canberra, Yakutsk, Port Moresby");
+        map("UTC+10:30", "Lord Howe Islands");
+        map("UTC+11:00", "Vladivostok, Noumea");
+        map("UTC+12:00", "Auckland, Suva");
+        map("UTC+12:45", "Chatham Islands");
+        map("UTC+13:00", "Phoenix Islands, Tokelau, Tonga");
+        map("UTC+14:00", "Line Islands");
 
     }
 
@@ -128,9 +128,10 @@ public final class TimeHelper {
         // utility class
     }
 
-    private static void map(ZoneId timeZone, String cities) {
-        TIME_ZONE_CITIES_MAP.put(timeZone, cities);
-        TIME_ZONE_VALUES.add(timeZone);
+    private static void map(String timeZone, String cities) {
+        ZoneId zone = ZoneId.of(timeZone);
+        TIME_ZONE_CITIES_MAP.put(zone, cities);
+        TIME_ZONE_VALUES.add(zone);
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -1,6 +1,7 @@
 package teammates.common.util;
 
 import java.lang.reflect.Field;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -558,4 +559,22 @@ public final class TimeHelper {
         return parseLocalDateTime(date + " " + hour + " " + min, "EEE, dd MMM, yyyy H m");
     }
 
+    /**
+     * Parses a {@code ZoneId} object from a string.
+     * Example: "Asia/Singapore" or "UTC+04:00".
+     *
+     * @param timeZone  a string containing the zone ID
+     * @return          ZoneId.of(timeZone) or {@code null} if {@code timeZone} is invalid.
+     */
+    public static ZoneId parseZoneId(String timeZone) {
+        if (timeZone == null) {
+            return null;
+        }
+
+        try {
+            return ZoneId.of(timeZone);
+        } catch (DateTimeException dte) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -28,8 +28,8 @@ public final class TimeHelper {
 
     private static final Logger log = Logger.getLogger();
 
-    private static final Map<String, String> TIME_ZONE_CITIES_MAP = new HashMap<>();
-    private static final List<Double> TIME_ZONE_VALUES = new ArrayList<>();
+    private static final Map<ZoneId, String> TIME_ZONE_CITIES_MAP = new HashMap<>();
+    private static final List<ZoneId> TIME_ZONE_VALUES = new ArrayList<>();
 
     /*
      *This time zone - city map was created by selecting major cities from each time zone.
@@ -39,45 +39,46 @@ public final class TimeHelper {
      */
 
     static {
-        map("-12.0", "Baker Island, Howland Island");
-        map("-11.0", "American Samoa, Niue");
-        map("-10.0", "Hawaii, Cook Islands");
-        map("-9.5", "Marquesas Islands");
-        map("-9.0", "Gambier Islands, Alaska");
-        map("-8.0", "Los Angeles, Vancouver, Tijuana");
-        map("-7.0", "Phoenix, Calgary, Ciudad Juárez");
-        map("-6.0", "Chicago, Guatemala City, Mexico City, San José, San Salvador, Tegucigalpa, Winnipeg");
-        map("-5.0", "New York, Lima, Toronto, Bogotá, Havana, Kingston");
-        map("-4.5", "Caracas");
-        map("-4.0", "Santiago, La Paz, San Juan de Puerto Rico, Manaus, Halifax");
-        map("-3.5", "St. John's");
-        map("-3.0", "Buenos Aires, Montevideo, São Paulo");
-        map("-2.0", "Fernando de Noronha, South Georgia and the South Sandwich Islands");
-        map("-1.0", "Cape Verde, Greenland, Azores islands");
-        map("0.0", "Accra, Abidjan, Casablanca, Dakar, Dublin, Lisbon, London");
-        map("1.0", "Belgrade, Berlin, Brussels, Lagos, Madrid, Paris, Rome, Tunis, Vienna, Warsaw");
-        map("2.0", "Athens, Sofia, Cairo, Kiev, Istanbul, Beirut, Helsinki, Jerusalem, Johannesburg, Bucharest");
-        map("3.0", "Nairobi, Baghdad, Doha, Khartoum, Minsk, Riyadh");
-        map("3.5", "Tehran");
-        map("4.0", "Baku, Dubai, Moscow");
-        map("4.5", "Kabul");
-        map("5.0", "Karachi, Tashkent");
-        map("5.5", "Colombo, Delhi");
-        map("5.75", "Kathmandu");
-        map("6.0", "Almaty, Dhaka, Yekaterinburg");
-        map("6.5", "Yangon");
-        map("7.0", "Jakarta, Bangkok, Novosibirsk, Hanoi");
-        map("8.0", "Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk");
-        map("8.75", "Eucla");
-        map("9.0", "Seoul, Tokyo, Pyongyang, Ambon, Irkutsk");
-        map("9.5", "Adelaide");
-        map("10.0", "Canberra, Yakutsk, Port Moresby");
-        map("10.5", "Lord Howe Islands");
-        map("11.0", "Vladivostok, Noumea");
-        map("12.0", "Auckland, Suva");
-        map("12.75", "Chatham Islands");
-        map("13.0", "Phoenix Islands, Tokelau, Tonga");
-        map("14.0", "Line Islands");
+        map(ZoneId.of("UTC-12:00"), "Baker Island, Howland Island");
+        map(ZoneId.of("UTC-11:00"), "American Samoa, Niue");
+        map(ZoneId.of("UTC-10:00"), "Hawaii, Cook Islands");
+        map(ZoneId.of("UTC-09:30"), "Marquesas Islands");
+        map(ZoneId.of("UTC-09:00"), "Gambier Islands, Alaska");
+        map(ZoneId.of("UTC-08:00"), "Los Angeles, Vancouver, Tijuana");
+        map(ZoneId.of("UTC-07:00"), "Phoenix, Calgary, Ciudad Juárez");
+        map(ZoneId.of("UTC-06:00"), "Chicago, Guatemala City, Mexico City, San José, San Salvador, Tegucigalpa, Winnipeg");
+        map(ZoneId.of("UTC-05:00"), "New York, Lima, Toronto, Bogotá, Havana, Kingston");
+        map(ZoneId.of("UTC-04:30"), "Caracas");
+        map(ZoneId.of("UTC-04:00"), "Santiago, La Paz, San Juan de Puerto Rico, Manaus, Halifax");
+        map(ZoneId.of("UTC-03:30"), "St. John's");
+        map(ZoneId.of("UTC-03:00"), "Buenos Aires, Montevideo, São Paulo");
+        map(ZoneId.of("UTC-02:00"), "Fernando de Noronha, South Georgia and the South Sandwich Islands");
+        map(ZoneId.of("UTC-01:00"), "Cape Verde, Greenland, Azores islands");
+        map(ZoneId.of("UTC"), "Accra, Abidjan, Casablanca, Dakar, Dublin, Lisbon, London");
+        map(ZoneId.of("UTC+01:00"), "Belgrade, Berlin, Brussels, Lagos, Madrid, Paris, Rome, Tunis, Vienna, Warsaw");
+        map(ZoneId.of("UTC+02:00"),
+                "Athens, Sofia, Cairo, Kiev, Istanbul, Beirut, Helsinki, Jerusalem, Johannesburg, Bucharest");
+        map(ZoneId.of("UTC+03:00"), "Nairobi, Baghdad, Doha, Khartoum, Minsk, Riyadh");
+        map(ZoneId.of("UTC+03:30"), "Tehran");
+        map(ZoneId.of("UTC+04:00"), "Baku, Dubai, Moscow");
+        map(ZoneId.of("UTC+04:30"), "Kabul");
+        map(ZoneId.of("UTC+05:00"), "Karachi, Tashkent");
+        map(ZoneId.of("UTC+05:30"), "Colombo, Delhi");
+        map(ZoneId.of("UTC+05:45"), "Kathmandu");
+        map(ZoneId.of("UTC+06:00"), "Almaty, Dhaka, Yekaterinburg");
+        map(ZoneId.of("UTC+06:30"), "Yangon");
+        map(ZoneId.of("UTC+07:00"), "Jakarta, Bangkok, Novosibirsk, Hanoi");
+        map(ZoneId.of("UTC+08:00"), "Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk");
+        map(ZoneId.of("UTC+08:45"), "Eucla");
+        map(ZoneId.of("UTC+09:00"), "Seoul, Tokyo, Pyongyang, Ambon, Irkutsk");
+        map(ZoneId.of("UTC+09:30"), "Adelaide");
+        map(ZoneId.of("UTC+10:00"), "Canberra, Yakutsk, Port Moresby");
+        map(ZoneId.of("UTC+10:30"), "Lord Howe Islands");
+        map(ZoneId.of("UTC+11:00"), "Vladivostok, Noumea");
+        map(ZoneId.of("UTC+12:00"), "Auckland, Suva");
+        map(ZoneId.of("UTC+12:45"), "Chatham Islands");
+        map(ZoneId.of("UTC+13:00"), "Phoenix Islands, Tokelau, Tonga");
+        map(ZoneId.of("UTC+14:00"), "Line Islands");
 
     }
 
@@ -127,9 +128,9 @@ public final class TimeHelper {
         // utility class
     }
 
-    private static void map(String timeZone, String cities) {
+    private static void map(ZoneId timeZone, String cities) {
         TIME_ZONE_CITIES_MAP.put(timeZone, cities);
-        TIME_ZONE_VALUES.add(Double.parseDouble(timeZone));
+        TIME_ZONE_VALUES.add(timeZone);
     }
 
     /**
@@ -179,11 +180,11 @@ public final class TimeHelper {
         log.info("Time zone set to " + SystemParams.TIME_ZONE.getID() + " (was " + originalTimeZone.getID() + ")");
     }
 
-    public static String getCitiesForTimeZone(String zone) {
+    public static String getCitiesForTimeZone(ZoneId zone) {
         return TIME_ZONE_CITIES_MAP.get(zone);
     }
 
-    public static List<Double> getTimeZoneValues() {
+    public static List<ZoneId> getTimeZoneValues() {
         return new ArrayList<>(TIME_ZONE_VALUES);
     }
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1,7 +1,6 @@
 package teammates.logic.api;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -388,9 +387,9 @@ public class Logic {
         return instructorsLogic.getEncryptedKeyForInstructor(courseId, email);
     }
 
-    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Date startUtc, Date endUtc) {
+    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Instant rangeStart, Instant rangeEnd) {
 
-        return feedbackSessionsLogic.getAllOpenFeedbackSessions(startUtc, endUtc);
+        return feedbackSessionsLogic.getAllOpenFeedbackSessions(rangeStart, rangeEnd);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -3,7 +3,6 @@ package teammates.logic.core;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,9 +109,8 @@ public final class FeedbackSessionsLogic {
         fsDb.createEntity(fsa);
     }
 
-    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Date startUtc, Date endUtc) {
-
-        return fsDb.getAllOpenFeedbackSessions(startUtc, endUtc);
+    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Instant rangeStart, Instant rangeEnd) {
+        return fsDb.getAllOpenFeedbackSessions(rangeStart, rangeEnd);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -33,13 +33,13 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
 
     public static final String ERROR_UPDATE_NON_EXISTENT = "Trying to update non-existent Feedback Session : ";
 
-    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Date startUtc, Date endUtc) {
+    public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Instant rangeStart, Instant rangeEnd) {
         List<FeedbackSessionAttributes> list = new LinkedList<>();
 
         Calendar startCal = Calendar.getInstance();
-        startCal.setTime(startUtc);
+        startCal.setTime(TimeHelper.convertInstantToDate(rangeStart));
         Calendar endCal = Calendar.getInstance();
-        endCal.setTime(endUtc);
+        endCal.setTime(TimeHelper.convertInstantToDate(rangeEnd));
 
         // To retrieve legacy data where local dates are stored instead of UTC
         // TODO: remove after all legacy data has been converted
@@ -63,17 +63,15 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
         startTimeEntities.removeAll(endTimeEntities);
         endTimeEntities.addAll(startTimeEntities);
 
-        Instant start = startUtc.toInstant();
-        Instant end = endUtc.toInstant();
-
         // TODO: remove after all legacy data has been converted
         for (FeedbackSession feedbackSession : endTimeEntities) {
             FeedbackSessionAttributes fs = makeAttributes(feedbackSession);
             Instant fsStart = fs.getStartTime();
             Instant fsEnd = fs.getEndTime();
 
-            boolean isStartTimeWithinRange = (fsStart.isAfter(start) || fsStart.equals(start)) && fsStart.isBefore(end);
-            boolean isEndTimeWithinRange = fsEnd.isAfter(start) && (fsEnd.isBefore(end) || fsEnd.equals(end));
+            boolean isStartTimeWithinRange = (fsStart.isAfter(rangeStart) || fsStart.equals(rangeStart))
+                    && fsStart.isBefore(rangeEnd);
+            boolean isEndTimeWithinRange = fsEnd.isAfter(rangeStart) && (fsEnd.isBefore(rangeEnd) || fsEnd.equals(rangeEnd));
 
             if (isStartTimeWithinRange || isEndTimeWithinRange) {
                 list.add(fs);

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -2,11 +2,10 @@ package teammates.storage.api;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -36,24 +35,19 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
     public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Instant rangeStart, Instant rangeEnd) {
         List<FeedbackSessionAttributes> list = new LinkedList<>();
 
-        Calendar startCal = Calendar.getInstance();
-        startCal.setTime(TimeHelper.convertInstantToDate(rangeStart));
-        Calendar endCal = Calendar.getInstance();
-        endCal.setTime(TimeHelper.convertInstantToDate(rangeEnd));
-
         // To retrieve legacy data where local dates are stored instead of UTC
         // TODO: remove after all legacy data has been converted
-        Date curStart = TimeHelper.convertToUserTimeZone(startCal, -25).getTime();
-        Date curEnd = TimeHelper.convertToUserTimeZone(endCal, 25).getTime();
+        Instant start = rangeStart.minus(Duration.ofHours(25));
+        Instant end = rangeEnd.plus(Duration.ofHours(25));
 
         List<FeedbackSession> endEntities = load()
-                .filter("endTime >", curStart)
-                .filter("endTime <=", curEnd)
+                .filter("endTime >", TimeHelper.convertInstantToDate(start))
+                .filter("endTime <=", TimeHelper.convertInstantToDate(end))
                 .list();
 
         List<FeedbackSession> startEntities = load()
-                .filter("startTime >=", curStart)
-                .filter("startTime <", curEnd)
+                .filter("startTime >=", TimeHelper.convertInstantToDate(start))
+                .filter("startTime <", TimeHelper.convertInstantToDate(end))
                 .list();
 
         List<FeedbackSession> endTimeEntities = new ArrayList<>(endEntities);

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -102,7 +102,6 @@ public class AdminSessionsPageAction extends Action {
             String timeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
 
             zone = ZoneId.of(timeZone);
-
             start = TimeHelper.parseLocalDateTimeForSessionsForm(startDate, startHour, startMin);
             end = TimeHelper.parseLocalDateTimeForSessionsForm(endDate, endHour, endMin);
 

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -240,50 +240,27 @@ public class AdminSessionsPageAction extends Action {
     }
 
     private int getTotalNumOfOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-
-        int numOfTotal = 0;
-        for (FeedbackSessionAttributes sessionAttributes : allOpenFeedbackSessionsList) {
-            if (sessionAttributes.isOpened()) {
-                numOfTotal += 1;
-            }
-        }
-
-        return numOfTotal;
+        return (int) allOpenFeedbackSessionsList.stream()
+                .filter(sessionAttributes -> sessionAttributes.isOpened())
+                .count();
     }
 
     private int getTotalNumOfCloseStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-
-        int numOfTotal = 0;
-        for (FeedbackSessionAttributes sessionAttributes : allOpenFeedbackSessionsList) {
-            if (sessionAttributes.isClosed()) {
-                numOfTotal += 1;
-            }
-        }
-
-        return numOfTotal;
+        return (int) allOpenFeedbackSessionsList.stream()
+                .filter(sessionAttributes -> sessionAttributes.isClosed())
+                .count();
     }
 
     private int getTotalNumOfWaitToOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-
-        int numOfTotal = 0;
-        for (FeedbackSessionAttributes sessionAttributes : allOpenFeedbackSessionsList) {
-            if (sessionAttributes.isWaitingToOpen()) {
-                numOfTotal += 1;
-            }
-        }
-
-        return numOfTotal;
+        return (int) allOpenFeedbackSessionsList.stream()
+                .filter(sessionAttributes -> sessionAttributes.isWaitingToOpen())
+                .count();
     }
 
     private int getTotalInstitutes(Map<String, List<FeedbackSessionAttributes>> map) {
-
-        int numOfTotal = 0;
-        for (String key : map.keySet()) {
-            if (!key.equals(UNKNOWN_INSTITUTION)) {
-                numOfTotal += 1;
-            }
-        }
-        return numOfTotal;
+        return (int) map.keySet().stream()
+                .filter(key -> !key.equals(UNKNOWN_INSTITUTION))
+                .count();
     }
 
     private boolean checkAllParameters(String condition) {

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -81,14 +81,10 @@ public class AdminSessionsPageAction extends Action {
     }
 
     private ActionResult validateParametersAndCreateShowPageResultIfInvalid() {
-        ZoneId zone = Const.DEFAULT_TIME_ZONE;
-        LocalDateTime start = LocalDateTime.now(zone).minusDays(3);
-        LocalDateTime end = LocalDateTime.now(zone).plusDays(4);
-
         if (checkAllParameters("null")) {
-            this.rangeStart = start;
-            this.rangeEnd = end;
-            this.timeZone = zone;
+            this.rangeStart = LocalDateTime.now(Const.DEFAULT_TIME_ZONE).minusDays(3);
+            this.rangeEnd = LocalDateTime.now(Const.DEFAULT_TIME_ZONE).plusDays(4);
+            this.timeZone = Const.DEFAULT_TIME_ZONE;
             return null;
         }
 
@@ -101,31 +97,31 @@ public class AdminSessionsPageAction extends Action {
             String endMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDMINUTE);
             String timeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
 
-            zone = ZoneId.of(timeZone);
-            start = TimeHelper.parseLocalDateTimeForSessionsForm(startDate, startHour, startMin);
-            end = TimeHelper.parseLocalDateTimeForSessionsForm(endDate, endHour, endMin);
+            this.rangeStart = TimeHelper.parseLocalDateTimeForSessionsForm(startDate, startHour, startMin);
+            this.rangeEnd = TimeHelper.parseLocalDateTimeForSessionsForm(endDate, endHour, endMin);
+            this.timeZone = ZoneId.of(timeZone);
 
-            if (start.isAfter(end)) {
-                isError = true;
-                statusToUser.add(new StatusMessage("The filter range is not valid."
-                        + " End time should be after start time.", StatusMessageColor.DANGER));
-                statusToAdmin = "Admin Sessions Page Load<br>"
-                        + "<span class=\"bold\"> Error: invalid filter range</span>";
-                prepareDefaultPageData(start, end);
-                return initializeDataAndCreateShowPageResult();
+            if (!this.rangeStart.isAfter(this.rangeEnd)) {
+                return null;
             }
-
-            this.rangeStart = start;
-            this.rangeEnd = end;
-            this.timeZone = zone;
-            return null;
         }
 
         isError = true;
-        statusToUser.add(new StatusMessage("Error: Missing Parameters", StatusMessageColor.DANGER));
-        statusToAdmin = "Admin Sessions Page Load<br>"
-                + "<span class=\"bold\"> Error: Missing Parameters</span>";
-        prepareDefaultPageData(start, end);
+        if (this.rangeStart.isAfter(this.rangeEnd)) {
+            statusToUser.add(new StatusMessage("The filter range is not valid."
+                    + " End time should be after start time.", StatusMessageColor.DANGER));
+            statusToAdmin = "Admin Sessions Page Load<br>"
+                    + "<span class=\"bold\"> Error: invalid filter range</span>";
+        } else {
+            statusToUser.add(new StatusMessage("Error: Missing Parameters", StatusMessageColor.DANGER));
+            statusToAdmin = "Admin Sessions Page Load<br>"
+                    + "<span class=\"bold\"> Error: Missing Parameters</span>";
+        }
+
+        prepareDefaultPageData(
+                LocalDateTime.now(Const.DEFAULT_TIME_ZONE).minusDays(3),
+                LocalDateTime.now(Const.DEFAULT_TIME_ZONE).plusDays(4)
+        );
         return initializeDataAndCreateShowPageResult();
     }
 

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -112,7 +112,7 @@ public class AdminSessionsPageAction extends Action {
                 statusToAdmin = "Admin Sessions Page Load<br>"
                         + "<span class=\"bold\"> Error: invalid filter range</span>";
                 prepareDefaultPageData(start, end);
-                return createShowPageResultWithDataInitialization();
+                return initializeDataAndCreateShowPageResult();
             }
 
             this.rangeStart = start;
@@ -126,10 +126,10 @@ public class AdminSessionsPageAction extends Action {
         statusToAdmin = "Admin Sessions Page Load<br>"
                 + "<span class=\"bold\"> Error: Missing Parameters</span>";
         prepareDefaultPageData(start, end);
-        return createShowPageResultWithDataInitialization();
+        return initializeDataAndCreateShowPageResult();
     }
 
-    private ActionResult createShowPageResultWithDataInitialization() {
+    private ActionResult initializeDataAndCreateShowPageResult() {
         data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,
                 this.totalOpenStatusSessions, this.totalClosedStatusSessions, this.totalWaitToOpenStatusSessions,
                 this.totalInstitutes, this.rangeStart, this.rangeEnd, this.timeZone, this.isShowAll);
@@ -150,7 +150,7 @@ public class AdminSessionsPageAction extends Action {
             this.totalClosedStatusSessions = 0;
             this.totalWaitToOpenStatusSessions = 0;
             this.totalInstitutes = 0;
-            return createShowPageResultWithDataInitialization();
+            return initializeDataAndCreateShowPageResult();
         }
 
         return null;
@@ -195,7 +195,7 @@ public class AdminSessionsPageAction extends Action {
                       + this.totalOpenStatusSessions;
 
         constructSessionToInstructorIdMap();
-        return createShowPageResultWithDataInitialization();
+        return initializeDataAndCreateShowPageResult();
     }
 
     private void constructSessionToInstructorIdMap() {

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -41,7 +41,7 @@ public class AdminSessionsPageAction extends Action {
         data = new AdminSessionsPageData(account, sessionToken);
         isShowAll = getRequestParamAsBoolean("all");
 
-        ActionResult result = createShowPageResultIfParametersInvalid();
+        ActionResult result = validateParametersAndCreateShowPageResultIfInvalid();
         if (result != null) {
             return result;
         }
@@ -81,7 +81,7 @@ public class AdminSessionsPageAction extends Action {
         this.rangeEnd = end;
     }
 
-    private ActionResult createShowPageResultIfParametersInvalid() {
+    private ActionResult validateParametersAndCreateShowPageResultIfInvalid() {
         String startDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE);
         String endDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE);
         String startHour = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTHOUR);

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -11,7 +11,6 @@ import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
 import teammates.common.util.TimeHelper;
@@ -82,28 +81,25 @@ public class AdminSessionsPageAction extends Action {
     }
 
     private ActionResult validateParametersAndCreateShowPageResultIfInvalid() {
-        String startDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE);
-        String endDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE);
-        String startHour = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTHOUR);
-        String endHour = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDHOUR);
-        String startMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTMINUTE);
-        String endMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDMINUTE);
-        String timeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
-
         ZoneId zone = Const.DEFAULT_TIME_ZONE;
         LocalDateTime start = LocalDateTime.now(zone).minusDays(3);
         LocalDateTime end = LocalDateTime.now(zone).plusDays(4);
 
         if (checkAllParameters("null")) {
-            // do nothing
-        } else if (checkAllParameters("notNull")) {
-            SanitizationHelper.sanitizeForHtml(startDate);
-            SanitizationHelper.sanitizeForHtml(endDate);
-            SanitizationHelper.sanitizeForHtml(startHour);
-            SanitizationHelper.sanitizeForHtml(endHour);
-            SanitizationHelper.sanitizeForHtml(startMin);
-            SanitizationHelper.sanitizeForHtml(endMin);
-            SanitizationHelper.sanitizeForHtml(timeZone);
+            this.rangeStart = start;
+            this.rangeEnd = end;
+            this.timeZone = zone;
+            return null;
+        }
+
+        if (checkAllParameters("notNull")) {
+            String startDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE);
+            String endDate = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE);
+            String startHour = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTHOUR);
+            String endHour = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDHOUR);
+            String startMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTMINUTE);
+            String endMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDMINUTE);
+            String timeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
 
             zone = ZoneId.of(timeZone);
 
@@ -116,24 +112,22 @@ public class AdminSessionsPageAction extends Action {
                         + " End time should be after start time.", StatusMessageColor.DANGER));
                 statusToAdmin = "Admin Sessions Page Load<br>"
                         + "<span class=\"bold\"> Error: invalid filter range</span>";
+                prepareDefaultPageData(start, end);
+                return createShowPageResultWithDataInitialization();
             }
-        } else {
-            isError = true;
-            statusToUser.add(new StatusMessage("Error: Missing Parameters", StatusMessageColor.DANGER));
-            statusToAdmin = "Admin Sessions Page Load<br>"
-                    + "<span class=\"bold\"> Error: Missing Parameters</span>";
+
+            this.rangeStart = start;
+            this.rangeEnd = end;
+            this.timeZone = zone;
+            return null;
         }
 
-        if (isError) {
-            prepareDefaultPageData(start, end);
-            return createShowPageResultWithDataInitialization();
-        }
-
-        this.rangeStart = start;
-        this.rangeEnd = end;
-        this.timeZone = zone;
-
-        return null;
+        isError = true;
+        statusToUser.add(new StatusMessage("Error: Missing Parameters", StatusMessageColor.DANGER));
+        statusToAdmin = "Admin Sessions Page Load<br>"
+                + "<span class=\"bold\"> Error: Missing Parameters</span>";
+        prepareDefaultPageData(start, end);
+        return createShowPageResultWithDataInitialization();
     }
 
     private ActionResult createShowPageResultWithDataInitialization() {

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -24,11 +24,11 @@ public class AdminSessionsPageAction extends Action {
 
     private Map<String, List<FeedbackSessionAttributes>> map;
     private Map<String, String> sessionToInstructorIdMap = new HashMap<>();
-    private int totalOngoingSessions;
-    private int totalOpenStatusSessions;
-    private int totalClosedStatusSessions;
-    private int totalWaitToOpenStatusSessions;
-    private int totalInstitutes;
+    private long totalOngoingSessions;
+    private long totalOpenStatusSessions;
+    private long totalClosedStatusSessions;
+    private long totalWaitToOpenStatusSessions;
+    private long totalInstitutes;
     private LocalDateTime rangeStart;
     private LocalDateTime rangeEnd;
     private ZoneId timeZone;
@@ -232,26 +232,26 @@ public class AdminSessionsPageAction extends Action {
         return null;
     }
 
-    private int getTotalNumOfOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-        return (int) allOpenFeedbackSessionsList.stream()
+    private long getTotalNumOfOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        return allOpenFeedbackSessionsList.stream()
                 .filter(sessionAttributes -> sessionAttributes.isOpened())
                 .count();
     }
 
-    private int getTotalNumOfCloseStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-        return (int) allOpenFeedbackSessionsList.stream()
+    private long getTotalNumOfCloseStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        return allOpenFeedbackSessionsList.stream()
                 .filter(sessionAttributes -> sessionAttributes.isClosed())
                 .count();
     }
 
-    private int getTotalNumOfWaitToOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
-        return (int) allOpenFeedbackSessionsList.stream()
+    private long getTotalNumOfWaitToOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        return allOpenFeedbackSessionsList.stream()
                 .filter(sessionAttributes -> sessionAttributes.isWaitingToOpen())
                 .count();
     }
 
-    private int getTotalInstitutes(Map<String, List<FeedbackSessionAttributes>> map) {
-        return (int) map.keySet().stream()
+    private long getTotalInstitutes(Map<String, List<FeedbackSessionAttributes>> map) {
+        return map.keySet().stream()
                 .filter(key -> !key.equals(UNKNOWN_INSTITUTION))
                 .count();
     }

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -1,6 +1,5 @@
 package teammates.ui.controller;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -31,8 +30,8 @@ public class AdminSessionsPageAction extends Action {
     private int totalClosedStatusSessions;
     private int totalWaitToOpenStatusSessions;
     private int totalInstitutes;
-    private Instant rangeStart;
-    private Instant rangeEnd;
+    private LocalDateTime rangeStart;
+    private LocalDateTime rangeEnd;
     private ZoneId timeZone;
     private boolean isShowAll;
 
@@ -50,7 +49,8 @@ public class AdminSessionsPageAction extends Action {
         }
 
         List<FeedbackSessionAttributes> allOpenFeedbackSessionsList =
-                logic.getAllOpenFeedbackSessions(rangeStart, rangeEnd);
+                logic.getAllOpenFeedbackSessions(TimeHelper.convertLocalDateTimeToInstant(rangeStart, timeZone),
+                        TimeHelper.convertLocalDateTimeToInstant(rangeEnd, timeZone));
 
         result = createShowPageResultIfNoOngoingSession(allOpenFeedbackSessionsList);
         if (result != null) {
@@ -74,7 +74,7 @@ public class AdminSessionsPageAction extends Action {
         }
     }
 
-    private void prepareDefaultPageData(Instant start, Instant end) {
+    private void prepareDefaultPageData(LocalDateTime start, LocalDateTime end) {
         this.map = new HashMap<>();
         this.totalOngoingSessions = 0;
         this.totalOpenStatusSessions = 0;
@@ -123,8 +123,7 @@ public class AdminSessionsPageAction extends Action {
                 statusToAdmin = "Admin Sessions Page Load<br>"
                               + "<span class=\"bold\"> Error: invalid filter range</span>";
 
-                prepareDefaultPageData(TimeHelper.convertLocalDateTimeToInstant(start, zone),
-                        TimeHelper.convertLocalDateTimeToInstant(end, zone));
+                prepareDefaultPageData(start, end);
                 data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,
                           this.totalOpenStatusSessions, this.totalClosedStatusSessions,
                           this.totalWaitToOpenStatusSessions, this.totalInstitutes, this.rangeStart,
@@ -139,8 +138,7 @@ public class AdminSessionsPageAction extends Action {
             statusToAdmin = "Admin Sessions Page Load<br>"
                           + "<span class=\"bold\"> Error: Missing Parameters</span>";
 
-            prepareDefaultPageData(TimeHelper.convertLocalDateTimeToInstant(start, zone),
-                    TimeHelper.convertLocalDateTimeToInstant(end, zone));
+            prepareDefaultPageData(start, end);
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,
                       this.totalOpenStatusSessions, this.totalClosedStatusSessions, this.totalWaitToOpenStatusSessions,
                       this.totalInstitutes, this.rangeStart, this.rangeEnd, this.timeZone, this.isShowAll);
@@ -148,8 +146,8 @@ public class AdminSessionsPageAction extends Action {
 
         }
 
-        this.rangeStart = TimeHelper.convertLocalDateTimeToInstant(start, zone);
-        this.rangeEnd = TimeHelper.convertLocalDateTimeToInstant(end, zone);
+        this.rangeStart = start;
+        this.rangeEnd = end;
         this.timeZone = zone;
 
         return null;

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -111,7 +111,7 @@ public class AdminSessionsPageAction extends Action {
             SanitizationHelper.sanitizeForHtml(endMin);
             SanitizationHelper.sanitizeForHtml(timeZone);
 
-            zone = TimeHelper.convertToZoneId(Double.parseDouble(timeZone));
+            zone = ZoneId.of(timeZone);
 
             start = TimeHelper.parseLocalDateTimeForSessionsForm(startDate, startHour, startMin);
             end = TimeHelper.parseLocalDateTimeForSessionsForm(endDate, endHour, endMin);

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,10 +49,8 @@ public class AdminSessionsPageAction extends Action {
             return result;
         }
 
-        Date rangeStartUtc = TimeHelper.convertInstantToDate(rangeStart);
-        Date rangeEndUtc = TimeHelper.convertInstantToDate(rangeEnd);
         List<FeedbackSessionAttributes> allOpenFeedbackSessionsList =
-                logic.getAllOpenFeedbackSessions(rangeStartUtc, rangeEndUtc);
+                logic.getAllOpenFeedbackSessions(rangeStart, rangeEnd);
 
         result = createShowPageResultIfNoOngoingSession(allOpenFeedbackSessionsList);
         if (result != null) {

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -1,7 +1,9 @@
 package teammates.ui.pagedata;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -21,9 +23,9 @@ public class AdminSessionsPageData extends PageData {
     private int totalClosedStatusSessions;
     private int totalWaitToOpenStatusSessions;
     private int totalInstitutes;
-    private Date rangeStart;
-    private Date rangeEnd;
-    private double zone;
+    private Instant rangeStart;
+    private Instant rangeEnd;
+    private ZoneId timeZone;
     private boolean isShowAll;
     private List<InstitutionPanel> institutionPanels;
     private AdminFilter filter;
@@ -36,8 +38,8 @@ public class AdminSessionsPageData extends PageData {
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap,
             int totalOngoingSessions, int totalOpenStatusSessions, int totalClosedStatusSessions,
-            int totalWaitToOpenStatusSessions, int totalInstitutes, Date rangeStart, Date rangeEnd,
-            double zone, boolean isShowAll) {
+            int totalWaitToOpenStatusSessions, int totalInstitutes, Instant rangeStart, Instant rangeEnd,
+            ZoneId timeZone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
         this.totalOpenStatusSessions = totalOpenStatusSessions;
@@ -46,7 +48,7 @@ public class AdminSessionsPageData extends PageData {
         this.totalInstitutes = totalInstitutes;
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
-        this.zone = zone;
+        this.timeZone = timeZone;
         this.isShowAll = isShowAll;
         setFilter();
         setInstitutionPanels(map, sessionToInstructorIdMap);
@@ -81,11 +83,19 @@ public class AdminSessionsPageData extends PageData {
     }
 
     public String getRangeStartString() {
-        return TimeHelper.formatTime12H(rangeStart);
+        return TimeHelper.formatTime12H(getRangeStartLocal());
     }
 
     public String getRangeEndString() {
-        return TimeHelper.formatTime12H(rangeEnd);
+        return TimeHelper.formatTime12H(getRangeEndLocal());
+    }
+
+    public LocalDateTime getRangeStartLocal() {
+        return TimeHelper.convertInstantToLocalDateTime(rangeStart, timeZone);
+    }
+
+    public LocalDateTime getRangeEndLocal() {
+        return TimeHelper.convertInstantToLocalDateTime(rangeEnd, timeZone);
     }
 
     public List<InstitutionPanel> getInstitutionPanels() {
@@ -99,33 +109,33 @@ public class AdminSessionsPageData extends PageData {
     }
 
     @SuppressWarnings("deprecation")
-    public List<String> getHourOptionsAsHtml(Date date) {
+    public List<String> getHourOptionsAsHtml(LocalDateTime ldt) {
         ArrayList<String> result = new ArrayList<>();
         for (int i = 0; i <= 23; i++) {
             result.add("<option value=\"" + i + "\"" + " "
-                       + (date.getHours() == i ? "selected" : "")
+                       + (ldt.getHour() == i ? "selected" : "")
                        + ">" + String.format("%02dH", i) + "</option>");
         }
         return result;
     }
 
     @SuppressWarnings("deprecation")
-    public List<String> getMinuteOptionsAsHtml(Date date) {
+    public List<String> getMinuteOptionsAsHtml(LocalDateTime ldt) {
         ArrayList<String> result = new ArrayList<>();
         for (int i = 0; i <= 59; i++) {
             result.add("<option value=\"" + i + "\"" + " "
-                       + (date.getMinutes() == i ? "selected" : "")
+                       + (ldt.getMinute() == i ? "selected" : "")
                        + ">" + String.format("%02d", i) + "</option>");
         }
         return result;
     }
 
     public List<String> getTimeZoneOptionsAsHtml() {
-        return getTimeZoneOptionsAsHtml(zone);
+        return getTimeZoneOptionsAsHtml(TimeHelper.convertToOffset(timeZone));
     }
 
     public String getTimeZoneAsString() {
-        return StringHelper.toUtcFormat(zone);
+        return StringHelper.toUtcFormat(TimeHelper.convertToOffset(timeZone));
     }
 
     public String getFeedbackSessionStatsLink(String courseId, String feedbackSessionName, String user) {
@@ -187,10 +197,10 @@ public class AdminSessionsPageData extends PageData {
     }
 
     private void setFilter() {
-        filter = new AdminFilter(
-                TimeHelper.formatDateForSessionsForm(rangeStart), getHourOptionsAsHtml(rangeStart),
-                getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDateForSessionsForm(rangeEnd),
-                getHourOptionsAsHtml(rangeEnd), getMinuteOptionsAsHtml(rangeEnd), getTimeZoneOptionsAsHtml());
+        filter = new AdminFilter(TimeHelper.formatDate(getRangeStartLocal()), getHourOptionsAsHtml(getRangeEndLocal()),
+                                 getMinuteOptionsAsHtml(getRangeStartLocal()), TimeHelper.formatDate(getRangeEndLocal()),
+                                 getHourOptionsAsHtml(getRangeEndLocal()), getMinuteOptionsAsHtml(getRangeEndLocal()),
+                                 getTimeZoneOptionsAsHtml());
     }
 
     public void setInstitutionPanels(

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.StringHelper;
 import teammates.common.util.TimeHelper;
 import teammates.common.util.Url;
 import teammates.ui.template.AdminFeedbackSessionRow;
@@ -131,11 +130,11 @@ public class AdminSessionsPageData extends PageData {
     }
 
     public List<String> getTimeZoneOptionsAsHtml() {
-        return getTimeZoneOptionsAsHtml(TimeHelper.convertToOffset(timeZone));
+        return getTimeZoneOptionsAsHtml(timeZone);
     }
 
     public String getTimeZoneAsString() {
-        return StringHelper.toUtcFormat(TimeHelper.convertToOffset(timeZone));
+        return timeZone.toString();
     }
 
     public String getFeedbackSessionStatsLink(String courseId, String feedbackSessionName, String user) {

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -187,8 +187,8 @@ public class AdminSessionsPageData extends PageData {
     }
 
     private void setFilter() {
-        filter = new AdminFilter(TimeHelper.formatDate(rangeStart), getHourOptionsAsHtml(rangeEnd),
-                                 getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDate(rangeEnd),
+        filter = new AdminFilter(TimeHelper.formatDateForSessionsForm(rangeStart), getHourOptionsAsHtml(rangeEnd),
+                                 getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDateForSessionsForm(rangeEnd),
                                  getHourOptionsAsHtml(rangeEnd), getMinuteOptionsAsHtml(rangeEnd),
                                  getTimeZoneOptionsAsHtml());
     }

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -1,6 +1,5 @@
 package teammates.ui.pagedata;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -22,8 +21,8 @@ public class AdminSessionsPageData extends PageData {
     private int totalClosedStatusSessions;
     private int totalWaitToOpenStatusSessions;
     private int totalInstitutes;
-    private Instant rangeStart;
-    private Instant rangeEnd;
+    private LocalDateTime rangeStart;
+    private LocalDateTime rangeEnd;
     private ZoneId timeZone;
     private boolean isShowAll;
     private List<InstitutionPanel> institutionPanels;
@@ -37,7 +36,7 @@ public class AdminSessionsPageData extends PageData {
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap,
             int totalOngoingSessions, int totalOpenStatusSessions, int totalClosedStatusSessions,
-            int totalWaitToOpenStatusSessions, int totalInstitutes, Instant rangeStart, Instant rangeEnd,
+            int totalWaitToOpenStatusSessions, int totalInstitutes, LocalDateTime rangeStart, LocalDateTime rangeEnd,
             ZoneId timeZone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
@@ -82,19 +81,11 @@ public class AdminSessionsPageData extends PageData {
     }
 
     public String getRangeStartString() {
-        return TimeHelper.formatTime12H(getRangeStartLocal());
+        return TimeHelper.formatTime12H(rangeStart);
     }
 
     public String getRangeEndString() {
-        return TimeHelper.formatTime12H(getRangeEndLocal());
-    }
-
-    public LocalDateTime getRangeStartLocal() {
-        return TimeHelper.convertInstantToLocalDateTime(rangeStart, timeZone);
-    }
-
-    public LocalDateTime getRangeEndLocal() {
-        return TimeHelper.convertInstantToLocalDateTime(rangeEnd, timeZone);
+        return TimeHelper.formatTime12H(rangeEnd);
     }
 
     public List<InstitutionPanel> getInstitutionPanels() {
@@ -196,9 +187,9 @@ public class AdminSessionsPageData extends PageData {
     }
 
     private void setFilter() {
-        filter = new AdminFilter(TimeHelper.formatDate(getRangeStartLocal()), getHourOptionsAsHtml(getRangeEndLocal()),
-                                 getMinuteOptionsAsHtml(getRangeStartLocal()), TimeHelper.formatDate(getRangeEndLocal()),
-                                 getHourOptionsAsHtml(getRangeEndLocal()), getMinuteOptionsAsHtml(getRangeEndLocal()),
+        filter = new AdminFilter(TimeHelper.formatDate(rangeStart), getHourOptionsAsHtml(rangeEnd),
+                                 getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDate(rangeEnd),
+                                 getHourOptionsAsHtml(rangeEnd), getMinuteOptionsAsHtml(rangeEnd),
                                  getTimeZoneOptionsAsHtml());
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -103,8 +103,8 @@ public class AdminSessionsPageData extends PageData {
         ArrayList<String> result = new ArrayList<>();
         for (int i = 0; i <= 23; i++) {
             result.add("<option value=\"" + i + "\"" + " "
-                       + (ldt.getHour() == i ? "selected" : "")
-                       + ">" + String.format("%02dH", i) + "</option>");
+                    + (ldt.getHour() == i ? "selected" : "")
+                    + ">" + String.format("%02dH", i) + "</option>");
         }
         return result;
     }
@@ -114,8 +114,8 @@ public class AdminSessionsPageData extends PageData {
         ArrayList<String> result = new ArrayList<>();
         for (int i = 0; i <= 59; i++) {
             result.add("<option value=\"" + i + "\"" + " "
-                       + (ldt.getMinute() == i ? "selected" : "")
-                       + ">" + String.format("%02d", i) + "</option>");
+                    + (ldt.getMinute() == i ? "selected" : "")
+                    + ">" + String.format("%02d", i) + "</option>");
         }
         return result;
     }
@@ -188,9 +188,9 @@ public class AdminSessionsPageData extends PageData {
 
     private void setFilter() {
         filter = new AdminFilter(TimeHelper.formatDateForSessionsForm(rangeStart), getHourOptionsAsHtml(rangeEnd),
-                                 getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDateForSessionsForm(rangeEnd),
-                                 getHourOptionsAsHtml(rangeEnd), getMinuteOptionsAsHtml(rangeEnd),
-                                 getTimeZoneOptionsAsHtml());
+                getMinuteOptionsAsHtml(rangeStart), TimeHelper.formatDateForSessionsForm(rangeEnd),
+                getHourOptionsAsHtml(rangeEnd), getMinuteOptionsAsHtml(rangeEnd),
+                getTimeZoneOptionsAsHtml());
     }
 
     public void setInstitutionPanels(

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -16,11 +16,11 @@ import teammates.ui.template.AdminFilter;
 import teammates.ui.template.InstitutionPanel;
 
 public class AdminSessionsPageData extends PageData {
-    private int totalOngoingSessions;
-    private int totalOpenStatusSessions;
-    private int totalClosedStatusSessions;
-    private int totalWaitToOpenStatusSessions;
-    private int totalInstitutes;
+    private long totalOngoingSessions;
+    private long totalOpenStatusSessions;
+    private long totalClosedStatusSessions;
+    private long totalWaitToOpenStatusSessions;
+    private long totalInstitutes;
     private LocalDateTime rangeStart;
     private LocalDateTime rangeEnd;
     private ZoneId timeZone;
@@ -35,8 +35,8 @@ public class AdminSessionsPageData extends PageData {
 
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap,
-            int totalOngoingSessions, int totalOpenStatusSessions, int totalClosedStatusSessions,
-            int totalWaitToOpenStatusSessions, int totalInstitutes, LocalDateTime rangeStart, LocalDateTime rangeEnd,
+            long totalOngoingSessions, long totalOpenStatusSessions, long totalClosedStatusSessions,
+            long totalWaitToOpenStatusSessions, long totalInstitutes, LocalDateTime rangeStart, LocalDateTime rangeEnd,
             ZoneId timeZone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
@@ -52,23 +52,23 @@ public class AdminSessionsPageData extends PageData {
         setInstitutionPanels(map, sessionToInstructorIdMap);
     }
 
-    public int getTotalOngoingSessions() {
+    public long getTotalOngoingSessions() {
         return totalOngoingSessions;
     }
 
-    public int getTotalOpenStatusSessions() {
+    public long getTotalOpenStatusSessions() {
         return totalOpenStatusSessions;
     }
 
-    public int getTotalClosedStatusSessions() {
+    public long getTotalClosedStatusSessions() {
         return totalClosedStatusSessions;
     }
 
-    public int getTotalWaitToOpenStatusSessions() {
+    public long getTotalWaitToOpenStatusSessions() {
         return totalWaitToOpenStatusSessions;
     }
 
-    public int getTotalInstitutes() {
+    public long getTotalInstitutes() {
         return totalInstitutes;
     }
 

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -129,21 +129,20 @@ public class AdminSessionsPageData extends PageData {
     }
 
     public String getFeedbackSessionStatsLink(String courseId, String feedbackSessionName, String user) {
-        String link;
         if (user.isEmpty()) {
-            link = "";
-        } else {
-            link = Const.ActionURIs.INSTRUCTOR_FEEDBACK_STATS_PAGE;
-            link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
-            link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
-            link = Url.addParamToUrl(link, Const.ParamsNames.USER_ID, user);
+            return "";
         }
+
+        String link = Const.ActionURIs.INSTRUCTOR_FEEDBACK_STATS_PAGE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
+        link = Url.addParamToUrl(link, Const.ParamsNames.USER_ID, user);
         return link;
     }
 
     public String getSessionStatusForShow(FeedbackSessionAttributes fs) {
-
         StringBuilder status = new StringBuilder(100);
+
         if (fs.isClosed()) {
             status.append("[Closed]");
         }

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -92,8 +92,8 @@ public class PageData {
         List<ZoneId> options = TimeHelper.getTimeZoneValues();
         ArrayList<String> result = new ArrayList<>();
         for (ZoneId timeZoneOption : options) {
-            result.add("<option value=\"" + timeZoneOption.toString() + "\""
-                    + (existingTimeZone.equals(timeZoneOption) ? " selected" : "") + ">" + "(" + timeZoneOption.toString()
+            result.add("<option value=\"" + timeZoneOption.getId() + "\""
+                    + (existingTimeZone.equals(timeZoneOption) ? " selected" : "") + ">" + "(" + timeZoneOption.getId()
                     + ") " + TimeHelper.getCitiesForTimeZone(timeZoneOption) + "</option>");
         }
         return result;

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -1,6 +1,7 @@
 package teammates.ui.pagedata;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -87,17 +88,13 @@ public class PageData {
      * Returns the timezone options as HTML code.
      * None is selected, since the selection should only be done in client side.
      */
-    protected List<String> getTimeZoneOptionsAsHtml(double existingTimeZone) {
-        List<Double> options = TimeHelper.getTimeZoneValues();
+    protected List<String> getTimeZoneOptionsAsHtml(ZoneId existingTimeZone) {
+        List<ZoneId> options = TimeHelper.getTimeZoneValues();
         ArrayList<String> result = new ArrayList<>();
-        if (existingTimeZone == Const.DOUBLE_UNINITIALIZED) {
-            result.add("<option value=\"" + Const.INT_UNINITIALIZED + "\" selected></option>");
-        }
-        for (Double timeZoneOption : options) {
-            String utcFormatOption = StringHelper.toUtcFormat(timeZoneOption);
-            result.add("<option value=\"" + formatAsString(timeZoneOption) + "\""
-                       + (existingTimeZone == timeZoneOption ? " selected" : "") + ">" + "(" + utcFormatOption
-                       + ") " + TimeHelper.getCitiesForTimeZone(Double.toString(timeZoneOption)) + "</option>");
+        for (ZoneId timeZoneOption : options) {
+            result.add("<option value=\"" + timeZoneOption.toString() + "\""
+                       + (existingTimeZone.equals(timeZoneOption) ? " selected" : "") + ">" + "(" + timeZoneOption.toString()
+                       + ") " + TimeHelper.getCitiesForTimeZone(timeZoneOption) + "</option>");
         }
         return result;
     }
@@ -767,13 +764,6 @@ public class PageData {
         }
         int defaultGracePeriod = 15;
         return gracePeriodOptionValue == defaultGracePeriod;
-    }
-
-    private static String formatAsString(double num) {
-        if ((int) num == num) {
-            return Integer.toString((int) num);
-        }
-        return Double.toString(num);
     }
 
     public boolean isResponseCommentVisibleTo(FeedbackQuestionAttributes qn,

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -93,8 +93,8 @@ public class PageData {
         ArrayList<String> result = new ArrayList<>();
         for (ZoneId timeZoneOption : options) {
             result.add("<option value=\"" + timeZoneOption.toString() + "\""
-                       + (existingTimeZone.equals(timeZoneOption) ? " selected" : "") + ">" + "(" + timeZoneOption.toString()
-                       + ") " + TimeHelper.getCitiesForTimeZone(timeZoneOption) + "</option>");
+                    + (existingTimeZone.equals(timeZoneOption) ? " selected" : "") + ">" + "(" + timeZoneOption.toString()
+                    + ") " + TimeHelper.getCitiesForTimeZone(timeZoneOption) + "</option>");
         }
         return result;
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.fail;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.List;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -4,7 +4,6 @@ import static org.testng.AssertJUnit.fail;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.List;
 


### PR DESCRIPTION
<!-- Fixes #8645 -->
Part of #8645 

**Outline of Solution**
1. Refactor `Date`/`double` fields in `AdminSessionsPageData` and `AdminSessionsPageAction` to `LocalDateTime`/`ZoneId` respectively.
2. Move deprecated calls from `*Logic` classes to `FeedbackSessionsDb` for removal at a later time, when `FeedbackSessionsDb` is migrated.
3. Change timezone dropdown menu (map in `TimeHelper`) to use `ZoneId` internally
    - ~~Update timezone autodetection~~ covered by #8687
    - ~~Update timezone dropdown list builders~~ 
    - Update all affected tests and test resources

We preserve the time offset dropdown menu for the admin's sessions page for usability concerns, since using the regional timezone format (e.g. `Asia/Singapore`) doesn't show the offset from UTC, may not be very friendly to the admin and we don't have any better solutions.

Some of the offsets in the list are wrong, like `Calgary` is actually in `UTC-06:00` but is listed as `UTC-07:00` and `Caracas` is actually in `UTC-04:00` but listed as `UTC-04:30`. I have not corrected them in this PR.