### PR TITLE
TimeHelper: update documentation and standardize method naming #8780

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/AdminEmailAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/AdminEmailAttributes.java
@@ -137,12 +137,12 @@ public class AdminEmailAttributes extends EntityAttributes<AdminEmail> {
         if (this.sendDate == null) {
             return "Draft";
         }
-        return TimeHelper.formatTime12H(TimeHelper.convertInstantToLocalDateTime(
+        return TimeHelper.formatDateTimeForDisplay(TimeHelper.convertInstantToLocalDateTime(
                 this.sendDate, Const.SystemParams.ADMIN_TIME_ZONE));
     }
 
     public String getCreateDateForDisplay() {
-        return TimeHelper.formatTime12H(TimeHelper.convertInstantToLocalDateTime(
+        return TimeHelper.formatDateTimeForDisplay(TimeHelper.convertInstantToLocalDateTime(
                 this.createDate, Const.SystemParams.ADMIN_TIME_ZONE));
     }
 

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -76,7 +76,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     public String getCreatedAtFullDateTimeString() {
         LocalDateTime localDateTime = TimeHelper.convertInstantToLocalDateTime(createdAt, timeZone);
-        return TimeHelper.formatTime12H(localDateTime);
+        return TimeHelper.formatDateTimeForDisplay(localDateTime);
     }
 
     public void setTimeZone(ZoneId timeZone) {

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -71,7 +71,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     public String getCreatedAtDateStamp() {
-        return TimeHelper.formatInstantToIso8601Utc(createdAt);
+        return TimeHelper.formatDateTimeToIso8601Utc(createdAt);
     }
 
     public String getCreatedAtFullDateTimeString() {

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -67,7 +67,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
     }
 
     public String getCreatedAtDateString() {
-        return TimeHelper.formatDateTimeForInstructorCoursesPage(createdAt, timeZone);
+        return TimeHelper.formatDateForInstructorCoursesPage(createdAt, timeZone);
     }
 
     public String getCreatedAtDateStamp() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -112,7 +112,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getStartTimeInIso8601UtcFormat() {
-        return TimeHelper.formatInstantToIso8601Utc(startTime);
+        return TimeHelper.formatDateTimeToIso8601Utc(startTime);
     }
 
     public String getEndTimeString() {
@@ -120,7 +120,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getEndTimeInIso8601UtcFormat() {
-        return TimeHelper.formatInstantToIso8601Utc(endTime);
+        return TimeHelper.formatDateTimeToIso8601Utc(endTime);
     }
 
     public String getInstructionsString() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -108,7 +108,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getStartTimeString() {
-        return TimeHelper.formatDateTimeForDisplayFull(startTime, timeZone);
+        return TimeHelper.formatDateTimeForDisplay(startTime, timeZone);
     }
 
     public String getStartTimeInIso8601UtcFormat() {
@@ -116,7 +116,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getEndTimeString() {
-        return TimeHelper.formatDateTimeForDisplayFull(endTime, timeZone);
+        return TimeHelper.formatDateTimeForDisplay(endTime, timeZone);
     }
 
     public String getEndTimeInIso8601UtcFormat() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -108,7 +108,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getStartTimeString() {
-        return TimeHelper.formatDateTimeForSessions(startTime, timeZone);
+        return TimeHelper.formatDateTimeForHomePage(startTime, timeZone);
     }
 
     public String getStartTimeInIso8601UtcFormat() {
@@ -116,7 +116,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getEndTimeString() {
-        return TimeHelper.formatDateTimeForSessions(endTime, timeZone);
+        return TimeHelper.formatDateTimeForHomePage(endTime, timeZone);
     }
 
     public String getEndTimeInIso8601UtcFormat() {

--- a/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/FeedbackSessionAttributes.java
@@ -108,7 +108,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getStartTimeString() {
-        return TimeHelper.formatDateTimeForHomePage(startTime, timeZone);
+        return TimeHelper.formatDateTimeForDisplayFull(startTime, timeZone);
     }
 
     public String getStartTimeInIso8601UtcFormat() {
@@ -116,7 +116,7 @@ public class FeedbackSessionAttributes extends EntityAttributes<FeedbackSession>
     }
 
     public String getEndTimeString() {
-        return TimeHelper.formatDateTimeForHomePage(endTime, timeZone);
+        return TimeHelper.formatDateTimeForDisplayFull(endTime, timeZone);
     }
 
     public String getEndTimeInIso8601UtcFormat() {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -174,11 +174,12 @@ public final class TimeHelper {
     }
 
     /**
-     * Convert a date string and time string of only the hour into a Date object.
-     * If the hour is 24, it is converted to 23:59. Returns null on error.
-     * @param inputDate         the date string in EEE, dd MMM, yyyy format
-     * @param inputTimeHours    the hour, 0-24
-     * @return                  a LocalDateTime at the specified date and hour
+     * Convert and combine a date string, and time string of only the hour, into a LocalDateTime object.
+     * If the {@code inputTimeHours} is "24", it is converted to "23:59".
+     *
+     * @param inputDate      date in format "EEE, dd MMM, yyyy"
+     * @param inputTimeHours hour-of-day (0-24)
+     * @return LocalDateTime at the specified date and hour, or null for invalid parameters
      */
     public static LocalDateTime combineDateTime(String inputDate, String inputTimeHours) {
         if ("24".equals(inputTimeHours)) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -483,7 +483,8 @@ public final class TimeHelper {
      * Parses an {@code Instant} object from a datetime string in the {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}.
      *
      * @param dateTimeString should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
-     * @return the parsed {@code Instant} object, or an {@code AssertionError} if there is a parsing error
+     * @return the parsed {@code Instant} object
+     * @throws AssertionError if there is a parsing error
      */
     public static Instant parseInstant(String dateTimeString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT);

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -172,21 +172,6 @@ public final class TimeHelper {
     }
 
     /**
-     * Convert and combine a date string, and time string of only the hour, into a LocalDateTime object.
-     * If the {@code inputTimeHours} is "24", it is converted to "23:59".
-     *
-     * @param inputDate      date in format "EEE, dd MMM, yyyy"
-     * @param inputTimeHours hour-of-day (0-24)
-     * @return LocalDateTime at the specified date and hour, or null for invalid parameters
-     */
-    public static LocalDateTime combineDateTime(String inputDate, String inputTimeHours) {
-        if ("24".equals(inputTimeHours)) {
-            return parseDateTimeFromSessionsForm(inputDate, "23", "59");
-        }
-        return parseDateTimeFromSessionsForm(inputDate, inputTimeHours, "0");
-    }
-
-    /**
      * Returns an Instant that is offset by a number of days from now.
      *
      * @param offsetInDays integer number of days offset by
@@ -301,11 +286,11 @@ public final class TimeHelper {
 
     /**
      * Returns a copy of the {@link LocalDateTime} adjusted to be compatible with the format output by
-     * {@link #combineDateTime}, i.e. either the time is 23:59, or the minute is 0 and the hour is not 0.
+     * {@link #parseDateTimeFromSessionsForm}, i.e. either the time is 23:59, or the minute is 0 and the hour is not 0.
      * The date time is first rounded to the nearest hour, then the special case 00:00 is handled.
      * @param ldt The {@link LocalDateTime} to be adjusted for compatibility.
      * @return a copy of {@code ldt} adjusted for compatibility, or null if {@code ldt} is null.
-     * @see #combineDateTime
+     * @see #parseDateTimeFromSessionsForm
      */
     public static LocalDateTime adjustLocalDateTimeForSessionsFormInputs(LocalDateTime ldt) {
         if (ldt == null) {
@@ -585,6 +570,21 @@ public final class TimeHelper {
         } catch (DateTimeException | NumberFormatException e) {
             return null;
         }
+    }
+
+    /**
+     * Convert and combine a date string, and time string of only the hour, into a LocalDateTime object.
+     * If the {@code inputTimeHours} is "24", it is converted to "23:59".
+     *
+     * @param inputDate      date in format "EEE, dd MMM, yyyy"
+     * @param inputTimeHours hour-of-day (0-24)
+     * @return the parsed {@code LocalDateTime} at the specified date and hour, or null for invalid parameters
+     */
+    public static LocalDateTime parseDateTimeFromSessionsForm(String inputDate, String inputTimeHours) {
+        if ("24".equals(inputTimeHours)) {
+            return parseDateTimeFromSessionsForm(inputDate, "23", "59");
+        }
+        return parseDateTimeFromSessionsForm(inputDate, inputTimeHours, "0");
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -536,8 +536,8 @@ public final class TimeHelper {
      * Parses a {@code LocalDate} object from a date string.
      * Example: date "Tue, 01 Apr, 2014"
      *
-     * @param date  date in format "EEE, dd MMM, yyyy"
-     * @return      the parsed {@code LocalDate} object, or {@code null} if there are errors
+     * @param date date in format "EEE, dd MMM, yyyy"
+     * @return the parsed {@code LocalDate} object, or {@code null} if there are errors
      */
     public static LocalDate parseDateFromSessionsForm(String date) {
         return parseLocalDate(date, "EEE, dd MMM, yyyy");

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -323,6 +323,19 @@ public final class TimeHelper {
         return formatInstant(instant, sessionTimeZone, "EEE, dd MMM yyyy, hh:mm a z");
     }
 
+    /**
+     * Format a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
+     * Example: Tue, 12 Apr 2018, 11:23 PM SGT (UTC+0800)
+     *
+     * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.
+     *
+     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
+     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT (UTC+0800)
+     *
+     * @param instant the interpreted instant to be formatted
+     * @param zone    the time zone causing the DST overlap
+     * @return the formatted datetime stamp string
+     */
     public static String formatDateTimeForDisambiguation(Instant instant, ZoneId zone) {
         return formatInstant(instant, zone, "EEE, dd MMM yyyy, hh:mm a z ('UTC'Z)");
     }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -371,7 +371,7 @@ public final class TimeHelper {
      * @param sessionTimeZone the time zone to compute local datetime
      * @return the formatted datetime stamp string
      */
-    public static String formatDateTimeForSessions(Instant instant, ZoneId sessionTimeZone) {
+    public static String formatDateTimeForHomePage(Instant instant, ZoneId sessionTimeZone) {
         return formatInstant(instant, sessionTimeZone, "EEE, dd MMM yyyy, hh:mm a z");
     }
 

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -573,7 +573,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Convert and combine a date string, and time string of only the hour, into a LocalDateTime object.
+     * Parses a date string and a time string of only the hour into a LocalDateTime object.
      * If the {@code inputTimeHours} is "24", it is converted to "23:59".
      *
      * @param inputDate      date in format "EEE, dd MMM, yyyy"

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -229,8 +229,14 @@ public final class TimeHelper {
     }
 
     /**
-     * Format {@code localDateTime} according to a specified {@code pattern}.
-     * PM is especially formatted as NOON if it's 12:00 PM, if present
+     * Format a datetime stamp from a {@code LocalDateTime} using a formatting pattern.
+     *
+     * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
+     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
+     *
+     * @param localDateTime the LocalDateTime to be formatted
+     * @param pattern       formatting pattern, see Oracle docs for DateTimeFormatter for pattern table
+     * @return the formatted datetime stamp string
      */
     private static String formatLocalDateTime(LocalDateTime localDateTime, String pattern) {
         if (localDateTime == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -571,8 +571,8 @@ public final class TimeHelper {
      * Parses a {@code ZoneId} object from a string.
      * Example: "Asia/Singapore" or "UTC+04:00".
      *
-     * @param timeZone  a string containing the zone ID
-     * @return          ZoneId.of(timeZone) or {@code null} if {@code timeZone} is invalid.
+     * @param timeZone a string containing the zone ID
+     * @return {@code ZoneId.of(timeZone)}, or {@code null} if {@code timeZone} is invalid.
      */
     public static ZoneId parseZoneId(String timeZone) {
         if (timeZone == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -265,7 +265,13 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats a date in the format EEE, dd MMM, yyyy. Example: Sat, 05 May, 2012
+     * Format a date stamp from a {@code localDateTime} for populating the sessions form.
+     * Example: Tue, 12 Apr, 2018
+     *
+     * <p>This method discards the time stored in the {@code localDateTime}.
+     *
+     * @param localDateTime the LocalDateTime to be formatted
+     * @return the formatted date stamp string
      */
     public static String formatDateForSessionsForm(LocalDateTime localDateTime) {
         return formatLocalDateTime(localDateTime, "EEE, dd MMM, yyyy");

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -399,14 +399,14 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats {@code instant} according to the ISO8601 format.
+     * Formats {@code instant} using the ISO8601 format in UTC.
      * Example: 2011-12-03T10:15:30Z
      *
      * <p>Used to inject a standardized date into date elements in Teammates for sortable tables.
      * Should not be used for anything user-facing.</p>
      *
      * @param instant the instant to be formatted
-     * @return the formatted datetime stamp in ISO8601 format
+     * @return the formatted datetime ISO8601 stamp in UTC
      */
     public static String formatDateTimeToIso8601Utc(Instant instant) {
         return instant == null ? null : DateTimeFormatter.ISO_INSTANT.format(instant);
@@ -419,7 +419,7 @@ public final class TimeHelper {
      * <p>A {@code null} instant is not a special time.</p>
      *
      * @param instant the instant to test
-     * @return {@code true} if the given instant is used as special representation, {@code false} otherwise
+     * @return {@code true} if the given instant is used as a special representation, {@code false} otherwise
      */
     public static boolean isSpecialTime(Instant instant) {
         if (instant == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -349,13 +349,6 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats {@code instant} according to the ISO8601 format.
-     */
-    public static String formatInstantToIso8601Utc(Instant instant) {
-        return instant == null ? null : DateTimeFormatter.ISO_INSTANT.format(instant);
-    }
-
-    /**
      * Formats {@code instant} for the admin's activity log page.
      * Example: 23/04/2018 12:00:01.481
      *
@@ -367,6 +360,20 @@ public final class TimeHelper {
      */
     public static String formatDateTimeForAdminLog(Instant instant, ZoneId zoneId) {
         return formatInstant(instant, zoneId, STAMP_DATETIME_ADMIN_LOG);
+    }
+
+    /**
+     * Formats {@code instant} according to the ISO8601 format.
+     * Example: 2011-12-03T10:15:30Z
+     *
+     * <p>Used to inject a standardized date into date elements in Teammates for sortable tables.
+     * Should not be used for anything user-facing.
+     *
+     * @param instant the instant to be formatted
+     * @return the formatted datetime stamp in ISO8601 format
+     */
+    public static String formatDateTimeToIso8601Utc(Instant instant) {
+        return instant == null ? null : DateTimeFormatter.ISO_INSTANT.format(instant);
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -212,7 +212,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a datetime stamp from a {@code LocalDateTime} using a formatting pattern.
+     * Formats a datetime stamp from a {@code LocalDateTime} using a formatting pattern.
      *
      * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
      * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
@@ -234,7 +234,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a datetime stamp from a {@code localDateTime}.
+     * Formats a datetime stamp from a {@code localDateTime}.
      * Example: Tue, 12 Apr 2018, 12:01 PM
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
@@ -248,7 +248,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a date stamp from a {@code localDateTime} for populating the sessions form.
+     * Formats a date stamp from a {@code localDateTime} for populating the sessions form.
      * Example: Tue, 12 Apr, 2018
      *
      * <p>This method discards the time stored in the {@code localDateTime}.
@@ -261,7 +261,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a short datetime stamp from a {@code localDateTime} for the instructor's home page.
+     * Formats a short datetime stamp from a {@code localDateTime} for the instructor's home page.
      * Example: 5 Apr 12:01 PM
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
@@ -319,7 +319,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a datetime stamp from an {@code instant} using a formatting pattern.
+     * Formats a datetime stamp from an {@code instant} using a formatting pattern.
      *
      * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
      * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
@@ -343,7 +343,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a datetime stamp from an {@code instant} including time zone name.
+     * Formats a datetime stamp from an {@code instant} including time zone name.
      * Example: Tue, 12 Apr 2018, 11:21 PM SGT
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
@@ -358,7 +358,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
+     * Formats a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
      * Example: Tue, 12 Apr 2018, 11:23 PM SGT (UTC+0800)
      *
      * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.
@@ -375,7 +375,7 @@ public final class TimeHelper {
     }
 
     /**
-     * Format a date stamp from an {@code instant} for the instructor's courses page.
+     * Formats a date stamp from an {@code instant} for the instructor's courses page.
      * Example: 5 May 2017
      *
      * @param instant the instant to be formatted

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -430,9 +430,13 @@ public final class TimeHelper {
     }
 
     /**
-     * Returns whether the given instant is being used as a special representation,
-     * signifying its face value should not be used without proper processing.
-     * A null instant is not a special time.
+     * Returns whether the given {@code instant} is being used as a special representation, signifying its face value
+     * should not be used without proper processing.
+     *
+     * <p>A {@code null} instant is not a special time.
+     *
+     * @param instant the instant to test
+     * @return {@code true} if the given instant is used as special representation, {@code false} otherwise
      */
     public static boolean isSpecialTime(Instant instant) {
         if (instant == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -393,10 +393,15 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats a date in the format d MMM yyyy. Example: 5 May 2017
+     * Format a date stamp from an {@code instant} for the instructor's courses page.
+     * Example: 5 May 2017
+     *
+     * @param instant the instant to be formatted
+     * @param zoneId  the time zone to calculate local date
+     * @return the formatted date stamp string
      */
-    public static String formatDateTimeForInstructorCoursesPage(Instant instant, ZoneId timeZoneId) {
-        return formatInstant(instant, timeZoneId, "d MMM yyyy");
+    public static String formatDateForInstructorCoursesPage(Instant instant, ZoneId zoneId) {
+        return formatInstant(instant, zoneId, "d MMM yyyy");
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -295,10 +295,16 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats a date in the format dd MMM yyyy, hh:mm a. 12:00 PM is especially formatted as 12:00 NOON
-     * Example: 05 May 2012, 2:04 PM<br>
+     * Format a standard pretty datetime stamp from a {@code localDateTime}.
+     * Example: Tue, 12 Apr 2018, 12:01 PM
+     *
+     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
+     * Example: Tue, 12 Apr 2018, 12:00 NOON
+     *
+     * @param localDateTime the LocalDateTime to be formatted
+     * @return              the formatted datetime stamp string
      */
-    public static String formatTime12H(LocalDateTime localDateTime) {
+    public static String formatDateTimeForDisplay(LocalDateTime localDateTime) {
         return formatLocalDateTime(localDateTime, "EEE, dd MMM yyyy, hh:mm a");
     }
 

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -433,21 +433,6 @@ public final class TimeHelper {
     }
 
     /**
-     * Converts the datetime string to an Instant object.
-     *
-     * @param dateTimeString should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
-     */
-    public static Instant parseInstant(String dateTimeString) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT);
-        try {
-            return ZonedDateTime.parse(dateTimeString, formatter).toInstant();
-        } catch (DateTimeParseException e) {
-            Assumption.fail("Date in String is in wrong format.");
-            return null;
-        }
-    }
-
-    /**
      * Returns whether the given {@code instant} is being used as a special representation, signifying its face value
      * should not be used without proper processing.
      *
@@ -512,6 +497,22 @@ public final class TimeHelper {
                 timeInMilliseconds / 60000,
                 (timeInMilliseconds % 60000) / 1000,
                 timeInMilliseconds % 1000);
+    }
+
+    /**
+     * Parses an {@code Instant} object from a datetime string in the {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}.
+     *
+     * @param dateTimeString should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
+     * @return the parsed {@code Instant} object, or {@code null} if there are errors
+     */
+    public static Instant parseInstant(String dateTimeString) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT);
+        try {
+            return ZonedDateTime.parse(dateTimeString, formatter).toInstant();
+        } catch (DateTimeParseException e) {
+            Assumption.fail("Date in String is in wrong format.");
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -245,11 +245,33 @@ public final class TimeHelper {
     }
 
     /**
+     * Format a datetime stamp from a {@code localDateTime}.
+     * Example: Tue, 12 Apr 2018, 12:01 PM
+     *
+     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
+     * Example: Tue, 12 Apr 2018, 12:00 NOON
+     *
+     * @param localDateTime the LocalDateTime to be formatted
+     * @return the formatted datetime stamp string
+     */
+    public static String formatDateTimeForDisplay(LocalDateTime localDateTime) {
+        return formatLocalDateTime(localDateTime, "EEE, dd MMM yyyy, hh:mm a");
+    }
+
+    /**
      * Formats a date in the format EEE, dd MMM, yyyy. Example: Sat, 05 May, 2012
      */
     public static String formatDateForSessionsForm(LocalDateTime localDateTime) {
         return formatLocalDateTime(localDateTime, "EEE, dd MMM, yyyy");
     }
+
+    /**
+     * Formats a date in the format d MMM h:mm a. Example: 5 May 11:59 PM
+     */
+    public static String formatDateTimeForInstructorHomePage(LocalDateTime localDateTime) {
+        return formatLocalDateTime(localDateTime, "d MMM h:mm a");
+    }
+
 
     /**
      * Convenience method to perform {@link #adjustLocalDateTimeForSessionsFormInputs} followed by
@@ -293,20 +315,6 @@ public final class TimeHelper {
             return rounded.minusMinutes(1);
         }
         return rounded;
-    }
-
-    /**
-     * Format a standard pretty datetime stamp from a {@code localDateTime}.
-     * Example: Tue, 12 Apr 2018, 12:01 PM
-     *
-     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON
-     *
-     * @param localDateTime the LocalDateTime to be formatted
-     * @return              the formatted datetime stamp string
-     */
-    public static String formatDateTimeForDisplay(LocalDateTime localDateTime) {
-        return formatLocalDateTime(localDateTime, "EEE, dd MMM yyyy, hh:mm a");
     }
 
     /**
@@ -363,13 +371,6 @@ public final class TimeHelper {
      */
     public static String formatDateTimeForDisambiguation(Instant instant, ZoneId zone) {
         return formatInstant(instant, zone, "EEE, dd MMM yyyy, hh:mm a z ('UTC'Z)");
-    }
-
-    /**
-     * Formats a date in the format d MMM h:mm a. Example: 5 May 11:59 PM
-     */
-    public static String formatDateTimeForInstructorHomePage(LocalDateTime localDateTime) {
-        return formatLocalDateTime(localDateTime, "d MMM h:mm a");
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -353,24 +353,22 @@ public final class TimeHelper {
      * @param sessionTimeZone the time zone to compute local datetime
      * @return the formatted datetime stamp string
      */
-    public static String formatDateTimeForDisplayFull(Instant instant, ZoneId sessionTimeZone) {
+    public static String formatDateTimeForDisplay(Instant instant, ZoneId sessionTimeZone) {
         return formatInstant(instant, sessionTimeZone, "EEE, dd MMM yyyy, hh:mm a z");
     }
 
     /**
-     * Formats a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
+     * Formats a datetime stamp from an {@code instant} including time zone name and offset.
      * Example: Sun, 01 Apr 2018, 11:23 PM SGT (UTC+0800)
-     *
-     * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.</p>
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
      * Example: Sun, 01 Apr 2018, 12:00 NOON SGT (UTC+0800)</p>
      *
      * @param instant the interpreted instant to be formatted
-     * @param zone    the time zone causing the DST overlap
+     * @param zone    the time zone to compute local datetime
      * @return the formatted datetime stamp string
      */
-    public static String formatDateTimeForDisambiguation(Instant instant, ZoneId zone) {
+    public static String formatDateTimeForDisplayFull(Instant instant, ZoneId zone) {
         return formatInstant(instant, zone, "EEE, dd MMM yyyy, hh:mm a z ('UTC'Z)");
     }
 

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -513,12 +513,11 @@ public final class TimeHelper {
     }
 
     /**
-     * Parses a {@code LocalDate} object from a date string according to a pattern.
-     * Returns {@code null} on error.
+     * Parses a {@code LocalDate} object from a date string and parsing pattern.
      *
-     * @param dateString        the string containing the date
-     * @param pattern           the pattern of the date string
-     * @return                  the parsed {@code LocalDate} object, or {@code null} if there are errors
+     * @param dateString the string containing the date
+     * @param pattern    the parsing pattern of the datetime string
+     * @return the parsed {@code LocalDate} object, or {@code null} if there are errors
      */
     public static LocalDate parseLocalDate(String dateString, String pattern) {
         if (dateString == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -188,9 +188,10 @@ public final class TimeHelper {
     }
 
     /**
-     * Returns an java.time.Instant object that is offset by a number of days from now.
-     * @param offsetInDays number of days offset by (integer).
-     * @return java.time.Instant offset by offsetInDays days.
+     * Returns an Instant that is offset by a number of days from now.
+     *
+     * @param offsetInDays integer number of days offset by
+     * @return an Instant offset by {@code offsetInDays} days
      */
     public static Instant getInstantDaysOffsetFromNow(long offsetInDays) {
         return Instant.now().plus(Duration.ofDays(offsetInDays));

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -26,8 +26,6 @@ import teammates.common.util.Const.SystemParams;
  * Time zone is assumed as UTC unless specifically mentioned.
  */
 public final class TimeHelper {
-    public static final String STAMP_DATETIME_ADMIN_LOG = "dd/MM/yyyy HH:mm:ss.SSS";
-
     private static final Logger log = Logger.getLogger();
     private static final Map<ZoneId, String> TIME_ZONE_CITIES_MAP = new LinkedHashMap<>();
 
@@ -415,7 +413,7 @@ public final class TimeHelper {
      * @return the formatted timestamp string
      */
     public static String formatDateTimeForAdminLog(Instant instant, ZoneId zoneId) {
-        return formatInstant(instant, zoneId, STAMP_DATETIME_ADMIN_LOG);
+        return formatInstant(instant, zoneId, "dd/MM/yyyy HH:mm:ss.SSS");
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -26,6 +26,7 @@ import teammates.common.util.Const.SystemParams;
  * Time zone is assumed as UTC unless specifically mentioned.
  */
 public final class TimeHelper {
+    public static final String STAMP_DATETIME_ADMIN_LOG = "dd/MM/yyyy HH:mm:ss.SSS";
 
     private static final Logger log = Logger.getLogger();
 
@@ -355,14 +356,17 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats {@code instant} in admin's activity log page.
+     * Formats {@code instant} for the admin's activity log page.
+     * Example: 23/04/2018 12:00:01.481
      *
-     * @param instant   the instant to be formatted
-     * @param zoneId    the time zone to calculate local date and time
-     * @return          the formatted string
+     * <p>Timestamp precision to millisecond. Used for dev/admin-facing pages only.
+     *
+     * @param instant the instant to be formatted
+     * @param zoneId  the time zone to calculate local date and time
+     * @return the formatted timestamp string
      */
-    public static String formatActivityLogTime(Instant instant, ZoneId zoneId) {
-        return formatInstant(instant, zoneId, "dd/MM/yyyy HH:mm:ss.SSS");
+    public static String formatDateTimeForAdminLog(Instant instant, ZoneId zoneId) {
+        return formatInstant(instant, zoneId, STAMP_DATETIME_ADMIN_LOG);
     }
 
     /**

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -483,7 +483,7 @@ public final class TimeHelper {
      * Parses an {@code Instant} object from a datetime string in the {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}.
      *
      * @param dateTimeString should be in the format {@link SystemParams#DEFAULT_DATE_TIME_FORMAT}
-     * @return the parsed {@code Instant} object, or {@code null} if there are errors
+     * @return the parsed {@code Instant} object, or an {@code AssertionError} if there is a parsing error
      */
     public static Instant parseInstant(String dateTimeString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT);

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -235,10 +235,10 @@ public final class TimeHelper {
 
     /**
      * Formats a datetime stamp from a {@code localDateTime}.
-     * Example: Tue, 12 Apr 2018, 12:01 PM
+     * Example: Sun, 01 Apr 2018, 12:01 PM
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON</p>
+     * Example: Sun, 01 Apr 2018, 12:00 NOON</p>
      *
      * @param localDateTime the LocalDateTime to be formatted
      * @return the formatted datetime stamp string
@@ -249,7 +249,7 @@ public final class TimeHelper {
 
     /**
      * Formats a date stamp from a {@code localDateTime} for populating the sessions form.
-     * Example: Tue, 12 Apr, 2018
+     * Example: Sun, 01 Apr, 2018
      *
      * <p>This method discards the time stored in the {@code localDateTime}.</p>
      *
@@ -344,10 +344,10 @@ public final class TimeHelper {
 
     /**
      * Formats a datetime stamp from an {@code instant} including time zone name.
-     * Example: Tue, 12 Apr 2018, 11:21 PM SGT
+     * Example: Sun, 01 Apr 2018, 11:21 PM SGT
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT</p>
+     * Example: Sun, 01 Apr 2018, 12:00 NOON SGT</p>
      *
      * @param instant         the instant to be formatted
      * @param sessionTimeZone the time zone to compute local datetime
@@ -359,12 +359,12 @@ public final class TimeHelper {
 
     /**
      * Formats a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
-     * Example: Tue, 12 Apr 2018, 11:23 PM SGT (UTC+0800)
+     * Example: Sun, 01 Apr 2018, 11:23 PM SGT (UTC+0800)
      *
      * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.</p>
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT (UTC+0800)</p>
+     * Example: Sun, 01 Apr 2018, 12:00 NOON SGT (UTC+0800)</p>
      *
      * @param instant the interpreted instant to be formatted
      * @param zone    the time zone causing the DST overlap
@@ -388,7 +388,7 @@ public final class TimeHelper {
 
     /**
      * Formats {@code instant} for the admin's activity log page.
-     * Example: 23/04/2018 12:00:01.481
+     * Example: 01/04/2018 12:00:01.481
      *
      * <p>Timestamp precision to millisecond. Used for dev/admin-facing pages only.</p>
      *

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -289,7 +289,6 @@ public final class TimeHelper {
         return formatLocalDateTime(localDateTime, "d MMM h:mm a");
     }
 
-
     /**
      * Convenience method to perform {@link #adjustLocalDateTimeForSessionsFormInputs} followed by
      * {@link #formatDateForSessionsForm} on a {@link LocalDateTime}.

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -29,7 +29,6 @@ public final class TimeHelper {
     public static final String STAMP_DATETIME_ADMIN_LOG = "dd/MM/yyyy HH:mm:ss.SSS";
 
     private static final Logger log = Logger.getLogger();
-
     private static final Map<ZoneId, String> TIME_ZONE_CITIES_MAP = new LinkedHashMap<>();
 
     /*
@@ -420,7 +419,6 @@ public final class TimeHelper {
      * A null instant is not a special time.
      */
     public static boolean isSpecialTime(Instant instant) {
-
         if (instant == null) {
             return false;
         }
@@ -430,7 +428,6 @@ public final class TimeHelper {
                 || instant.equals(Const.TIME_REPRESENTS_LATER)
                 || instant.equals(Const.TIME_REPRESENTS_NEVER)
                 || instant.equals(Const.TIME_REPRESENTS_NOW);
-
     }
 
     /**
@@ -471,7 +468,6 @@ public final class TimeHelper {
      * <p>Example: 1200 milliseconds ---> 0:1:200.
      */
     public static String convertToStandardDuration(Long timeInMilliseconds) {
-
         return timeInMilliseconds == null
              ? ""
              : String.format("%d:%d:%d",

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -319,6 +319,17 @@ public final class TimeHelper {
         return zonedDateTime.format(formatter);
     }
 
+    /**
+     * Format a datetime stamp from an {@code instant} including time zone name.
+     * Example: Tue, 12 Apr 2018, 11:21 PM SGT
+     *
+     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
+     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT
+     *
+     * @param instant         the instant to be formatted
+     * @param sessionTimeZone the time zone to compute local datetime
+     * @return the formatted datetime stamp string
+     */
     public static String formatDateTimeForSessions(Instant instant, ZoneId sessionTimeZone) {
         return formatInstant(instant, sessionTimeZone, "EEE, dd MMM yyyy, hh:mm a z");
     }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -215,7 +215,7 @@ public final class TimeHelper {
      * Formats a datetime stamp from a {@code LocalDateTime} using a formatting pattern.
      *
      * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
-     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
+     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".</p>
      *
      * @param localDateTime the LocalDateTime to be formatted
      * @param pattern       formatting pattern, see Oracle docs for DateTimeFormatter for pattern table
@@ -238,7 +238,7 @@ public final class TimeHelper {
      * Example: Tue, 12 Apr 2018, 12:01 PM
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON
+     * Example: Tue, 12 Apr 2018, 12:00 NOON</p>
      *
      * @param localDateTime the LocalDateTime to be formatted
      * @return the formatted datetime stamp string
@@ -251,7 +251,7 @@ public final class TimeHelper {
      * Formats a date stamp from a {@code localDateTime} for populating the sessions form.
      * Example: Tue, 12 Apr, 2018
      *
-     * <p>This method discards the time stored in the {@code localDateTime}.
+     * <p>This method discards the time stored in the {@code localDateTime}.</p>
      *
      * @param localDateTime the LocalDateTime to be formatted
      * @return the formatted date stamp string
@@ -265,7 +265,7 @@ public final class TimeHelper {
      * Example: 5 Apr 12:01 PM
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: 5 Apr 12:01 NOON
+     * Example: 5 Apr 12:01 NOON</p>
      *
      * @param localDateTime the LocalDateTime to be formatted
      * @return the formatted datetime stamp string
@@ -322,7 +322,7 @@ public final class TimeHelper {
      * Formats a datetime stamp from an {@code instant} using a formatting pattern.
      *
      * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
-     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
+     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".</p>
      *
      * @param instant  the instant to be formatted
      * @param timeZone the time zone to compute local datetime
@@ -347,7 +347,7 @@ public final class TimeHelper {
      * Example: Tue, 12 Apr 2018, 11:21 PM SGT
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT
+     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT</p>
      *
      * @param instant         the instant to be formatted
      * @param sessionTimeZone the time zone to compute local datetime
@@ -361,10 +361,10 @@ public final class TimeHelper {
      * Formats a datetime stamp from an {@code instant} for DST disambiguation including time zone name and offset.
      * Example: Tue, 12 Apr 2018, 11:23 PM SGT (UTC+0800)
      *
-     * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.
+     * <p>This is used to generate the warning to instructors for datetimes that fall in DST overlaps.</p>
      *
      * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
-     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT (UTC+0800)
+     * Example: Tue, 12 Apr 2018, 12:00 NOON SGT (UTC+0800)</p>
      *
      * @param instant the interpreted instant to be formatted
      * @param zone    the time zone causing the DST overlap
@@ -390,7 +390,7 @@ public final class TimeHelper {
      * Formats {@code instant} for the admin's activity log page.
      * Example: 23/04/2018 12:00:01.481
      *
-     * <p>Timestamp precision to millisecond. Used for dev/admin-facing pages only.
+     * <p>Timestamp precision to millisecond. Used for dev/admin-facing pages only.</p>
      *
      * @param instant the instant to be formatted
      * @param zoneId  the time zone to calculate local date and time
@@ -405,7 +405,7 @@ public final class TimeHelper {
      * Example: 2011-12-03T10:15:30Z
      *
      * <p>Used to inject a standardized date into date elements in Teammates for sortable tables.
-     * Should not be used for anything user-facing.
+     * Should not be used for anything user-facing.</p>
      *
      * @param instant the instant to be formatted
      * @return the formatted datetime stamp in ISO8601 format
@@ -418,7 +418,7 @@ public final class TimeHelper {
      * Returns whether the given {@code instant} is being used as a special representation, signifying its face value
      * should not be used without proper processing.
      *
-     * <p>A {@code null} instant is not a special time.
+     * <p>A {@code null} instant is not a special time.</p>
      *
      * @param instant the instant to test
      * @return {@code true} if the given instant is used as special representation, {@code false} otherwise

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -308,8 +308,15 @@ public final class TimeHelper {
     }
 
     /**
-     * Format {@code instant} at a {@code timeZone} according to a specified {@code pattern}.
-     * PM is especially formatted as NOON if it's 12:00 PM, if present.
+     * Format a datetime stamp from an {@code instant} using a formatting pattern.
+     *
+     * <p>Note: a formatting pattern containing 'a' (for the period; AM/PM) is treated differently at noon/midday.
+     * Using that pattern with a datetime whose time falls on "12:00 PM" will cause it to be formatted as "12:00 NOON".
+     *
+     * @param instant  the instant to be formatted
+     * @param timeZone the time zone to compute local datetime
+     * @param pattern  formatting pattern, see Oracle docs for DateTimeFormatter for pattern table
+     * @return the formatted datetime stamp string
      */
     private static String formatInstant(Instant instant, ZoneId timeZone, String pattern) {
         if (instant == null || timeZone == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -244,13 +244,6 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats a date in the format dd/MM/yyyy.
-     */
-    public static String formatDate(LocalDateTime localDateTime) {
-        return formatLocalDateTime(localDateTime, "dd/MM/yyyy");
-    }
-
-    /**
      * Formats a date in the format EEE, dd MMM, yyyy. Example: Sat, 05 May, 2012
      */
     public static String formatDateForSessionsForm(LocalDateTime localDateTime) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -278,7 +278,14 @@ public final class TimeHelper {
     }
 
     /**
-     * Formats a date in the format d MMM h:mm a. Example: 5 May 11:59 PM
+     * Format a short datetime stamp from a {@code localDateTime} for the instructor's home page.
+     * Example: 5 Apr 12:01 PM
+     *
+     * <p>Note: a datetime with time "12:00 PM" is specially formatted to "12:00 NOON"
+     * Example: 5 Apr 12:01 NOON
+     *
+     * @param localDateTime the LocalDateTime to be formatted
+     * @return the formatted datetime stamp string
      */
     public static String formatDateTimeForInstructorHomePage(LocalDateTime localDateTime) {
         return formatLocalDateTime(localDateTime, "d MMM h:mm a");

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -493,12 +493,11 @@ public final class TimeHelper {
     }
 
     /**
-     * Parses a {@code LocalDateTime} object from a date time string according to a pattern.
-     * Returns {@code null} on error.
+     * Parses a {@code LocalDateTime} object from a datetime string and parsing pattern.
      *
-     * @param dateTimeString    the string containing the date and time
-     * @param pattern           the pattern of the date and time string
-     * @return                  the parsed {@code LocalDateTime} object, or {@code null} if there are errors
+     * @param dateTimeString the string containing the datetime
+     * @param pattern        the parsing pattern of the datetime string
+     * @return the parsed {@code LocalDateTime} object, or {@code null} if there are errors
      */
     public static LocalDateTime parseLocalDateTime(String dateTimeString, String pattern) {
         if (dateTimeString == null || pattern == null) {

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -353,7 +353,7 @@ public final class TimeHelper {
      * @param sessionTimeZone the time zone to compute local datetime
      * @return the formatted datetime stamp string
      */
-    public static String formatDateTimeForHomePage(Instant instant, ZoneId sessionTimeZone) {
+    public static String formatDateTimeForDisplayFull(Instant instant, ZoneId sessionTimeZone) {
         return formatInstant(instant, sessionTimeZone, "EEE, dd MMM yyyy, hh:mm a z");
     }
 

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -182,9 +182,9 @@ public final class TimeHelper {
      */
     public static LocalDateTime combineDateTime(String inputDate, String inputTimeHours) {
         if ("24".equals(inputTimeHours)) {
-            return parseLocalDateTimeForSessionsForm(inputDate, "23", "59");
+            return parseDateTimeFromSessionsForm(inputDate, "23", "59");
         }
-        return parseLocalDateTimeForSessionsForm(inputDate, inputTimeHours, "0");
+        return parseDateTimeFromSessionsForm(inputDate, inputTimeHours, "0");
     }
 
     /**
@@ -495,7 +495,7 @@ public final class TimeHelper {
      * @param date  date in format "EEE, dd MMM, yyyy"
      * @return      the parsed {@code LocalDate} object, or {@code null} if there are errors
      */
-    public static LocalDate parseLocalDateForSessionsForm(String date) {
+    public static LocalDate parseDateFromSessionsForm(String date) {
         return parseLocalDate(date, "EEE, dd MMM, yyyy");
     }
 
@@ -503,13 +503,13 @@ public final class TimeHelper {
      * Parses a {@code LocalDateTime} object from separated date, hour and minute strings.
      * Example: date "Tue, 01 Apr, 2014", hour "23", min "59"
      *
-     * @param date  date in format "EEE, dd MMM, yyyy"
-     * @param hour  hour-of-day (0-23)
-     * @param min   minute-of-hour (0-59)
-     * @return      the parsed {@code LocalDateTime} object, or {@code null} if there are errors
+     * @param date date in format "EEE, dd MMM, yyyy"
+     * @param hour hour-of-day (0-23)
+     * @param min  minute-of-hour (0-59)
+     * @return the parsed {@code LocalDateTime} object, or {@code null} if there are errors
      */
-    public static LocalDateTime parseLocalDateTimeForSessionsForm(String date, String hour, String min) {
-        LocalDate localDate = parseLocalDateForSessionsForm(date);
+    public static LocalDateTime parseDateTimeFromSessionsForm(String date, String hour, String min) {
+        LocalDate localDate = parseDateFromSessionsForm(date);
         if (localDate == null) {
             return null;
         }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -174,7 +174,7 @@ public final class TimeHelper {
     /**
      * Returns an Instant that is offset by a number of days from now.
      *
-     * @param offsetInDays integer number of days offset by
+     * @param offsetInDays integer number of days to offset by
      * @return an Instant offset by {@code offsetInDays} days
      */
     public static Instant getInstantDaysOffsetFromNow(long offsetInDays) {

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -237,7 +237,7 @@ public class EmailGenerator {
                 "${deadline}", SanitizationHelper.sanitizeForHtml(session.getEndTimeString()),
                 "${submitUrl}", submitUrl,
                 "${timeStamp}", SanitizationHelper.sanitizeForHtml(
-                        TimeHelper.formatDateTimeForHomePage(timestamp, session.getTimeZone())),
+                        TimeHelper.formatDateTimeForDisplayFull(timestamp, session.getTimeZone())),
                 "${additionalContactInformation}", additionalContactInformation);
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(userEmail);

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -237,7 +237,7 @@ public class EmailGenerator {
                 "${deadline}", SanitizationHelper.sanitizeForHtml(session.getEndTimeString()),
                 "${submitUrl}", submitUrl,
                 "${timeStamp}", SanitizationHelper.sanitizeForHtml(
-                        TimeHelper.formatDateTimeForSessions(timestamp, session.getTimeZone())),
+                        TimeHelper.formatDateTimeForHomePage(timestamp, session.getTimeZone())),
                 "${additionalContactInformation}", additionalContactInformation);
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(userEmail);

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -237,7 +237,7 @@ public class EmailGenerator {
                 "${deadline}", SanitizationHelper.sanitizeForHtml(session.getEndTimeString()),
                 "${submitUrl}", submitUrl,
                 "${timeStamp}", SanitizationHelper.sanitizeForHtml(
-                        TimeHelper.formatDateTimeForDisplayFull(timestamp, session.getTimeZone())),
+                        TimeHelper.formatDateTimeForDisplay(timestamp, session.getTimeZone())),
                 "${additionalContactInformation}", additionalContactInformation);
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(userEmail);

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -159,10 +159,10 @@ public class AdminActivityLogPageAction extends Action {
             targetTimeZone = Const.SystemParams.ADMIN_TIME_ZONE;
         }
 
-        String timeInAdminTimeZone = TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime),
+        String timeInAdminTimeZone = TimeHelper.formatDateTimeForAdminLog(Instant.ofEpochMilli(earliestSearchTime),
                 Const.SystemParams.ADMIN_TIME_ZONE);
         String timeInUserTimeZone =
-                TimeHelper.formatActivityLogTime(Instant.ofEpochMilli(earliestSearchTime), targetTimeZone);
+                TimeHelper.formatDateTimeForAdminLog(Instant.ofEpochMilli(earliestSearchTime), targetTimeZone);
 
         status.append("The earliest log entry checked on <b>" + timeInAdminTimeZone + "</b> in Admin Time Zone ("
                 + Const.SystemParams.ADMIN_TIME_ZONE.getId() + ") and ");
@@ -350,7 +350,7 @@ public class AdminActivityLogPageAction extends Action {
             return "Local Time Unavailable";
         }
         Instant logInstant = Instant.ofEpochMilli(Long.parseLong(logUnixTimeMillis));
-        return TimeHelper.formatActivityLogTime(logInstant, timeZone) + " [" + timeZone.getId() + "]";
+        return TimeHelper.formatDateTimeForAdminLog(logInstant, timeZone) + " [" + timeZone.getId() + "]";
     }
 
 }

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -97,8 +97,8 @@ public class AdminSessionsPageAction extends Action {
             String endMin = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDMINUTE);
             String timeZone = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_TIMEZONE);
 
-            this.rangeStart = TimeHelper.parseLocalDateTimeForSessionsForm(startDate, startHour, startMin);
-            this.rangeEnd = TimeHelper.parseLocalDateTimeForSessionsForm(endDate, endHour, endMin);
+            this.rangeStart = TimeHelper.parseDateTimeFromSessionsForm(startDate, startHour, startMin);
+            this.rangeEnd = TimeHelper.parseDateTimeFromSessionsForm(endDate, endHour, endMin);
             this.timeZone = TimeHelper.parseZoneId(timeZone);
             // validate parsed filter fields
             if (this.rangeStart == null || this.rangeEnd == null || this.timeZone == null) {

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
@@ -52,10 +52,10 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
                 .withTimeZone(course.getTimeZone())
                 .build();
 
-        inputStartTimeLocal = TimeHelper.combineDateTime(
+        inputStartTimeLocal = TimeHelper.parseDateTimeFromSessionsForm(
                 getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTDATE),
                 getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_STARTTIME));
-        inputEndTimeLocal = TimeHelper.combineDateTime(
+        inputEndTimeLocal = TimeHelper.parseDateTimeFromSessionsForm(
                 getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDDATE),
                 getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_ENDTIME));
         attributes.setStartTime(TimeHelper.convertLocalDateTimeToInstant(inputStartTimeLocal, attributes.getTimeZone()));
@@ -73,7 +73,7 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
         String type = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_RESULTSVISIBLEBUTTON);
         switch (type) {
         case Const.INSTRUCTOR_FEEDBACK_RESULTS_VISIBLE_TIME_CUSTOM:
-            inputPublishTimeLocal = TimeHelper.combineDateTime(
+            inputPublishTimeLocal = TimeHelper.parseDateTimeFromSessionsForm(
                     getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHDATE),
                     getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_PUBLISHTIME));
             attributes.setResultsVisibleFromTime(TimeHelper.convertLocalDateTimeToInstant(
@@ -92,7 +92,7 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
         type = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_SESSIONVISIBLEBUTTON);
         switch (type) {
         case Const.INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_CUSTOM:
-            inputVisibleTimeLocal = TimeHelper.combineDateTime(
+            inputVisibleTimeLocal = TimeHelper.parseDateTimeFromSessionsForm(
                     getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLEDATE),
                     getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_VISIBLETIME));
             attributes.setSessionVisibleFromTime(TimeHelper.convertLocalDateTimeToInstant(

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
@@ -141,7 +141,8 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
             return;
         case GAP:
             String gapWarningText = String.format(Const.StatusMessages.AMBIGUOUS_LOCAL_DATE_TIME_GAP, fieldName,
-                    TimeHelper.formatDateTimeForDisplay(dateTime), TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
+                    TimeHelper.formatDateTimeForDisplay(dateTime),
+                    TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
             statusToUser.add(new StatusMessage(gapWarningText, StatusMessageColor.WARNING));
             break;
         case OVERLAP:

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
@@ -142,7 +142,7 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
         case GAP:
             String gapWarningText = String.format(Const.StatusMessages.AMBIGUOUS_LOCAL_DATE_TIME_GAP, fieldName,
                     TimeHelper.formatDateTimeForDisplay(dateTime),
-                    TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
+                    TimeHelper.formatDateTimeForDisplayFull(resolved, zone));
             statusToUser.add(new StatusMessage(gapWarningText, StatusMessageColor.WARNING));
             break;
         case OVERLAP:
@@ -150,9 +150,9 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
             Instant laterInterpretation = dateTime.atZone(zone).withLaterOffsetAtOverlap().toInstant();
             String overlapWarningText = String.format(Const.StatusMessages.AMBIGUOUS_LOCAL_DATE_TIME_OVERLAP, fieldName,
                     TimeHelper.formatDateTimeForDisplay(dateTime),
-                    TimeHelper.formatDateTimeForDisambiguation(earlierInterpretation, zone),
-                    TimeHelper.formatDateTimeForDisambiguation(laterInterpretation, zone),
-                    TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
+                    TimeHelper.formatDateTimeForDisplayFull(earlierInterpretation, zone),
+                    TimeHelper.formatDateTimeForDisplayFull(laterInterpretation, zone),
+                    TimeHelper.formatDateTimeForDisplayFull(resolved, zone));
             statusToUser.add(new StatusMessage(overlapWarningText, StatusMessageColor.WARNING));
             break;
         default:

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAbstractAction.java
@@ -141,14 +141,14 @@ public abstract class InstructorFeedbackAbstractAction extends Action {
             return;
         case GAP:
             String gapWarningText = String.format(Const.StatusMessages.AMBIGUOUS_LOCAL_DATE_TIME_GAP, fieldName,
-                    TimeHelper.formatTime12H(dateTime), TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
+                    TimeHelper.formatDateTimeForDisplay(dateTime), TimeHelper.formatDateTimeForDisambiguation(resolved, zone));
             statusToUser.add(new StatusMessage(gapWarningText, StatusMessageColor.WARNING));
             break;
         case OVERLAP:
             Instant earlierInterpretation = dateTime.atZone(zone).withEarlierOffsetAtOverlap().toInstant();
             Instant laterInterpretation = dateTime.atZone(zone).withLaterOffsetAtOverlap().toInstant();
             String overlapWarningText = String.format(Const.StatusMessages.AMBIGUOUS_LOCAL_DATE_TIME_OVERLAP, fieldName,
-                    TimeHelper.formatTime12H(dateTime),
+                    TimeHelper.formatDateTimeForDisplay(dateTime),
                     TimeHelper.formatDateTimeForDisambiguation(earlierInterpretation, zone),
                     TimeHelper.formatDateTimeForDisambiguation(laterInterpretation, zone),
                     TimeHelper.formatDateTimeForDisambiguation(resolved, zone));

--- a/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSessionsPageData.java
@@ -81,11 +81,11 @@ public class AdminSessionsPageData extends PageData {
     }
 
     public String getRangeStartString() {
-        return TimeHelper.formatTime12H(rangeStart);
+        return TimeHelper.formatDateTimeForDisplay(rangeStart);
     }
 
     public String getRangeEndString() {
-        return TimeHelper.formatTime12H(rangeEnd);
+        return TimeHelper.formatDateTimeForDisplay(rangeEnd);
     }
 
     public List<InstitutionPanel> getInstitutionPanels() {
@@ -173,9 +173,9 @@ public class AdminSessionsPageData extends PageData {
                             feedbackSession.getCourseId(),
                             feedbackSession.getFeedbackSessionName(),
                             googleId),
-                    TimeHelper.formatTime12H(feedbackSession.getStartTimeLocal()),
+                    TimeHelper.formatDateTimeForDisplay(feedbackSession.getStartTimeLocal()),
                     feedbackSession.getStartTimeInIso8601UtcFormat(),
-                    TimeHelper.formatTime12H(feedbackSession.getEndTimeLocal()),
+                    TimeHelper.formatDateTimeForDisplay(feedbackSession.getEndTimeLocal()),
                     feedbackSession.getEndTimeInIso8601UtcFormat(),
                     getInstructorHomePageViewLink(googleId),
                     feedbackSession.getCreatorEmail(),

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
@@ -95,9 +95,9 @@ public class InstructorFeedbackResponseCommentAjaxPageData extends PageData {
     public String createEditedCommentDetails(String giverName, String editorName) {
         boolean isGiverAnonymous = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT.equals(giverName);
         return "From: " + giverName + " ["
-                + TimeHelper.formatDateTimeForDisplayFull(comment.createdAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForDisplay(comment.createdAt, sessionTimeZone)
                 + "] (last edited " + (isGiverAnonymous ? "" : "by " + editorName + " ") + "at "
-                + TimeHelper.formatDateTimeForDisplayFull(comment.lastEditedAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForDisplay(comment.lastEditedAt, sessionTimeZone)
                 + ")";
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
@@ -95,9 +95,9 @@ public class InstructorFeedbackResponseCommentAjaxPageData extends PageData {
     public String createEditedCommentDetails(String giverName, String editorName) {
         boolean isGiverAnonymous = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT.equals(giverName);
         return "From: " + giverName + " ["
-                + TimeHelper.formatDateTimeForSessions(comment.createdAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForHomePage(comment.createdAt, sessionTimeZone)
                 + "] (last edited " + (isGiverAnonymous ? "" : "by " + editorName + " ") + "at "
-                + TimeHelper.formatDateTimeForSessions(comment.lastEditedAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForHomePage(comment.lastEditedAt, sessionTimeZone)
                 + ")";
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorFeedbackResponseCommentAjaxPageData.java
@@ -95,9 +95,9 @@ public class InstructorFeedbackResponseCommentAjaxPageData extends PageData {
     public String createEditedCommentDetails(String giverName, String editorName) {
         boolean isGiverAnonymous = Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT.equals(giverName);
         return "From: " + giverName + " ["
-                + TimeHelper.formatDateTimeForHomePage(comment.createdAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForDisplayFull(comment.createdAt, sessionTimeZone)
                 + "] (last edited " + (isGiverAnonymous ? "" : "by " + editorName + " ") + "at "
-                + TimeHelper.formatDateTimeForHomePage(comment.lastEditedAt, sessionTimeZone)
+                + TimeHelper.formatDateTimeForDisplayFull(comment.lastEditedAt, sessionTimeZone)
                 + ")";
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -130,10 +130,10 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
                     getInstructorPublishedStatusForFeedbackSession(session),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getStartTimeLocal()),
                     session.getStartTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForSessions(session.getStartTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForHomePage(session.getStartTime(), session.getTimeZone()),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getEndTimeLocal()),
                     session.getEndTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForSessions(session.getEndTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone()),
                     getInstructorFeedbackStatsLink(session.getCourseId(), session.getFeedbackSessionName()),
                     getInstructorFeedbackSessionActions(
                             session, Const.ActionURIs.INSTRUCTOR_HOME_PAGE, instructor));

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -130,10 +130,10 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
                     getInstructorPublishedStatusForFeedbackSession(session),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getStartTimeLocal()),
                     session.getStartTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForDisplayFull(session.getStartTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplay(session.getStartTime(), session.getTimeZone()),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getEndTimeLocal()),
                     session.getEndTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplay(session.getEndTime(), session.getTimeZone()),
                     getInstructorFeedbackStatsLink(session.getCourseId(), session.getFeedbackSessionName()),
                     getInstructorFeedbackSessionActions(
                             session, Const.ActionURIs.INSTRUCTOR_HOME_PAGE, instructor));

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -130,10 +130,10 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
                     getInstructorPublishedStatusForFeedbackSession(session),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getStartTimeLocal()),
                     session.getStartTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForHomePage(session.getStartTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplayFull(session.getStartTime(), session.getTimeZone()),
                     TimeHelper.formatDateTimeForInstructorHomePage(session.getEndTimeLocal()),
                     session.getEndTimeInIso8601UtcFormat(),
-                    TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone()),
                     getInstructorFeedbackStatsLink(session.getCourseId(), session.getFeedbackSessionName()),
                     getInstructorFeedbackSessionActions(
                             session, Const.ActionURIs.INSTRUCTOR_HOME_PAGE, instructor));

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -70,7 +70,7 @@ public class StudentHomePageData extends PageData {
                     getStudentPublishedTooltipForSession(feedbackSession),
                     getStudentSubmissionStatusForSession(feedbackSession, hasSubmitted),
                     getStudentPublishedStatusForSession(feedbackSession),
-                    TimeHelper.formatDateTimeForSessions(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
+                    TimeHelper.formatDateTimeForHomePage(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
                     feedbackSession.getEndTimeInIso8601UtcFormat(),
                     getStudentFeedbackSessionActions(feedbackSession, hasSubmitted),
                     sessionIdx));

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -70,7 +70,7 @@ public class StudentHomePageData extends PageData {
                     getStudentPublishedTooltipForSession(feedbackSession),
                     getStudentSubmissionStatusForSession(feedbackSession, hasSubmitted),
                     getStudentPublishedStatusForSession(feedbackSession),
-                    TimeHelper.formatDateTimeForHomePage(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplayFull(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
                     feedbackSession.getEndTimeInIso8601UtcFormat(),
                     getStudentFeedbackSessionActions(feedbackSession, hasSubmitted),
                     sessionIdx));

--- a/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
+++ b/src/main/java/teammates/ui/pagedata/StudentHomePageData.java
@@ -70,7 +70,7 @@ public class StudentHomePageData extends PageData {
                     getStudentPublishedTooltipForSession(feedbackSession),
                     getStudentSubmissionStatusForSession(feedbackSession, hasSubmitted),
                     getStudentPublishedStatusForSession(feedbackSession),
-                    TimeHelper.formatDateTimeForDisplayFull(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
+                    TimeHelper.formatDateTimeForDisplay(feedbackSession.getEndTime(), feedbackSession.getTimeZone()),
                     feedbackSession.getEndTimeInIso8601UtcFormat(),
                     getStudentFeedbackSessionActions(feedbackSession, hasSubmitted),
                     sessionIdx));

--- a/src/main/java/teammates/ui/template/AdminAccountManagementAccountTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminAccountManagementAccountTableRow.java
@@ -35,7 +35,7 @@ public class AdminAccountManagementAccountTableRow {
     }
 
     public String getCreatedAt() {
-        return TimeHelper.formatTime12H(TimeHelper.convertInstantToLocalDateTime(
+        return TimeHelper.formatDateTimeForDisplay(TimeHelper.convertInstantToLocalDateTime(
                 account.createdAt, Const.SystemParams.ADMIN_TIME_ZONE));
     }
 

--- a/src/main/java/teammates/ui/template/AdminActivityLogTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminActivityLogTableRow.java
@@ -112,7 +112,7 @@ public class AdminActivityLogTableRow {
 
     public String getDisplayedLogTime() {
         Instant logInstant = Instant.ofEpochMilli(activityLog.getLogTime());
-        return TimeHelper.formatActivityLogTime(logInstant, Const.SystemParams.ADMIN_TIME_ZONE);
+        return TimeHelper.formatDateTimeForAdminLog(logInstant, Const.SystemParams.ADMIN_TIME_ZONE);
     }
 
     public String getDisplayedRole() {

--- a/src/main/java/teammates/ui/template/AdminEmailTableRow.java
+++ b/src/main/java/teammates/ui/template/AdminEmailTableRow.java
@@ -22,7 +22,7 @@ public class AdminEmailTableRow {
     // -------- Enhancement to fields in EmailLogEntry --------
 
     public String getTimeForDisplay() {
-        return TimeHelper.formatTime12H(TimeHelper.convertInstantToLocalDateTime(
+        return TimeHelper.formatDateTimeForDisplay(TimeHelper.convertInstantToLocalDateTime(
                 Instant.ofEpochMilli(emailEntry.getTime()), Const.SystemParams.ADMIN_TIME_ZONE));
     }
 

--- a/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
@@ -45,7 +45,7 @@ public class FeedbackResponseCommentRow {
         this.commentId = frc.getId();
         this.giverDisplay = giverDisplay;
         this.sessionTimeZone = sessionTimeZone;
-        this.createdAt = TimeHelper.formatDateTimeForSessions(frc.createdAt, this.sessionTimeZone);
+        this.createdAt = TimeHelper.formatDateTimeForHomePage(frc.createdAt, this.sessionTimeZone);
         this.commentText = frc.commentText.getValue();
 
         //TODO TO REMOVE AFTER DATA MIGRATION
@@ -265,6 +265,6 @@ public class FeedbackResponseCommentRow {
                 + (isGiverAnonymous
                     ? ""
                     : "by " + SanitizationHelper.sanitizeForHtml(instructorEmailNameTable.get(lastEditorEmail)) + " ")
-                + "at " + TimeHelper.formatDateTimeForSessions(lastEditedAt, sessionTimeZone) + ")";
+                + "at " + TimeHelper.formatDateTimeForHomePage(lastEditedAt, sessionTimeZone) + ")";
     }
 }

--- a/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
@@ -45,7 +45,7 @@ public class FeedbackResponseCommentRow {
         this.commentId = frc.getId();
         this.giverDisplay = giverDisplay;
         this.sessionTimeZone = sessionTimeZone;
-        this.createdAt = TimeHelper.formatDateTimeForHomePage(frc.createdAt, this.sessionTimeZone);
+        this.createdAt = TimeHelper.formatDateTimeForDisplayFull(frc.createdAt, this.sessionTimeZone);
         this.commentText = frc.commentText.getValue();
 
         //TODO TO REMOVE AFTER DATA MIGRATION
@@ -265,6 +265,6 @@ public class FeedbackResponseCommentRow {
                 + (isGiverAnonymous
                     ? ""
                     : "by " + SanitizationHelper.sanitizeForHtml(instructorEmailNameTable.get(lastEditorEmail)) + " ")
-                + "at " + TimeHelper.formatDateTimeForHomePage(lastEditedAt, sessionTimeZone) + ")";
+                + "at " + TimeHelper.formatDateTimeForDisplayFull(lastEditedAt, sessionTimeZone) + ")";
     }
 }

--- a/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
+++ b/src/main/java/teammates/ui/template/FeedbackResponseCommentRow.java
@@ -45,7 +45,7 @@ public class FeedbackResponseCommentRow {
         this.commentId = frc.getId();
         this.giverDisplay = giverDisplay;
         this.sessionTimeZone = sessionTimeZone;
-        this.createdAt = TimeHelper.formatDateTimeForDisplayFull(frc.createdAt, this.sessionTimeZone);
+        this.createdAt = TimeHelper.formatDateTimeForDisplay(frc.createdAt, this.sessionTimeZone);
         this.commentText = frc.commentText.getValue();
 
         //TODO TO REMOVE AFTER DATA MIGRATION
@@ -265,6 +265,6 @@ public class FeedbackResponseCommentRow {
                 + (isGiverAnonymous
                     ? ""
                     : "by " + SanitizationHelper.sanitizeForHtml(instructorEmailNameTable.get(lastEditorEmail)) + " ")
-                + "at " + TimeHelper.formatDateTimeForDisplayFull(lastEditedAt, sessionTimeZone) + ")";
+                + "at " + TimeHelper.formatDateTimeForDisplay(lastEditedAt, sessionTimeZone) + ")";
     }
 }

--- a/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
+++ b/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
@@ -26,8 +26,8 @@ public class InstructorFeedbackResultsSessionPanel {
         this.courseId = SanitizationHelper.sanitizeForHtml(session.getCourseId());
         this.feedbackSessionName = SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName());
         this.editLink = editLink;
-        this.startTime = TimeHelper.formatDateTimeForSessions(session.getStartTime(), session.getTimeZone());
-        this.endTime = TimeHelper.formatDateTimeForSessions(session.getEndTime(), session.getTimeZone());
+        this.startTime = TimeHelper.formatDateTimeForHomePage(session.getStartTime(), session.getTimeZone());
+        this.endTime = TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone());
         this.resultsVisibleFrom = getResultsVisibleFromText(session);
         this.feedbackSessionPublishButton = feedbackSessionPublishButton;
         this.selectedSection = selectedSection;
@@ -78,15 +78,15 @@ public class InstructorFeedbackResultsSessionPanel {
     private String getResultsVisibleFromText(FeedbackSessionAttributes feedbackSession) {
         if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)) {
             if (feedbackSession.getSessionVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
-                return TimeHelper.formatDateTimeForSessions(feedbackSession.getStartTime(), feedbackSession.getTimeZone());
+                return TimeHelper.formatDateTimeForHomePage(feedbackSession.getStartTime(), feedbackSession.getTimeZone());
             } else {
-                return TimeHelper.formatDateTimeForSessions(
+                return TimeHelper.formatDateTimeForHomePage(
                         feedbackSession.getSessionVisibleFromTime(), feedbackSession.getTimeZone());
             }
         } else if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_LATER)) {
             return "I want to manually publish the results.";
         } else {
-            return TimeHelper.formatDateTimeForSessions(
+            return TimeHelper.formatDateTimeForHomePage(
                     feedbackSession.getResultsVisibleFromTime(), feedbackSession.getTimeZone());
         }
     }

--- a/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
+++ b/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
@@ -26,8 +26,8 @@ public class InstructorFeedbackResultsSessionPanel {
         this.courseId = SanitizationHelper.sanitizeForHtml(session.getCourseId());
         this.feedbackSessionName = SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName());
         this.editLink = editLink;
-        this.startTime = TimeHelper.formatDateTimeForHomePage(session.getStartTime(), session.getTimeZone());
-        this.endTime = TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone());
+        this.startTime = TimeHelper.formatDateTimeForDisplayFull(session.getStartTime(), session.getTimeZone());
+        this.endTime = TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone());
         this.resultsVisibleFrom = getResultsVisibleFromText(session);
         this.feedbackSessionPublishButton = feedbackSessionPublishButton;
         this.selectedSection = selectedSection;
@@ -78,15 +78,16 @@ public class InstructorFeedbackResultsSessionPanel {
     private String getResultsVisibleFromText(FeedbackSessionAttributes feedbackSession) {
         if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)) {
             if (feedbackSession.getSessionVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
-                return TimeHelper.formatDateTimeForHomePage(feedbackSession.getStartTime(), feedbackSession.getTimeZone());
+                return TimeHelper.formatDateTimeForDisplayFull(
+                        feedbackSession.getStartTime(), feedbackSession.getTimeZone());
             } else {
-                return TimeHelper.formatDateTimeForHomePage(
+                return TimeHelper.formatDateTimeForDisplayFull(
                         feedbackSession.getSessionVisibleFromTime(), feedbackSession.getTimeZone());
             }
         } else if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_LATER)) {
             return "I want to manually publish the results.";
         } else {
-            return TimeHelper.formatDateTimeForHomePage(
+            return TimeHelper.formatDateTimeForDisplayFull(
                     feedbackSession.getResultsVisibleFromTime(), feedbackSession.getTimeZone());
         }
     }

--- a/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
+++ b/src/main/java/teammates/ui/template/InstructorFeedbackResultsSessionPanel.java
@@ -26,8 +26,8 @@ public class InstructorFeedbackResultsSessionPanel {
         this.courseId = SanitizationHelper.sanitizeForHtml(session.getCourseId());
         this.feedbackSessionName = SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName());
         this.editLink = editLink;
-        this.startTime = TimeHelper.formatDateTimeForDisplayFull(session.getStartTime(), session.getTimeZone());
-        this.endTime = TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone());
+        this.startTime = TimeHelper.formatDateTimeForDisplay(session.getStartTime(), session.getTimeZone());
+        this.endTime = TimeHelper.formatDateTimeForDisplay(session.getEndTime(), session.getTimeZone());
         this.resultsVisibleFrom = getResultsVisibleFromText(session);
         this.feedbackSessionPublishButton = feedbackSessionPublishButton;
         this.selectedSection = selectedSection;
@@ -78,16 +78,16 @@ public class InstructorFeedbackResultsSessionPanel {
     private String getResultsVisibleFromText(FeedbackSessionAttributes feedbackSession) {
         if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)) {
             if (feedbackSession.getSessionVisibleFromTime().equals(Const.TIME_REPRESENTS_FOLLOW_OPENING)) {
-                return TimeHelper.formatDateTimeForDisplayFull(
+                return TimeHelper.formatDateTimeForDisplay(
                         feedbackSession.getStartTime(), feedbackSession.getTimeZone());
             } else {
-                return TimeHelper.formatDateTimeForDisplayFull(
+                return TimeHelper.formatDateTimeForDisplay(
                         feedbackSession.getSessionVisibleFromTime(), feedbackSession.getTimeZone());
             }
         } else if (feedbackSession.getResultsVisibleFromTime().equals(Const.TIME_REPRESENTS_LATER)) {
             return "I want to manually publish the results.";
         } else {
-            return TimeHelper.formatDateTimeForDisplayFull(
+            return TimeHelper.formatDateTimeForDisplay(
                     feedbackSession.getResultsVisibleFromTime(), feedbackSession.getTimeZone());
         }
     }

--- a/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/AdminActivityLogPageActionTest.java
@@ -94,7 +94,7 @@ public class AdminActivityLogPageActionTest extends BaseActionTest {
     }
 
     private String getExpectedAjaxTimeString(Instant instant, ZoneId zoneId) {
-        return TimeHelper.formatActivityLogTime(instant, zoneId) + " [" + zoneId.getId() + "]";
+        return TimeHelper.formatDateTimeForAdminLog(instant, zoneId) + " [" + zoneId.getId() + "]";
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -218,8 +218,8 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         feedbackEditPage = getFeedbackEditPageOfSessionIndDstCourse();
         FeedbackSessionAttributes dstSession = testData.feedbackSessions.get("dstSession");
 
-        LocalDateTime overlapStartTime = TimeHelper.parseLocalDateTimeForSessionsForm("Sun, 05 Apr, 2015", "2", "0");
-        LocalDateTime gapEndTime = TimeHelper.parseLocalDateTimeForSessionsForm("Sun, 01 Oct, 2017", "2", "0");
+        LocalDateTime overlapStartTime = TimeHelper.parseDateTimeFromSessionsForm("Sun, 05 Apr, 2015", "2", "0");
+        LocalDateTime gapEndTime = TimeHelper.parseDateTimeFromSessionsForm("Sun, 01 Oct, 2017", "2", "0");
 
         feedbackEditPage.editFeedbackSession(overlapStartTime, gapEndTime,
                 dstSession.getInstructions(), dstSession.getGracePeriodMinutes());

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -240,7 +240,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         BackDoor.editCourse(course);
 
         String dstSessionName = "DST Session";
-        LocalDateTime gapStart = TimeHelper.parseLocalDateTimeForSessionsForm("Fri, 30 Dec, 2011", "7", "0");
+        LocalDateTime gapStart = TimeHelper.parseDateTimeFromSessionsForm("Fri, 30 Dec, 2011", "7", "0");
 
         feedbackPage = getFeedbackPageForInstructor(idOfInstructorWithSessions);
         feedbackPage.addFeedbackSession(
@@ -908,8 +908,8 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         String templateSessionName = "!Invalid name";
         feedbackPage.addFeedbackSession(
                 templateSessionName, newSession.getCourseId(),
-                TimeHelper.parseLocalDateTimeForSessionsForm("Sun, 01 Apr, 2035", "22", "00"),
-                TimeHelper.parseLocalDateTimeForSessionsForm("Mon, 30 Apr, 2035", "22", "00"),
+                TimeHelper.parseDateTimeFromSessionsForm("Sun, 01 Apr, 2035", "22", "00"),
+                TimeHelper.parseDateTimeFromSessionsForm("Mon, 30 Apr, 2035", "22", "00"),
                 null, null,
                 newSession.getInstructions(), newSession.getGracePeriodMinutes());
 
@@ -925,8 +925,8 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         templateSessionName = "!Invalid name";
         feedbackPage.addFeedbackSession(
                 templateSessionName, newSession.getCourseId(),
-                TimeHelper.parseLocalDateTimeForSessionsForm("Sun, 01 Apr, 2035", "10", "00"),
-                TimeHelper.parseLocalDateTimeForSessionsForm("Mon, 30 Apr, 2035", "22", "00"),
+                TimeHelper.parseDateTimeFromSessionsForm("Sun, 01 Apr, 2035", "10", "00"),
+                TimeHelper.parseDateTimeFromSessionsForm("Mon, 30 Apr, 2035", "22", "00"),
                 null, null,
                 newSession.getInstructions(), newSession.getGracePeriodMinutes());
 

--- a/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
@@ -260,7 +260,8 @@ public class AdminEmailAttributesTest extends BaseAttributesTest {
     @Test
     public void testSendDateForDisplay() {
         validAdminEmailAttributesObject.sendDate = Instant.now();
-        String expectedDate = TimeHelper.formatDateTimeForDisplay(convertToAdminTime(validAdminEmailAttributesObject.sendDate));
+        String expectedDate = TimeHelper.formatDateTimeForDisplay(
+                convertToAdminTime(validAdminEmailAttributesObject.sendDate));
         String actualDate = validAdminEmailAttributesObject.getSendDateForDisplay();
         assertEquals(expectedDate, actualDate);
     }
@@ -268,7 +269,8 @@ public class AdminEmailAttributesTest extends BaseAttributesTest {
     @Test
     public void testCreateDateForDisplay() {
         validAdminEmailAttributesObject.createDate = Instant.now();
-        String expectedDate = TimeHelper.formatDateTimeForDisplay(convertToAdminTime(validAdminEmailAttributesObject.createDate));
+        String expectedDate = TimeHelper.formatDateTimeForDisplay(
+                convertToAdminTime(validAdminEmailAttributesObject.createDate));
         String actualDate = validAdminEmailAttributesObject.getCreateDateForDisplay();
         assertEquals(expectedDate, actualDate);
     }

--- a/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
@@ -260,7 +260,7 @@ public class AdminEmailAttributesTest extends BaseAttributesTest {
     @Test
     public void testSendDateForDisplay() {
         validAdminEmailAttributesObject.sendDate = Instant.now();
-        String expectedDate = TimeHelper.formatTime12H(convertToAdminTime(validAdminEmailAttributesObject.sendDate));
+        String expectedDate = TimeHelper.formatDateTimeForDisplay(convertToAdminTime(validAdminEmailAttributesObject.sendDate));
         String actualDate = validAdminEmailAttributesObject.getSendDateForDisplay();
         assertEquals(expectedDate, actualDate);
     }
@@ -268,7 +268,7 @@ public class AdminEmailAttributesTest extends BaseAttributesTest {
     @Test
     public void testCreateDateForDisplay() {
         validAdminEmailAttributesObject.createDate = Instant.now();
-        String expectedDate = TimeHelper.formatTime12H(convertToAdminTime(validAdminEmailAttributesObject.createDate));
+        String expectedDate = TimeHelper.formatDateTimeForDisplay(convertToAdminTime(validAdminEmailAttributesObject.createDate));
         String actualDate = validAdminEmailAttributesObject.getCreateDateForDisplay();
         assertEquals(expectedDate, actualDate);
     }

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
@@ -28,9 +28,9 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
     public void classSetup() {
         ZoneId timeZone = ZoneId.of("Asia/Singapore");
         startTime = TimeHelper.convertLocalDateTimeToInstant(
-                TimeHelper.parseDateTimeFromSessionsForm("Mon, 09 May, 2016", "1000"), timeZone);
+                TimeHelper.parseDateTimeFromSessionsForm("Mon, 09 May, 2016", "10", "0"), timeZone);
         endTime = TimeHelper.convertLocalDateTimeToInstant(
-                TimeHelper.parseDateTimeFromSessionsForm("Tue, 09 May, 2017", "1000"), timeZone);
+                TimeHelper.parseDateTimeFromSessionsForm("Tue, 09 May, 2017", "10", "0"), timeZone);
 
         fsa = FeedbackSessionAttributes
                 .builder("", "", "")

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
@@ -28,9 +28,9 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
     public void classSetup() {
         ZoneId timeZone = ZoneId.of("Asia/Singapore");
         startTime = TimeHelper.convertLocalDateTimeToInstant(
-                TimeHelper.combineDateTime("Mon, 09 May, 2016", "1000"), timeZone);
+                TimeHelper.parseDateTimeFromSessionsForm("Mon, 09 May, 2016", "1000"), timeZone);
         endTime = TimeHelper.convertLocalDateTimeToInstant(
-                TimeHelper.combineDateTime("Tue, 09 May, 2017", "1000"), timeZone);
+                TimeHelper.parseDateTimeFromSessionsForm("Tue, 09 May, 2017", "1000"), timeZone);
 
         fsa = FeedbackSessionAttributes
                 .builder("", "", "")

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -131,7 +131,7 @@ public class StudentHomePageDataTest extends BaseTestCase {
             String expectedPublishedStatus) {
         StudentHomeFeedbackSessionRow studentRow = (StudentHomeFeedbackSessionRow) row;
         assertEquals(session.getFeedbackSessionName(), studentRow.getName());
-        assertEquals(TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone()),
+        assertEquals(TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone()),
                 studentRow.getEndTime());
         assertEquals(session.getEndTimeInIso8601UtcFormat(), studentRow.getEndTimeIso8601Utc());
         assertEquals(expectedSubmissionsTooltip, studentRow.getSubmissionsTooltip());

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -131,7 +131,7 @@ public class StudentHomePageDataTest extends BaseTestCase {
             String expectedPublishedStatus) {
         StudentHomeFeedbackSessionRow studentRow = (StudentHomeFeedbackSessionRow) row;
         assertEquals(session.getFeedbackSessionName(), studentRow.getName());
-        assertEquals(TimeHelper.formatDateTimeForDisplayFull(session.getEndTime(), session.getTimeZone()),
+        assertEquals(TimeHelper.formatDateTimeForDisplay(session.getEndTime(), session.getTimeZone()),
                 studentRow.getEndTime());
         assertEquals(session.getEndTimeInIso8601UtcFormat(), studentRow.getEndTimeIso8601Utc());
         assertEquals(expectedSubmissionsTooltip, studentRow.getSubmissionsTooltip());

--- a/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/StudentHomePageDataTest.java
@@ -131,7 +131,7 @@ public class StudentHomePageDataTest extends BaseTestCase {
             String expectedPublishedStatus) {
         StudentHomeFeedbackSessionRow studentRow = (StudentHomeFeedbackSessionRow) row;
         assertEquals(session.getFeedbackSessionName(), studentRow.getName());
-        assertEquals(TimeHelper.formatDateTimeForSessions(session.getEndTime(), session.getTimeZone()),
+        assertEquals(TimeHelper.formatDateTimeForHomePage(session.getEndTime(), session.getTimeZone()),
                 studentRow.getEndTime());
         assertEquals(session.getEndTimeInIso8601UtcFormat(), studentRow.getEndTimeIso8601Utc());
         assertEquals(expectedSubmissionsTooltip, studentRow.getSubmissionsTooltip());

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -60,7 +60,7 @@ public class TimeHelperTest extends BaseTestCase {
         LocalDateTime date = LocalDateTime.of(2015, Month.DECEMBER, 30, 12, 0);
         assertEquals("Wed, 30 Dec, 2015", TimeHelper.formatDateForSessionsForm(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatDateTimeForDisplay(date));
-        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForHomePage(
+        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplayFull(
                 date.atZone(ZoneId.of("UTC")).toInstant(), ZoneId.of("UTC")));
         assertEquals("30 Dec 12:00 NOON", TimeHelper.formatDateTimeForInstructorHomePage(date));
     }
@@ -69,16 +69,16 @@ public class TimeHelperTest extends BaseTestCase {
     public void testFormatDateTimeForSessions() {
         ZoneId zoneId = ZoneId.of("UTC");
         Instant instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 12, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForHomePage(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
 
         zoneId = ZoneId.of("Asia/Singapore");
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 16, 0).atZone(zoneId).toInstant();
         assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT",
-                TimeHelper.formatDateTimeForHomePage(instant, zoneId));
+                TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
 
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 4, 0).atZone(zoneId).toInstant();
         assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT",
-                TimeHelper.formatDateTimeForHomePage(instant, zoneId));
+                TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -19,40 +19,40 @@ import teammates.test.cases.BaseTestCase;
 public class TimeHelperTest extends BaseTestCase {
 
     @Test
-    public void testCombineDateTime() {
+    public void testParseDateTimeFromSessionsForm() {
         String testDate = "Fri, 01 Feb, 2013";
         String testTime = "0";
         LocalDateTime expectedOutput = LocalDateTime.of(2013, Month.FEBRUARY, 1, 0, 0);
 
         testTime = "0";
         ______TS("boundary case: time = 0");
-        assertEquals(expectedOutput, TimeHelper.combineDateTime(testDate, testTime));
+        assertEquals(expectedOutput, TimeHelper.parseDateTimeFromSessionsForm(testDate, testTime));
 
         ______TS("boundary case: time = 24");
         testTime = "24";
         expectedOutput = LocalDateTime.of(2013, Month.FEBRUARY, 1, 23, 59);
-        assertEquals(expectedOutput, TimeHelper.combineDateTime(testDate, testTime));
+        assertEquals(expectedOutput, TimeHelper.parseDateTimeFromSessionsForm(testDate, testTime));
 
         ______TS("negative time");
-        assertNull(TimeHelper.combineDateTime(testDate, "-5"));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(testDate, "-5"));
 
         ______TS("large time");
-        assertNull(TimeHelper.combineDateTime(testDate, "68"));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(testDate, "68"));
 
         ______TS("date null");
-        assertNull(TimeHelper.combineDateTime(null, testTime));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(null, testTime));
 
         ______TS("time null");
-        assertNull(TimeHelper.combineDateTime(testDate, null));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(testDate, null));
 
         ______TS("invalid time");
-        assertNull(TimeHelper.combineDateTime(testDate, "invalid time"));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(testDate, "invalid time"));
 
         ______TS("fractional time");
-        assertNull(TimeHelper.combineDateTime(testDate, "5.5"));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm(testDate, "5.5"));
 
         ______TS("invalid date");
-        assertNull(TimeHelper.combineDateTime("invalid date", testDate));
+        assertNull(TimeHelper.parseDateTimeFromSessionsForm("invalid date", testDate));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -58,7 +58,6 @@ public class TimeHelperTest extends BaseTestCase {
     @Test
     public void testEndOfYearDates() {
         LocalDateTime date = LocalDateTime.of(2015, Month.DECEMBER, 30, 12, 0);
-        assertEquals("30/12/2015", TimeHelper.formatDate(date));
         assertEquals("Wed, 30 Dec, 2015", TimeHelper.formatDateForSessionsForm(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatTime12H(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForSessions(

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -60,23 +60,23 @@ public class TimeHelperTest extends BaseTestCase {
         LocalDateTime date = LocalDateTime.of(2015, Month.DECEMBER, 30, 12, 0);
         assertEquals("Wed, 30 Dec, 2015", TimeHelper.formatDateForSessionsForm(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatDateTimeForDisplay(date));
-        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplayFull(
+        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplay(
                 date.atZone(ZoneId.of("UTC")).toInstant(), ZoneId.of("UTC")));
         assertEquals("30 Dec 12:00 NOON", TimeHelper.formatDateTimeForInstructorHomePage(date));
     }
 
     @Test
-    public void testFormatDateTimeForDisplayFull() {
+    public void testFormatDateTimeForDisplay() {
         ZoneId zoneId = ZoneId.of("UTC");
         Instant instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 12, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplay(instant, zoneId));
 
         zoneId = ZoneId.of("Asia/Singapore");
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 16, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT", TimeHelper.formatDateTimeForDisplay(instant, zoneId));
 
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 4, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT", TimeHelper.formatDateTimeForDisplay(instant, zoneId));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -59,7 +59,7 @@ public class TimeHelperTest extends BaseTestCase {
     public void testEndOfYearDates() {
         LocalDateTime date = LocalDateTime.of(2015, Month.DECEMBER, 30, 12, 0);
         assertEquals("Wed, 30 Dec, 2015", TimeHelper.formatDateForSessionsForm(date));
-        assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatTime12H(date));
+        assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatDateTimeForDisplay(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForSessions(
                 date.atZone(ZoneId.of("UTC")).toInstant(), ZoneId.of("UTC")));
         assertEquals("30 Dec 12:00 NOON", TimeHelper.formatDateTimeForInstructorHomePage(date));

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -60,7 +60,7 @@ public class TimeHelperTest extends BaseTestCase {
         LocalDateTime date = LocalDateTime.of(2015, Month.DECEMBER, 30, 12, 0);
         assertEquals("Wed, 30 Dec, 2015", TimeHelper.formatDateForSessionsForm(date));
         assertEquals("Wed, 30 Dec 2015, 12:00 NOON", TimeHelper.formatDateTimeForDisplay(date));
-        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForSessions(
+        assertEquals("Wed, 30 Dec 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForHomePage(
                 date.atZone(ZoneId.of("UTC")).toInstant(), ZoneId.of("UTC")));
         assertEquals("30 Dec 12:00 NOON", TimeHelper.formatDateTimeForInstructorHomePage(date));
     }
@@ -69,16 +69,16 @@ public class TimeHelperTest extends BaseTestCase {
     public void testFormatDateTimeForSessions() {
         ZoneId zoneId = ZoneId.of("UTC");
         Instant instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 12, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForSessions(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForHomePage(instant, zoneId));
 
         zoneId = ZoneId.of("Asia/Singapore");
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 16, 0).atZone(zoneId).toInstant();
         assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT",
-                TimeHelper.formatDateTimeForSessions(instant, zoneId));
+                TimeHelper.formatDateTimeForHomePage(instant, zoneId));
 
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 4, 0).atZone(zoneId).toInstant();
         assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT",
-                TimeHelper.formatDateTimeForSessions(instant, zoneId));
+                TimeHelper.formatDateTimeForHomePage(instant, zoneId));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/TimeHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/TimeHelperTest.java
@@ -66,19 +66,17 @@ public class TimeHelperTest extends BaseTestCase {
     }
 
     @Test
-    public void testFormatDateTimeForSessions() {
+    public void testFormatDateTimeForDisplayFull() {
         ZoneId zoneId = ZoneId.of("UTC");
         Instant instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 12, 0).atZone(zoneId).toInstant();
         assertEquals("Mon, 30 Nov 2015, 12:00 NOON UTC", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
 
         zoneId = ZoneId.of("Asia/Singapore");
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 16, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT",
-                TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 04:00 PM SGT", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
 
         instant = LocalDateTime.of(2015, Month.NOVEMBER, 30, 4, 0).atZone(zoneId).toInstant();
-        assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT",
-                TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
+        assertEquals("Mon, 30 Nov 2015, 04:00 AM SGT", TimeHelper.formatDateTimeForDisplayFull(instant, zoneId));
     }
 
     @Test

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -523,7 +523,7 @@ public final class HtmlHelper {
                 .replace("<!-- now.datetime -->", TimeHelper.formatDateTimeForDisplay(
                         TimeHelper.convertInstantToLocalDateTime(now, Const.DEFAULT_TIME_ZONE)))
                 .replace("<!-- now.datetime.sessions -->",
-                        TimeHelper.formatDateTimeForHomePage(now, Const.DEFAULT_TIME_ZONE))
+                        TimeHelper.formatDateTimeForDisplayFull(now, Const.DEFAULT_TIME_ZONE))
                 .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateTimeToIso8601Utc(now))
                 .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateForInstructorCoursesPage(
                         now, Const.DEFAULT_TIME_ZONE));

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -520,7 +520,7 @@ public final class HtmlHelper {
                         StringHelper.truncateLongId(TestProperties.TEST_INSTRUCTOR_ACCOUNT))
                 .replace("<!-- test.admin -->", TestProperties.TEST_ADMIN_ACCOUNT)
                 .replace("<!-- test.admin.truncated -->", StringHelper.truncateLongId(TestProperties.TEST_ADMIN_ACCOUNT))
-                .replace("<!-- now.datetime -->", TimeHelper.formatTime12H(
+                .replace("<!-- now.datetime -->", TimeHelper.formatDateTimeForDisplay(
                         TimeHelper.convertInstantToLocalDateTime(now, Const.DEFAULT_TIME_ZONE)))
                 .replace("<!-- now.datetime.sessions -->",
                         TimeHelper.formatDateTimeForSessions(now, Const.DEFAULT_TIME_ZONE))

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -523,7 +523,7 @@ public final class HtmlHelper {
                 .replace("<!-- now.datetime -->", TimeHelper.formatDateTimeForDisplay(
                         TimeHelper.convertInstantToLocalDateTime(now, Const.DEFAULT_TIME_ZONE)))
                 .replace("<!-- now.datetime.sessions -->",
-                        TimeHelper.formatDateTimeForDisplayFull(now, Const.DEFAULT_TIME_ZONE))
+                        TimeHelper.formatDateTimeForDisplay(now, Const.DEFAULT_TIME_ZONE))
                 .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateTimeToIso8601Utc(now))
                 .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateForInstructorCoursesPage(
                         now, Const.DEFAULT_TIME_ZONE));

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -524,7 +524,7 @@ public final class HtmlHelper {
                         TimeHelper.convertInstantToLocalDateTime(now, Const.DEFAULT_TIME_ZONE)))
                 .replace("<!-- now.datetime.sessions -->",
                         TimeHelper.formatDateTimeForSessions(now, Const.DEFAULT_TIME_ZONE))
-                .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatInstantToIso8601Utc(now))
+                .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateTimeToIso8601Utc(now))
                 .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateTimeForInstructorCoursesPage(
                         now, Const.DEFAULT_TIME_ZONE));
     }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -525,7 +525,7 @@ public final class HtmlHelper {
                 .replace("<!-- now.datetime.sessions -->",
                         TimeHelper.formatDateTimeForHomePage(now, Const.DEFAULT_TIME_ZONE))
                 .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateTimeToIso8601Utc(now))
-                .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateTimeForInstructorCoursesPage(
+                .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateForInstructorCoursesPage(
                         now, Const.DEFAULT_TIME_ZONE));
     }
 

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -523,7 +523,7 @@ public final class HtmlHelper {
                 .replace("<!-- now.datetime -->", TimeHelper.formatDateTimeForDisplay(
                         TimeHelper.convertInstantToLocalDateTime(now, Const.DEFAULT_TIME_ZONE)))
                 .replace("<!-- now.datetime.sessions -->",
-                        TimeHelper.formatDateTimeForSessions(now, Const.DEFAULT_TIME_ZONE))
+                        TimeHelper.formatDateTimeForHomePage(now, Const.DEFAULT_TIME_ZONE))
                 .replace("<!-- now.datetime.iso8601utc -->", TimeHelper.formatDateTimeToIso8601Utc(now))
                 .replace("<!-- now.datetime.courses -->", TimeHelper.formatDateTimeForInstructorCoursesPage(
                         now, Const.DEFAULT_TIME_ZONE));

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -123,7 +123,7 @@ public class AdminActivityLogPage extends AppPage {
     public Instant getDateOfEarliestLog() {
         String dateTimeString = getLogsTable().findElement(By.cssSelector("tr:last-child > td > a")).getText();
 
-        return TimeHelper.parseLocalDateTime(dateTimeString, "dd/MM/yyyy HH:mm:ss.SSS")
+        return TimeHelper.parseLocalDateTime(dateTimeString, TimeHelper.STAMP_DATETIME_ADMIN_LOG)
                 .atZone(Const.SystemParams.ADMIN_TIME_ZONE).toInstant();
 
     }

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -123,7 +123,7 @@ public class AdminActivityLogPage extends AppPage {
     public Instant getDateOfEarliestLog() {
         String dateTimeString = getLogsTable().findElement(By.cssSelector("tr:last-child > td > a")).getText();
 
-        return TimeHelper.parseLocalDateTime(dateTimeString, TimeHelper.STAMP_DATETIME_ADMIN_LOG)
+        return TimeHelper.parseLocalDateTime(dateTimeString, "dd/MM/yyyy HH:mm:ss.SSS")
                 .atZone(Const.SystemParams.ADMIN_TIME_ZONE).toInstant();
 
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -972,7 +972,7 @@ public class InstructorFeedbackEditPage extends AppPage {
     private boolean navigate(WebElement dateBox, LocalDate date) throws ParseException {
 
         click(dateBox);
-        LocalDate selectedDate = TimeHelper.parseLocalDateForSessionsForm(dateBox.getAttribute("value"));
+        LocalDate selectedDate = TimeHelper.parseDateFromSessionsForm(dateBox.getAttribute("value"));
         String month = date.getMonth().getDisplayName(TextStyle.FULL, Locale.ENGLISH);
         String year = Integer.toString(date.getYear());
 


### PR DESCRIPTION
Fixes #8780 

This PR touches a lot of files due to the renaming of methods in `TimeHelper`. There are no changes in logic made by this PR.

### Outline
- Remove `formatDate`: it's not used anywhere other than a unit test for itself.
- Standardize method naming: they should now follow the form `(verb)(date|datetime|object)[(direction)(destination|object)]` for clarity on their intended purpose and behavior.
- Some methods have to be renamed to accurately reflect what is expected/returned.
For example, this is before:
```java 
formatTime12H
formatDateTimeForInstructorCoursesPage // this method returns a date stamp, not a datetime stamp
formatActivityLogTime // this is only used in admin-facing pages
formatInstantToIso8601Utc // this makes a ISO 8601 datetime stamp
```

And after, in the same order:
```
formatDateTimeForDisplay
formatDateForInstructorCoursesPage
formatDateTimeForAdminLog
formatDateTimeToIso8601Utc
```

- Some methods are rearranged for sensible grouping in the class.
- Deprecated methods are not changed since they will be removed anyway.
- Add/update javadocs:
    - Standardize use of annotations
    - Standardize phrasing, examples