### PR TITLE
Instructor: view results: fix bug: sorting results by team is broken #8837

### DIFF
--- a/src/main/webapp/dev/js/common/sortBy.js
+++ b/src/main/webapp/dev/js/common/sortBy.js
@@ -219,18 +219,14 @@ class TableButtonHelpers {
  * @param shouldSortAscending
  *     If this is true, sort in ascending order.
  *     Otherwise, sort in descending order
- * @param rowOffset
- *     Ignore rows above this when sorting. Start sorting from this row.
- *     The main use case for this is to ignore the first row, which usually contains the table headers.
- *     In that case, set rowOffset to 1 (thus ignoring row 0).
  */
-function sortTable($table, colIdx, comparatorOrNull, extractorOrNull, shouldSortAscending, rowOffset) {
+function sortTable($table, colIdx, comparatorOrNull, extractorOrNull, shouldSortAscending) {
     let columnType = 0;
     let store = [];
-    const $rowList = $('tr', $table);
+    const $rowList = $table.find('>tbody > tr');
 
     // Iterate through column's contents to decide which comparator to use
-    for (let i = rowOffset; i < $rowList.length; i += 1) {
+    for (let i = 0; i < $rowList.length; i += 1) {
         if ($rowList[i].cells[colIdx - 1] === undefined) {
             continue;
         }
@@ -300,9 +296,8 @@ function toggleSort($button, comparatorStringOrNull, extractorStringOrNull) {
     const comparatorOrNull = isDefined(comparatorStringOrNull) ? Comparators[comparatorStringOrNull] : null;
     const extractorOrNull = isDefined(extractorStringOrNull) ? Extractors[extractorStringOrNull] : null;
     const shouldSortAscending = !isSortedAscending;
-    const rowToStartSortingFrom = 1; // <th> occupies row 0
 
-    sortTable($table, colIdx, comparatorOrNull, extractorOrNull, shouldSortAscending, rowToStartSortingFrom);
+    sortTable($table, colIdx, comparatorOrNull, extractorOrNull, shouldSortAscending);
 
     // update the button and icon states
     if (shouldSortAscending) {

--- a/src/main/webapp/dev/js/common/sortBy.js
+++ b/src/main/webapp/dev/js/common/sortBy.js
@@ -223,7 +223,7 @@ class TableButtonHelpers {
 function sortTable($table, colIdx, comparatorOrNull, extractorOrNull, shouldSortAscending) {
     let columnType = 0;
     let store = [];
-    const $rowList = $table.find('>tbody > tr');
+    const $rowList = $table.find('> tbody > tr');
 
     // Iterate through column's contents to decide which comparator to use
     for (let i = 0; i < $rowList.length; i += 1) {


### PR DESCRIPTION
Fixes #8837


**Outline of Solution**

- Initially the statement `const $rowList = $('tr', $table);` found all rows of the `$table` object which included all rows of child table (Part of the `add Comment` modal for the instructor) and hence it extracted and sorted them as well.

- This also results in simpler logic to query rows which are to be sorted

- This PR queries only the rows inside required tbody which are to be sorted and hence doesn't add any more content thereby fixing the bug.


P.S. I will be investigating soon why no tests took care of this and add extra tests in future PR as this is of urgent priority and should be merged ASAP
