### PR TITLE
Instructor: existing feedback sessions with fixed offsets: reduce occurrence of confirmation modals #8748

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1,6 +1,7 @@
 package teammates.logic.api;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -1111,22 +1112,19 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null.
      */
-    public FeedbackSessionAttributes copyFeedbackSession(String copiedFeedbackSessionName,
-                                                         String copiedCourseId,
-                                                         String feedbackSessionName,
-                                                         String courseId,
-                                                         String instructorEmail) throws EntityAlreadyExistsException,
-                                                                                        InvalidParametersException,
-                                                                                        EntityDoesNotExistException {
+    public FeedbackSessionAttributes copyFeedbackSession(String newFeedbackSessionName, String newCourseId,
+            ZoneId newTimeZone, String feedbackSessionName, String courseId, String instructorEmail)
+            throws EntityAlreadyExistsException, InvalidParametersException, EntityDoesNotExistException {
 
-        Assumption.assertNotNull(copiedFeedbackSessionName);
-        Assumption.assertNotNull(copiedCourseId);
+        Assumption.assertNotNull(newFeedbackSessionName);
+        Assumption.assertNotNull(newCourseId);
+        Assumption.assertNotNull(newTimeZone);
         Assumption.assertNotNull(feedbackSessionName);
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(instructorEmail);
 
-        return feedbackSessionsLogic.copyFeedbackSession(copiedFeedbackSessionName,
-                copiedCourseId, feedbackSessionName, courseId, instructorEmail);
+        return feedbackSessionsLogic.copyFeedbackSession(newFeedbackSessionName, newCourseId, newTimeZone,
+                feedbackSessionName, courseId, instructorEmail);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1,6 +1,7 @@
 package teammates.logic.core;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -127,13 +128,14 @@ public final class FeedbackSessionsLogic {
         return fsDb.getFeedbackSessionsForCourse(courseId);
     }
 
-    public FeedbackSessionAttributes copyFeedbackSession(String newFeedbackSessionName,
-            String newCourseId, String feedbackSessionName, String courseId, String instructorEmail)
+    public FeedbackSessionAttributes copyFeedbackSession(String newFeedbackSessionName, String newCourseId,
+            ZoneId newTimeZone, String feedbackSessionName, String courseId, String instructorEmail)
             throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {
         FeedbackSessionAttributes copiedFeedbackSession = getFeedbackSession(feedbackSessionName, courseId);
         copiedFeedbackSession.setCreatorEmail(instructorEmail);
         copiedFeedbackSession.setFeedbackSessionName(newFeedbackSessionName);
         copiedFeedbackSession.setCourseId(newCourseId);
+        copiedFeedbackSession.setTimeZone(newTimeZone);
         copiedFeedbackSession.setCreatedTime(Instant.now());
         copiedFeedbackSession.setRespondingInstructorList(new HashSet<String>());
         copiedFeedbackSession.setRespondingStudentList(new HashSet<String>());

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackEditCopyAction.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -66,10 +67,11 @@ public class InstructorFeedbackEditCopyAction extends Action {
             for (String courseIdToCopyTo : coursesIdToCopyTo) {
                 InstructorAttributes instructorForCourse =
                         logic.getInstructorForGoogleId(courseIdToCopyTo, account.googleId);
-                gateKeeper.verifyAccessible(instructorForCourse, logic.getCourse(courseIdToCopyTo),
+                CourseAttributes courseToCopyTo = logic.getCourse(courseIdToCopyTo);
+                gateKeeper.verifyAccessible(instructorForCourse, courseToCopyTo,
                                             Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 
-                fs = logic.copyFeedbackSession(newFeedbackSessionName, courseIdToCopyTo,
+                fs = logic.copyFeedbackSession(newFeedbackSessionName, courseIdToCopyTo, courseToCopyTo.getTimeZone(),
                         originalFeedbackSessionName, originalCourseId, instructor.email);
             }
 

--- a/src/main/webapp/dev/js/common/instructor.js
+++ b/src/main/webapp/dev/js/common/instructor.js
@@ -91,13 +91,14 @@ function setupFsCopyModal() {
     });
 }
 
-function initializeTimeZoneOptions($selectElement) {
+function initializeTimeZoneOptions($selectElement, unrecognizedZoneOkCallback, unrecognizedZoneCancelCallback) {
     if (typeof moment !== 'undefined') {
         TimeZone.prepareTimeZoneInput($selectElement);
 
         const existingTimeZone = $selectElement.data('timeZone');
         if (existingTimeZone) {
-            TimeZone.updateTimeZone($selectElement, existingTimeZone);
+            TimeZone.updateTimeZone(
+                    $selectElement, existingTimeZone, unrecognizedZoneOkCallback, unrecognizedZoneCancelCallback);
         } else {
             TimeZone.autoDetectAndUpdateTimeZone($selectElement);
         }

--- a/src/main/webapp/dev/js/common/timezone.js
+++ b/src/main/webapp/dev/js/common/timezone.js
@@ -1,7 +1,7 @@
 /* global moment:false */
 
 import {
-    showModalAlert,
+    showModalConfirmation,
 } from './bootboxWrapper';
 
 import {
@@ -59,18 +59,20 @@ const TimeZone = {
     /**
      * Updates the specified <select> field with the chosen time zone.
      * If the chosen time zone is unrecognized, the field is updated with
-     * an auto-detected time zone instead and a modal alert is displayed.
+     * an auto-detected time zone instead and a modal confirmation is displayed.
      */
-    updateTimeZone($selectElement, timeZone) {
+    updateTimeZone($selectElement, timeZone, unrecognizedZoneOkCallback, unrecognizedZoneCancelCallback) {
         if (moment.tz.names().filter(isSupportedByJava).indexOf(timeZone) === -1) {
             const detectedTimeZone = moment.tz.guess();
             $selectElement.val(detectedTimeZone);
-            showModalAlert('We are switching to geographical time zones',
+            showModalConfirmation('We are switching to geographical time zones',
                     `This session is using the fixed offset time zone ${timeZone}. TEAMMATES now uses ` +
                     'time zones based on geographical location, with support for daylight saving time. ' +
                     `We have detected that your geographical time zone is ${detectedTimeZone}. ` +
-                    'Please verify that this is correct, then save the session.',
-                    null, BootstrapContextualColors.WARNING);
+                    'If this is not correct, please modify it manually then save the session.',
+                    unrecognizedZoneOkCallback, unrecognizedZoneCancelCallback,
+                    'Correct', 'Not correct. I will modify it manually',
+                    BootstrapContextualColors.WARNING);
             return;
         }
         $selectElement.val(timeZone);

--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -1181,7 +1181,19 @@ function readyFeedbackEditPage() {
     formatCheckBoxes();
     formatQuestionNumbers();
     collapseIfPrivateSession();
-    initializeTimeZoneOptions($(`#${ParamsNames.FEEDBACK_SESSION_TIMEZONE}`));
+    const $timeZoneSelect = $(`#${ParamsNames.FEEDBACK_SESSION_TIMEZONE}`);
+    const enableEditFsIfRequired = () => {
+        if ($('#form_feedbacksession').data(`${ParamsNames.FEEDBACK_SESSION_ENABLE_EDIT}`) !== true) {
+            enableEditFS();
+        }
+    };
+    initializeTimeZoneOptions($timeZoneSelect, () => {
+        enableEditFsIfRequired();
+        $('#fsSaveLink').click();
+    }, () => {
+        enableEditFsIfRequired();
+        scrollToElement($timeZoneSelect[0], { duration: 1000 });
+    });
 
     setupFsCopyModal();
 

--- a/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
+++ b/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
@@ -13,7 +13,7 @@ import teammates.test.pageobjects.QUnitPage;
  */
 public class AllJsTests extends BaseUiTestCase {
 
-    private static final float MIN_COVERAGE_REQUIREMENT = 37;
+    private static final float MIN_COVERAGE_REQUIREMENT = 36.95f;
 
     private QUnitPage page;
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -216,7 +216,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage.clickDefaultPublishTimeButton();
         feedbackEditPage.clickSaveSessionButton();
 
-        ______TS("test fixed offset modal warning");
+        ______TS("test fixed offset modal and confirm");
         savedSession = getFeedbackSessionWithRetry(
                 editedSession.getCourseId(), editedSession.getFeedbackSessionName());
         ZoneId originalTimeZone = savedSession.getTimeZone();
@@ -227,11 +227,22 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         status = BackDoor.editFeedbackSession(savedSession);
         assertEquals(Const.StatusCodes.BACKDOOR_STATUS_SUCCESS, status);
 
-        // Check for modal
+        // Check for modal and confirm; should update session to detected time zone
         feedbackEditPage.reloadPage();
+        String detectedTimeZone = feedbackEditPage.getDetectedTimeZone();
         feedbackEditPage.waitForConfirmationModalAndClickOk();
+        feedbackEditPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_SESSION_EDITED);
+        savedSession = getFeedbackSessionWithRetry(editedSession.getCourseId(), editedSession.getFeedbackSessionName());
+        assertEquals(detectedTimeZone, savedSession.getTimeZone().getId());
 
-        // Restore defaults
+        ______TS("test fixed offset modal and cancel");
+        savedSession.setTimeZone(fixedOffsetTimeZone);
+        status = BackDoor.editFeedbackSession(savedSession);
+        assertEquals(Const.StatusCodes.BACKDOOR_STATUS_SUCCESS, status);
+
+        // Check for modal and cancel; should be able to edit session details and restore original time zone
+        feedbackEditPage.reloadPage();
+        feedbackEditPage.waitForConfirmationModalAndClickCancel();
         feedbackEditPage.selectTimeZone(editedSession.getTimeZone());
         feedbackEditPage.clickSaveSessionButton();
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -312,7 +312,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         InstructorAttributes instructor2OfCourse1 = dataBundle.instructors.get("instructor2OfCourse1");
         CourseAttributes typicalCourse2 = dataBundle.courses.get("typicalCourse2");
         FeedbackSessionAttributes copiedSession = fsLogic.copyFeedbackSession(
-                "Copied Session", typicalCourse2.getId(),
+                "Copied Session", typicalCourse2.getId(), typicalCourse2.getTimeZone(),
                 session1InCourse1.getFeedbackSessionName(),
                 session1InCourse1.getCourseId(), instructor2OfCourse1.email);
         verifyPresentInDatastore(copiedSession);
@@ -346,7 +346,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         try {
             fsLogic.copyFeedbackSession(
                     session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId(),
-                    session1InCourse1.getFeedbackSessionName(),
+                    session1InCourse1.getTimeZone(), session1InCourse1.getFeedbackSessionName(),
                     session1InCourse1.getCourseId(), instructor2OfCourse1.email);
             signalFailureToDetectException();
         } catch (EntityAlreadyExistsException e) {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -158,6 +158,10 @@ public class InstructorFeedbackEditPage extends AppPage {
         return browser.driver.findElement(By.name("fsname")).getAttribute("value");
     }
 
+    public String getDetectedTimeZone() {
+        return (String) executeScript("return moment.tz.guess()");
+    }
+
     /**
      * Returns number of question edit forms + question add form.
      */

--- a/src/test/resources/data/InstructorFeedbackSessionsPageUiTest.json
+++ b/src/test/resources/data/InstructorFeedbackSessionsPageUiTest.json
@@ -50,7 +50,7 @@
     "anotherCourse": {
       "id": "CFeedbackUiT.CS1101",
       "name": "Programming Methodology",
-      "timeZone": "UTC"
+      "timeZone": "Africa/Johannesburg"
     }
   },
   "instructors": {


### PR DESCRIPTION
Fixes #8748

**Outline of Solution**
- Allow user to upgrade an existing session to the geographical time zone with a single click (clicking `Correct` automatically saves the session)
<br><img width="628" alt="screen shot 2018-04-04 at 12 28 48 am" src="https://user-images.githubusercontent.com/6811428/38262232-2f2e80e8-379f-11e8-9d0d-3962d96e8f08.png">
<br>![apr-04-2018 00-31-56](https://user-images.githubusercontent.com/6811428/38262599-4b24c8f6-37a0-11e8-8d16-6599d662c1dd.gif)
- ~~When copying from sessions using fixed offset time zones, use detected geographical time zone~~
  - ~~When creating a single new session, use the client-detected time zone~~
  - ~~When copying an existing session to multiple courses, use each destination course's time zone~~
- When copying sessions, use destination course time zone