### PR TITLE
Use builder instead of telescoping constructor antipattern in FeedbackQuestionAttributes class #7190

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -231,6 +231,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
                 .withShowRecipientNameTo(showRecipientNameTo)
                 .withCreatedAt(createdAt)
                 .withUpdatedAt(updatedAt)
+                .withFeedbackQuestionId(feedbackQuestionId)
                 .build();
     }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -120,7 +120,6 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
             return this;
         }
 
-
         public Builder withQuestionDescription(Text questionDescription) {
             if (questionDescription != null) {
                 feedbackQuestionAttributes.setQuestionDescription(questionDescription);
@@ -161,22 +160,22 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
 
         public Builder withShowResponseTo(List<FeedbackParticipantType> showResponseTo) {
             feedbackQuestionAttributes.showResponsesTo =
-                    showResponseTo == null ? new ArrayList<>() :
-                                                new ArrayList<>(showResponseTo);
+                    showResponseTo == null ? new ArrayList<>()
+                            : new ArrayList<>(showResponseTo);
             return this;
         }
 
         public Builder withShowGiverNameTo(List<FeedbackParticipantType> showGiverNameTo) {
             feedbackQuestionAttributes.showGiverNameTo =
-                    showGiverNameTo == null ? new ArrayList<>() :
-                                                new ArrayList<>(showGiverNameTo);
+                    showGiverNameTo == null ? new ArrayList<>()
+                            : new ArrayList<>(showGiverNameTo);
             return this;
         }
 
         public Builder withShowRecipientNameTo(List<FeedbackParticipantType> showRecipientNameTo) {
             feedbackQuestionAttributes.showRecipientNameTo =
-                    showRecipientNameTo == null ? new ArrayList<>() :
-                                                    new ArrayList<>(showRecipientNameTo);
+                    showRecipientNameTo == null ? new ArrayList<>()
+                            : new ArrayList<>(showRecipientNameTo);
             return this;
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -86,33 +86,45 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public Builder withFeedbackSessionName(String feedbackSessionName) {
-            feedbackQuestionAttributes.feedbackSessionName = feedbackSessionName;
+            if (feedbackSessionName != null) {
+                feedbackQuestionAttributes.feedbackSessionName = feedbackSessionName;
+            }
             return this;
         }
 
         public Builder withCourseId(String courseId) {
-            feedbackQuestionAttributes.courseId = courseId;
+            if (courseId != null) {
+                feedbackQuestionAttributes.courseId = courseId;
+            }
             return this;
         }
 
         public Builder withCreatorEmail(String creatorEmail) {
-            feedbackQuestionAttributes.creatorEmail = creatorEmail;
+            if (creatorEmail != null) {
+                feedbackQuestionAttributes.creatorEmail = creatorEmail;
+            }
             return this;
         }
 
         public Builder withQuestionMetaData(Text questionMetaData) {
-            feedbackQuestionAttributes.questionMetaData = questionMetaData;
+            if (questionMetaData != null) {
+                feedbackQuestionAttributes.questionMetaData = questionMetaData;
+            }
             return this;
         }
 
         public Builder withQuestionMetaData(FeedbackQuestionDetails questionDetails) {
-            feedbackQuestionAttributes.setQuestionDetails(questionDetails);
+            if (questionDetails != null) {
+                feedbackQuestionAttributes.setQuestionDetails(questionDetails);
+            }
             return this;
         }
 
 
         public Builder withQuestionDescription(Text questionDescription) {
-            feedbackQuestionAttributes.setQuestionDescription(questionDescription);
+            if (questionDescription != null) {
+                feedbackQuestionAttributes.setQuestionDescription(questionDescription);
+            }
             return this;
         }
 
@@ -122,17 +134,23 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public Builder withQuestionType(FeedbackQuestionType questionType) {
-            feedbackQuestionAttributes.questionType = questionType;
+            if (questionType != null) {
+                feedbackQuestionAttributes.questionType = questionType;
+            }
             return this;
         }
 
         public Builder withGiverType(FeedbackParticipantType giverType) {
-            feedbackQuestionAttributes.giverType = giverType;
+            if (giverType != null) {
+                feedbackQuestionAttributes.giverType = giverType;
+            }
             return this;
         }
 
         public Builder withRecipientType(FeedbackParticipantType recipientType) {
-            feedbackQuestionAttributes.recipientType = recipientType;
+            if (recipientType != null) {
+                feedbackQuestionAttributes.recipientType = recipientType;
+            }
             return this;
         }
 
@@ -142,32 +160,44 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public Builder withShowResponseTo(List<FeedbackParticipantType> showResponseTo) {
-            feedbackQuestionAttributes.showResponsesTo = new ArrayList<>(showResponseTo);
+            feedbackQuestionAttributes.showResponsesTo =
+                    showResponseTo == null ? new ArrayList<>() :
+                                                new ArrayList<>(showResponseTo);
             return this;
         }
 
         public Builder withShowGiverNameTo(List<FeedbackParticipantType> showGiverNameTo) {
-            feedbackQuestionAttributes.showGiverNameTo = new ArrayList<>(showGiverNameTo);
+            feedbackQuestionAttributes.showGiverNameTo =
+                    showGiverNameTo == null ? new ArrayList<>() :
+                                                new ArrayList<>(showGiverNameTo);
             return this;
         }
 
         public Builder withShowRecipientNameTo(List<FeedbackParticipantType> showRecipientNameTo) {
-            feedbackQuestionAttributes.showRecipientNameTo = new ArrayList<>(showRecipientNameTo);
+            feedbackQuestionAttributes.showRecipientNameTo =
+                    showRecipientNameTo == null ? new ArrayList<>() :
+                                                    new ArrayList<>(showRecipientNameTo);
             return this;
         }
 
         public Builder withCreatedAt(Instant createdAt) {
-            feedbackQuestionAttributes.createdAt = createdAt;
+            if (createdAt != null) {
+                feedbackQuestionAttributes.createdAt = createdAt;
+            }
             return this;
         }
 
         public Builder withUpdatedAt(Instant updatedAt) {
-            feedbackQuestionAttributes.updatedAt = updatedAt;
+            if (updatedAt != null) {
+                feedbackQuestionAttributes.updatedAt = updatedAt;
+            }
             return this;
         }
 
         public Builder withFeedbackQuestionId(String feedbackQuestionId) {
-            feedbackQuestionAttributes.feedbackQuestionId = feedbackQuestionId;
+            if (feedbackQuestionId != null) {
+                feedbackQuestionAttributes.feedbackQuestionId = feedbackQuestionId;
+            }
             return this;
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -53,8 +53,8 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     }
 
     public static FeedbackQuestionAttributes valueOf(FeedbackQuestion fq) {
-        return builder().
-                withFeedbackSessionName(fq.getFeedbackSessionName())
+        return builder()
+                .withFeedbackSessionName(fq.getFeedbackSessionName())
                 .withCourseId(fq.getCourseId())
                 .withCreatorEmail(fq.getCreatorEmail())
                 .withQuestionMetaData(fq.getQuestionMetaData())
@@ -76,6 +76,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     /**
      * A Builder class for {@link FeedbackQuestionAttributes}.
      */
+
     public static class Builder {
 
         private final FeedbackQuestionAttributes feedbackQuestionAttributes;
@@ -179,8 +180,8 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     }
 
     public FeedbackQuestionAttributes getCopy() {
-        return builder().
-                withFeedbackSessionName(feedbackSessionName)
+        return builder()
+                .withFeedbackSessionName(feedbackSessionName)
                 .withCourseId(courseId)
                 .withCreatorEmail(creatorEmail)
                 .withQuestionMetaData(questionMetaData)

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -44,6 +44,10 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     protected transient Instant updatedAt;
     private String feedbackQuestionId;
 
+    protected FeedbackQuestionAttributes() {
+        //attributes to be built by Builder
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -179,7 +179,23 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     }
 
     public FeedbackQuestionAttributes getCopy() {
-        return valueOf(toEntity());
+        return builder().
+                withFeedbackSessionName(feedbackSessionName)
+                .withCourseId(courseId)
+                .withCreatorEmail(creatorEmail)
+                .withQuestionMetaData(questionMetaData)
+                .withQuestionDescription(questionDescription)
+                .withQuestionNumber(questionNumber)
+                .withQuestionType(questionType)
+                .withGiverType(giverType)
+                .withRecipientType(recipientType)
+                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
+                .withShowResponseTo(showResponsesTo)
+                .withShowGiverNameTo(showGiverNameTo)
+                .withShowRecipientNameTo(showRecipientNameTo)
+                .withCreatedAt(createdAt)
+                .withUpdatedAt(updatedAt)
+                .build();
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -73,11 +73,11 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
                 .build();
 
     }
+
     /**
      * A Builder class for {@link FeedbackQuestionAttributes}.
      */
     public static class Builder {
-
         private final FeedbackQuestionAttributes feedbackQuestionAttributes;
 
         public Builder() {
@@ -202,7 +202,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         public FeedbackQuestionAttributes build() {
             feedbackQuestionAttributes.questionDescription =
                     SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
-            if(feedbackQuestionAttributes.recipientType != null) {
+            if (feedbackQuestionAttributes.recipientType != null) {
                 feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
             }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -135,17 +135,17 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public Builder withShowResponseTo(List<FeedbackParticipantType> showResponseTo) {
-            feedbackQuestionAttributes.showResponsesTo = showResponseTo;
+            feedbackQuestionAttributes.showResponsesTo = new ArrayList<>(showResponseTo);
             return this;
         }
 
         public Builder withShowGiverNameTo(List<FeedbackParticipantType> showGiverNameTo) {
-            feedbackQuestionAttributes.showGiverNameTo = showGiverNameTo;
+            feedbackQuestionAttributes.showGiverNameTo = new ArrayList<>(showGiverNameTo);
             return this;
         }
 
         public Builder withShowRecipientNameTo(List<FeedbackParticipantType> showRecipientNameTo) {
-            feedbackQuestionAttributes.showRecipientNameTo = showRecipientNameTo;
+            feedbackQuestionAttributes.showRecipientNameTo = new ArrayList<>(showRecipientNameTo);
             return this;
         }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -45,50 +45,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     private String feedbackQuestionId;
 
     public FeedbackQuestionAttributes() {
-        // attributes to be set after construction
-    }
-
-    public FeedbackQuestionAttributes(FeedbackQuestion fq) {
-        this.feedbackQuestionId = fq.getId();
-        this.feedbackSessionName = fq.getFeedbackSessionName();
-        this.courseId = fq.getCourseId();
-        this.creatorEmail = fq.getCreatorEmail();
-        this.questionMetaData = fq.getQuestionMetaData();
-        this.questionDescription = SanitizationHelper.sanitizeForRichText(fq.getQuestionDescription());
-        this.questionNumber = fq.getQuestionNumber();
-        this.questionType = fq.getQuestionType();
-        this.giverType = fq.getGiverType();
-        this.recipientType = fq.getRecipientType();
-        this.numberOfEntitiesToGiveFeedbackTo = fq.getNumberOfEntitiesToGiveFeedbackTo();
-        this.showResponsesTo = new ArrayList<>(fq.getShowResponsesTo());
-        this.showGiverNameTo = new ArrayList<>(fq.getShowGiverNameTo());
-        this.showRecipientNameTo = new ArrayList<>(fq.getShowRecipientNameTo());
-
-        this.createdAt = fq.getCreatedAt();
-        this.updatedAt = fq.getUpdatedAt();
-
-        removeIrrelevantVisibilityOptions();
-    }
-
-    private FeedbackQuestionAttributes(FeedbackQuestionAttributes other) {
-        this.feedbackQuestionId = other.getId();
-        this.feedbackSessionName = other.getFeedbackSessionName();
-        this.courseId = other.getCourseId();
-        this.creatorEmail = other.getCreatorEmail();
-        this.questionMetaData = other.getQuestionMetaData();
-        this.questionNumber = other.getQuestionNumber();
-        this.questionType = other.getQuestionType();
-        this.giverType = other.getGiverType();
-        this.recipientType = other.getRecipientType();
-        this.numberOfEntitiesToGiveFeedbackTo = other.getNumberOfEntitiesToGiveFeedbackTo();
-        this.showResponsesTo = new ArrayList<>(other.getShowResponsesTo());
-        this.showGiverNameTo = new ArrayList<>(other.getShowGiverNameTo());
-        this.showRecipientNameTo = new ArrayList<>(other.getShowRecipientNameTo());
-
-        this.createdAt = other.getCreatedAt();
-        this.updatedAt = other.getUpdatedAt();
-
-        removeIrrelevantVisibilityOptions();
+        // Empty constructor for builder to construct object
     }
 
     public static Builder builder() {
@@ -216,7 +173,24 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     }
 
     public FeedbackQuestionAttributes getCopy() {
-        return new FeedbackQuestionAttributes(this);
+        return builder().
+                withFeedbackSessionName(feedbackSessionName)
+                .withCourseId(courseId)
+                .withCreatorEmail(creatorEmail)
+                .withQuestionMetaData(questionMetaData)
+                .withQuestionDescription(questionDescription)
+                .withQuestionNumber(questionNumber)
+                .withQuestionType(questionType)
+                .withGiverType(giverType)
+                .withRecipientType(recipientType)
+                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
+                .withShowResponseTo(showResponsesTo)
+                .withShowGiverNameTo(showGiverNameTo)
+                .withShowRecipientNameTo(showRecipientNameTo)
+                .withCreatedAt(createdAt)
+                .withUpdatedAt(updatedAt)
+                .withFeedbackQuestionId(feedbackQuestionId)
+                .build();
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -101,6 +101,12 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
             return this;
         }
 
+        public Builder withQuestionMetaData(FeedbackQuestionDetails questionDetails) {
+            feedbackQuestionAttributes.setQuestionDetails(questionDetails);
+            return this;
+        }
+
+
         public Builder withQuestionDescription(Text questionDescription) {
             feedbackQuestionAttributes.setQuestionDescription(questionDescription);
             return this;

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -76,7 +76,6 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     /**
      * A Builder class for {@link FeedbackQuestionAttributes}.
      */
-
     public static class Builder {
 
         private final FeedbackQuestionAttributes feedbackQuestionAttributes;
@@ -203,13 +202,10 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         public FeedbackQuestionAttributes build() {
             feedbackQuestionAttributes.questionDescription =
                     SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
-            feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
-            return feedbackQuestionAttributes;
-        }
+            if(feedbackQuestionAttributes.recipientType != null) {
+                feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
+            }
 
-        public FeedbackQuestionAttributes buildWithoutRemovingIrrelevantVisibilityOptions() {
-            feedbackQuestionAttributes.questionDescription =
-                    SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
             return feedbackQuestionAttributes;
         }
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -179,24 +179,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     }
 
     public FeedbackQuestionAttributes getCopy() {
-        return builder().
-                withFeedbackSessionName(feedbackSessionName)
-                .withCourseId(courseId)
-                .withCreatorEmail(creatorEmail)
-                .withQuestionMetaData(questionMetaData)
-                .withQuestionDescription(questionDescription)
-                .withQuestionNumber(questionNumber)
-                .withQuestionType(questionType)
-                .withGiverType(giverType)
-                .withRecipientType(recipientType)
-                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
-                .withShowResponseTo(showResponsesTo)
-                .withShowGiverNameTo(showGiverNameTo)
-                .withShowRecipientNameTo(showRecipientNameTo)
-                .withCreatedAt(createdAt)
-                .withUpdatedAt(updatedAt)
-                .withFeedbackQuestionId(feedbackQuestionId)
-                .build();
+        return valueOf(toEntity());
     }
 
     public Instant getCreatedAt() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -90,7 +90,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public Builder withCourseId(String courseId) {
-            feedbackQuestionAttributes.setId(courseId);
+            feedbackQuestionAttributes.courseId = courseId;
             return this;
         }
 
@@ -168,6 +168,12 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
             feedbackQuestionAttributes.questionDescription =
                     SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
             feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
+            return feedbackQuestionAttributes;
+        }
+
+        public FeedbackQuestionAttributes buildWithoutRemovingIrrelevantVisibilityOptions() {
+            feedbackQuestionAttributes.questionDescription =
+                    SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
             return feedbackQuestionAttributes;
         }
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -208,6 +208,9 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
 
         public FeedbackQuestionAttributes build() {
+            feedbackQuestionAttributes.questionDescription =
+                    SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
+            feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
             return feedbackQuestionAttributes;
         }
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -214,27 +214,6 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         }
     }
 
-    public FeedbackQuestionAttributes getCopy() {
-        return builder()
-                .withFeedbackSessionName(feedbackSessionName)
-                .withCourseId(courseId)
-                .withCreatorEmail(creatorEmail)
-                .withQuestionMetaData(questionMetaData)
-                .withQuestionDescription(questionDescription)
-                .withQuestionNumber(questionNumber)
-                .withQuestionType(questionType)
-                .withGiverType(giverType)
-                .withRecipientType(recipientType)
-                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
-                .withShowResponseTo(showResponsesTo)
-                .withShowGiverNameTo(showGiverNameTo)
-                .withShowRecipientNameTo(showRecipientNameTo)
-                .withCreatedAt(createdAt)
-                .withUpdatedAt(updatedAt)
-                .withFeedbackQuestionId(feedbackQuestionId)
-                .build();
-    }
-
     public Instant getCreatedAt() {
         return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -44,10 +44,6 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     protected transient Instant updatedAt;
     private String feedbackQuestionId;
 
-    public FeedbackQuestionAttributes() {
-        // Empty constructor for builder to construct object
-    }
-
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -91,6 +91,127 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         removeIrrelevantVisibilityOptions();
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static FeedbackQuestionAttributes valueOf(FeedbackQuestion fq) {
+        return builder().
+                withFeedbackSessionName(fq.getFeedbackSessionName())
+                .withCourseId(fq.getCourseId())
+                .withCreatorEmail(fq.getCreatorEmail())
+                .withQuestionMetaData(fq.getQuestionMetaData())
+                .withQuestionDescription(fq.getQuestionDescription())
+                .withQuestionNumber(fq.getQuestionNumber())
+                .withQuestionType(fq.getQuestionType())
+                .withGiverType(fq.getGiverType())
+                .withRecipientType(fq.getRecipientType())
+                .withNumOfEntitiesToGiveFeedbackTo(fq.getNumberOfEntitiesToGiveFeedbackTo())
+                .withShowResponseTo(fq.getShowResponsesTo())
+                .withShowGiverNameTo(fq.getShowGiverNameTo())
+                .withShowRecipientNameTo(fq.getShowRecipientNameTo())
+                .withCreatedAt(fq.getCreatedAt())
+                .withUpdatedAt(fq.getUpdatedAt())
+                .withFeedbackQuestionId(fq.getId())
+                .build();
+
+    }
+    /**
+     * A Builder class for {@link FeedbackQuestionAttributes}.
+     */
+    public static class Builder {
+
+        private final FeedbackQuestionAttributes feedbackQuestionAttributes;
+
+        public Builder() {
+            feedbackQuestionAttributes = new FeedbackQuestionAttributes();
+        }
+
+        public Builder withFeedbackSessionName(String feedbackSessionName) {
+            feedbackQuestionAttributes.feedbackSessionName = feedbackSessionName;
+            return this;
+        }
+
+        public Builder withCourseId(String courseId) {
+            feedbackQuestionAttributes.setId(courseId);
+            return this;
+        }
+
+        public Builder withCreatorEmail(String creatorEmail) {
+            feedbackQuestionAttributes.creatorEmail = creatorEmail;
+            return this;
+        }
+
+        public Builder withQuestionMetaData(Text questionMetaData) {
+            feedbackQuestionAttributes.questionMetaData = questionMetaData;
+            return this;
+        }
+
+        public Builder withQuestionDescription(Text questionDescription) {
+            feedbackQuestionAttributes.setQuestionDescription(questionDescription);
+            return this;
+        }
+
+        public Builder withQuestionNumber(int questionNumber) {
+            feedbackQuestionAttributes.questionNumber = questionNumber;
+            return this;
+        }
+
+        public Builder withQuestionType(FeedbackQuestionType questionType) {
+            feedbackQuestionAttributes.questionType = questionType;
+            return this;
+        }
+
+        public Builder withGiverType(FeedbackParticipantType giverType) {
+            feedbackQuestionAttributes.giverType = giverType;
+            return this;
+        }
+
+        public Builder withRecipientType(FeedbackParticipantType recipientType) {
+            feedbackQuestionAttributes.recipientType = recipientType;
+            return this;
+        }
+
+        public Builder withNumOfEntitiesToGiveFeedbackTo(int numOfEntitiesToGiveFeedbackTo) {
+            feedbackQuestionAttributes.numberOfEntitiesToGiveFeedbackTo = numOfEntitiesToGiveFeedbackTo;
+            return this;
+        }
+
+        public Builder withShowResponseTo(List<FeedbackParticipantType> showResponseTo) {
+            feedbackQuestionAttributes.showResponsesTo = showResponseTo;
+            return this;
+        }
+
+        public Builder withShowGiverNameTo(List<FeedbackParticipantType> showGiverNameTo) {
+            feedbackQuestionAttributes.showGiverNameTo = showGiverNameTo;
+            return this;
+        }
+
+        public Builder withShowRecipientNameTo(List<FeedbackParticipantType> showRecipientNameTo) {
+            feedbackQuestionAttributes.showRecipientNameTo = showRecipientNameTo;
+            return this;
+        }
+
+        public Builder withCreatedAt(Instant createdAt) {
+            feedbackQuestionAttributes.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder withUpdatedAt(Instant updatedAt) {
+            feedbackQuestionAttributes.updatedAt = updatedAt;
+            return this;
+        }
+
+        public Builder withFeedbackQuestionId(String feedbackQuestionId) {
+            feedbackQuestionAttributes.feedbackQuestionId = feedbackQuestionId;
+            return this;
+        }
+
+        public FeedbackQuestionAttributes build() {
+            return feedbackQuestionAttributes;
+        }
+    }
+
     public FeedbackQuestionAttributes getCopy() {
         return new FeedbackQuestionAttributes(this);
     }
@@ -639,5 +760,4 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     public String getQuestionAdditionalInfoHtml() {
         return getQuestionDetails().getQuestionAdditionalInfoHtml(questionNumber, "");
     }
-
 }

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributes.java
@@ -202,9 +202,7 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
         public FeedbackQuestionAttributes build() {
             feedbackQuestionAttributes.questionDescription =
                     SanitizationHelper.sanitizeForRichText(feedbackQuestionAttributes.questionDescription);
-            if (feedbackQuestionAttributes.recipientType != null) {
-                feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
-            }
+            feedbackQuestionAttributes.removeIrrelevantVisibilityOptions();
 
             return feedbackQuestionAttributes;
         }
@@ -614,37 +612,49 @@ public class FeedbackQuestionAttributes extends EntityAttributes<FeedbackQuestio
     public void removeIrrelevantVisibilityOptions() {
         List<FeedbackParticipantType> optionsToRemove = new ArrayList<>();
 
-        switch (recipientType) {
-        case NONE:
-            optionsToRemove.add(FeedbackParticipantType.RECEIVER);
-            optionsToRemove.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
-            break;
-        case TEAMS:
-        case INSTRUCTORS:
-        case OWN_TEAM:
-        case OWN_TEAM_MEMBERS:
-            optionsToRemove.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
-            break;
-        default:
-            break;
+        if (recipientType != null) {
+            switch (recipientType) {
+            case NONE:
+                optionsToRemove.add(FeedbackParticipantType.RECEIVER);
+                optionsToRemove.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
+                break;
+            case TEAMS:
+            case INSTRUCTORS:
+            case OWN_TEAM:
+            case OWN_TEAM_MEMBERS:
+                optionsToRemove.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
+                break;
+            default:
+                break;
+            }
         }
 
-        switch (giverType) {
-        case TEAMS:
-        case INSTRUCTORS:
-            optionsToRemove.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
-            break;
-        default:
-            break;
+        if (giverType != null) {
+            switch (giverType) {
+            case TEAMS:
+            case INSTRUCTORS:
+                optionsToRemove.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
+                break;
+            default:
+                break;
+            }
         }
 
         removeVisibilities(optionsToRemove);
     }
 
     private void removeVisibilities(List<FeedbackParticipantType> optionsToRemove) {
-        showResponsesTo.removeAll(optionsToRemove);
-        showGiverNameTo.removeAll(optionsToRemove);
-        showRecipientNameTo.removeAll(optionsToRemove);
+        if (showRecipientNameTo != null) {
+            showResponsesTo.removeAll(optionsToRemove);
+        }
+
+        if (showGiverNameTo != null) {
+            showGiverNameTo.removeAll(optionsToRemove);
+        }
+
+        if (showRecipientNameTo != null) {
+            showRecipientNameTo.removeAll(optionsToRemove);
+        }
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -245,6 +245,6 @@ public class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, FeedbackQu
     protected FeedbackQuestionAttributes makeAttributes(FeedbackQuestion entity) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entity);
 
-        return new FeedbackQuestionAttributes(entity);
+        return FeedbackQuestionAttributes.valueOf(entity);
     }
 }

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -128,12 +128,6 @@ public class FeedbackQuestion extends BaseEntity {
         return Key.create(FeedbackQuestion.class, feedbackQuestionId).toWebSafeString();
     }
 
-    //for unit testing of valueOf() in FeedbackAttributeTest
-    public void setId(long id) {
-        Key key = Key.create(FeedbackQuestion.class, id);
-        feedbackQuestionId = key.getId();
-    }
-
     public String getFeedbackSessionName() {
         return feedbackSessionName;
     }

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -128,6 +128,12 @@ public class FeedbackQuestion extends BaseEntity {
         return Key.create(FeedbackQuestion.class, feedbackQuestionId).toWebSafeString();
     }
 
+    //for unit testing of valueOf() in FeedbackAttributeTest
+    public void setId(long id) {
+        Key key = Key.create(FeedbackQuestion.class, id);
+        feedbackQuestionId = key.getId();
+    }
+
     public String getFeedbackSessionName() {
         return feedbackSessionName;
     }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
@@ -13,7 +13,6 @@ import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.JsonUtils;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
@@ -118,7 +117,8 @@ public class InstructorFeedbackQuestionAddAction extends Action {
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO));
         List<FeedbackParticipantType> showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO));
-        List<FeedbackParticipantType> showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showRecipientNameTo =
+                FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
         String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
@@ -79,35 +79,28 @@ public class InstructorFeedbackQuestionAddAction extends Action {
     }
 
     private FeedbackQuestionAttributes extractFeedbackQuestionData(String creatorEmail) {
-        String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, courseId);
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
+        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 
-        String feedbackQuestionGiverType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE, feedbackQuestionGiverType);
+        String feedbackQuestionGiverType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
         FeedbackParticipantType giverType = FeedbackParticipantType.valueOf(feedbackQuestionGiverType);
 
-        String feedbackQuestionRecipientType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE, feedbackQuestionRecipientType);
+        String feedbackQuestionRecipientType =
+                getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
         FeedbackParticipantType recipientType = FeedbackParticipantType.valueOf(feedbackQuestionRecipientType);
 
-        String feedbackQuestionNumber = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER, feedbackQuestionNumber);
+        String feedbackQuestionNumber = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
         int questionNumber = Integer.parseInt(feedbackQuestionNumber);
         Assumption.assertTrue("Invalid question number", questionNumber >= 1);
 
-        String numberOfEntityTypes = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE, numberOfEntityTypes);
+        String numberOfEntityTypes = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
 
         int numberOfEntitiesToGiveFeedbackTo;
         if ("custom".equals(numberOfEntityTypes)
                 && (recipientType == FeedbackParticipantType.STUDENTS
                         || recipientType == FeedbackParticipantType.TEAMS)) {
-            String numberOfEntities = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
-            Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES, numberOfEntities);
-
+            String numberOfEntities = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
             numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(numberOfEntities);
         } else {
             numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
@@ -121,8 +114,7 @@ public class InstructorFeedbackQuestionAddAction extends Action {
                 FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
-        String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionTypeInString);
+        String questionTypeInString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
         questionTypeInString = FeedbackQuestionType.standardizeIfConstSum(questionTypeInString);
         FeedbackQuestionType questionType = FeedbackQuestionType.valueOf(questionTypeInString);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java
@@ -137,7 +137,7 @@ public class InstructorFeedbackQuestionAddAction extends Action {
                 .withQuestionType(questionType)
                 .withQuestionMetaData(questionDetails)
                 .withQuestionDescription(new Text(questionDescription))
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
     }
 
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -228,7 +228,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
                 .withQuestionType(questionType)
                 .withQuestionMetaData(questionDetails)
                 .withQuestionDescription(new Text(questionDescription))
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
     }
 
     private static boolean numberOfEntitiesIsUserDefined(FeedbackParticipantType recipientType, String nEntityTypes) {

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -144,14 +144,11 @@ public class InstructorFeedbackQuestionEditAction extends Action {
     }
 
     private FeedbackQuestionAttributes extractFeedbackQuestionData() {
-        String feedbackQuestionId = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_ID, feedbackQuestionId);
+        String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
 
-        String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, courseId);
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
+        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 
         // TODO thoroughly investigate when and why these parameters can be null
         // and check all possibilities in the tests
@@ -181,8 +178,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
             recipientType = FeedbackParticipantType.valueOf(recipientTypeInString);
         }
 
-        String feedbackQuestionNumber = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER, feedbackQuestionNumber);
+        String feedbackQuestionNumber = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
         int questionNumber = Integer.parseInt(feedbackQuestionNumber);
         Assumption.assertTrue("Invalid question number", questionNumber >= 1);
 
@@ -191,8 +187,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
 
         int numberOfEntitiesToGiveFeedbackTo;
         if (numberOfEntitiesIsUserDefined(recipientType, nEntityTypes)) {
-            String nEntities = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
-            Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES, nEntities);
+            String nEntities = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
             numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(nEntities);
         } else {
             numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
@@ -206,8 +201,7 @@ public class InstructorFeedbackQuestionEditAction extends Action {
                 FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
-        String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionTypeInString);
+        String questionTypeInString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
         FeedbackQuestionType questionType = FeedbackQuestionType.valueOf(questionTypeInString);
 
         // Can be null

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -144,13 +144,14 @@ public class InstructorFeedbackQuestionEditAction extends Action {
     }
 
     private FeedbackQuestionAttributes extractFeedbackQuestionData() {
-        FeedbackQuestionAttributes newQuestion = new FeedbackQuestionAttributes();
+        String feedbackQuestionId = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_ID, feedbackQuestionId);
 
-        newQuestion.setId(getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID));
+        String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, courseId);
 
-        newQuestion.courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
-
-        newQuestion.feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, feedbackSessionName);
 
         // TODO thoroughly investigate when and why these parameters can be null
         // and check all possibilities in the tests
@@ -167,54 +168,72 @@ public class InstructorFeedbackQuestionEditAction extends Action {
         // givertype
 
         // Can be null
-        String giverType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
-        if (giverType != null) {
-            newQuestion.giverType = FeedbackParticipantType.valueOf(giverType);
+        FeedbackParticipantType giverType = null;
+        String giverTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
+        if (giverTypeInString != null) {
+            giverType = FeedbackParticipantType.valueOf(giverTypeInString);
         }
 
         // Can be null
-        String recipientType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
-        if (recipientType != null) {
-            newQuestion.recipientType = FeedbackParticipantType.valueOf(recipientType);
+        FeedbackParticipantType recipientType = null;
+        String recipientTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
+        if (recipientTypeInString != null) {
+            recipientType = FeedbackParticipantType.valueOf(recipientTypeInString);
         }
 
-        String questionNumber = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
-        newQuestion.questionNumber = Integer.parseInt(questionNumber);
-        Assumption.assertTrue("Invalid question number", newQuestion.questionNumber >= 1);
+        String feedbackQuestionNumber = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBER, feedbackQuestionNumber);
+        int questionNumber = Integer.parseInt(feedbackQuestionNumber);
+        Assumption.assertTrue("Invalid question number", questionNumber >= 1);
 
         // Can be null
         String nEntityTypes = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
 
-        if (numberOfEntitiesIsUserDefined(newQuestion.recipientType, nEntityTypes)) {
-            String nEntities = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
-            newQuestion.numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(nEntities);
+        int numberOfEntitiesToGiveFeedbackTo;
+        if (numberOfEntitiesIsUserDefined(recipientType, nEntityTypes)) {
+            String nEntities = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
+            Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES, nEntities);
+            numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(nEntities);
         } else {
-            newQuestion.numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
+            numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
         }
 
-        newQuestion.showResponsesTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showResponsesTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO));
-        newQuestion.showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO));
-        newQuestion.showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
-        String questionType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
-        newQuestion.questionType = FeedbackQuestionType.valueOf(questionType);
+        String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionTypeInString);
+        FeedbackQuestionType questionType = FeedbackQuestionType.valueOf(questionTypeInString);
 
         // Can be null
         String questionText = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TEXT);
+        FeedbackQuestionDetails questionDetails = null;
         if (questionText != null && !questionText.isEmpty()) {
-            FeedbackQuestionDetails questionDetails = FeedbackQuestionDetails.createQuestionDetails(
-                    requestParameters, newQuestion.questionType);
-            newQuestion.setQuestionDetails(questionDetails);
+            questionDetails = FeedbackQuestionDetails.createQuestionDetails(
+                    requestParameters, questionType);
         }
 
         String questionDescription = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_DESCRIPTION);
 
-        newQuestion.setQuestionDescription(new Text(questionDescription));
-
-        return newQuestion;
+        return FeedbackQuestionAttributes.builder()
+                .withFeedbackQuestionId(feedbackQuestionId)
+                .withCourseId(courseId)
+                .withFeedbackSessionName(feedbackSessionName)
+                .withGiverType(giverType)
+                .withRecipientType(recipientType)
+                .withQuestionNumber(questionNumber)
+                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
+                .withShowResponseTo(showResponsesTo)
+                .withShowGiverNameTo(showGiverNameTo)
+                .withShowRecipientNameTo(showRecipientNameTo)
+                .withQuestionType(questionType)
+                .withQuestionMetaData(questionDetails)
+                .withQuestionDescription(new Text(questionDescription))
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
     }
 
     private static boolean numberOfEntitiesIsUserDefined(FeedbackParticipantType recipientType, String nEntityTypes) {

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionEditAction.java
@@ -202,7 +202,8 @@ public class InstructorFeedbackQuestionEditAction extends Action {
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO));
         List<FeedbackParticipantType> showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO));
-        List<FeedbackParticipantType> showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showRecipientNameTo =
+                FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
         String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
@@ -24,29 +24,21 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
     }
 
     private FeedbackQuestionAttributes extractFeedbackQuestionData(String creatorEmail) {
-        String feedbackQuestionGiverType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
-
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE, feedbackQuestionGiverType);
+        String feedbackQuestionGiverType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
 
         FeedbackParticipantType giverType = FeedbackParticipantType.valueOf(feedbackQuestionGiverType);
 
-        String feedbackQuestionRecipientType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
-
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE, feedbackQuestionRecipientType);
+        String feedbackQuestionRecipientType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
 
         FeedbackParticipantType recipientType = FeedbackParticipantType.valueOf(feedbackQuestionRecipientType);
 
-        String numberOfEntityTypes = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
-
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE, numberOfEntityTypes);
+        String numberOfEntityTypes = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
 
         int numberOfEntitiesToGiveFeedbackTo;
         if ("custom".equals(numberOfEntityTypes)
                 && (recipientType == FeedbackParticipantType.STUDENTS
                         || recipientType == FeedbackParticipantType.TEAMS)) {
-            String numberOfEntities = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
-
-            Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES, numberOfEntities);
+            String numberOfEntities = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
 
             numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(numberOfEntities);
         } else {
@@ -61,8 +53,7 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
                 FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
-        String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionTypeInString);
+        String questionTypeInString = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
         questionTypeInString = FeedbackQuestionType.standardizeIfConstSum(questionTypeInString);
 
         FeedbackQuestionType questionType = FeedbackQuestionType.valueOf(questionTypeInString);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
@@ -24,53 +24,58 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
     }
 
     private FeedbackQuestionAttributes extractFeedbackQuestionData(String creatorEmail) {
-        FeedbackQuestionAttributes newQuestion = new FeedbackQuestionAttributes();
-
-        newQuestion.creatorEmail = creatorEmail;
-
         String feedbackQuestionGiverType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE);
 
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_GIVERTYPE, feedbackQuestionGiverType);
 
-        newQuestion.giverType = FeedbackParticipantType.valueOf(feedbackQuestionGiverType);
+        FeedbackParticipantType giverType = FeedbackParticipantType.valueOf(feedbackQuestionGiverType);
 
         String feedbackQuestionRecipientType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
 
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE, feedbackQuestionRecipientType);
 
-        newQuestion.recipientType = FeedbackParticipantType.valueOf(feedbackQuestionRecipientType);
+        FeedbackParticipantType recipientType = FeedbackParticipantType.valueOf(feedbackQuestionRecipientType);
 
         String numberOfEntityTypes = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE);
 
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIESTYPE, numberOfEntityTypes);
 
+        int numberOfEntitiesToGiveFeedbackTo;
         if ("custom".equals(numberOfEntityTypes)
-                && (newQuestion.recipientType == FeedbackParticipantType.STUDENTS
-                        || newQuestion.recipientType == FeedbackParticipantType.TEAMS)) {
+                && (recipientType == FeedbackParticipantType.STUDENTS
+                        || recipientType == FeedbackParticipantType.TEAMS)) {
             String numberOfEntities = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES);
 
             Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_NUMBEROFENTITIES, numberOfEntities);
 
-            newQuestion.numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(numberOfEntities);
+            numberOfEntitiesToGiveFeedbackTo = Integer.parseInt(numberOfEntities);
         } else {
-            newQuestion.numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
+            numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
         }
 
-        newQuestion.showResponsesTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showResponsesTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO));
-        newQuestion.showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO));
-        newQuestion.showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
-        String questionType = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
-        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionType);
-        questionType = FeedbackQuestionType.standardizeIfConstSum(questionType);
+        String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_QUESTION_TYPE, questionTypeInString);
+        questionTypeInString = FeedbackQuestionType.standardizeIfConstSum(questionTypeInString);
 
-        newQuestion.questionType = FeedbackQuestionType.valueOf(questionType);
-        newQuestion.removeIrrelevantVisibilityOptions();
+        FeedbackQuestionType questionType = FeedbackQuestionType.valueOf(questionTypeInString);
 
-        return newQuestion;
+        return FeedbackQuestionAttributes.builder()
+                .withCreatorEmail(creatorEmail)
+                .withGiverType(giverType)
+                .withRecipientType(recipientType)
+                .withNumOfEntitiesToGiveFeedbackTo(numberOfEntitiesToGiveFeedbackTo)
+                .withShowResponseTo(showResponsesTo)
+                .withShowGiverNameTo(showGiverNameTo)
+                .withShowRecipientNameTo(showRecipientNameTo)
+                .withQuestionType(questionType)
+                .build();
     }
 
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
@@ -57,7 +57,8 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRESPONSESTO));
         List<FeedbackParticipantType> showGiverNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWGIVERTO));
-        List<FeedbackParticipantType> showRecipientNameTo = FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
+        List<FeedbackParticipantType> showRecipientNameTo =
+                FeedbackParticipantType.getParticipantListFromCommaSeparatedValues(
                 getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_SHOWRECIPIENTTO));
 
         String questionTypeInString = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_TYPE);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionVisibilityMessageAction.java
@@ -5,7 +5,6 @@ import java.util.List;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
-import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.ui.pagedata.InstructorFeedbackQuestionVisibilityMessagePageData;
 
@@ -28,7 +27,8 @@ public class InstructorFeedbackQuestionVisibilityMessageAction extends Action {
 
         FeedbackParticipantType giverType = FeedbackParticipantType.valueOf(feedbackQuestionGiverType);
 
-        String feedbackQuestionRecipientType = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
+        String feedbackQuestionRecipientType =
+                getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_RECIPIENTTYPE);
 
         FeedbackParticipantType recipientType = FeedbackParticipantType.valueOf(feedbackQuestionRecipientType);
 

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -106,7 +106,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         FeedbackParticipantType recipientType = FeedbackParticipantType.TEAMS;
 
         List<FeedbackParticipantType> participants = new ArrayList<>();
-        participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
         participants.add(FeedbackParticipantType.RECEIVER);
         Instant createdAt = Instant.now();
         Instant updatedAt = Instant.ofEpochMilli(9876545);
@@ -129,7 +128,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withCreatedAt(createdAt)
                 .withUpdatedAt(updatedAt)
                 .withFeedbackQuestionId(feedbackQuestionId)
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertEquals(feedbackSession, feedbackQuestionAttributes.getFeedbackSessionName());
         assertEquals(courseId, feedbackQuestionAttributes.getCourseId());
@@ -158,7 +157,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withQuestionMetaData(new Text("test qn from teams->none."))
                 .withQuestionDescription(contentWithWhitespaces)
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertEquals(new Text("content to be sanitized by removing leading/trailing whitespace"),
                 feedbackQuestionAttributes.getQuestionDescription());
@@ -169,7 +168,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withQuestionMetaData(new Text("test qn from teams->none."))
                 .withQuestionDescription(codeblock)
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertEquals(new Text("<code>System.out.println(&#34;Hello World&#34;);</code>"),
                 feedbackQuestionAttributes.getQuestionDescription());
@@ -181,7 +180,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withQuestionMetaData(new Text("test qn from teams->none."))
                 .withQuestionDescription(superscript)
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertEquals(new Text("f(x) &#61; x<sup>2</sup>"), feedbackQuestionAttributes.getQuestionDescription());
 
@@ -191,7 +190,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withQuestionMetaData(new Text("test qn from teams->none."))
                 .withQuestionDescription(chemicalFormula)
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertEquals(new Text("<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>"),
                 feedbackQuestionAttributes.getQuestionDescription());
@@ -200,7 +199,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     @Test
     public void testBuilderWithDefaultValues() {
         FeedbackQuestionAttributes observedFeedbackQuestionAttributes =
-                FeedbackQuestionAttributes.builder().buildWithoutRemovingIrrelevantVisibilityOptions();
+                FeedbackQuestionAttributes.builder().build();
 
         assertEquals(0, observedFeedbackQuestionAttributes.questionNumber);
         assertNull(observedFeedbackQuestionAttributes.recipientType);
@@ -238,7 +237,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
-    public void testValidate() throws Exception {
+    public void testValidate() {
 
         List<FeedbackParticipantType> showGiverNameToList = new ArrayList<>();
         showGiverNameToList.add(FeedbackParticipantType.SELF);
@@ -262,7 +261,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withShowGiverNameTo(new ArrayList<>(showGiverNameToList))
                 .withShowRecipientNameTo(new ArrayList<>(showRecipientNameToList))
                 .withShowResponseTo(new ArrayList<>(showResponseToList))
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         assertFalse(fq.isValid());
 

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -38,6 +38,44 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
+    public void testBuilderCopy() {
+        List<FeedbackParticipantType> participants = new ArrayList<>();
+        participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
+        participants.add(FeedbackParticipantType.RECEIVER);
+        participants.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
+        List<FeedbackParticipantType> participantsForShowResponseTo = new ArrayList<>(participants);
+        participantsForShowResponseTo.add(FeedbackParticipantType.STUDENTS);
+
+        FeedbackQuestionAttributes original = FeedbackQuestionAttributes.builder()
+                .withFeedbackSessionName("test session")
+                .withCourseId("some course")
+                .withCreatorEmail("test@case.com")
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionNumber(1)
+                .withQuestionType(FeedbackQuestionType.TEXT)
+                .withGiverType(FeedbackParticipantType.TEAMS)
+                .withRecipientType(FeedbackParticipantType.NONE)
+                .withShowGiverNameTo(new ArrayList<>(participants))
+                .withShowRecipientNameTo(new ArrayList<>(participants))
+                .withShowResponseTo(new ArrayList<>(participantsForShowResponseTo))
+                .build();
+
+        FeedbackQuestionAttributes copy = original.getCopy();
+
+        assertEquals(copy.getFeedbackSessionName(), original.getFeedbackSessionName());
+        assertEquals(copy.getCourseId(), original.getCourseId());
+        assertEquals(copy.getCreatorEmail(), original.getCreatorEmail());
+        assertEquals(copy.getQuestionMetaData(), original.getQuestionMetaData());
+        assertEquals(copy.getQuestionNumber(), original.getQuestionNumber());
+        assertEquals(copy.getQuestionType(), original.getQuestionType());
+        assertEquals(copy.getGiverType(), original.getGiverType());
+        assertEquals(copy.getRecipientType(), original.getRecipientType());
+        assertEquals(copy.getShowGiverNameTo(), original.getShowGiverNameTo());
+        assertEquals(copy.getShowRecipientNameTo(), original.getShowRecipientNameTo());
+        assertEquals(copy.getShowResponsesTo(), copy.getShowResponsesTo());
+    }
+
+    @Test
     public void testDefaultTimestamp() {
 
         FeedbackQuestionAttributesWithModifiableTimestamp fq =

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.google.appengine.api.datastore.Text;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.appengine.api.datastore.Text;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -42,8 +42,10 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
     @Test
     public void testValueOf() {
-        //Solves the problem of "java.lang.NullPointerException: No API environment is registered for this thread on Unit testing"
-        //https://stackoverflow.com/questions/31994264/java-lang-nullpointerexception-no-api-environment-is-registered-for-this-thread
+        /* Solves the problem of "java.lang.NullPointerException: No API environment is registered for this thread on
+         Unit testing".
+         https://stackoverflow.com/questions/31994264/java-lang-nullpointerexception-no-api-environment-
+         is-registered-for-this-thread */
         LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
         helper.setUp();
 
@@ -51,8 +53,8 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
         participants.add(FeedbackParticipantType.RECEIVER);
 
-        List<FeedbackParticipantType> participantTypesAfterRemovingIrrelevantVisibilitiesOptions
-                = new ArrayList<>(participants);
+        List<FeedbackParticipantType> participantTypesAfterRemovingIrrelevantVisibilitiesOptions =
+                new ArrayList<>(participants);
         participantTypesAfterRemovingIrrelevantVisibilitiesOptions.remove(FeedbackParticipantType.OWN_TEAM_MEMBERS);
         participantTypesAfterRemovingIrrelevantVisibilitiesOptions.remove(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
 
@@ -63,7 +65,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         qn.setId(12345678910L);
 
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.valueOf(qn);
-
         assertEquals(qn.getFeedbackSessionName(), feedbackQuestionAttributes.getFeedbackSessionName());
         assertEquals(qn.getCourseId(), feedbackQuestionAttributes.getCourseId());
         assertEquals(qn.getCreatorEmail(), feedbackQuestionAttributes.getCreatorEmail());
@@ -76,8 +77,8 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertEquals(qn.getGiverType(), feedbackQuestionAttributes.getGiverType());
         assertEquals(qn.getRecipientType(), feedbackQuestionAttributes.getRecipientType());
 
-        /* .build() in valueOf() will remove irrelevant visibilities options, so the lists showResponsesTo, showGiverNameTo, and
-        showRecipientNameTo are not the same as the ones in qn */
+        /* .build() in valueOf() will remove irrelevant visibilities options, so the lists showResponsesTo,
+        showGiverNameTo, and showRecipientNameTo are not the same as the ones in qn */
         assertEquals(participantTypesAfterRemovingIrrelevantVisibilitiesOptions,
                 feedbackQuestionAttributes.getShowGiverNameTo());
         assertEquals(participantTypesAfterRemovingIrrelevantVisibilitiesOptions,
@@ -109,6 +110,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         participants.add(FeedbackParticipantType.RECEIVER);
         Instant createdAt = Instant.now();
         Instant updatedAt = Instant.ofEpochMilli(9876545);
+        String feedbackQuestionId = "agR0ZXN0choLEhBGZWVkYmFja1F1ZXN0aW9uGL648P4tDA";
 
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withFeedbackSessionName(feedbackSession)
@@ -126,6 +128,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withShowResponseTo(new ArrayList<>(participants))
                 .withCreatedAt(createdAt)
                 .withUpdatedAt(updatedAt)
+                .withFeedbackQuestionId(feedbackQuestionId)
                 .buildWithoutRemovingIrrelevantVisibilityOptions();
 
         assertEquals(feedbackSession, feedbackQuestionAttributes.getFeedbackSessionName());
@@ -143,6 +146,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertEquals(participants, feedbackQuestionAttributes.showRecipientNameTo);
         assertEquals(createdAt, feedbackQuestionAttributes.getCreatedAt());
         assertEquals(updatedAt, feedbackQuestionAttributes.getUpdatedAt());
+        assertEquals(feedbackQuestionId, feedbackQuestionAttributes.getFeedbackQuestionId());
     }
 
     @Test
@@ -214,7 +218,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
-    public void testBuilderCopy() {
+    public void testGetCopy() {
         List<FeedbackParticipantType> participants = new ArrayList<>();
         participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
         participants.add(FeedbackParticipantType.RECEIVER);
@@ -234,6 +238,10 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withShowGiverNameTo(new ArrayList<>(participants))
                 .withShowRecipientNameTo(new ArrayList<>(participants))
                 .withShowResponseTo(new ArrayList<>(participantsForShowResponseTo))
+                .withCreatedAt(Instant.now())
+                .withUpdatedAt(Instant.MAX)
+                .withQuestionDescription(new Text("some description"))
+                .withNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS)
                 .build();
 
         FeedbackQuestionAttributes copy = original.getCopy();
@@ -250,6 +258,10 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         assertEquals(copy.getShowGiverNameTo(), original.getShowGiverNameTo());
         assertEquals(copy.getShowRecipientNameTo(), original.getShowRecipientNameTo());
         assertEquals(copy.getShowResponsesTo(), copy.getShowResponsesTo());
+        assertEquals(copy.getCreatedAt(), original.getCreatedAt());
+        assertEquals(copy.getUpdatedAt(), original.getUpdatedAt());
+        assertEquals(copy.getNumberOfEntitiesToGiveFeedbackTo(), original.getNumberOfEntitiesToGiveFeedbackTo());
+        assertEquals(copy.getFeedbackQuestionId(), original.getFeedbackQuestionId());
     }
 
     @Test
@@ -441,6 +453,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withShowGiverNameTo(new ArrayList<>(participants))
                 .withShowRecipientNameTo(new ArrayList<>(participants))
                 .withShowResponseTo(new ArrayList<>(participantsForShowResponseTo))
+                .withNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS)
                 .build();
 
         assertTrue(question.showGiverNameTo.isEmpty());

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -77,7 +77,7 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
 
         FeedbackQuestionsDb db = new FeedbackQuestionsDb();
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
-        FeedbackQuestion qn = db.createEntity(fqa);
+        FeedbackQuestion qn = db.createEntityWithoutExistenceCheck(fqa);
 
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.valueOf(qn);
 
@@ -179,39 +179,6 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
                 .build();
 
         assertEquals(new Text("content to be sanitized by removing leading/trailing whitespace"),
-                feedbackQuestionAttributes.getQuestionDescription());
-
-        ______TS("sanitize code block");
-
-        Text codeblock = new Text("<code>System.out.println(\"Hello World\");</code>");
-        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
-                .withQuestionMetaData(new Text("test qn from teams->none."))
-                .withQuestionDescription(codeblock)
-                .build();
-
-        assertEquals(new Text("<code>System.out.println(&#34;Hello World&#34;);</code>"),
-                feedbackQuestionAttributes.getQuestionDescription());
-
-        ______TS("sanitize superscript");
-
-        Text superscript = new Text("f(x) = x<sup>2</sup>");
-
-        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
-                .withQuestionMetaData(new Text("test qn from teams->none."))
-                .withQuestionDescription(superscript)
-                .build();
-
-        assertEquals(new Text("f(x) &#61; x<sup>2</sup>"), feedbackQuestionAttributes.getQuestionDescription());
-
-        ______TS("sanitize chemical formula");
-
-        Text chemicalFormula = new Text("<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>");
-        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
-                .withQuestionMetaData(new Text("test qn from teams->none."))
-                .withQuestionDescription(chemicalFormula)
-                .build();
-
-        assertEquals(new Text("<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>"),
                 feedbackQuestionAttributes.getQuestionDescription());
     }
 

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -38,6 +38,26 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
+    public void testBuilderWithDefaultValues() {
+        FeedbackQuestionAttributes observedFeedbackQuestionAttributes =
+                FeedbackQuestionAttributes.builder().buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(0, observedFeedbackQuestionAttributes.questionNumber);
+        assertNull(observedFeedbackQuestionAttributes.recipientType);
+        assertNull(observedFeedbackQuestionAttributes.giverType);
+        assertNull(observedFeedbackQuestionAttributes.courseId);
+        assertNull(observedFeedbackQuestionAttributes.feedbackSessionName);
+        assertNull(observedFeedbackQuestionAttributes.showResponsesTo);
+        assertNull(observedFeedbackQuestionAttributes.showGiverNameTo);
+        assertNull(observedFeedbackQuestionAttributes.showRecipientNameTo);
+        assertNull(observedFeedbackQuestionAttributes.questionDescription);
+        assertNull(observedFeedbackQuestionAttributes.questionType);
+        assertNull(observedFeedbackQuestionAttributes.questionMetaData);
+        assertNull(observedFeedbackQuestionAttributes.creatorEmail);
+        assertEquals(0, observedFeedbackQuestionAttributes.numberOfEntitiesToGiveFeedbackTo);
+    }
+
+    @Test
     public void testBuilderCopy() {
         List<FeedbackParticipantType> participants = new ArrayList<>();
         participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -59,26 +59,33 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
     @Test
     public void testValidate() throws Exception {
-        FeedbackQuestionAttributes fq = new FeedbackQuestionAttributes();
 
-        fq.feedbackSessionName = "";
-        fq.courseId = "";
-        fq.creatorEmail = "";
-        fq.questionType = FeedbackQuestionType.TEXT;
-        fq.giverType = FeedbackParticipantType.NONE;
-        fq.recipientType = FeedbackParticipantType.RECEIVER;
+        List<FeedbackParticipantType> showGiverNameToList = new ArrayList<>();
+        showGiverNameToList.add(FeedbackParticipantType.SELF);
+        showGiverNameToList.add(FeedbackParticipantType.STUDENTS);
 
-        fq.showGiverNameTo = new ArrayList<>();
-        fq.showGiverNameTo.add(FeedbackParticipantType.SELF);
-        fq.showGiverNameTo.add(FeedbackParticipantType.STUDENTS);
+        List<FeedbackParticipantType> showRecipientNameToList = new ArrayList<>();
+        showRecipientNameToList.add(FeedbackParticipantType.SELF);
+        showRecipientNameToList.add(FeedbackParticipantType.STUDENTS);
 
-        fq.showRecipientNameTo = new ArrayList<>();
-        fq.showRecipientNameTo.add(FeedbackParticipantType.SELF);
-        fq.showRecipientNameTo.add(FeedbackParticipantType.STUDENTS);
+        List<FeedbackParticipantType> showResponseToList = new ArrayList<>();
+        showResponseToList.add(FeedbackParticipantType.NONE);
+        showResponseToList.add(FeedbackParticipantType.SELF);
 
-        fq.showResponsesTo = new ArrayList<>();
-        fq.showResponsesTo.add(FeedbackParticipantType.NONE);
-        fq.showResponsesTo.add(FeedbackParticipantType.SELF);
+        FeedbackQuestionAttributes fq = FeedbackQuestionAttributes.builder()
+                .withFeedbackSessionName("")
+                .withCourseId("")
+                .withCreatorEmail("")
+                .withQuestionType(FeedbackQuestionType.TEXT)
+                .withGiverType(FeedbackParticipantType.NONE)
+                .withRecipientType(FeedbackParticipantType.RECEIVER)
+                .withShowGiverNameTo(new ArrayList<>(showGiverNameToList))
+                .withShowRecipientNameTo(new ArrayList<>(showRecipientNameToList))
+                .withShowResponseTo(new ArrayList<>(showResponseToList))
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+
+
 
         assertFalse(fq.isValid());
 
@@ -117,6 +124,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                                               FieldValidator.VIEWER_TYPE_NAME);
 
         assertEquals(errorMessage, StringHelper.toString(fq.getInvalidityInfo()));
+
 
         fq.feedbackSessionName = "First Feedback Session";
         fq.courseId = "CS1101";
@@ -203,27 +211,26 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
         ______TS("test teams->none");
 
-        FeedbackQuestionAttributes question = new FeedbackQuestionAttributes();
         List<FeedbackParticipantType> participants = new ArrayList<>();
-
-        question.feedbackSessionName = "test session";
-        question.courseId = "some course";
-        question.creatorEmail = "test@case.com";
-        question.questionMetaData = new Text("test qn from teams->none.");
-        question.questionNumber = 1;
-        question.questionType = FeedbackQuestionType.TEXT;
-        question.giverType = FeedbackParticipantType.TEAMS;
-        question.recipientType = FeedbackParticipantType.NONE;
-        question.numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
         participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
         participants.add(FeedbackParticipantType.RECEIVER);
         participants.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
-        question.showGiverNameTo = new ArrayList<>(participants);
-        question.showRecipientNameTo = new ArrayList<>(participants);
-        participants.add(FeedbackParticipantType.STUDENTS);
-        question.showResponsesTo = new ArrayList<>(participants);
+        List<FeedbackParticipantType> participantsForShowResponseTo = new ArrayList<>(participants);
+        participantsForShowResponseTo.add(FeedbackParticipantType.STUDENTS);
 
-        question.removeIrrelevantVisibilityOptions();
+        FeedbackQuestionAttributes question = FeedbackQuestionAttributes.builder()
+                .withFeedbackSessionName("test session")
+                .withCourseId("some course")
+                .withCreatorEmail("test@case.com")
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionNumber(1)
+                .withQuestionType(FeedbackQuestionType.TEXT)
+                .withGiverType(FeedbackParticipantType.TEAMS)
+                .withRecipientType(FeedbackParticipantType.NONE)
+                .withShowGiverNameTo(new ArrayList<>(participants))
+                .withShowRecipientNameTo(new ArrayList<>(participants))
+                .withShowResponseTo(new ArrayList<>(participantsForShowResponseTo))
+                .build();
 
         assertTrue(question.showGiverNameTo.isEmpty());
         assertTrue(question.showRecipientNameTo.isEmpty());

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -56,7 +56,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
         Instant createdAt = Instant.now();
         Instant updatedAt = Instant.ofEpochMilli(9876545);
 
-
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
                 .withFeedbackSessionName(feedbackSession)
                 .withCourseId(courseId)
@@ -99,9 +98,9 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
         Text contentWithWhitespaces = new Text(" content to be sanitized by removing leading/trailing whitespace ");
         FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
-            .withQuestionMetaData(new Text("test qn from teams->none."))
-            .withQuestionDescription(contentWithWhitespaces)
-            .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionDescription(contentWithWhitespaces)
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
 
         assertEquals(new Text("content to be sanitized by removing leading/trailing whitespace"),
                 feedbackQuestionAttributes.getQuestionDescription());

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -82,6 +82,7 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
 
         FeedbackQuestionAttributes copy = original.getCopy();
 
+        assertNotSame(copy, original);
         assertEquals(copy.getFeedbackSessionName(), original.getFeedbackSessionName());
         assertEquals(copy.getCourseId(), original.getCourseId());
         assertEquals(copy.getCreatorEmail(), original.getCreatorEmail());

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -142,9 +142,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                 .withShowResponseTo(new ArrayList<>(showResponseToList))
                 .buildWithoutRemovingIrrelevantVisibilityOptions();
 
-
-
-
         assertFalse(fq.isValid());
 
         String errorMessage = getPopulatedEmptyStringErrorMessage(
@@ -182,7 +179,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
                                               FieldValidator.VIEWER_TYPE_NAME);
 
         assertEquals(errorMessage, StringHelper.toString(fq.getInvalidityInfo()));
-
 
         fq.feedbackSessionName = "First Feedback Session";
         fq.courseId = "CS1101";

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -38,6 +38,109 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
+    public void testBuilderWithPopulatedFieldValues() {
+        String feedbackSession = "test session";
+        String courseId = "some course";
+        String creatorEmail = "test@case.com";
+        Text questionMetaData = new Text("test qn from teams->none.");
+        Text questionDescription = new Text("some description");
+        int questionNumber = 1;
+        int numOfEntities = 4;
+        FeedbackQuestionType questionType = FeedbackQuestionType.TEXT;
+        FeedbackParticipantType giverType = FeedbackParticipantType.TEAMS;
+        FeedbackParticipantType recipientType = FeedbackParticipantType.TEAMS;
+
+        List<FeedbackParticipantType> participants = new ArrayList<>();
+        participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
+        participants.add(FeedbackParticipantType.RECEIVER);
+        Instant createdAt = Instant.now();
+        Instant updatedAt = Instant.ofEpochMilli(9876545);
+
+
+        FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withFeedbackSessionName(feedbackSession)
+                .withCourseId(courseId)
+                .withCreatorEmail(creatorEmail)
+                .withQuestionMetaData(questionMetaData)
+                .withQuestionDescription(questionDescription)
+                .withQuestionNumber(questionNumber)
+                .withNumOfEntitiesToGiveFeedbackTo(numOfEntities)
+                .withQuestionType(questionType)
+                .withGiverType(giverType)
+                .withRecipientType(recipientType)
+                .withShowGiverNameTo(new ArrayList<>(participants))
+                .withShowRecipientNameTo(new ArrayList<>(participants))
+                .withShowResponseTo(new ArrayList<>(participants))
+                .withCreatedAt(createdAt)
+                .withUpdatedAt(updatedAt)
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(feedbackSession, feedbackQuestionAttributes.getFeedbackSessionName());
+        assertEquals(courseId, feedbackQuestionAttributes.getCourseId());
+        assertEquals(creatorEmail, feedbackQuestionAttributes.getCreatorEmail());
+        assertEquals(questionMetaData, feedbackQuestionAttributes.getQuestionMetaData());
+        assertEquals(questionDescription, feedbackQuestionAttributes.questionDescription);
+        assertEquals(questionNumber, feedbackQuestionAttributes.getQuestionNumber());
+        assertEquals(numOfEntities, feedbackQuestionAttributes.numberOfEntitiesToGiveFeedbackTo);
+        assertEquals(questionType, feedbackQuestionAttributes.getQuestionType());
+        assertEquals(giverType, feedbackQuestionAttributes.getGiverType());
+        assertEquals(recipientType, feedbackQuestionAttributes.getRecipientType());
+        assertEquals(participants, feedbackQuestionAttributes.showGiverNameTo);
+        assertEquals(participants, feedbackQuestionAttributes.showResponsesTo);
+        assertEquals(participants, feedbackQuestionAttributes.showRecipientNameTo);
+        assertEquals(createdAt, feedbackQuestionAttributes.getCreatedAt());
+        assertEquals(updatedAt, feedbackQuestionAttributes.getUpdatedAt());
+    }
+
+    @Test
+    public void testBuilderSanitizeForBuild() {
+
+        ______TS("sanitize whitespace");
+
+        Text contentWithWhitespaces = new Text(" content to be sanitized by removing leading/trailing whitespace ");
+        FeedbackQuestionAttributes feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+            .withQuestionMetaData(new Text("test qn from teams->none."))
+            .withQuestionDescription(contentWithWhitespaces)
+            .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(new Text("content to be sanitized by removing leading/trailing whitespace"),
+                feedbackQuestionAttributes.getQuestionDescription());
+
+        ______TS("sanitize code block");
+
+        Text codeblock = new Text("<code>System.out.println(\"Hello World\");</code>");
+        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionDescription(codeblock)
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(new Text("<code>System.out.println(&#34;Hello World&#34;);</code>"),
+                feedbackQuestionAttributes.getQuestionDescription());
+
+        ______TS("sanitize superscript");
+
+        Text superscript = new Text("f(x) = x<sup>2</sup>");
+
+        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionDescription(superscript)
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(new Text("f(x) &#61; x<sup>2</sup>"), feedbackQuestionAttributes.getQuestionDescription());
+
+        ______TS("sanitize chemical formula");
+
+        Text chemicalFormula = new Text("<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>");
+        feedbackQuestionAttributes = FeedbackQuestionAttributes.builder()
+                .withQuestionMetaData(new Text("test qn from teams->none."))
+                .withQuestionDescription(chemicalFormula)
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
+
+        assertEquals(new Text("<p>Chemical formula: C<sub>6</sub>H<sub>12</sub>O<sub>6</sub></p>"),
+                feedbackQuestionAttributes.getQuestionDescription());
+    }
+
+    @Test
     public void testBuilderWithDefaultValues() {
         FeedbackQuestionAttributes observedFeedbackQuestionAttributes =
                 FeedbackQuestionAttributes.builder().buildWithoutRemovingIrrelevantVisibilityOptions();

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -218,53 +218,6 @@ public class FeedbackQuestionAttributesTest extends BaseTestCase {
     }
 
     @Test
-    public void testGetCopy() {
-        List<FeedbackParticipantType> participants = new ArrayList<>();
-        participants.add(FeedbackParticipantType.OWN_TEAM_MEMBERS);
-        participants.add(FeedbackParticipantType.RECEIVER);
-        participants.add(FeedbackParticipantType.RECEIVER_TEAM_MEMBERS);
-        List<FeedbackParticipantType> participantsForShowResponseTo = new ArrayList<>(participants);
-        participantsForShowResponseTo.add(FeedbackParticipantType.STUDENTS);
-
-        FeedbackQuestionAttributes original = FeedbackQuestionAttributes.builder()
-                .withFeedbackSessionName("test session")
-                .withCourseId("some course")
-                .withCreatorEmail("test@case.com")
-                .withQuestionMetaData(new Text("test qn from teams->none."))
-                .withQuestionNumber(1)
-                .withQuestionType(FeedbackQuestionType.TEXT)
-                .withGiverType(FeedbackParticipantType.TEAMS)
-                .withRecipientType(FeedbackParticipantType.NONE)
-                .withShowGiverNameTo(new ArrayList<>(participants))
-                .withShowRecipientNameTo(new ArrayList<>(participants))
-                .withShowResponseTo(new ArrayList<>(participantsForShowResponseTo))
-                .withCreatedAt(Instant.now())
-                .withUpdatedAt(Instant.MAX)
-                .withQuestionDescription(new Text("some description"))
-                .withNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS)
-                .build();
-
-        FeedbackQuestionAttributes copy = original.getCopy();
-
-        assertNotSame(copy, original);
-        assertEquals(copy.getFeedbackSessionName(), original.getFeedbackSessionName());
-        assertEquals(copy.getCourseId(), original.getCourseId());
-        assertEquals(copy.getCreatorEmail(), original.getCreatorEmail());
-        assertEquals(copy.getQuestionMetaData(), original.getQuestionMetaData());
-        assertEquals(copy.getQuestionNumber(), original.getQuestionNumber());
-        assertEquals(copy.getQuestionType(), original.getQuestionType());
-        assertEquals(copy.getGiverType(), original.getGiverType());
-        assertEquals(copy.getRecipientType(), original.getRecipientType());
-        assertEquals(copy.getShowGiverNameTo(), original.getShowGiverNameTo());
-        assertEquals(copy.getShowRecipientNameTo(), original.getShowRecipientNameTo());
-        assertEquals(copy.getShowResponsesTo(), copy.getShowResponsesTo());
-        assertEquals(copy.getCreatedAt(), original.getCreatedAt());
-        assertEquals(copy.getUpdatedAt(), original.getUpdatedAt());
-        assertEquals(copy.getNumberOfEntitiesToGiveFeedbackTo(), original.getNumberOfEntitiesToGiveFeedbackTo());
-        assertEquals(copy.getFeedbackQuestionId(), original.getFeedbackQuestionId());
-    }
-
-    @Test
     public void testDefaultTimestamp() {
 
         FeedbackQuestionAttributesWithModifiableTimestamp fq =

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -296,7 +296,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
                 .withShowResponseTo(new ArrayList<>())
                 .withShowRecipientNameTo(new ArrayList<>())
                 .withShowGiverNameTo(new ArrayList<>())
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
 
         fqLogic.createFeedbackQuestion(fq);
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -283,19 +283,20 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         ______TS("test delete");
         fs = getNewFeedbackSession();
         // Create a question under the session to test for cascading during delete.
-        FeedbackQuestionAttributes fq = new FeedbackQuestionAttributes();
-        fq.feedbackSessionName = fs.getFeedbackSessionName();
-        fq.courseId = fs.getCourseId();
-        fq.questionNumber = 1;
-        fq.creatorEmail = fs.getCreatorEmail();
-        fq.numberOfEntitiesToGiveFeedbackTo = Const.MAX_POSSIBLE_RECIPIENTS;
-        fq.giverType = FeedbackParticipantType.STUDENTS;
-        fq.recipientType = FeedbackParticipantType.TEAMS;
-        fq.questionMetaData = new Text("question to be deleted through cascade");
-        fq.questionType = FeedbackQuestionType.TEXT;
-        fq.showResponsesTo = new ArrayList<>();
-        fq.showRecipientNameTo = new ArrayList<>();
-        fq.showGiverNameTo = new ArrayList<>();
+        FeedbackQuestionAttributes fq = FeedbackQuestionAttributes.builder()
+                .withFeedbackSessionName(fs.getFeedbackSessionName())
+                .withCourseId(fs.getCourseId())
+                .withQuestionNumber(1)
+                .withCreatorEmail(fs.getCreatorEmail())
+                .withNumOfEntitiesToGiveFeedbackTo(Const.MAX_POSSIBLE_RECIPIENTS)
+                .withGiverType(FeedbackParticipantType.STUDENTS)
+                .withRecipientType(FeedbackParticipantType.TEAMS)
+                .withQuestionMetaData(new Text("question to be deleted through cascade"))
+                .withQuestionType(FeedbackQuestionType.TEXT)
+                .withShowResponseTo(new ArrayList<>())
+                .withShowRecipientNameTo(new ArrayList<>())
+                .withShowGiverNameTo(new ArrayList<>())
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
 
         fqLogic.createFeedbackQuestion(fq);
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -3,8 +3,9 @@ package teammates.test.cases.storage;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.appengine.api.datastore.Text;
 import org.testng.annotations.Test;
+
+import com.google.appengine.api.datastore.Text;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
@@ -351,7 +352,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
     private FeedbackQuestionAttributes getNewFeedbackQuestionAttributes() {
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails("Question text.");
 
-        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.builder()
+        return FeedbackQuestionAttributes.builder()
                 .withCourseId("testCourse")
                 .withCreatorEmail("instructor@email.com")
                 .withFeedbackSessionName("testFeedbackSession")
@@ -366,8 +367,6 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
                 .withShowRecipientNameTo(new ArrayList<>())
                 .withShowResponseTo(new ArrayList<>())
                 .buildWithoutRemovingIrrelevantVisibilityOptions();
-
-        return fqa;
     }
 
     private List<FeedbackQuestionAttributes> createFeedbackQuestions(int num) throws Exception {

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -362,7 +362,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
                 .withShowGiverNameTo(new ArrayList<>())
                 .withShowRecipientNameTo(new ArrayList<>())
                 .withShowResponseTo(new ArrayList<>())
-                .buildWithoutRemovingIrrelevantVisibilityOptions();
+                .build();
     }
 
     private List<FeedbackQuestionAttributes> createFeedbackQuestions(int num) throws Exception {

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -3,6 +3,7 @@ package teammates.test.cases.storage;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.appengine.api.datastore.Text;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -14,6 +15,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.JsonUtils;
 import teammates.storage.api.FeedbackQuestionsDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
@@ -347,23 +349,23 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
     }
 
     private FeedbackQuestionAttributes getNewFeedbackQuestionAttributes() {
-        FeedbackQuestionAttributes fqa = new FeedbackQuestionAttributes();
-
-        fqa.courseId = "testCourse";
-        fqa.creatorEmail = "instructor@email.com";
-        fqa.feedbackSessionName = "testFeedbackSession";
-        fqa.giverType = FeedbackParticipantType.INSTRUCTORS;
-        fqa.recipientType = FeedbackParticipantType.SELF;
-        fqa.numberOfEntitiesToGiveFeedbackTo = 1;
-        fqa.questionNumber = 1;
-
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails("Question text.");
-        fqa.questionType = FeedbackQuestionType.TEXT;
-        fqa.setQuestionDetails(questionDetails);
 
-        fqa.showGiverNameTo = new ArrayList<>();
-        fqa.showRecipientNameTo = new ArrayList<>();
-        fqa.showResponsesTo = new ArrayList<>();
+        FeedbackQuestionAttributes fqa = FeedbackQuestionAttributes.builder()
+                .withCourseId("testCourse")
+                .withCreatorEmail("instructor@email.com")
+                .withFeedbackSessionName("testFeedbackSession")
+                .withGiverType(FeedbackParticipantType.INSTRUCTORS)
+                .withRecipientType(FeedbackParticipantType.SELF)
+                .withNumOfEntitiesToGiveFeedbackTo(1)
+                .withQuestionNumber(1)
+                .withQuestionType(FeedbackQuestionType.TEXT)
+                .withQuestionMetaData(new Text(JsonUtils.toJson(questionDetails,
+                        FeedbackQuestionType.TEXT.getQuestionDetailsClass())))
+                .withShowGiverNameTo(new ArrayList<>())
+                .withShowRecipientNameTo(new ArrayList<>())
+                .withShowResponseTo(new ArrayList<>())
+                .buildWithoutRemovingIrrelevantVisibilityOptions();
 
         return fqa;
     }

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
-import com.google.appengine.api.datastore.Text;
-
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
@@ -16,7 +14,6 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
-import teammates.common.util.JsonUtils;
 import teammates.storage.api.FeedbackQuestionsDb;
 import teammates.test.cases.BaseComponentTestCase;
 import teammates.test.driver.AssertHelper;
@@ -361,8 +358,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
                 .withNumOfEntitiesToGiveFeedbackTo(1)
                 .withQuestionNumber(1)
                 .withQuestionType(FeedbackQuestionType.TEXT)
-                .withQuestionMetaData(new Text(JsonUtils.toJson(questionDetails,
-                        FeedbackQuestionType.TEXT.getQuestionDetailsClass())))
+                .withQuestionMetaData(questionDetails)
                 .withShowGiverNameTo(new ArrayList<>())
                 .withShowRecipientNameTo(new ArrayList<>())
                 .withShowResponseTo(new ArrayList<>())


### PR DESCRIPTION
Part of #7190
<!-- Fixes #7190 -->

**Outline of Solution**
- Created Builder class for `FeedbackQuestionAttributes`
- Added test 

Note to reviewer:
I have not use builder for instances like the one below so that a `NullPostParameterException` can be thrown if any parameter is null :
https://github.com/TEAMMATES/teammates/blob/a5240982dce465a8889cfe020094b559a7f9cb69/src/main/java/teammates/ui/controller/InstructorFeedbackQuestionAddAction.java#L81-L138
