### PR TITLE
Instructor: delete course: rephrase message shown when there are no more courses left #8980

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1291,7 +1291,7 @@ public final class Const {
         public static final String COURSE_UNARCHIVED = "The course %s has been unarchived.";
         public static final String COURSE_DELETED = "The course %s has been deleted.";
         public static final String COURSE_EMPTY =
-                "You have not created any courses yet. Use the form above to create a course.";
+                "You do not seem to have any courses. Use the form above to create a course.";
         public static final String COURSE_EMPTY_IN_INSTRUCTOR_FEEDBACKS =
                 "You have not created any courses yet, or you have no active courses. Go <a href=\""
                 + ActionURIs.INSTRUCTOR_COURSES_PAGE + "${user}\">here</a> to create or unarchive a course.";

--- a/src/test/java/teammates/test/cases/action/InstructorCoursesPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCoursesPageActionTest.java
@@ -91,7 +91,7 @@ public class InstructorCoursesPageActionTest extends BaseActionTest {
         assertEquals(
                 getPageResultDestination(Const.ViewURIs.INSTRUCTOR_COURSES, false, "idOfInstructor1OfCourse1"),
                 r.getDestinationWithParams());
-        assertEquals("You have not created any courses yet. Use the form above to create a course.", r.getStatusMessage());
+        assertEquals("You do not seem to have any courses. Use the form above to create a course.", r.getStatusMessage());
         assertFalse(r.isError);
 
         pageData = (InstructorCoursesPageData) r.data;

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -136,7 +136,7 @@
   <br>
   <div id="statusMessagesToUser" style="">
     <div class="overflow-auto alert alert-warning icon-warning statusMessage">
-      You have not created any courses yet. Use the form above to create a course.
+      You do not seem to have any courses. Use the form above to create a course.
     </div>
   </div>
   <br>


### PR DESCRIPTION
Fixes #8980

Replaced message "You have not created any courses yet. Use the form above to create a course." with 
 "You do not seem to have any courses. Use the form above to create a course." in main as well as test cases 
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
