### PR TITLE
Instructor: Option to select multiple students under the remind particular students modal #8823

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -16,15 +16,13 @@
             Remind Particular Students
             <small>(Select the student(s) you want to remind)</small>
           </h4>
-          <div class="checkbox">
+          <div>
             <input id="remind_all" type="checkbox" value="">
             <label for="remind_all">
               <strong>
                 Select all students
               </strong>
             </label>
-          </div>
-          <div class="checkbox">
             <input id="remind_not_submitted" type="checkbox" value="">
             <label for="remind_not_submitted">
               <strong>

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -17,11 +17,11 @@
             <small>(Select the student(s) you want to remind)</small>
           </h4>
           <div>
-            <input id="remind_all" type="checkbox" value="">
+            <input id="remind_all" type="checkbox">
             <label style="width:250px;" for="remind_all">
               Select all respondents
             </label>
-            <input id="remind_not_submitted" type="checkbox" value="">
+            <input id="remind_not_submitted" type="checkbox">
             <label for="remind_not_submitted">
               Select all respondents not yet submitted
             </label>

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -19,12 +19,11 @@
           <div>
             <input id="remind_all" type="checkbox" value="">
             <label style="width:250px;" for="remind_all">
+              Select all respondents
             </label>
             <input id="remind_not_submitted" type="checkbox" value="">
             <label for="remind_not_submitted">
-              <strong>
-                Select all students not submitted
-              </strong>
+              Select all respondents not yet submitted
             </label>
           </div>
         </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -18,7 +18,7 @@
           </h4>
           <div>
             <input id="remind_all" type="checkbox">
-            <label style="width:250px;" for="remind_all">
+            <label for="remind_all" class="remind-all">
               Select all respondents
             </label>
             <input id="remind_not_submitted" type="checkbox">

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -16,6 +16,14 @@
             Remind Particular Students
             <small>(Select the student(s) you want to remind)</small>
           </h4>
+          <div class="checkbox">
+            <input id="remind_all" type="checkbox" value="">
+            <label for="remind_all">
+              <strong>
+                Select all students
+              </strong>
+            </label>
+          </div>
         </div>
         <div class="modal-body">
           <div id="studentList" class="form-group"></div>

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -18,10 +18,7 @@
           </h4>
           <div>
             <input id="remind_all" type="checkbox" value="">
-            <label for="remind_all">
-              <strong>
-                Select all students
-              </strong>
+            <label style="width:250px;" for="remind_all">
             </label>
             <input id="remind_not_submitted" type="checkbox" value="">
             <label for="remind_not_submitted">

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -17,12 +17,12 @@
             <small>(Select the student(s) you want to remind)</small>
           </h4>
           <div>
-            <input id="remind_all" type="checkbox">
-            <label for="remind_all" class="remind-all">
+            <input id="remindAll" type="checkbox">
+            <label for="remindAll" class="remind-all">
               Select all respondents
             </label>
-            <input id="remind_not_submitted" type="checkbox">
-            <label for="remind_not_submitted">
+            <input id="remindNotSubmitted" type="checkbox">
+            <label for="remindNotSubmitted">
               Select all respondents not yet submitted
             </label>
           </div>

--- a/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/remindParticularStudentsModal.tag
@@ -24,6 +24,14 @@
               </strong>
             </label>
           </div>
+          <div class="checkbox">
+            <input id="remind_not_submitted" type="checkbox" value="">
+            <label for="remind_not_submitted">
+              <strong>
+                Select all students not submitted
+              </strong>
+            </label>
+          </div>
         </div>
         <div class="modal-body">
           <div id="studentList" class="form-group"></div>

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -15,39 +15,7 @@ function populateCheckBoxes($button) {
     }
 }
 
-function prepareRemindModal() {
-    $('#remindModal').on('show.bs.modal', (event) => {
-        const button = $(event.relatedTarget); // Button that triggered the modal
-        const actionlink = button.data('actionlink');
-
-        $.ajax({
-            type: 'POST',
-            cache: false,
-            url: actionlink,
-            beforeSend() {
-                $('#studentList').html('<img class="margin-center-horizontal" src="/images/ajax-loader.gif"/>');
-                $('#remindModal .remind-particular-button').prop('disabled', true).prop('value', 'Loading...');
-            },
-            error() {
-                $('#studentList').html('Error retrieving student list. Please close the dialog window and try again.');
-            },
-            success(data) {
-                setTimeout(() => {
-                    $('#studentList').html(data);
-                    populateCheckBoxes(button);
-                    $('#remindModal .remind-particular-button').prop('disabled', false).prop('value', 'Remind');
-                }, 500);
-            },
-        });
-    });
-    $('#remindModal .remind-particular-button').on('click', (event) => {
-        const $remindButton = $(event.currentTarget);
-        const $form = $remindButton.parents('form:first');
-        const action = $form.attr('action');
-        const formData = $form.serialize();
-        const url = `${action}&${formData}`;
-        sendRemindersToStudents(url);
-    });
+function bindingSelectAllCheckBoxes() {
     $('#remind_all').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-"]').prop('checked', true);
@@ -82,6 +50,42 @@ function prepareRemindModal() {
         } else {
             $('#remind_not_submitted').prop('checked', false);
         }
+    });
+}
+
+function prepareRemindModal() {
+    $('#remindModal').on('show.bs.modal', (event) => {
+        const button = $(event.relatedTarget); // Button that triggered the modal
+        const actionlink = button.data('actionlink');
+
+        $.ajax({
+            type: 'POST',
+            cache: false,
+            url: actionlink,
+            beforeSend() {
+                $('#studentList').html('<img class="margin-center-horizontal" src="/images/ajax-loader.gif"/>');
+                $('#remindModal .remind-particular-button').prop('disabled', true).prop('value', 'Loading...');
+            },
+            error() {
+                $('#studentList').html('Error retrieving student list. Please close the dialog window and try again.');
+            },
+            success(data) {
+                setTimeout(() => {
+                    $('#studentList').html(data);
+                    populateCheckBoxes(button);
+                    $('#remindModal .remind-particular-button').prop('disabled', false).prop('value', 'Remind');
+                    bindingSelectAllCheckBoxes();
+                }, 500);
+            },
+        });
+    });
+    $('#remindModal .remind-particular-button').on('click', (event) => {
+        const $remindButton = $(event.currentTarget);
+        const $form = $remindButton.parents('form:first');
+        const action = $form.attr('action');
+        const formData = $form.serialize();
+        const url = `${action}&${formData}`;
+        sendRemindersToStudents(url);
     });
 }
 

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -50,19 +50,15 @@ function prepareRemindModal() {
     });
     $('#remind_all').on('change', function () {
         if (this.checked) {
-            $('#remind_not_submitted').prop('disabled', true);
             $('input[id^="all-students-"]').prop('checked', true);
         } else {
-            $('#remind_not_submitted').prop('disabled', false);
             $('input[id^="all-students-"]').prop('checked', false);
         }
     });
     $('#remind_not_submitted').on('change', function () {
         if (this.checked) {
-            $('#remind_all').prop('disabled', true);
             $('input[id^="all-students-not-responded"]').prop('checked', true);
         } else {
-            $('#remind_all').prop('disabled', false);
             $('input[id^="all-students-not-responded"]').prop('checked', false);
         }
     });

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -32,7 +32,7 @@ function bindingSelectAllCheckBoxes() {
     $('#remindNotSubmitted').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-not-responded"]').prop('checked', true);
-            if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
+            if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
                 $('#remindAll').prop('checked', true);
             }
         } else {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -57,6 +57,15 @@ function prepareRemindModal() {
             $('input[id^="all-students-"]').prop('checked', false);
         }
     });
+    $('#remind_not_submitted').on('change', function () {
+        if (this.checked) {
+            $('#remind_all').prop('disabled', true);
+            $('input[id^="all-students-not-responded"]').prop('checked', true);
+        } else {
+            $('#remind_all').prop('disabled', false);
+            $('input[id^="all-students-not-responded"]').prop('checked', false);
+        }
+    });
 }
 
 export {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -22,33 +22,32 @@ function bindingSelectAllCheckBoxes() {
     // checks binding of select all checkboxes populated in the header
     $('#remindAll').on('change', function () {
         if (this.checked) {
-            $('input[id^="all-students-"]').prop('checked', true);
+            $('input[class^="student-"]').prop('checked', true);
             $('#remindNotSubmitted').prop('checked', true);
         } else {
-            $('input[id^="all-students-"]').prop('checked', false);
+            $('input[class^="student-"]').prop('checked', false);
             $('#remindNotSubmitted').prop('checked', false);
         }
     });
     $('#remindNotSubmitted').on('change', function () {
         if (this.checked) {
-            $('input[id^="all-students-not-responded"]').prop('checked', true);
-            if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
+            $('input[class^="student-not-"]').prop('checked', true);
+            if ($('input[class^="student-"]:checked').length === $('input[class^="student-"]').length) {
                 $('#remindAll').prop('checked', true);
             }
         } else {
-            $('input[id^="all-students-not-responded"]').prop('checked', false);
+            $('input[class^="student-not-"]').prop('checked', false);
             $('#remindAll').prop('checked', false);
         }
     });
     // checks binding of each checkbox populated in the data
-    $('input[id^="all-students-"]').on('change', () => {
-        if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
+    $('input[class^="student-"]').on('change', () => {
+        if ($('input[class^="student-"]:checked').length === $('input[class^="student-"]').length) {
             $('#remindAll').prop('checked', true);
         } else {
             $('#remindAll').prop('checked', false);
         }
-        if ($('input[id^="all-students-not-responded"]:checked').length ===
-                $('input[id^="all-students-not-responded"]').length) {
+        if ($('input[class^="student-not-"]:checked').length === $('input[class^="student-not-"]').length) {
             $('#remindNotSubmitted').prop('checked', true);
         } else {
             $('#remindNotSubmitted').prop('checked', false);

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -60,8 +60,14 @@ function prepareRemindModal() {
     $('#remind_not_submitted').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-not-responded"]').prop('checked', true);
+            if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
+                $('#remind_all').prop('checked', true);
+            }
         } else {
             $('input[id^="all-students-not-responded"]').prop('checked', false);
+            if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
+                $('#remind_all').prop('checked', false);
+            }
         }
     });
     $('input[id^="all-students-"]').on('change', () => {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -62,6 +62,19 @@ function prepareRemindModal() {
             $('input[id^="all-students-not-responded"]').prop('checked', false);
         }
     });
+    $('input[id^="all-students-"]').on('change', () => {
+        if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
+            $('#remind_all').prop('checked', true);
+        } else {
+            $('#remind_all').prop('checked', false);
+        }
+        if ($('input[id^="all-students-not-responded"]:checked').length ===
+                $('input[id^="all-students-not-responded"]').length) {
+            $('#remind_not_submitted').prop('checked', true);
+        } else {
+            $('#remind_not_submitted').prop('checked', false);
+        }
+    });
 }
 
 export {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -16,6 +16,7 @@ function populateCheckBoxes($button) {
 }
 
 function bindingSelectAllCheckBoxes() {
+    // checks binding of select all checkboxes populated in the header
     $('#remind_all').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-"]').prop('checked', true);
@@ -38,6 +39,7 @@ function bindingSelectAllCheckBoxes() {
             }
         }
     });
+    // checks binding of each checkbox populated in the data
     $('input[id^="all-students-"]').on('change', () => {
         if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
             $('#remind_all').prop('checked', true);

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -37,9 +37,7 @@ function bindingSelectAllCheckBoxes() {
             }
         } else {
             $('input[id^="all-students-not-responded"]').prop('checked', false);
-            if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
-                $('#remindAll').prop('checked', false);
-            }
+            $('#remindAll').prop('checked', false);
         }
     });
     // checks binding of each checkbox populated in the data

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -48,6 +48,15 @@ function prepareRemindModal() {
         const url = `${action}&${formData}`;
         sendRemindersToStudents(url);
     });
+    $('#remind_all').on('change', function () {
+        if (this.checked) {
+            $('#remind_not_submitted').prop('disabled', true);
+            $('input[id^="all-students-"]').prop('checked', true);
+        } else {
+            $('#remind_not_submitted').prop('disabled', false);
+            $('input[id^="all-students-"]').prop('checked', false);
+        }
+    });
 }
 
 export {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -16,6 +16,9 @@ function populateCheckBoxes($button) {
 }
 
 function bindingSelectAllCheckBoxes() {
+    // set default checkboxes as unchecked
+    $('#remindAll').prop('checked', false);
+    $('#remindNotSubmitted').prop('checked', false);
     // checks binding of select all checkboxes populated in the header
     $('#remindAll').on('change', function () {
         if (this.checked) {

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -17,40 +17,40 @@ function populateCheckBoxes($button) {
 
 function bindingSelectAllCheckBoxes() {
     // checks binding of select all checkboxes populated in the header
-    $('#remind_all').on('change', function () {
+    $('#remindAll').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-"]').prop('checked', true);
-            $('#remind_not_submitted').prop('checked', true);
+            $('#remindNotSubmitted').prop('checked', true);
         } else {
             $('input[id^="all-students-"]').prop('checked', false);
-            $('#remind_not_submitted').prop('checked', false);
+            $('#remindNotSubmitted').prop('checked', false);
         }
     });
-    $('#remind_not_submitted').on('change', function () {
+    $('#remindNotSubmitted').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-not-responded"]').prop('checked', true);
             if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
-                $('#remind_all').prop('checked', true);
+                $('#remindAll').prop('checked', true);
             }
         } else {
             $('input[id^="all-students-not-responded"]').prop('checked', false);
             if ($('input[id^="all-students-not-responded"]').length === $('input[id^="all-students-"]').length) {
-                $('#remind_all').prop('checked', false);
+                $('#remindAll').prop('checked', false);
             }
         }
     });
     // checks binding of each checkbox populated in the data
     $('input[id^="all-students-"]').on('change', () => {
         if ($('input[id^="all-students-"]:checked').length === $('input[id^="all-students-"]').length) {
-            $('#remind_all').prop('checked', true);
+            $('#remindAll').prop('checked', true);
         } else {
-            $('#remind_all').prop('checked', false);
+            $('#remindAll').prop('checked', false);
         }
         if ($('input[id^="all-students-not-responded"]:checked').length ===
                 $('input[id^="all-students-not-responded"]').length) {
-            $('#remind_not_submitted').prop('checked', true);
+            $('#remindNotSubmitted').prop('checked', true);
         } else {
-            $('#remind_not_submitted').prop('checked', false);
+            $('#remindNotSubmitted').prop('checked', false);
         }
     });
 }

--- a/src/main/webapp/dev/js/common/remindModal.js
+++ b/src/main/webapp/dev/js/common/remindModal.js
@@ -51,8 +51,10 @@ function prepareRemindModal() {
     $('#remind_all').on('change', function () {
         if (this.checked) {
             $('input[id^="all-students-"]').prop('checked', true);
+            $('#remind_not_submitted').prop('checked', true);
         } else {
             $('input[id^="all-students-"]').prop('checked', false);
+            $('#remind_not_submitted').prop('checked', false);
         }
     });
     $('#remind_not_submitted').on('change', function () {

--- a/src/main/webapp/jsp/instructorFeedbackAjaxRemindParticularStudentsModal.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackAjaxRemindParticularStudentsModal.jsp
@@ -32,7 +32,7 @@
       <td class="align-center">
         <div class="checkbox">
           <label>
-            <input type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
+            <input id="all-students-not-responded" type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
           </label>
         </div>
       </td>
@@ -58,7 +58,7 @@
       <td class="align-center">
         <div class="checkbox">
           <label>
-            <input type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
+            <input id="all-students-responded" type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
           </label>
         </div>
       </td>

--- a/src/main/webapp/jsp/instructorFeedbackAjaxRemindParticularStudentsModal.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackAjaxRemindParticularStudentsModal.jsp
@@ -32,7 +32,7 @@
       <td class="align-center">
         <div class="checkbox">
           <label>
-            <input id="all-students-not-responded" type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
+            <input type="checkbox" class="student-not-responded table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
           </label>
         </div>
       </td>
@@ -58,7 +58,7 @@
       <td class="align-center">
         <div class="checkbox">
           <label>
-            <input id="all-students-responded" type="checkbox" class="table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
+            <input type="checkbox" class="student-responded table-column-no-float" name="<%= Const.ParamsNames.SUBMISSION_REMIND_USERLIST %>" value="${userToRemindEmail}">
           </label>
         </div>
       </td>

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1225,6 +1225,10 @@ Default to alert color for visibility titles used within an alert context.
     display: block;
 }
 
+.remind-all {
+    width: 250px;
+}
+
 .remind-no-response {
     display: inline-block;
     padding-right: 5px;

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -1068,12 +1068,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -1067,6 +1067,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -1064,6 +1064,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -1065,12 +1065,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -1425,6 +1425,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -1426,12 +1426,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -1073,12 +1073,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -1072,6 +1072,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -821,6 +821,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -822,12 +822,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -728,6 +728,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -729,12 +729,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -1078,12 +1078,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -1077,6 +1077,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -840,12 +840,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -839,6 +839,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -2291,12 +2291,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -2290,6 +2290,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -4260,12 +4260,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -4259,6 +4259,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -2602,6 +2602,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -2603,12 +2603,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -927,12 +927,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -926,6 +926,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -2417,6 +2417,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -2418,12 +2418,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -4163,6 +4163,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -4164,12 +4164,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -2416,12 +2416,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -2415,6 +2415,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -841,12 +841,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -840,6 +840,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsEditComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsEditComment.html
@@ -4683,6 +4683,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsEditComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsEditComment.html
@@ -4684,12 +4684,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
+++ b/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
@@ -4683,6 +4683,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
+++ b/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
@@ -4684,12 +4684,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
@@ -176,6 +176,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageEmpty.html
@@ -177,12 +177,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
@@ -809,6 +809,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
@@ -810,12 +810,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -6598,12 +6598,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -6597,6 +6597,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
@@ -748,12 +748,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperOne.html
@@ -747,6 +747,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -2410,6 +2410,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -2411,12 +2411,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
@@ -464,12 +464,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
@@ -463,6 +463,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
@@ -464,12 +464,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGRQView.html
@@ -463,6 +463,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -1309,6 +1309,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -1310,12 +1310,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -1227,12 +1227,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRGQView.html
@@ -1226,6 +1226,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -1222,6 +1222,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -1223,12 +1223,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRecipient.html
@@ -3202,6 +3202,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRecipient.html
@@ -3203,12 +3203,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -1556,12 +1556,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -1555,6 +1555,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -1298,12 +1298,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -1297,6 +1297,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -1591,6 +1591,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -1592,12 +1592,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -1319,6 +1319,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -1320,12 +1320,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -1479,12 +1479,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -1478,6 +1478,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -882,6 +882,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -883,12 +883,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -2291,12 +2291,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -2290,6 +2290,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -2978,12 +2978,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -2977,6 +2977,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -4260,12 +4260,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -4259,6 +4259,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -4302,12 +4302,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -4301,6 +4301,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
@@ -2595,6 +2595,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionTeam.html
@@ -2596,12 +2596,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -4163,6 +4163,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -4164,12 +4164,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -4206,12 +4206,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -4205,6 +4205,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -2416,12 +2416,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -2415,6 +2415,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -3102,6 +3102,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -3103,12 +3103,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -2228,12 +2228,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -2227,6 +2227,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -2978,12 +2978,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -2977,6 +2977,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -2796,6 +2796,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -2797,12 +2797,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -2880,6 +2880,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -2881,12 +2881,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
@@ -1501,12 +1501,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestionTeam.html
@@ -1500,6 +1500,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -2428,12 +2428,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -2427,6 +2427,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -2511,6 +2511,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -2512,12 +2512,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -2949,12 +2949,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -2948,6 +2948,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -3688,6 +3688,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -3689,12 +3689,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -1073,12 +1073,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -1072,6 +1072,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -49,12 +49,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -48,6 +48,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
@@ -46,6 +46,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
@@ -47,12 +47,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLEmpty.html
+++ b/src/test/resources/pages/instructorHomeHTMLEmpty.html
@@ -57,12 +57,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLEmpty.html
+++ b/src/test/resources/pages/instructorHomeHTMLEmpty.html
@@ -56,6 +56,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -125,12 +125,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -124,6 +124,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -57,12 +57,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -56,6 +56,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
@@ -57,12 +57,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithoutSampleCourse.html
@@ -56,6 +56,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -41,6 +41,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -42,12 +42,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
@@ -12448,6 +12448,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFirstFeedbackSessionResultsPage.html
@@ -12449,12 +12449,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -57,12 +57,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -56,6 +56,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/newlyJoinedInstructorSecondFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorSecondFeedbackSessionResultsPage.html
@@ -416,12 +416,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/newlyJoinedInstructorSecondFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorSecondFeedbackSessionResultsPage.html
@@ -415,6 +415,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">

--- a/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
@@ -14373,12 +14373,12 @@
               </small>
             </h4>
             <div>
-              <input id="remind_all" type="checkbox" value="">
-              <label for="remind_all" style="width:250px;">
+              <input id="remindAll" type="checkbox">
+              <label class="remind-all" for="remindAll">
                 Select all respondents
               </label>
-              <input id="remind_not_submitted" type="checkbox" value="">
-              <label for="remind_not_submitted">
+              <input id="remindNotSubmitted" type="checkbox">
+              <label for="remindNotSubmitted">
                 Select all respondents not yet submitted
               </label>
             </div>

--- a/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorThirdFeedbackSessionResultsPage.html
@@ -14372,6 +14372,16 @@
                 (Select the student(s) you want to remind)
               </small>
             </h4>
+            <div>
+              <input id="remind_all" type="checkbox" value="">
+              <label for="remind_all" style="width:250px;">
+                Select all respondents
+              </label>
+              <input id="remind_not_submitted" type="checkbox" value="">
+              <label for="remind_not_submitted">
+                Select all respondents not yet submitted
+              </label>
+            </div>
           </div>
           <div class="modal-body">
             <div class="form-group" id="studentList">


### PR DESCRIPTION
Fixes #8823 

**Outline of Solution**

Added 2 new checkboxes to select multiple students as shown in the image below. As the options of selecting complement each other, I disabled the option to select both so only 1 option can be selected.

<img width="697" alt="screen shot 2018-05-15 at 4 25 24 pm" src="https://user-images.githubusercontent.com/28522090/40045620-632bb6ca-585d-11e8-8dc3-3177ee5023ca.png">

Demo:

![](https://user-images.githubusercontent.com/28522090/40476888-bdf17628-5f77-11e8-9776-bc990b048b25.gif)

