### PR TITLE
Testing: unstable behaviour in CI Config.APP_URL can be null sometimes #8898

### DIFF
--- a/src/test/java/teammates/test/cases/BaseTestCaseWithMinimalGaeEnvironment.java
+++ b/src/test/java/teammates/test/cases/BaseTestCaseWithMinimalGaeEnvironment.java
@@ -1,16 +1,11 @@
 package teammates.test.cases;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 
-import teammates.test.driver.TestProperties;
+import teammates.test.driver.GaeSimulation;
 
 /**
  * Base class for all test cases which require a minimal GAE API environment registered.
@@ -21,24 +16,13 @@ public class BaseTestCaseWithMinimalGaeEnvironment extends BaseTestCase {
 
     @BeforeClass
     public void setUpGae() {
-        helper.setEnvAttributes(generateEnvironmentAttributesWithApplicationHostnameSet());
+        helper.setEnvAttributes(GaeSimulation.getEnvironmentAttributesWithApplicationHostname());
         helper.setUp();
     }
 
     @AfterClass
     public void tearDownGae() {
         helper.tearDown();
-    }
-
-    public Map<String, Object> generateEnvironmentAttributesWithApplicationHostnameSet() {
-        Map<String, Object> attributes = new HashMap<>();
-        try {
-            attributes.put("com.google.appengine.runtime.default_version_hostname",
-                    new URL(TestProperties.TEAMMATES_URL).getAuthority());
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-        return attributes;
     }
 
 }

--- a/src/test/java/teammates/test/cases/BaseTestCaseWithMinimalGaeEnvironment.java
+++ b/src/test/java/teammates/test/cases/BaseTestCaseWithMinimalGaeEnvironment.java
@@ -1,9 +1,16 @@
 package teammates.test.cases;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import teammates.test.driver.TestProperties;
 
 /**
  * Base class for all test cases which require a minimal GAE API environment registered.
@@ -14,12 +21,24 @@ public class BaseTestCaseWithMinimalGaeEnvironment extends BaseTestCase {
 
     @BeforeClass
     public void setUpGae() {
+        helper.setEnvAttributes(generateEnvironmentAttributesWithApplicationHostnameSet());
         helper.setUp();
     }
 
     @AfterClass
     public void tearDownGae() {
         helper.tearDown();
+    }
+
+    public Map<String, Object> generateEnvironmentAttributesWithApplicationHostnameSet() {
+        Map<String, Object> attributes = new HashMap<>();
+        try {
+            attributes.put("com.google.appengine.runtime.default_version_hostname",
+                    new URL(TestProperties.TEAMMATES_URL).getAuthority());
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+        return attributes;
     }
 
 }

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
@@ -12,13 +12,13 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.StringHelper;
 import teammates.storage.entity.CourseStudent;
-import teammates.test.cases.BaseTestCase;
+import teammates.test.cases.BaseTestCaseWithMinimalGaeEnvironment;
 import teammates.test.driver.StringHelperExtension;
 
 /**
  * SUT: {@link StudentAttributes}.
  */
-public class StudentAttributesTest extends BaseTestCase {
+public class StudentAttributesTest extends BaseTestCaseWithMinimalGaeEnvironment {
 
     @Test
     public void testBuilderWithDefaultValues() {

--- a/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackEditPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorFeedbackEditPageDataTest.java
@@ -21,7 +21,7 @@ import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.SanitizationHelper;
 import teammates.common.util.TimeHelper;
-import teammates.test.cases.BaseTestCase;
+import teammates.test.cases.BaseTestCaseWithMinimalGaeEnvironment;
 import teammates.ui.pagedata.InstructorFeedbackEditPageData;
 import teammates.ui.template.FeedbackQuestionEditForm;
 import teammates.ui.template.FeedbackQuestionFeedbackPathSettings;
@@ -33,7 +33,7 @@ import teammates.ui.template.FeedbackSessionsForm;
 /**
  * SUT: {@link InstructorFeedbackEditPageData}.
  */
-public class InstructorFeedbackEditPageDataTest extends BaseTestCase {
+public class InstructorFeedbackEditPageDataTest extends BaseTestCaseWithMinimalGaeEnvironment {
 
     private static final int DEFAULT_NUM_ENTITIES_TO_GIVE_RESPONSES_TO = 1;
     private static DataBundle dataBundle = getTypicalDataBundle();

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -82,7 +82,7 @@ public class GaeSimulation {
         helper = new LocalServiceTestHelper(localDatastore, localMail, localUserServices,
                                             localTasks, localSearch, localModules, localLog);
 
-        helper.setEnvAttributes(generateEnvironmentAttributesWithApplicationHostnameSet());
+        helper.setEnvAttributes(getEnvironmentAttributesWithApplicationHostname());
         helper.setUp();
 
         sc = new ServletRunner().newClient();
@@ -234,7 +234,10 @@ public class GaeSimulation {
         }
     }
 
-    private Map<String, Object> generateEnvironmentAttributesWithApplicationHostnameSet() {
+    /**
+     * Returns an environment attribute with application host name.
+     */
+    public static Map<String, Object> getEnvironmentAttributesWithApplicationHostname() {
         Map<String, Object> attributes = new HashMap<>();
         try {
             attributes.put("com.google.appengine.runtime.default_version_hostname",

--- a/static-analysis/teammates-macker.xml
+++ b/static-analysis/teammates-macker.xml
@@ -316,6 +316,7 @@
                                 <include class="${testCases}.automated.**" />
                                 <include class="${testCases}.search.**" />
                                 <include class="${testCases}.BaseComponentTestCase" />
+                                <include class="${testCases}.BaseTestCaseWithMinimalGaeEnvironment" />
 
                                 <!-- violation that needs fixing -->
                                 <include class="${testCases}.pagedata.StudentFeedbackResultsPageDataTest" />


### PR DESCRIPTION
Fixes #8898 

**Outline of Solution**
- Added the hostname setup logic to `BaseTestCaseWithMinimalGaeEnvironment`
- `InstructorFeedbackEditPageDataTest` and `StudentAttributeTest` now extends `BaseTestCaseWithMinimalGaeEnvironment` class
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
@xpdavid  As BaseComponentTestCase extends `BaseTestCaseWithMinimalGaeEnvironment` and overrides `setUpGae()` and `tearDownGae()` to executes `gaeSimulation.setup()`, So I did not completely move the hostname setup logic to `BaseTestCaseWithMinimalGaeEnvironment`, instead I added it. 

Is this what you had in mind?

<!-- This portion can be skipped if the fix is trivial. -->
