### PR TITLE
Fix Issue #8980 Instructor: delete course: rephrase message shown

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1291,7 +1291,7 @@ public final class Const {
         public static final String COURSE_UNARCHIVED = "The course %s has been unarchived.";
         public static final String COURSE_DELETED = "The course %s has been deleted.";
         public static final String COURSE_EMPTY =
-                "You have not created any courses yet. Use the form above to create a course.";
+                "You do not seem to have any courses. Use the form above to create a course.";
         public static final String COURSE_EMPTY_IN_INSTRUCTOR_FEEDBACKS =
                 "You have not created any courses yet, or you have no active courses. Go <a href=\""
                 + ActionURIs.INSTRUCTOR_COURSES_PAGE + "${user}\">here</a> to create or unarchive a course.";


### PR DESCRIPTION
Changed String COURSE_EMPTY from "You have not created any courses yet. Use the form above to create a course." to "You do not seem to have any courses. Use the form above to create a course." as suggested in the issue description.

Fixes #8980

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [ ] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr
  - [ ] Added the issue number to the "Fixes" keyword above
  - [ ] Titled the PR as specified in the abovementioned document
- [ ] Made your changes on a branch other than `master` and `release`
- [ ] Gone through all the changes in this PR and ensured that:
  - [ ] They addressed one (and only one) issue
  - [ ] No unintended changes were made
- [ ] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [ ] Added/updated tests, if changes in functionality were involved
- [ ] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
