### PR TITLE
Instructor: Feedback Session: Improve display of more information for advanced settings #8932

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsFormAdditionalSettings.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsFormAdditionalSettings.tag
@@ -11,11 +11,14 @@
     <div class="row">
       <div class="col-xs-12 col-md-6">
         <div class="row">
-          <div class="col-xs-12"
+          <div class="col-xs-5"
               title="<%= Const.Tooltips.FEEDBACK_SESSION_SESSIONVISIBLELABEL %>"
               data-toggle="tooltip"
               data-placement="top">
             <label class="label-control">Make session visible </label>
+          </div>
+          <div class="col-xs-7 text-color-primary" id="sessionVisibleCustomInfo">
+            <span class="glyphicon glyphicon-info-sign cursor-pointer"></span>
           </div>
         </div>
         <div class="row radio">

--- a/src/main/webapp/dev/js/common/instructorFeedbacks.js
+++ b/src/main/webapp/dev/js/common/instructorFeedbacks.js
@@ -1,4 +1,8 @@
 import {
+    showModalAlert,
+} from './bootboxWrapper';
+
+import {
     ParamsNames,
 } from './const';
 
@@ -94,6 +98,37 @@ function formatResponsesVisibilityGroup() {
     });
 }
 
+function setupSessionVisibilityInfoModal() {
+    const generalInfo = `
+    <p>
+        This option allows you to select when you want the questions
+        for the feedback session to be visible to users who need to participate.<br><br>
+        <label>Note:</label> Users cannot submit their responses until the submissions
+        opening time set using this option.
+    </p>
+    `;
+
+    const atOptionInfo = `
+    <p>
+        <label>At:</label> Select this option to enter in a custom date and time for which
+        the feedback session will become visible. Note that you can make
+        a session visible before it is open for submissions so that users can preview the questions.
+    </p>
+    `;
+
+    const openTimeOptionInfo = `
+    <p>
+        <label>Submission opening time:</label> Select this option to have the feedback
+        session become visible when it is open for submissions as set before.
+    </p>
+    `;
+
+    const modalText = `${generalInfo}<br>${atOptionInfo}<br>${openTimeOptionInfo}`;
+    $('#sessionVisibleCustomInfo').on('click', () => {
+        showModalAlert('Session Visibility Options', modalText);
+    });
+}
+
 /**
  * Hides / shows the 'Submissions Opening/Closing Time' and 'Grace Period' options
  * depending on whether a private session is selected.<br>
@@ -118,6 +153,7 @@ export {
     bindUncommonSettingsEvents,
     formatResponsesVisibilityGroup,
     formatSessionVisibilityGroup,
+    setupSessionVisibilityInfoModal,
     showUncommonPanelsIfNotInDefaultValues,
     updateUncommonSettingsInfo,
 };

--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -34,6 +34,7 @@ import {
     bindUncommonSettingsEvents,
     formatResponsesVisibilityGroup,
     formatSessionVisibilityGroup,
+    setupSessionVisibilityInfoModal,
     showUncommonPanelsIfNotInDefaultValues,
     updateUncommonSettingsInfo,
 } from '../common/instructorFeedbacks';
@@ -1212,6 +1213,8 @@ function readyFeedbackEditPage() {
     formatQuestionNumbers();
 
     setupFsCopyModal();
+
+    setupSessionVisibilityInfoModal();
 
     bindAssignWeightsCheckboxes();
     bindMcqHasAssignedWeightsCheckbox();


### PR DESCRIPTION
Fixes #8932 

**Outline of Solution**
Added a modal for displaying session visibility options instead of using tooltips. This PR includes more such enhancements for displaying helpful information in feedback sessions.

![adv_settings_modal1](https://user-images.githubusercontent.com/11634699/43370873-dd3802c8-937e-11e8-970a-763fb9f95aab.gif)
