### PR TITLE
Student: submit responses: warn if there are unanswered questions #8598

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1420,8 +1420,8 @@ public final class Const {
                 "Note that you can use the Submit button to save responses already entered, "
                 + "and continue to answer remaining questions after that. "
                 + "You may also edit your submission any number of times before the closing time of this session.";
-        public static final String FEEDBACK_INCOMPLETE_QUESTIONS = "Note that your feedback session is incomplete. "
-                + "These are the incomplete questions: ";
+        public static final String FEEDBACK_INCOMPLETE_QUESTIONS = "Note that some questions are yet to be answered. "
+                + "They are: ";
 
         public static final String FEEDBACK_RESULTS_SOMETHINGNEW =
                 "You have received feedback from others. Please see below.";

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1420,7 +1420,7 @@ public final class Const {
                 "Note that you can use the Submit button to save responses already entered, "
                 + "and continue to answer remaining questions after that. "
                 + "You may also edit your submission any number of times before the closing time of this session.";
-        public static final String FEEDBACK_INCOMPLETE_QUESTIONS = "Note that some questions are yet to be answered. "
+        public static final String FEEDBACK_UNANSWERED_QUESTIONS = "Note that some questions are yet to be answered. "
                 + "They are: ";
 
         public static final String FEEDBACK_RESULTS_SOMETHINGNEW =

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1420,6 +1420,8 @@ public final class Const {
                 "Note that you can use the Submit button to save responses already entered, "
                 + "and continue to answer remaining questions after that. "
                 + "You may also edit your submission any number of times before the closing time of this session.";
+        public static final String FEEDBACK_INCOMPLETE_QUESTIONS = "Note that your feedback session is incomplete. "
+                + "These are the incomplete questions: ";
 
         public static final String FEEDBACK_RESULTS_SOMETHINGNEW =
                 "You have received feedback from others. Please see below.";

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -365,6 +365,16 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
         return response;
     }
 
+    private String getIncompleteQuestionMessage(HashSet<Integer> questionsWithMissingAnswers) {
+        String incompleteQuestionsMessage = Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS;
+
+        for (int qns : questionsWithMissingAnswers) {
+            incompleteQuestionsMessage += Integer.toString(qns) + ", ";
+        }
+        incompleteQuestionsMessage = incompleteQuestionsMessage.substring(0, incompleteQuestionsMessage.length() - 2) + ".";
+        return incompleteQuestionsMessage;
+    }
+
     /**
      * To be used to set any extra parameters or attributes that
      * a class inheriting FeedbackSubmissionEditSaveAction requires.

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -141,14 +141,17 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
                 if (response.responseMetaData.getValue().isEmpty()) {
                     // deletes the response since answer is empty
                     addToPendingResponses(response);
-                    // add the question index to show User the incompleted question numbers
-                    questionsWithMissingAnswers.add(questionIndx);
                 } else {
                     response.giver = questionAttributes.giverType.isTeam() ? userTeamForCourse
                                                                                 : userEmailForCourse;
                     response.giverSection = userSectionForCourse;
                     responsesForQuestion.add(response);
                 }
+            }
+
+            if (responsesForQuestion.isEmpty() && numOfResponsesToGet > 0) {
+                // add the question index to show user unanswered questions
+                questionsWithMissingAnswers.add(questionIndx);
             }
 
             List<String> questionSpecificErrors =

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -183,6 +183,11 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, StatusMessageColor.SUCCESS));
         }
 
+        if (!questionsWithMissingAnswers.isEmpty() && !isError) {
+            statusToUser.add(new StatusMessage(getIncompleteQuestionMessage(questionsWithMissingAnswers),
+                                                StatusMessageColor.INFO));
+        }
+
         if (isUserRespondentOfSession()) {
             appendRespondent();
         } else {

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -2,7 +2,6 @@ package teammates.ui.controller;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +77,7 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
 
         String userTeamForCourse = getUserTeamForCourse();
         String userSectionForCourse = getUserSectionForCourse();
-        HashSet<Integer> questionsWithMissingAnswers = new HashSet<Integer>();
+        List<Integer> questionsWithMissingAnswers = new ArrayList<>();
 
         int numOfQuestionsToGet = data.bundle.questionResponseBundle.size();
 

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -140,6 +140,8 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
                 if (response.responseMetaData.getValue().isEmpty()) {
                     // deletes the response since answer is empty
                     addToPendingResponses(response);
+                    // add the question index to show User the incompleted question numbers
+                    questionsWithMissingAnswers.add(questionIndx);
                 } else {
                     response.giver = questionAttributes.giverType.isTeam() ? userTeamForCourse
                                                                                 : userEmailForCourse;

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -185,7 +185,7 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
         if (!isError) {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, StatusMessageColor.SUCCESS));
             if (!questionsWithMissingAnswers.isEmpty()) {
-                statusToUser.add(new StatusMessage(getIncompleteQuestionMessage(questionsWithMissingAnswers),
+                statusToUser.add(new StatusMessage(getUnansweredQuestionMessage(questionsWithMissingAnswers),
                         StatusMessageColor.INFO));
             }
         }
@@ -367,8 +367,8 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
         return response;
     }
 
-    private String getIncompleteQuestionMessage(Set<Integer> questionsWithMissingAnswers) {
-        StringBuilder incompleteQuestionsMessage = new StringBuilder(Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS);
+    private String getUnansweredQuestionMessage(List<Integer> questionsWithMissingAnswers) {
+        StringBuilder incompleteQuestionsMessage = new StringBuilder(Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS);
         Iterator questions = questionsWithMissingAnswers.iterator();
         while (questions.hasNext()) {
             incompleteQuestionsMessage.append(questions.next().toString());

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -181,11 +181,10 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
 
         if (!isError) {
             statusToUser.add(new StatusMessage(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, StatusMessageColor.SUCCESS));
-        }
-
-        if (!questionsWithMissingAnswers.isEmpty() && !isError) {
-            statusToUser.add(new StatusMessage(getIncompleteQuestionMessage(questionsWithMissingAnswers),
-                                                StatusMessageColor.INFO));
+            if (!questionsWithMissingAnswers.isEmpty()) {
+                statusToUser.add(new StatusMessage(getIncompleteQuestionMessage(questionsWithMissingAnswers),
+                        StatusMessageColor.INFO));
+            }
         }
 
         if (isUserRespondentOfSession()) {

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -3,6 +3,7 @@ package teammates.ui.controller;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -364,14 +365,18 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
         return response;
     }
 
-    private String getIncompleteQuestionMessage(HashSet<Integer> questionsWithMissingAnswers) {
-        String incompleteQuestionsMessage = Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS;
-
-        for (int qns : questionsWithMissingAnswers) {
-            incompleteQuestionsMessage += Integer.toString(qns) + ", ";
+    private String getIncompleteQuestionMessage(Set<Integer> questionsWithMissingAnswers) {
+        StringBuilder incompleteQuestionsMessage = new StringBuilder(Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS);
+        Iterator questions = questionsWithMissingAnswers.iterator();
+        while (questions.hasNext()) {
+            incompleteQuestionsMessage.append(questions.next().toString());
+            if (questions.hasNext()) {
+                incompleteQuestionsMessage.append(", ");
+            } else {
+                incompleteQuestionsMessage.append('.');
+            }
         }
-        incompleteQuestionsMessage = incompleteQuestionsMessage.substring(0, incompleteQuestionsMessage.length() - 2) + ".";
-        return incompleteQuestionsMessage;
+        return incompleteQuestionsMessage.toString();
     }
 
     /**

--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditSaveAction.java
@@ -2,6 +2,7 @@ package teammates.ui.controller;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -76,6 +77,7 @@ public abstract class FeedbackSubmissionEditSaveAction extends Action {
 
         String userTeamForCourse = getUserTeamForCourse();
         String userSectionForCourse = getUserSectionForCourse();
+        HashSet<Integer> questionsWithMissingAnswers = new HashSet<Integer>();
 
         int numOfQuestionsToGet = data.bundle.questionResponseBundle.size();
 

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1140,8 +1140,13 @@ function showModalWarningIfSessionClosingSoon() {
 }
 
 function showModalSuccessIfResponsesSubmitted() {
-    if (hasSuccessMessage()) {
-        showModalAlert(getSuccessMessage(), RESPONSES_SUCCESSFULLY_SUBMITTED, null, BootstrapContextualColors.SUCCESS);
+    if (hasSuccessMessage() && hasIncompleteQuestionMessage()) {
+        showModalAlert(getSuccessMessage(), getIncompleteQuestionMessage() + RESPONSES_SUCCESSFULLY_SUBMITTED,
+            null, BootstrapContextualColors.SUCCESS);
+    }
+    else if (hasSuccessMessage()) {
+        showModalAlert(getSuccessMessage(), RESPONSES_SUCCESSFULLY_SUBMITTED,
+            null, BootstrapContextualColors.SUCCESS);
     }
 }
 /**

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1120,7 +1120,7 @@ function getSuccessMessage() {
 }
 
 function getIncompleteQuestionMessage() {
-    return "<p>&#10071; " + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
+    return "<p><span style=font-size:175%> &#10071; </span>" + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
 }
 
 function hasIncompleteQuestionMessage() {

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1144,10 +1144,10 @@ function showModalSuccessIfResponsesSubmitted() {
     const unansweredMessage = '<p class="unanswered-message">'.concat(enlargedImportantIcon).concat('<span>')
             .concat(getUnansweredQuestionMessage()).concat('</span></p>');
 
-    if(hasSuccessMessage()) {
+    if (hasSuccessMessage()) {
         showModalAlert(getSuccessMessage(),
-            (hasUnansweredQuestionMessage() ? unansweredMessage : "") + RESPONSES_SUCCESSFULLY_SUBMITTED,
-            null, BootstrapContextualColors.SUCCESS);
+                (hasUnansweredQuestionMessage() ? unansweredMessage : '') + RESPONSES_SUCCESSFULLY_SUBMITTED,
+                null, BootstrapContextualColors.SUCCESS);
     }
 }
 /**

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1120,7 +1120,7 @@ function getSuccessMessage() {
 }
 
 function getIncompleteQuestionMessage() {
-    return "<p><span class=\"glyphicon glyphicon-exclamation-sign\"></span> " + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
+    return "<p>&#10071; " + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
 }
 
 function hasIncompleteQuestionMessage() {

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1120,7 +1120,7 @@ function getSuccessMessage() {
 }
 
 function getIncompleteQuestionMessage() {
-    return "<p><span style=font-size:175%> &#10071; </span>" + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
+    return $(INFO_STATUS_MESSAGE).html().trim();
 }
 
 function hasIncompleteQuestionMessage() {
@@ -1141,10 +1141,10 @@ function showModalWarningIfSessionClosingSoon() {
 
 function showModalSuccessIfResponsesSubmitted() {
     if (hasSuccessMessage() && hasIncompleteQuestionMessage()) {
-        showModalAlert(getSuccessMessage(), getIncompleteQuestionMessage() + RESPONSES_SUCCESSFULLY_SUBMITTED,
-            null, BootstrapContextualColors.SUCCESS);
-    }
-    else if (hasSuccessMessage()) {
+        const enlargedImportantIcon = '<span style="font-size:250%"> &#10071; </span>';
+        const incompleteMessage = enlargedImportantIcon + getIncompleteQuestionMessage();
+        showModalAlert(getSuccessMessage(), incompleteMessage + RESPONSES_SUCCESSFULLY_SUBMITTED,
+                null, BootstrapContextualColors.SUCCESS);
     } else if (hasSuccessMessage()) {
         showModalAlert(getSuccessMessage(), RESPONSES_SUCCESSFULLY_SUBMITTED,
                 null, BootstrapContextualColors.SUCCESS);

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1119,6 +1119,10 @@ function getSuccessMessage() {
     return $(SUCCESS_STATUS_MESSAGE).html().trim();
 }
 
+function hasIncompleteQuestionMessage() {
+    return $(INFO_STATUS_MESSAGE).length;
+}
+
 function showModalWarningIfSessionClosed() {
     if (hasWarningMessage()) {
         showModalAlert(SESSION_NOT_OPEN, getWarningMessage(), null, BootstrapContextualColors.WARNING);

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1140,8 +1140,8 @@ function showModalWarningIfSessionClosingSoon() {
 }
 
 function showModalSuccessIfResponsesSubmitted() {
-    const enlargedImportantIcon = '<span style="font-size:200%"> &#10071; </span>';
     const unansweredMessage = enlargedImportantIcon + getUnansweredQuestionMessage();
+    const enlargedImportantIcon = '<span class="unanswered-exclamation-mark"> &#10071; </span>';
 
     if(hasSuccessMessage()) {
         showModalAlert(getSuccessMessage(),

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1119,12 +1119,15 @@ function getSuccessMessage() {
     return $(SUCCESS_STATUS_MESSAGE).html().trim();
 }
 
-function getUnansweredQuestionMessage() {
-    return $(INFO_STATUS_MESSAGE).html().trim();
-}
-
 function hasUnansweredQuestionMessage() {
     return $(INFO_STATUS_MESSAGE).length;
+}
+
+function getUnansweredQuestionMessage() {
+    if (!hasUnansweredQuestionMessage()) {
+        return '';
+    }
+    return $(INFO_STATUS_MESSAGE).html().trim();
 }
 
 function showModalWarningIfSessionClosed() {

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1140,8 +1140,9 @@ function showModalWarningIfSessionClosingSoon() {
 }
 
 function showModalSuccessIfResponsesSubmitted() {
-    const unansweredMessage = enlargedImportantIcon + getUnansweredQuestionMessage();
     const enlargedImportantIcon = '<span class="unanswered-exclamation-mark"> &#10071; </span>';
+    const unansweredMessage = '<p class="unanswered-message">'.concat(enlargedImportantIcon).concat('<span>')
+            .concat(getUnansweredQuestionMessage()).concat('</span></p>');
 
     if(hasSuccessMessage()) {
         showModalAlert(getSuccessMessage(),

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -41,6 +41,7 @@ import {
 const FEEDBACK_RESPONSE_RECIPIENT = 'responserecipient';
 const FEEDBACK_RESPONSE_TEXT = 'responsetext';
 const FEEDBACK_MISSING_RECIPIENT = 'You did not specify a recipient for your response in question(s)';
+const INFO_STATUS_MESSAGE = '.alert-info.statusMessage';
 const WARNING_STATUS_MESSAGE = '.alert-warning.statusMessage';
 const SUCCESS_STATUS_MESSAGE = '.alert-success.statusMessage';
 const END_TIME = '#end-time';

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1119,6 +1119,10 @@ function getSuccessMessage() {
     return $(SUCCESS_STATUS_MESSAGE).html().trim();
 }
 
+function getIncompleteQuestionMessage() {
+    return "<p><span class=\"glyphicon glyphicon-exclamation-sign\"></span> " + $(INFO_STATUS_MESSAGE).html().trim() + "</p>";
+}
+
 function hasIncompleteQuestionMessage() {
     return $(INFO_STATUS_MESSAGE).length;
 }

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1145,8 +1145,9 @@ function showModalSuccessIfResponsesSubmitted() {
             null, BootstrapContextualColors.SUCCESS);
     }
     else if (hasSuccessMessage()) {
+    } else if (hasSuccessMessage()) {
         showModalAlert(getSuccessMessage(), RESPONSES_SUCCESSFULLY_SUBMITTED,
-            null, BootstrapContextualColors.SUCCESS);
+                null, BootstrapContextualColors.SUCCESS);
     }
 }
 /**

--- a/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/dev/js/main/feedbackSubmissionsEdit.js
@@ -1119,11 +1119,11 @@ function getSuccessMessage() {
     return $(SUCCESS_STATUS_MESSAGE).html().trim();
 }
 
-function getIncompleteQuestionMessage() {
+function getUnansweredQuestionMessage() {
     return $(INFO_STATUS_MESSAGE).html().trim();
 }
 
-function hasIncompleteQuestionMessage() {
+function hasUnansweredQuestionMessage() {
     return $(INFO_STATUS_MESSAGE).length;
 }
 
@@ -1140,14 +1140,13 @@ function showModalWarningIfSessionClosingSoon() {
 }
 
 function showModalSuccessIfResponsesSubmitted() {
-    if (hasSuccessMessage() && hasIncompleteQuestionMessage()) {
-        const enlargedImportantIcon = '<span style="font-size:250%"> &#10071; </span>';
-        const incompleteMessage = enlargedImportantIcon + getIncompleteQuestionMessage();
-        showModalAlert(getSuccessMessage(), incompleteMessage + RESPONSES_SUCCESSFULLY_SUBMITTED,
-                null, BootstrapContextualColors.SUCCESS);
-    } else if (hasSuccessMessage()) {
-        showModalAlert(getSuccessMessage(), RESPONSES_SUCCESSFULLY_SUBMITTED,
-                null, BootstrapContextualColors.SUCCESS);
+    const enlargedImportantIcon = '<span style="font-size:200%"> &#10071; </span>';
+    const unansweredMessage = enlargedImportantIcon + getUnansweredQuestionMessage();
+
+    if(hasSuccessMessage()) {
+        showModalAlert(getSuccessMessage(),
+            (hasUnansweredQuestionMessage() ? unansweredMessage : "") + RESPONSES_SUCCESSFULLY_SUBMITTED,
+            null, BootstrapContextualColors.SUCCESS);
     }
 }
 /**

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1265,6 +1265,11 @@ Default to alert color for visibility titles used within an alert context.
     font-size: 200%;
 }
 
+.unanswered-message span {
+    display: table-cell;
+    vertical-align: middle;
+}
+
 /* /////////////////////////////////////////////////////////
 ////////////////// Dropdowns with Submenus /////////////////
 ///////////////////////////////////////////////////////// */

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1261,6 +1261,10 @@ Default to alert color for visibility titles used within an alert context.
     padding: 14px 15px 15px;
 }
 
+.unanswered-exclamation-mark {
+    font-size: 200%;
+}
+
 /* /////////////////////////////////////////////////////////
 ////////////////// Dropdowns with Submenus /////////////////
 ///////////////////////////////////////////////////////// */

--- a/src/test/java/teammates/test/cases/action/InstructorEditInstructorFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditInstructorFeedbackSaveActionTest.java
@@ -108,7 +108,7 @@ public class InstructorEditInstructorFeedbackSaveActionTest extends BaseActionTe
 
         assertFalse(redirectResult.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", redirectResult.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", redirectResult.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_INSTRUCTOR_FEEDBACK_PAGE,
@@ -143,7 +143,7 @@ public class InstructorEditInstructorFeedbackSaveActionTest extends BaseActionTe
 
         assertFalse(redirectResult.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", redirectResult.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", redirectResult.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_INSTRUCTOR_FEEDBACK_PAGE,

--- a/src/test/java/teammates/test/cases/action/InstructorEditInstructorFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditInstructorFeedbackSaveActionTest.java
@@ -107,7 +107,8 @@ public class InstructorEditInstructorFeedbackSaveActionTest extends BaseActionTe
         redirectResult = getRedirectResult(editInstructorFsAction);
 
         assertFalse(redirectResult.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, redirectResult.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", redirectResult.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_INSTRUCTOR_FEEDBACK_PAGE,
@@ -141,7 +142,8 @@ public class InstructorEditInstructorFeedbackSaveActionTest extends BaseActionTe
         redirectResult = getRedirectResult(editInstructorFsAction);
 
         assertFalse(redirectResult.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, redirectResult.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", redirectResult.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_INSTRUCTOR_FEEDBACK_PAGE,

--- a/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
@@ -110,7 +110,8 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_STUDENT_FEEDBACK_PAGE,
@@ -145,7 +146,8 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_STUDENT_FEEDBACK_PAGE,

--- a/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
@@ -111,7 +111,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_STUDENT_FEEDBACK_PAGE,
@@ -147,7 +147,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_EDIT_STUDENT_FEEDBACK_PAGE,

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackSubmissionEditSaveActionTest.java
@@ -142,7 +142,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "instructor1InCourse1"),
@@ -180,7 +180,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "instructor1InCourse1"),
@@ -353,7 +353,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -412,7 +412,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -480,7 +480,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -555,7 +555,7 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackSubmissionEditSaveActionTest.java
@@ -141,7 +141,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "instructor1InCourse1"),
@@ -178,7 +179,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "instructor1InCourse1"),
@@ -350,7 +352,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -408,7 +411,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -475,7 +479,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),
@@ -549,7 +554,8 @@ public class InstructorFeedbackSubmissionEditSaveActionTest extends BaseActionTe
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_HOME_PAGE, r.isError, "FSQTT.idOfInstructor1OfCourse1"),

--- a/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
@@ -111,7 +111,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -141,7 +142,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -253,7 +255,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -352,7 +355,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -456,7 +460,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -639,7 +644,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -712,7 +718,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -779,7 +786,8 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
         r = getRedirectResult(a);
 
         assertFalse(r.isError);
-        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED, r.getStatusMessage());
+        assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
+                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,

--- a/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
@@ -112,7 +112,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -143,7 +143,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -256,7 +256,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -356,7 +356,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -461,7 +461,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -645,7 +645,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -719,7 +719,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,
@@ -787,7 +787,7 @@ public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest 
 
         assertFalse(r.isError);
         assertEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED + Const.HTML_BR_TAG
-                + Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1.", r.getStatusMessage());
+                + Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1.", r.getStatusMessage());
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_PAGE,

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
@@ -79,7 +79,8 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
 
         // Submit
         submitPage.clickSubmitButton();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.");
 
         FeedbackQuestionAttributes fq1 = BackDoor.getFeedbackQuestion("FRankUiT.CS4221", "Student Session", 1);
         assertNotNull(BackDoor.getFeedbackResponse(fq1.getId(),

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
@@ -80,7 +80,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
         // Submit
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.");
 
         FeedbackQuestionAttributes fq1 = BackDoor.getFeedbackQuestion("FRankUiT.CS4221", "Student Session", 1);
         assertNotNull(BackDoor.getFeedbackResponse(fq1.getId(),

--- a/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/FeedbackRankQuestionUiTest.java
@@ -80,7 +80,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
         // Submit
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "4, 6, 7, 8, 9, 10, 11, 12, 13, 14.");
 
         FeedbackQuestionAttributes fq1 = BackDoor.getFeedbackQuestion("FRankUiT.CS4221", "Student Session", 1);
         assertNotNull(BackDoor.getFeedbackResponse(fq1.getId(),

--- a/src/test/java/teammates/test/cases/browsertests/InstructorEditStudentFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorEditStudentFeedbackPageUiTest.java
@@ -67,7 +67,7 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
 
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                 Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2.");
+                 Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2.");
         submitPage.verifyAndCloseSuccessfulSubmissionModal("2.");
 
         fq = BackDoor.getFeedbackQuestion("IESFPTCourse", "First feedback session", 1);
@@ -107,7 +107,7 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
         submitPage.clickSubmitButton();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1, 2.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1, 2.");
         submitPage.verifyAndCloseSuccessfulSubmissionModal("1, 2.");
 
         FeedbackQuestionAttributes fq = BackDoor.getFeedbackQuestion("IESFPTCourse", "First feedback session", 1);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorEditStudentFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorEditStudentFeedbackPageUiTest.java
@@ -66,8 +66,9 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
         submitPage.fillResponseRichTextEditor(1, 0, "Good design");
 
         submitPage.clickSubmitButton();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                 Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("2.");
 
         fq = BackDoor.getFeedbackQuestion("IESFPTCourse", "First feedback session", 1);
 
@@ -94,7 +95,7 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
 
         // Full HTML verification already done in InstructorFeedbackSubmitPageUiTest
         submitPage.verifyHtmlMainContent("/instructorEditStudentFeedbackPageModified.html");
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("");
     }
 
     private void testDeleteResponse() {
@@ -105,8 +106,9 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
         submitPage.fillResponseTextBox(1, 0, "");
         submitPage.clickSubmitButton();
 
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "1, 2.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("1, 2.");
 
         FeedbackQuestionAttributes fq = BackDoor.getFeedbackQuestion("IESFPTCourse", "First feedback session", 1);
         FeedbackResponseAttributes fr = BackDoor.getFeedbackResponse(fq.getId(),

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -249,7 +249,8 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
         submitPage.submitWithoutConfirmationEmail();
 
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21.");
         assertEquals("<p>" + editedResponse + "</p>",
                     BackDoor.getFeedbackResponse(
                                  fq.getId(), "IFSubmitUiT.instr@gmail.tmt",

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -134,8 +134,8 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, 12, "
-                + "14, 15, 16, 18, 19, 20, 21, 22, 23.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 5, 7, 9, 10, 11, 12, 14, "
+                        + "15, 16, 18, 19, 20, 21, 22, 23.");
 
         assertNotNull(BackDoor.getFeedbackResponse(
                                    fq.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.alice.b@gmail.tmt"));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -133,7 +133,9 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
 
         submitPage.submitWithoutConfirmationEmail();
 
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, 12, "
+                + "14, 15, 16, 18, 19, 20, 21, 22, 23.");
 
         assertNotNull(BackDoor.getFeedbackResponse(
                                    fq.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.alice.b@gmail.tmt"));

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -134,7 +134,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, 12, "
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, 12, "
                 + "14, 15, 16, 18, 19, 20, 21, 22, 23.");
 
         assertNotNull(BackDoor.getFeedbackResponse(
@@ -250,7 +250,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21.");
         assertEquals("<p>" + editedResponse + "</p>",
                     BackDoor.getFeedbackResponse(
                                  fq.getId(), "IFSubmitUiT.instr@gmail.tmt",

--- a/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -235,7 +235,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 7, 9, 10, 11, 12, 13, 15, "
                 + "16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 7, 9, 10, 11, 12, "
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 7, 9, 10, 11, 12, "
                 + "13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
 
         assertNotNull(BackDoor.getFeedbackResponse(fq.getId(),
@@ -363,7 +363,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         //check edited
         submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 22, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 22, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 22, 23, 24, 25, 26, 27.");
         assertEquals("<p>" + editedResponse + "</p>",
                      BackDoor.getFeedbackResponse(fq.getId(), "SFSubmitUiT.alice.b@gmail.tmt",
                                                   "SFSubmitUiT.benny.c@gmail.tmt").responseMetaData.getValue());
@@ -429,14 +429,14 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.toggleMsqOption(qnNumber, 0, "Drop out (Team 2)");
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response with 3 options checked
         submitPage.toggleMsqOption(qnNumber, 0, "Emily (Team 3)");
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response with 4 options checked
@@ -460,7 +460,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.toggleMsqOption(qnNumber, 0, "E");
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response for 1st recipient with 4 options checked
@@ -522,7 +522,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
                 + "15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, "
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, "
                 + "12, 13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.verifyHtmlMainContent("/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html");
 
@@ -548,7 +548,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         FeedbackQuestionAttributes fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -567,7 +567,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -588,7 +588,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -606,7 +606,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
             submitPage.fillResponseTextBox(14, 0, "5");
             submitPage.submitWithoutConfirmationEmail();
             submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                    Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                    Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         }
 
         ______TS("write response without specifying recipient");
@@ -633,7 +633,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                 "Extra guy (Team 2)"));
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         ______TS("cannot choose self when generating choices from teams (excluding self)");
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
@@ -644,7 +644,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertTrue(submitPage.checkIfMcqOrMsqChoiceExists(27, 0, "Team 2"));
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
     }
 
@@ -752,7 +752,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
 
         ______TS("Responses with invalid recipients do not prevent submission");
         StudentAttributes alice = testData.students.get("Alice");
@@ -776,7 +776,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         // verify that existing responses with invalid recipients do not affect submission
         submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
 
     }
 

--- a/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -232,11 +232,11 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 7, 9, 10, 11, 12, 13, 15, "
-                + "16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 5, 10, 11, 12, 13, 15, 16, 17, 19, "
+                + "21, 22, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 7, 9, 10, 11, 12, "
-                + "13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 5, 10, 11, 12, 13, 15, 16, 17, 19, "
+                        + "21, 22, 23, 24, 25, 26, 27.");
 
         assertNotNull(BackDoor.getFeedbackResponse(fq.getId(),
                                                    "SFSubmitUiT.alice.b@gmail.tmt",
@@ -275,8 +275,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 7, 9, 10, 11, 12, 13, 15, "
-                + "16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 5, 10, 11, 12, 13, 15, 16, 17, 19, "
+                + "21, 22, 23, 24, 25, 26, 27.");
         assertNull(BackDoor.getFeedbackResponse(fqMcq.getId(), aliceTeam, "Team 3"));
 
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
@@ -460,7 +460,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.toggleMsqOption(qnNumber, 0, "E");
         submitPage.clickSubmitButton();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response for 1st recipient with 4 options checked
@@ -519,11 +519,11 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
-                + "15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 5, 6, 8, 10, 11, 12, 13, "
+                + "15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, "
-                + "12, 13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 5, 6, 8, 10, 11, 12, 13, "
+                        + "15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.verifyHtmlMainContent("/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html");
 
         assertNotNull(BackDoor.getFeedbackResponse(fq.getId(), "drop.out@gmail.tmt", "SFSubmitUiT.benny.c@gmail.tmt"));
@@ -546,9 +546,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.fillResponseTextBox(14, 0, "");
         submitPage.fillResponseTextBox(14, 0, "0");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
 
         FeedbackQuestionAttributes fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -565,9 +565,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
         submitPage.fillResponseTextBox(14, 0, "50000");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -586,9 +586,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
         submitPage.fillResponseTextBox(14, 0, "-99999");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -606,7 +606,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
             submitPage.fillResponseTextBox(14, 0, "5");
             submitPage.submitWithoutConfirmationEmail();
             submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                    Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                    Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
         }
 
         ______TS("write response without specifying recipient");
@@ -633,7 +633,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                 "Extra guy (Team 2)"));
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
 
         ______TS("cannot choose self when generating choices from teams (excluding self)");
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
@@ -644,7 +644,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertTrue(submitPage.checkIfMcqOrMsqChoiceExists(27, 0, "Team 2"));
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 23, 24, 25, 26, 27.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24, 25, 26, 27.");
 
     }
 
@@ -702,8 +702,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                                         "drop.out@gmail.tmt",
                                         "SFSubmitUiT.charlie.d@gmail.tmt"));
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
-                + "15, 16, 17, 19, 20, 22, 23, 24, 25, 26, 27.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 5, 6, 8, 10, 11, 12, 13, 15, 16, "
+                + "17, 19, 22, 23, 24, 25, 26, 27.");
         assertEquals("[-1, 1]", BackDoor.getFeedbackResponse(fqRubric.getId(),
                                         "drop.out@gmail.tmt",
                                         "SFSubmitUiT.danny.e@gmail.tmt").getResponseDetails().getAnswerString());
@@ -750,9 +750,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         // verify submission with no-response questions are possible
         submitPage.fillResponseTextBox(19, 2, "100");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("10, 21, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "10, 21, 24, 25, 26, 27.");
 
         ______TS("Responses with invalid recipients do not prevent submission");
         StudentAttributes alice = testData.students.get("Alice");
@@ -774,9 +774,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
 
         submitPage.submitWithoutConfirmationEmail();
         // verify that existing responses with invalid recipients do not affect submission
-        submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("10, 21, 24, 25, 26, 27.");
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "10, 21, 24, 25, 26, 27.");
 
     }
 

--- a/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -232,8 +232,11 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 7, 9, 10, 11, 12, 13, 15, "
+                + "16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 7, 9, 10, 11, 12, "
+                + "13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
 
         assertNotNull(BackDoor.getFeedbackResponse(fq.getId(),
                                                    "SFSubmitUiT.alice.b@gmail.tmt",
@@ -272,7 +275,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 7, 9, 10, 11, 12, 13, 15, "
+                + "16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
         assertNull(BackDoor.getFeedbackResponse(fqMcq.getId(), aliceTeam, "Team 3"));
 
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
@@ -357,8 +361,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                                                    "Team 2"));
 
         //check edited
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 22, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 22, 23, 24, 25, 26, 27.");
         assertEquals("<p>" + editedResponse + "</p>",
                      BackDoor.getFeedbackResponse(fq.getId(), "SFSubmitUiT.alice.b@gmail.tmt",
                                                   "SFSubmitUiT.benny.c@gmail.tmt").responseMetaData.getValue());
@@ -423,13 +428,15 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         // Submit response with 2 options checked
         submitPage.toggleMsqOption(qnNumber, 0, "Drop out (Team 2)");
         submitPage.clickSubmitButton();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response with 3 options checked
         submitPage.toggleMsqOption(qnNumber, 0, "Emily (Team 3)");
         submitPage.clickSubmitButton();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response with 4 options checked
@@ -452,7 +459,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         // Submit response for 1st recipient with 3 options checked
         submitPage.toggleMsqOption(qnNumber, 0, "E");
         submitPage.clickSubmitButton();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         submitPage.waitForConfirmationModalAndClickOk();
 
         // Submit response for 1st recipient with 4 options checked
@@ -511,8 +519,11 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
 
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
+                + "15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "3, 4, 5, 6, 7, 8, 9, 10, 11, "
+                + "12, 13, 15, 16, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27.");
         submitPage.verifyHtmlMainContent("/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html");
 
         assertNotNull(BackDoor.getFeedbackResponse(fq.getId(), "drop.out@gmail.tmt", "SFSubmitUiT.benny.c@gmail.tmt"));
@@ -535,8 +546,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.fillResponseTextBox(14, 0, "");
         submitPage.fillResponseTextBox(14, 0, "0");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         FeedbackQuestionAttributes fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -553,8 +565,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
         submitPage.fillResponseTextBox(14, 0, "50000");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -573,8 +586,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
         submitPage.fillResponseTextBox(14, 0, "-99999");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("21, 23, 24, 25, 26, 27.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         fqNumscale = BackDoor.getFeedbackQuestion("SFSubmitUiT.CS2104", "First Session", 15);
 
@@ -591,8 +605,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
             submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
             submitPage.fillResponseTextBox(14, 0, "5");
             submitPage.submitWithoutConfirmationEmail();
-            submitPage.verifyAndCloseSuccessfulSubmissionModal();
-            submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+            submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                    Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
         }
 
         ______TS("write response without specifying recipient");
@@ -618,8 +632,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertTrue(submitPage.checkIfMcqOrMsqChoiceExists(25, 0,
                 "Extra guy (Team 2)"));
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
         ______TS("cannot choose self when generating choices from teams (excluding self)");
         submitPage = loginToStudentFeedbackSubmitPage("Alice", "Open Session");
@@ -629,8 +643,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertFalse(submitPage.checkIfMcqOrMsqChoiceExists(27, 0, "Team 1"));
         assertTrue(submitPage.checkIfMcqOrMsqChoiceExists(27, 0, "Team 2"));
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "21, 23, 24, 25, 26, 27.");
 
     }
 
@@ -688,7 +702,8 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                                         "drop.out@gmail.tmt",
                                         "SFSubmitUiT.charlie.d@gmail.tmt"));
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, "
+                + "15, 16, 17, 19, 20, 22, 23, 24, 25, 26, 27.");
         assertEquals("[-1, 1]", BackDoor.getFeedbackResponse(fqRubric.getId(),
                                         "drop.out@gmail.tmt",
                                         "SFSubmitUiT.danny.e@gmail.tmt").getResponseDetails().getAnswerString());
@@ -735,8 +750,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         // verify submission with no-response questions are possible
         submitPage.fillResponseTextBox(19, 2, "100");
         submitPage.submitWithoutConfirmationEmail();
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
 
         ______TS("Responses with invalid recipients do not prevent submission");
         StudentAttributes alice = testData.students.get("Alice");
@@ -758,8 +774,9 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
 
         submitPage.submitWithoutConfirmationEmail();
         // verify that existing responses with invalid recipients do not affect submission
-        submitPage.verifyAndCloseSuccessfulSubmissionModal();
-        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
+        submitPage.verifyAndCloseSuccessfulSubmissionModal("2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_INCOMPLETE_QUESTIONS + "2, 4, 21, 7, 23, 24, 9, 25, 10, 26, 27, 15.");
 
     }
 

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -238,7 +238,7 @@ public class FeedbackSubmitPage extends AppPage {
         closeMoreInfoAboutEqualShareModal();
     }
 
-    public void verifyAndCloseSuccessfulSubmissionModal(String incompleteQuestionsMessage) {
+    public void verifyAndCloseSuccessfulSubmissionModal(String unansweredQuestionsMessage) {
         // Waiting for modal visibility
         WebElement closeButton = browser.driver.findElement(By.className("bootbox-close-button"));
         waitForElementToBeClickable(closeButton);
@@ -255,9 +255,9 @@ public class FeedbackSubmitPage extends AppPage {
         StringBuilder expectedModalMessage = new StringBuilder("All your responses have been successfully recorded! "
                 + "You may now leave this page.\n"
                 + "Note that you can change your responses and submit them again any time before the session closes.");
-        if (!incompleteQuestionsMessage.isEmpty()) {
+        if (!unansweredQuestionsMessage.isEmpty()) {
             expectedModalMessage.insert(0, "❗ Note that some questions are yet to be answered. They are: "
-                    + incompleteQuestionsMessage + "\n");
+                    + unansweredQuestionsMessage + "\n");
         }
         WebElement modalMessage = browser.driver.findElement(By.xpath("//div[@class='bootbox-body']"));
         assertEquals(modalMessage.getText(), expectedModalMessage.toString());

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -238,7 +238,7 @@ public class FeedbackSubmitPage extends AppPage {
         closeMoreInfoAboutEqualShareModal();
     }
 
-    public void verifyAndCloseSuccessfulSubmissionModal() {
+    public void verifyAndCloseSuccessfulSubmissionModal(String incompleteQuestionsMessage) {
         // Waiting for modal visibility
         WebElement closeButton = browser.driver.findElement(By.className("bootbox-close-button"));
         waitForElementToBeClickable(closeButton);
@@ -251,10 +251,14 @@ public class FeedbackSubmitPage extends AppPage {
         WebElement modalTitle = browser.driver.findElement(By.xpath("//h4[@class='modal-title icon-success']"));
         assertEquals(modalTitle.getText(), Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
 
-        // Verify message content
-        final String expectedModalMessage = "All your responses have been successfully recorded! "
+        // Verify modal message content
+        String expectedModalMessage = "All your responses have been successfully recorded! "
                 + "You may now leave this page.\n"
                 + "Note that you can change your responses and submit them again any time before the session closes.";
+        if (!incompleteQuestionsMessage.isEmpty()) {
+            expectedModalMessage = "❗ Note that some questions are yet to be answered. They are: "
+                    + incompleteQuestionsMessage + "\n" + expectedModalMessage;
+        }
         WebElement modalMessage = browser.driver.findElement(By.xpath("//div[@class='bootbox-body']"));
         assertEquals(modalMessage.getText(), expectedModalMessage);
 

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -252,15 +252,15 @@ public class FeedbackSubmitPage extends AppPage {
         assertEquals(modalTitle.getText(), Const.StatusMessages.FEEDBACK_RESPONSES_SAVED);
 
         // Verify modal message content
-        String expectedModalMessage = "All your responses have been successfully recorded! "
+        StringBuilder expectedModalMessage = new StringBuilder("All your responses have been successfully recorded! "
                 + "You may now leave this page.\n"
-                + "Note that you can change your responses and submit them again any time before the session closes.";
+                + "Note that you can change your responses and submit them again any time before the session closes.");
         if (!incompleteQuestionsMessage.isEmpty()) {
-            expectedModalMessage = "❗ Note that some questions are yet to be answered. They are: "
-                    + incompleteQuestionsMessage + "\n" + expectedModalMessage;
+            expectedModalMessage.insert(0, "❗ Note that some questions are yet to be answered. They are: "
+                    + incompleteQuestionsMessage + "\n");
         }
         WebElement modalMessage = browser.driver.findElement(By.xpath("//div[@class='bootbox-body']"));
-        assertEquals(modalMessage.getText(), expectedModalMessage);
+        assertEquals(modalMessage.getText(), expectedModalMessage.toString());
 
         clickDismissModalButtonAndWaitForModalHidden(closeButton);
     }

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -32,6 +32,9 @@
       <div class="overflow-auto alert alert-success icon-success statusMessage">
         All responses submitted successfully!
       </div>
+      <div class="overflow-auto alert alert-info icon-info statusMessage">
+        Note that some questions are yet to be answered. They are: 3, 5, 6, 8, 10, 11, 12, 13, 15, 16, 17, 19, 21, 22, 23, 24, 25, 26, 27.
+      </div>
     </div>
     <script defer="" src="/js/statusMessage.js" type="text/javascript">
     </script>


### PR DESCRIPTION
Fixes #8598 

**Outline of Solution**
In the feedback submission page, create an HashSet to store the indexes of the incomplete questions. Using the question indexes, create a status message using INFO status. Then, use javascript to retrieve that status message to be shown in the modal. The results are shown below:
![screen shot 2018-04-10 at 3 39 05 am](https://user-images.githubusercontent.com/28522090/38518879-c271f1a2-3c70-11e8-8523-fa409a81a06c.png)
![screen shot 2018-04-10 at 3 38 12 am](https://user-images.githubusercontent.com/28522090/38518854-afd8f05e-3c70-11e8-89d3-58d62b4027e1.png)

However, I hardcoded the exclamation mark in and I am not sure if it serves the purpose cos it is not that visible. Hope you can advise me on this @Haozhe321 before I work on all the test cases. Thanks.

