### PR TITLE
Student: submit feedback: feedback button not greyed out when there are no recipients for any questions #8772

### DIFF
--- a/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/FeedbackSubmissionEditPageData.java
@@ -118,7 +118,8 @@ public class FeedbackSubmissionEditPageData extends PageData {
     }
 
     public boolean isSubmittable() {
-        return isSessionOpenForSubmission || isModeration;
+        return isSessionOpenForSubmission && isEntitiesToGiveFeedbackToPresent()
+                || isModeration;
     }
 
     public List<StudentFeedbackSubmissionEditQuestionsWithResponses> getQuestionsWithResponses() {
@@ -188,6 +189,16 @@ public class FeedbackSubmissionEditPageData extends PageData {
         });
 
         return result;
+    }
+
+    private boolean isEntitiesToGiveFeedbackToPresent() {
+        for (Map.Entry<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>>
+                entry : bundle.questionResponseBundle.entrySet()) {
+            if (entry.getKey().numberOfEntitiesToGiveFeedbackTo >= 1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isResponseRecipientValid(FeedbackResponseAttributes existingResponse) {


### PR DESCRIPTION
Fixes #8772.

**Outline of Solution**
1. Added method `isEntitiesToGiveFeedbackToPresent` in `FeedbackSubmissionEditPageData`. This method checks whether there is an existing recipient to give feedback to. If there are no recipients to give feedback to, the `Submit Feedback` button would be greyed out for the student.

**Might do**:
1. Add test cases

`FeedbackSubmissionEditPageDataTest` currently populates `pageData` with a set of question/responses chosen from `typicalDataBundle.json`. The same `pageData` is used by all test cases in this file.

Is it worth creating another set of customized question(s) to test this new feature? Would appreciate some input here.
