### PR TITLE
InstructorFeedbackResultsPage: Show consistent data on the webpage and downloaded data #8929

### DIFF
--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -479,7 +479,6 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
         feedbackResponses.addAll(load()
                 .filter("feedbackQuestionId =", feedbackQuestionId)
                 .filter("giverSection =", section)
-                .filter("receiverSection =", section)
                 .list());
 
         feedbackResponses.addAll(load()

--- a/src/main/resources/InstructorSampleData.json
+++ b/src/main/resources/InstructorSampleData.json
@@ -962,7 +962,7 @@
         "value": "Wow! You are really good at designing!"
       },
       "giverSection": "Tutorial Group 1",
-      "recipientSection": "Tutorial Group 1"
+      "recipientSection": "Tutorial Group 2"
     },
     "aliceResponse5": {
       "feedbackSessionName": "Session with different question types",

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -242,7 +242,7 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         List<FeedbackResponseAttributes> responses = frDb.getFeedbackResponsesForQuestionInSection(questionId, "Section 1");
 
-        assertEquals(3, responses.size());
+        assertEquals(4, responses.size());
 
         ______TS("No responses as they are filtered out");
 


### PR DESCRIPTION
Fixes #8929 

**Outline of Solution**
Instead of filtering both `givers` and `recipients` by `section`. Merely filter `givers` by `section` to be consistent with downloadable data.
