### PR TITLE
Instructor: home page: tweak spacing in drop-down buttons #8869

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/home/coursePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/coursePanel.tag
@@ -22,7 +22,7 @@
                 <div class="dropdown courses-table-dropdown">
                   <button class="btn btn-primary btn-xs dropdown-toggle" type="button" data-toggle="dropdown">
                     ${button.content}
-                    <span class="caret dropdown-toggle"></span>
+                    <span class="caret dropdown-toggle" style="margin-left: 3px;"></span>
                   </button>
                   <ul class="dropdown-menu">
                     <c:forEach items="${button.nestedElements}" var="menuItem">


### PR DESCRIPTION
Fixes #8869 

I added margin-left of 3px to the element's style of the arrows.

Before:
![before](https://user-images.githubusercontent.com/12675382/41511963-985ad95a-7281-11e8-8164-755673d5a6e5.png)

After:
![after](https://user-images.githubusercontent.com/12675382/41511966-9de9e302-7281-11e8-9ffa-889c4c1df770.png)

