### PR TITLE
Instructor: edit student details: email contains raw template literals after resending past links to the new email #8935

### DIFF
--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -129,7 +129,7 @@ public class EmailGenerator {
                                    ? Templates.populateTemplate(EmailTemplates.FRAGMENT_STUDENT_COURSE_JOIN,
                                            "${joinUrl}", joinUrl,
                                            "${courseName}", SanitizationHelper.sanitizeForHtml(course.getName()),
-                                            "${coOwnersEmails}", generateCoOwnersEmailsLine(course.getId()))
+                                           "${coOwnersEmails}", generateCoOwnersEmailsLine(course.getId()))
                                    : "";
 
         for (FeedbackSessionAttributes fsa : sessions) {

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -128,7 +128,8 @@ public class EmailGenerator {
         String joinFragmentValue = isYetToJoinCourse(student)
                                    ? Templates.populateTemplate(EmailTemplates.FRAGMENT_STUDENT_COURSE_JOIN,
                                            "${joinUrl}", joinUrl,
-                                           "${courseName}", SanitizationHelper.sanitizeForHtml(course.getName()))
+                                           "${courseName}", SanitizationHelper.sanitizeForHtml(course.getName()),
+                                            "${coOwnersEmails}", generateCoOwnersEmailsLine(course.getId()))
                                    : "";
 
         for (FeedbackSessionAttributes fsa : sessions) {

--- a/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
@@ -63,6 +63,9 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         StudentAttributes student1 = studentsLogic.getStudentForEmail(course.getId(), "student1InCourse1@gmail.tmt");
 
+        // Unregistered student
+        StudentAttributes student2 = studentsLogic.getUnregisteredStudentsForCourse("idOfUnregisteredCourse").get(0);
+
         InstructorAttributes instructor1 =
                 instructorsLogic.getInstructorForEmail(course.getId(), "instructor1@course1.tmt");
 
@@ -157,12 +160,21 @@ public class EmailGeneratorTest extends BaseLogicTest {
         verifyEmailReceivedCorrectly(emails, student1.email, subject, "/sessionUnpublishedEmailForStudent.html");
         verifyEmailReceivedCorrectly(emails, instructor1.email, subject, "/sessionUnpublishedEmailForInstructor.html");
 
-        ______TS("send summary of all feedback sessions of course email");
+        ______TS("send summary of all feedback sessions of course email to new student. "
+                + "Previous student has joined the course");
 
         EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, student1.email, subject, "/summaryOfFeedbackSessionsOfCourseEmailForStudent.html");
+
+        ______TS("send summary of all feedback sessions of course email to new student. "
+                + "Previous student has not joined the course");
+
+        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student2);
+        subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
+
+        verifyEmail(email, student2.email, subject, "/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html");
 
         ______TS("feedback session submission email");
 

--- a/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
@@ -62,9 +62,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
         CourseAttributes course = coursesLogic.getCourse(session.getCourseId());
 
         StudentAttributes student1 = studentsLogic.getStudentForEmail(course.getId(), "student1InCourse1@gmail.tmt");
-
-        // Unregistered student
-        StudentAttributes student2 = studentsLogic.getUnregisteredStudentsForCourse("idOfUnregisteredCourse").get(0);
+        StudentAttributes unregisteredStudent = studentsLogic.getStudentForEmail("idOfUnregisteredCourse",
+                "student1InUnregisteredCourse@gmail.tmt");
 
         InstructorAttributes instructor1 =
                 instructorsLogic.getInstructorForEmail(course.getId(), "instructor1@course1.tmt");
@@ -161,7 +160,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         verifyEmailReceivedCorrectly(emails, instructor1.email, subject, "/sessionUnpublishedEmailForInstructor.html");
 
         ______TS("send summary of all feedback sessions of course email to new student. "
-                + "Previous student has joined the course");
+                + "Edited student has joined the course");
 
         EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
@@ -169,12 +168,13 @@ public class EmailGeneratorTest extends BaseLogicTest {
         verifyEmail(email, student1.email, subject, "/summaryOfFeedbackSessionsOfCourseEmailForStudent.html");
 
         ______TS("send summary of all feedback sessions of course email to new student. "
-                + "Previous student has not joined the course");
+                + "Edited student has not joined the course");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student2);
+        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), unregisteredStudent);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
 
-        verifyEmail(email, student2.email, subject, "/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html");
+        verifyEmail(email, unregisteredStudent.email, subject,
+                "/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html");
 
         ______TS("feedback session submission email");
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -1,0 +1,94 @@
+<p>Hello student1 In unregisteredCourse,</p>
+
+<p>
+  An instructor has updated your email address in the course [Course name: Typical Course 1 with 2 Evals] [Course ID: idOfTypicalCourse1].
+  Given below are the relevant links for the course, updated to work with your new email address student1InUnregisteredCourse@gmail.tmt.
+</p>
+
+<p>
+  The course <em>Typical Course 1 with 2 Evals</em> is using the TEAMMATES System to collect feedback.
+</p>
+<p>
+  <strong>To "join" the course, please go to this Web address: </strong>
+  <a href="${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt&courseid=idOfUnregisteredCourse">${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt&courseid=idOfUnregisteredCourse</a>
+  <ul>
+    <li>
+      If prompted to log in, use your Google account to log in.
+      If you do not have a Google account, please create one from the <a href="https://accounts.google.com/NewAccount">Google Accounts page</a>.
+    </li>
+    <li>
+      The above link is unique to you. Please do not share it with your classmates.
+    </li>
+  </ul>
+</p>
+
+<p>
+  Note that If you wish to access TEAMMATES without using your Google account, you do not need to ‘join’ the course as instructed above.
+  You will still be able to submit/view feedback by following the instructions sent to you by TEAMMATES at the appropriate times.
+  However, we recommend joining the course using your Google account, because it gives you more convenient access to all your feedback stored in TEAMMATES.
+</p>
+
+<p>
+  For any non-technical queries (e.g. assigned to the wrong team, misspelled name, request for deadline extension, etc.), you can contact your instructor(s) at: Instructor Not Yet Joined Course 1 (instructorNotYetJoinedCourse1@email.tmt), Instructor1 Course1 (instructor1@course1.tmt), Instructor3 Course1 (instructor3@course1.tmt).
+</p>
+
+<p>
+  Below are the feedback sessions of the course.
+  <br><br>
+<br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
+<br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
+<br>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+<br>
+<br>
+To view the responses for this session, please go to this Web address: <a href="${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+<br>
+<br><br>
+<br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
+<br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
+<br>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+<br>
+<br>
+To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br><br>
+<br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
+<br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
+<br>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+<br>
+<br>
+To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br><br>
+<br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
+<br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
+<br>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+<br>
+<br>
+To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+</p>
+
+<p>
+  <ul>
+    <li>
+      <strong>Requests for deadline extensions, problems regarding team/student data</strong> (e.g. wrong team, misspelled name),
+      and <strong>other non-technical queries</strong> about the feedback session:
+      <br>
+      Contact the instructors of the course: Instructor Not Yet Joined Course 1 (instructorNotYetJoinedCourse1@email.tmt), Instructor1 Course1 (instructor1@course1.tmt), Instructor3 Course1 (instructor3@course1.tmt)
+    </li>
+    <li>
+      <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
+      Email TEAMMATES support team at ${support.email}.
+    </li>
+  </ul>
+</p>
+
+<p>
+  Regards,
+  <br>TEAMMATES Team.
+</p>


### PR DESCRIPTION
Fixes #8935 

**Outline of Solution**

- Added a required variable to be replaced in the template literal. The template literal originated from the template file `studentEmailFragment-courseJoin.html`.
