### PR TITLE
Instructor: create session: Improve error message shown when session created with invalid information #8471

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -141,6 +141,9 @@ public class FieldValidator {
             EMPTY_STRING_ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_NON_EMPTY;
     public static final String SIZE_CAPPED_POSSIBLY_EMPTY_STRING_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_SIZE_CAPPED_POSSIBLY_EMPTY;
+    public static final String SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING_FOR_SESSION_NAME =
+            "The field '${fieldName}' should not be empty." + " "
+            + "The value of '${fieldName}' field should be no longer than ${maxLength} characters.";
     public static final String INVALID_NAME_ERROR_MESSAGE =
             ERROR_INFO + " " + HINT_FOR_CORRECT_FORMAT_FOR_INVALID_NAME;
     public static final String WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE =
@@ -563,8 +566,14 @@ public class FieldValidator {
         Assumption.assertNotNull("Non-null value expected for " + fieldName, value);
 
         if (value.isEmpty()) {
-            return getPopulatedEmptyStringErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                                            fieldName, maxLength);
+            if (fieldName.equals(FEEDBACK_SESSION_NAME_FIELD_NAME)) {
+                return getPopulatedEmptyStringErrorMessage(
+                        SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING_FOR_SESSION_NAME,
+                        fieldName, maxLength);
+            } else {
+                return getPopulatedEmptyStringErrorMessage(SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                        fieldName, maxLength);
+            }
         }
         if (isUntrimmed(value)) {
             return WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE.replace("${fieldName}", fieldName);

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackCopyActionTest.java
@@ -159,16 +159,16 @@ public class InstructorFeedbackCopyActionTest extends BaseActionTest {
                      pageResult.getDestinationWithParams());
         assertTrue(pageResult.isError);
         assertEquals(getPopulatedEmptyStringErrorMessage(
-                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING_FOR_SESSION_NAME,
                          FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                          FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH),
                      pageResult.getStatusMessage());
 
         expectedString =
                 teammatesLogMessage + "Servlet Action Failure : "
-                + "The field 'feedback session name' is empty. "
-                + "The value of a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackCopy";
+                + "The field 'feedback session name' should not be empty. "
+                + "The value of 'feedback session name' field should be no longer than 38 characters."
+                + "|||/page/instructorFeedbackCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Masquerade mode");

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackEditCopyActionTest.java
@@ -232,17 +232,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field 'feedback session name' is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
-                         + "It should not be empty.";
+        expectedString = "The field 'feedback session name' should not be empty. "
+                         + "The value of 'feedback session name' field should be no longer than 38 characters.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
-                + "a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackEditCopy";
+                + "Servlet Action Failure : The field 'feedback session name' should not be empty. The value of "
+                + "'feedback session name' field should be no longer than 38 characters."
+                + "|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Failure case: empty name, instructor feedbacks page");
@@ -261,17 +260,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field 'feedback session name' is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
-                         + "It should not be empty.";
+        expectedString = "The field 'feedback session name' should not be empty. "
+                         + "The value of 'feedback session name' field should be no longer than 38 characters.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
-                + "a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackEditCopy";
+                + "Servlet Action Failure : The field 'feedback session name' should not be empty. The value of "
+                + "'feedback session name' field should be no longer than 38 characters."
+                + "|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Failure case: empty name, instructor feedback copy page");
@@ -290,17 +288,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field 'feedback session name' is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
-                         + "It should not be empty.";
+        expectedString = "The field 'feedback session name' should not be empty. "
+                         + "The value of 'feedback session name' field should be no longer than 38 characters.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
-                + "a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackEditCopy";
+                + "Servlet Action Failure : The field 'feedback session name' should not be empty. The value of "
+                + "'feedback session name' field should be no longer than 38 characters."
+                + "|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Failure case: empty name, instructor feedback edit page");
@@ -319,17 +316,16 @@ public class InstructorFeedbackEditCopyActionTest extends BaseActionTest {
 
         assertEquals("", editCopyData.redirectUrl);
 
-        expectedString = "The field 'feedback session name' is empty. "
-                         + "The value of a/an feedback session name should be no longer than 38 characters. "
-                         + "It should not be empty.";
+        expectedString = "The field 'feedback session name' should not be empty. "
+                         + "The value of 'feedback session name' field should be no longer than 38 characters.";
         assertEquals(expectedString, editCopyData.errorMessage);
 
         expectedString =
                 "TEAMMATESLOG|||instructorFeedbackEditCopy|||instructorFeedbackEditCopy|||true|||"
                 + "Instructor|||Instructor 2|||FeedbackEditCopyinstructor2|||tmms.instr@gmail.tmt|||"
-                + "Servlet Action Failure : The field 'feedback session name' is empty. The value of "
-                + "a/an feedback session name should be no longer than 38 characters. "
-                + "It should not be empty.|||/page/instructorFeedbackEditCopy";
+                + "Servlet Action Failure : The field 'feedback session name' should not be empty. The value of "
+                + "'feedback session name' field should be no longer than 38 characters."
+                + "|||/page/instructorFeedbackEditCopy";
         AssertHelper.assertLogMessageEquals(expectedString, a.getLogMessage());
 
         ______TS("Successful case");

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -982,7 +982,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
                 newSession.getGracePeriodMinutes());
         feedbackPage.waitForTextsForAllStatusMessagesToUserEquals(
                 getPopulatedEmptyStringErrorMessage(
-                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING_FOR_SESSION_NAME,
                         FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                         FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH));
         assertTrue(feedbackPage.isVisible(By.id("timeFramePanel")));

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackQuestionAttributesTest.java
@@ -252,7 +252,7 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
         assertFalse(fq.isValid());
 
         String errorMessage = getPopulatedEmptyStringErrorMessage(
-                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                                  FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING_FOR_SESSION_NAME,
                                   FieldValidator.FEEDBACK_SESSION_NAME_FIELD_NAME,
                                   FieldValidator.FEEDBACK_SESSION_NAME_MAX_LENGTH) + System.lineSeparator()
                               + getPopulatedEmptyStringErrorMessage(

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackSessionAttributesTest.java
@@ -123,8 +123,8 @@ public class FeedbackSessionAttributesTest extends BaseTestCase {
     }
 
     private List<String> buildExpectedErrorMessages() {
-        String feedbackSessionNameError = "The field 'feedback session name' is empty. The value of a/an feedback "
-                + "session name should be no longer than 38 characters. It should not be empty.";
+        String feedbackSessionNameError = "The field 'feedback session name' should not be empty. The value of 'feedback "
+                + "session name' field should be no longer than 38 characters.";
         String courseIdError = "The field 'course ID' is empty. A course ID can contain letters, numbers, fullstops, "
                 + "hyphens, underscores, and dollar signs. It cannot be longer than 40 characters, cannot be empty and "
                 + "cannot contain spaces.";


### PR DESCRIPTION
Fixes #8471 

**Outline of Solution**
* Regarding to correcting the grammar I made a change in order for the error to be more neutral. So instead of:
> The field 'feedback session name' is empty. The value of a/an feedback session name should be no longer than 38 characters. It should not be empty.

now says:
> The field 'feedback session name' should not be empty. The value of 'feedback session name' field should be no longer than 38 characters.

* Regarding to the appearance, ~~I put the icon in the middle and the errors next to it with the same allignment.~~ it appears that statusMessage.tag file is used and inserting bullets in each fault causes a lot of problems in testing UI because there are many kinds of status messages. So, putting in all of them bullets is not acceptable throughout the app. If you have something else to propose let me know so as to implement it.
![html](https://user-images.githubusercontent.com/22797140/40756055-06be39b0-648a-11e8-8f51-5565aa27e46e.jpg)

