### PR TITLE
Remove JS coverage requirement #8768

### DIFF
--- a/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
+++ b/src/test/java/teammates/test/cases/browsertests/AllJsTests.java
@@ -13,8 +13,6 @@ import teammates.test.pageobjects.QUnitPage;
  */
 public class AllJsTests extends BaseUiTestCase {
 
-    private static final float MIN_COVERAGE_REQUIREMENT = 36.85f;
-
     private QUnitPage page;
 
     @Override
@@ -49,13 +47,12 @@ public class AllJsTests extends BaseUiTestCase {
             return;
         }
 
-        page.navigateTo(createUrl(Const.ViewURIs.JS_UNIT_TEST + (TestProperties.isDevServer() ? "?coverage" : "")));
+        page.navigateTo(createUrl(Const.ViewURIs.JS_UNIT_TEST + "?coverage"));
         page.waitForCoverageVisibility();
 
         float coverage = page.getCoverage();
 
-        print(coverage + "% of scripts covered, the minimum requirement is " + MIN_COVERAGE_REQUIREMENT + "%");
-        assertTrue(coverage >= MIN_COVERAGE_REQUIREMENT);
+        print(coverage + "% of scripts covered");
     }
 
 }


### PR DESCRIPTION
Fixes #8768

**Outline of Solution**

Removed assert which checks for minimum coverage. 
The test still prints the current coverage although it's not 100% true, it might be useful to have an estimate of what is it.

Ready for Review @Crphang @LiHaoTan 
