### PR TITLE
Instructor: enroll students: add a 'paste' option to the context menu #8972

### DIFF
--- a/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
@@ -59,10 +59,10 @@ function getUpdatedData(spreadsheetDataRows) {
  * Function to show modal box when user clicks on the 'paste' option in the Handsontable context menu.
  */
 function showModalPasteBox() {
-    const messageText = 'Pasting data through the context menu is not supported due to security complications. ' +
-            'Please use <kbd>Ctrl + V</kbd> or <kbd>⌘ + V</kbd> to paste your data instead.';
+    const messageText = 'Pasting data through the context menu is not supported due to security complications. '
+            + 'Please use <kbd>Ctrl + V</kbd> or <kbd>⌘ + V</kbd> to paste your data instead.';
 
-    const okCallback = function (){};
+    const okCallback = () => {};
     showModalConfirmation('Pasting data through the context menu', messageText,
             okCallback, null, null, null, BootstrapContextualColors.WARNING);
 }

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
@@ -56,10 +56,10 @@ function getUpdatedData(spreadsheetDataRows) {
 }
 
 /**
- * Function to show modal box when user clicks on the 'paste' option in the Handsontable context menu.
+ * Shows modal box when user clicks on the 'paste' option in the Handsontable context menu.
  */
 function showPasteModalBox() {
-    const messageText = 'Pasting data through the context menu is not supported due to security complications. '
+    const messageText = 'Pasting data through the context menu is not supported due to browser restrictions. '
             + 'Please use <kbd>Ctrl + V</kbd> or <kbd>⌘ + V</kbd> to paste your data instead.';
 
     const okCallback = () => {};

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
@@ -1,3 +1,11 @@
+import {
+    showModalConfirmation,
+} from '../common/bootboxWrapper';
+
+import {
+    BootstrapContextualColors,
+} from '../common/const';
+
 /**
  * Retrieves updated column header order and generates a header string.
  *
@@ -47,8 +55,21 @@ function getUpdatedData(spreadsheetDataRows) {
     return spreadsheetDataRows.map(row => row.split('|'));
 }
 
+/**
+ * Function to show modal box when user clicks on the 'paste' option in the Handsontable context menu.
+ */
+function showModalPasteBox() {
+    const messageText = 'Pasting data through the context menu is not supported due to security complications. ' +
+            'Please use <kbd>Ctrl + V</kbd> or <kbd>⌘ + V</kbd> to paste your data instead.';
+
+    const okCallback = function (){};
+    showModalConfirmation('Pasting data through the context menu', messageText,
+            okCallback, null, null, null, BootstrapContextualColors.WARNING);
+}
+
 export {
     getUpdatedHeaderString,
     getUserDataRows,
     getUpdatedData,
+    showModalPasteBox,
 };

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollHelper.js
@@ -58,7 +58,7 @@ function getUpdatedData(spreadsheetDataRows) {
 /**
  * Function to show modal box when user clicks on the 'paste' option in the Handsontable context menu.
  */
-function showModalPasteBox() {
+function showPasteModalBox() {
     const messageText = 'Pasting data through the context menu is not supported due to security complications. '
             + 'Please use <kbd>Ctrl + V</kbd> or <kbd>⌘ + V</kbd> to paste your data instead.';
 
@@ -71,5 +71,5 @@ export {
     getUpdatedHeaderString,
     getUserDataRows,
     getUpdatedData,
-    showModalPasteBox,
+    showPasteModalBox,
 };

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
@@ -15,7 +15,6 @@ import {
 
 const container = document.getElementById('spreadsheet');
 
-
 const handsontable = new Handsontable(container, {
     height: 500,
     autoWrapRow: true,
@@ -41,9 +40,9 @@ const handsontable = new Handsontable(container, {
         {
             key: 'paste',
             name: 'Paste',
-            callback: function() {
+            callback: () => {
                 showModalPasteBox();
-            }
+            },
         },
         'make_read_only',
         'alignment',

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
@@ -40,9 +40,7 @@ const handsontable = new Handsontable(container, {
         {
             key: 'paste',
             name: 'Paste',
-            callback: () => {
-                showPasteModalBox();
-            },
+            callback: showPasteModalBox,
         },
         'make_read_only',
         'alignment',

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
@@ -10,7 +10,7 @@ import {
     getUpdatedHeaderString,
     getUserDataRows,
     getUpdatedData,
-    showModalPasteBox,
+    showPasteModalBox,
 } from './instructorCourseEnrollHelper';
 
 const container = document.getElementById('spreadsheet');
@@ -41,7 +41,7 @@ const handsontable = new Handsontable(container, {
             key: 'paste',
             name: 'Paste',
             callback: () => {
-                showModalPasteBox();
+                showPasteModalBox();
             },
         },
         'make_read_only',

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
@@ -1,6 +1,7 @@
 /**
  * Holds Handsontable settings, reference and other information for the spreadsheet interface.
  */
+/* global Handsontable:false */
 import {
     prepareInstructorPages,
 } from '../common/instructor';
@@ -13,7 +14,7 @@ import {
 
 const container = document.getElementById('spreadsheet');
 
-/* global Handsontable:false */
+
 const handsontable = new Handsontable(container, {
     height: 500,
     autoWrapRow: true,

--- a/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
+++ b/src/main/webapp/dev/js/main/instructorCourseEnrollPage.js
@@ -10,6 +10,7 @@ import {
     getUpdatedHeaderString,
     getUserDataRows,
     getUpdatedData,
+    showModalPasteBox,
 } from './instructorCourseEnrollHelper';
 
 const container = document.getElementById('spreadsheet');
@@ -37,6 +38,13 @@ const handsontable = new Handsontable(container, {
         'remove_row',
         'undo',
         'redo',
+        {
+            key: 'paste',
+            name: 'Paste',
+            callback: function() {
+                showModalPasteBox();
+            }
+        },
         'make_read_only',
         'alignment',
     ],


### PR DESCRIPTION
Fixes #8972 

**Outline of Solution**
1. Added new modal box in helper file for paste option in `Handsontable` context menu.
2. Added new paste option in `Handsontable` context menu.