### PR TITLE
AccountAttributesTest: fix instability due to modified timestamp comparison #8709

### DIFF
--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -315,6 +315,7 @@ public class AccountAttributesTest extends BaseAttributesTest {
                     .withGender(gender)
                     .withMoreInfo(moreInfo)
                     .withPictureKey(pictureKey)
+                    .withModifiedDate(Instant.parse("2018-03-30T13:23:42.663Z"))
                     .build())
                 .build();
 

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -6,6 +6,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
+import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StringHelper;
@@ -315,7 +316,7 @@ public class AccountAttributesTest extends BaseAttributesTest {
                     .withGender(gender)
                     .withMoreInfo(moreInfo)
                     .withPictureKey(pictureKey)
-                    .withModifiedDate(Instant.parse("2018-03-30T13:23:42.663Z"))
+                    .withModifiedDate(Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP)
                     .build())
                 .build();
 


### PR DESCRIPTION
Fixes #8709

**Outline of Solution**

- `Instant.now()` is unstable in tests
- So we need to hardcode the `modifiedDate` in tests to make it stable

Note:
As the migration to `java.time`  is still going on, there might be more such cases of unstable tests
