### PR TITLE
Instructor: creating a session: able to manipulate the option when checkbox is not checked #8838

### DIFF
--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -581,7 +581,7 @@ function enableNewQuestion() {
     toggleMcqGeneratedOptions($(`#generateMcqOptionsCheckbox-${NEW_QUESTION}`), NEW_QUESTION);
     toggleMsqGeneratedOptions($(`#generateMsqOptionsCheckbox-${NEW_QUESTION}`), NEW_QUESTION);
 
-    toggleConstSumDistributePointsOptions($(`#constSum_UnevenDistribution-${NEW_QUESTION}`, NEW_QUESTION));
+    toggleConstSumDistributePointsOptions($(`#constSum_UnevenDistribution-${NEW_QUESTION}`), NEW_QUESTION);
 
     toggleMsqMaxSelectableChoices(NEW_QUESTION);
     toggleMsqMinSelectableChoices(NEW_QUESTION);


### PR DESCRIPTION
Fixes #8838

**Outline of Solution**
There was a bracket placement error while calling method `toggleConstSumDistributePointsOptions`
The New question number was not being passed as second parameter.
