### PR TITLE
Instructor: edit student details: resend past links to the new email not working #8880

### DIFF
--- a/src/main/webapp/dev/js/main/instructorCourseStudentEdit.js
+++ b/src/main/webapp/dev/js/main/instructorCourseStudentEdit.js
@@ -17,11 +17,11 @@ function sendEmailToNewEmailOption(event, newStudentEmail) {
     event.preventDefault();
     const messageText = `Do you want to resend past session links of this course to the new email ${newStudentEmail}?`;
     const yesCallback = function () {
-        $('#isSendEmail').val(true);
+        $('[name=\'sessionsummarysendemail\']').val(true);
         event.currentTarget.submit();
     };
     const noCallback = function () {
-        $('#isSendEmail').val(false);
+        $('[name=\'sessionsummarysendemail\']').val(false);
         event.currentTarget.submit();
     };
     showModalConfirmationWithCancel('Resend past links to the new email?', messageText,


### PR DESCRIPTION
Fixes #8880

**Outline of Solution**
1. Corrected the parameter name required by `studentInformationTable.tag`.