### PR TITLE
Remove wrong Godmode changes due to unstable test #8937

### DIFF
--- a/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
+++ b/src/test/resources/pages/instructorFeedbackResultsEditCommentByDifferentInstructor.html
@@ -996,7 +996,7 @@
                                     </table>
                                   </div>
                                   <div class="form-group">
-                                    <div class="panel panel-default panel-body content-editor empty" id="responsecommenttext-1-0-1-1-1" spellcheck="false" style="position: relative;">
+                                    <div class="panel panel-default panel-body content-editor" id="responsecommenttext-1-0-1-1-1" spellcheck="false" style="position: relative;">
                                       <p>
                                         Comment edited by different instructor
                                       </p>

--- a/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageGQRWithSanitizedData.html
@@ -462,7 +462,7 @@
                                 <div class="row" id="commentBar-1-1-0-1-1">
                                   <div class="col-xs-10">
                                     <span class="text-muted">
-                                      From: Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; [Mon, 02 Mar 2026, 07:59 AM SGT] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM SGT)
+                                      From: Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 07:59 AM SGT] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM SGT)
                                     </span>
                                   </div>
                                   <div class="col-xs-2">

--- a/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageWithSanitizedData.html
@@ -463,7 +463,7 @@
                               <div class="row" id="commentBar-2-1-0-1">
                                 <div class="col-xs-10">
                                   <span class="text-muted">
-                                    From: Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; [Mon, 02 Mar 2026, 07:59 AM SGT] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM SGT)
+                                    From: Instructor&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt; [Mon, 02 Mar 2026, 07:59 AM SGT] (last edited by Instructor&lt;script&gt; alert('hi!'); &lt;/script&gt; at Tue, 03 Mar 2026, 07:59 AM SGT)
                                   </span>
                                 </div>
                                 <div class="col-xs-2">


### PR DESCRIPTION
Fixes #8937


**Outline of Solution**

- Remove extra `empty` class added in due to godmode of unstable tests
- Reverted two sanitization places caused unnecessary changes


Note: Working on fixing the unstable test
