### PR TITLE
AccountAttributes: remove HTML sanitization before saving for email #8775

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/AccountAttributes.java
@@ -217,7 +217,6 @@ public class AccountAttributes extends EntityAttributes<Account> {
     public void sanitizeForSaving() {
         this.googleId = SanitizationHelper.sanitizeForHtml(googleId);
         this.name = SanitizationHelper.sanitizeForHtml(name);
-        this.email = SanitizationHelper.sanitizeForHtml(email);
         this.institute = SanitizationHelper.sanitizeForHtml(institute);
         if (studentProfile == null) {
             return;

--- a/src/main/webapp/WEB-INF/tags/admin/accounts/accountDetailsForInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/accounts/accountDetailsForInstructorPanel.tag
@@ -1,5 +1,6 @@
 <%@ tag trimDirectiveWhitespaces="true" %>
 <%@ tag description="Instructor Account Details" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ attribute name="accountInformation" type="teammates.common.datatransfer.attributes.AccountAttributes" required="true" %>
 
 <div class="well well-plain">
@@ -22,7 +23,7 @@
       <div class="form-group">
         <label class="col-sm-2 control-label">Email:</label>
         <div class="col-sm-10">
-          <p class="form-control-static">${accountInformation.email}</p>
+          <p class="form-control-static">${fn:escapeXml(accountInformation.email)}</p>
         </div>
       </div>
 

--- a/src/main/webapp/WEB-INF/tags/admin/activity/activityLogTableRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/activityLogTableRow.tag
@@ -1,6 +1,7 @@
 <%@ tag trimDirectiveWhitespaces="true" %>
 <%@ tag description="Activity Log Table in Admin Activity Log Page" pageEncoding="UTF-8" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ attribute name="log" type="teammates.ui.template.AdminActivityLogTableRow" required="true" %>
 <%@ tag import="teammates.common.util.Const" %>
 
@@ -58,7 +59,7 @@
           </c:choose>
           <c:choose>
             <c:when test="${log.hasUserEmail}">
-              <a href="mailto:${log.userEmail}" target="_blank">${log.userEmail}</a>
+              <a href="mailto:${fn:escapeXml(log.userEmail)}" target="_blank">${fn:escapeXml(log.userEmail)}</a>
             </c:when>
             <c:otherwise>
               <%= Const.ActivityLog.UNKNOWN %>
@@ -70,7 +71,7 @@
             : log.isActionErrorReport ? "btn-danger" : "btn-info"}">
           <span class="glyphicon glyphicon-zoom-in"></span>
         </button>
-        <input type="hidden" name="filterQuery" value="person:${log.userIdentity}">
+        <input type="hidden" name="filterQuery" value="person:${fn:escapeXml(log.userIdentity)}">
         <input class="ifShowAll_for_person" type="hidden" name="all" value="false">
         <input class="ifShowTestData_for_person" type="hidden" name="testdata" value="false">
       </h4>

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -120,7 +120,6 @@ public class AccountAttributesTest extends BaseAttributesTest {
 
         assertEquals(SanitizationHelper.sanitizeForHtml(expectedAccount.googleId), actualAccount.googleId);
         assertEquals(SanitizationHelper.sanitizeForHtml(expectedAccount.name), actualAccount.name);
-        assertEquals(SanitizationHelper.sanitizeForHtml(expectedAccount.email), actualAccount.email);
         assertEquals(SanitizationHelper.sanitizeForHtml(expectedAccount.institute), actualAccount.institute);
         expectedAccount.studentProfile.sanitizeForSaving();
         assertEquals(expectedAccount.studentProfile.toString(), actualAccount.studentProfile.toString());


### PR DESCRIPTION
Fixes #8775

The only time these email addresses are displayed in the frontend are in admin pages. Hence, handling of double sanitisation (which happens when displaying existing accounts with already-sanitised emails) is not done.