### PR TITLE
Instructor: Courses Page: Recycle Bin feature for courses #9002

### DIFF
--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -22,6 +22,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     //Note: be careful when changing these variables as their names are used in *.json files.
     public Instant createdAt;
+    public Instant deletedAt;
     private String id;
     private String name;
     private ZoneId timeZone;
@@ -31,6 +32,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         this.name = SanitizationHelper.sanitizeTitle(name);
         this.timeZone = timeZone;
         this.createdAt = Instant.now();
+        this.deletedAt = null;
     }
 
     /**
@@ -79,6 +81,44 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
         return TimeHelper.formatDateTimeForDisplay(localDateTime);
     }
 
+    public String getDeletedAtDateString() {
+        if (this.deletedAt == null) {
+            return Const.DELETION_DATE_NOT_APPLICABLE;
+        }
+        return TimeHelper.formatDateForInstructorCoursesPage(deletedAt, timeZone);
+    }
+
+    public String getDeletedAtDateStamp() {
+        if (this.deletedAt == null) {
+            return Const.DELETION_DATE_NOT_APPLICABLE;
+        }
+        return TimeHelper.formatDateTimeToIso8601Utc(deletedAt);
+    }
+
+    public String getDeletedAtFullDateTimeString() {
+        if (this.deletedAt == null) {
+            return Const.DELETION_DATE_NOT_APPLICABLE;
+        }
+        LocalDateTime localDateTime = TimeHelper.convertInstantToLocalDateTime(deletedAt, timeZone);
+        return TimeHelper.formatDateTimeForDisplay(localDateTime);
+    }
+
+    public void setDeletedAt() {
+        this.deletedAt = Instant.now();
+    }
+
+    public void setDeletedAt(Instant deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public void resetDeletedAt() {
+        this.deletedAt = null;
+    }
+
+    public boolean isCourseDeleted() {
+        return this.deletedAt != null;
+    }
+
     public void setTimeZone(ZoneId timeZone) {
         this.timeZone = timeZone;
     }
@@ -98,7 +138,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     @Override
     public Course toEntity() {
-        return new Course(getId(), getName(), getTimeZone().getId(), createdAt);
+        return new Course(getId(), getName(), getTimeZone().getId(), createdAt, null);
     }
 
     @Override
@@ -162,6 +202,12 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
             if (createdAt != null) {
                 courseAttributes.createdAt = createdAt;
             }
+
+            return this;
+        }
+
+        public Builder withDeletedAt(Instant deletedAt) {
+            courseAttributes.deletedAt = deletedAt;
 
             return this;
         }

--- a/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/CourseAttributes.java
@@ -138,7 +138,7 @@ public class CourseAttributes extends EntityAttributes<Course> implements Compar
 
     @Override
     public Course toEntity() {
-        return new Course(getId(), getName(), getTimeZone().getId(), createdAt, null);
+        return new Course(getId(), getName(), getTimeZone().getId(), createdAt, deletedAt);
     }
 
     @Override

--- a/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/attributes/StudentAttributes.java
@@ -125,6 +125,10 @@ public class StudentAttributes extends EntityAttributes<CourseStudent> {
         return email;
     }
 
+    public String getCourse() {
+        return course;
+    }
+
     public String getKey() {
         return key;
     }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -30,6 +30,7 @@ public final class Const {
     public static final String JOIN_LINK = "[Join Link]";
 
     public static final String NONE_OF_THE_ABOVE = "None of the above";
+    public static final String DELETION_DATE_NOT_APPLICABLE = "Not Applicable";
 
     public static final String INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_CUSTOM = "custom";
     public static final String INSTRUCTOR_FEEDBACK_SESSION_VISIBLE_TIME_ATOPEN = "atopen";
@@ -159,6 +160,10 @@ public final class Const {
                         ActionURIs.INSTRUCTOR_COURSE_ADD,
                         ActionURIs.INSTRUCTOR_COURSE_ARCHIVE,
                         ActionURIs.INSTRUCTOR_COURSE_DELETE,
+                        ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE,
+                        ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE_ALL,
+                        ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE,
+                        ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE_ALL,
                         ActionURIs.INSTRUCTOR_COURSE_EDIT_SAVE,
                         ActionURIs.INSTRUCTOR_COURSE_ENROLL_SAVE,
                         ActionURIs.INSTRUCTOR_COURSE_INSTRUCTOR_ADD,
@@ -224,7 +229,16 @@ public final class Const {
         public static final String COURSE_ENROLL = "Enroll student into the course";
         public static final String COURSE_DETAILS = "View, edit and send invitation emails to the students in the course";
         public static final String COURSE_EDIT = "Edit Course information and instructor list";
-        public static final String COURSE_DELETE = "Delete the course and its corresponding students and sessions";
+        public static final String COURSE_MOVE_TO_RECOVERY =
+                "Delete the course and its corresponding students and sessions";
+        public static final String COURSE_DELETE =
+                "Permanently delete the course and its corresponding students and sessions";
+        public static final String COURSE_DELETE_ALL =
+                "Permanently delete all courses and their corresponding students and sessions";
+        public static final String COURSE_RESTORE =
+                "Restore the deleted course and its corresponding students and sessions";
+        public static final String COURSE_RESTORE_ALL =
+                "Restore all deleted courses and their corresponding students and sessions";
         public static final String COURSE_ARCHIVE =
                 "Archive the course so that it will not be shown in the home page any more "
                 + "(you can still access it from the 'Courses' tab)";
@@ -942,6 +956,12 @@ public final class Const {
         public static final String INSTRUCTOR_COURSE_ADD = "/page/instructorCourseAdd";
         public static final String INSTRUCTOR_COURSE_DELETE = "/page/instructorCourseDelete";
         public static final String INSTRUCTOR_COURSE_ARCHIVE = "/page/instructorCourseArchive";
+        public static final String INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE = "/page/instructorRecoveryRestoreCourse";
+        public static final String INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE_ALL =
+                "/page/instructorRecoveryRestoreAllCourses";
+        public static final String INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE = "/page/instructorRecoveryDeleteCourse";
+        public static final String INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE_ALL =
+                "/page/instructorRecoveryDeleteAllCourses";
         public static final String INSTRUCTOR_COURSE_DETAILS_PAGE = "/page/instructorCourseDetailsPage";
         public static final String INSTRUCTOR_COURSE_EDIT_PAGE = "/page/instructorCourseEditPage";
         public static final String INSTRUCTOR_COURSE_EDIT_SAVE = "/page/instructorCourseEditSave";
@@ -1289,7 +1309,15 @@ public final class Const {
                 COURSE_ARCHIVED + " You can access archived courses from the 'Courses' tab.<br>"
                 + "Go there to undo the archiving and bring the course back to the home page.";
         public static final String COURSE_UNARCHIVED = "The course %s has been unarchived.";
-        public static final String COURSE_DELETED = "The course %s has been deleted.";
+        public static final String COURSE_MOVED_TO_RECYCLE_BIN_FROM_HOMEPAGE =
+                "The course %s has been deleted. You can restore it from the 'Courses' tab.";
+        public static final String COURSE_MOVED_TO_RECYCLE_BIN =
+                "The course %s has been deleted. You can restore it from the deleted courses table below.";
+        public static final String COURSE_RESTORED = "The course %s has been restored.";
+        public static final String COURSE_ALL_RESTORED = "All courses have been restored.";
+        public static final String COURSE_DELETED =
+                "The course %s has been permanently deleted.";
+        public static final String COURSE_ALL_DELETED = "All courses have been permanently deleted.";
         public static final String COURSE_EMPTY =
                 "You do not seem to have any courses. Use the form above to create a course.";
         public static final String COURSE_EMPTY_IN_INSTRUCTOR_FEEDBACKS =

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -668,12 +668,30 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null.
      *
-     * @return Courses the given instructors is in.
+     * @return Courses the given instructors is in except for courses in recycle bin.
      */
     public List<CourseAttributes> getCoursesForInstructor(List<InstructorAttributes> instructorList) {
 
         Assumption.assertNotNull(instructorList);
         return coursesLogic.getCoursesForInstructor(instructorList);
+    }
+
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     *
+     * @return Courses in Recycle Bin that the given instructors is in.
+     */
+    public List<CourseAttributes> getRecoveryCoursesForInstructors(List<InstructorAttributes> instructorList) {
+
+        Assumption.assertNotNull(instructorList);
+        return coursesLogic.getRecoveryCoursesForInstructors(instructorList);
+    }
+
+    public CourseAttributes getRecoveryCourseForInstructor(InstructorAttributes instructor) {
+
+        Assumption.assertNotNull(instructor);
+        return coursesLogic.getRecoveryCourseForInstructor(instructor);
     }
 
     /**
@@ -708,8 +726,8 @@ public class Logic {
     }
 
     /**
-     * Deletes the course and all data related to the course
-     * (instructors, students, feedback sessions).
+     * Permanently deletes a course and all data related to the course
+     * (instructors, students, feedback sessions) from Recycle Bin.
      * Fails silently if no such account. <br>
      * Preconditions: <br>
      * * All parameters are non-null.
@@ -717,6 +735,43 @@ public class Logic {
     public void deleteCourse(String courseId) {
         Assumption.assertNotNull(courseId);
         coursesLogic.deleteCourseCascade(courseId);
+    }
+
+    /**
+     * Permanently deletes all courses and all data related to these courses
+     * (instructors, students, feedback sessions) from Recycle Bin.
+     */
+    public void deleteAllCourses(List<InstructorAttributes> instructorList) {
+        Assumption.assertNotNull(instructorList);
+        coursesLogic.deleteAllCoursesCascade(instructorList);
+    }
+
+    /**
+     * Moves a course to Recycle Bin by its given corresponding ID.
+     * All data related will not be deleted.
+     */
+    public void moveCourseToRecovery(String courseId) throws InvalidParametersException, EntityDoesNotExistException {
+        Assumption.assertNotNull(courseId);
+        coursesLogic.moveCourseToRecovery(courseId);
+    }
+
+    /**
+     * Restores a course and all data related to the course from Recycle Bin by
+     * its given corresponding ID.
+     */
+    public void restoreCourseFromRecovery(String courseId)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        Assumption.assertNotNull(courseId);
+        coursesLogic.restoreCourseFromRecovery(courseId);
+    }
+
+    /**
+     * Restores all courses and all data related to these courses from Recycle Bin.
+     */
+    public void restoreAllCoursesFromRecovery(List<InstructorAttributes> instructorList)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        Assumption.assertNotNull(instructorList);
+        coursesLogic.restoreAllCoursesFromRecovery(instructorList);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.CourseDetailsBundle;
 import teammates.common.datatransfer.CourseSummaryBundle;
@@ -473,15 +474,17 @@ public final class CoursesLogic {
             throw new EntityDoesNotExistException("Student with Google ID " + googleId + " does not exist");
         }
 
-        List<String> courseIds = new ArrayList<>();
-        for (StudentAttributes s : studentDataList) {
-            courseIds.add(s.course);
-        }
+        List<String> courseIds = studentDataList.stream()
+                .filter(student -> !getCourse(student.course).isCourseDeleted())
+                .map(StudentAttributes::getCourse)
+                .collect(Collectors.toList());
+
         return coursesDb.getCourses(courseIds);
     }
 
     /**
-     * Returns a list of {@link CourseAttributes} for all courses a given instructor belongs to.
+     * Returns a list of {@link CourseAttributes} for all courses a given instructor belongs to,
+     * except for courses in recycle bin.
      *
      * @param googleId The Google ID of the instructor
      */
@@ -490,7 +493,8 @@ public final class CoursesLogic {
     }
 
     /**
-     * Returns a list of {@link CourseAttributes} for courses a given instructor belongs to.
+     * Returns a list of {@link CourseAttributes} for courses a given instructor belongs to,
+     * except for courses in recycle bin.
      *
      * @param googleId The Google ID of the instructor
      * @param omitArchived if {@code true}, omits all the archived courses from the return
@@ -501,15 +505,16 @@ public final class CoursesLogic {
     }
 
     /**
-     * Returns a list of {@link CourseAttributes} for all courses for a given list of instructors.
+     * Returns a list of {@link CourseAttributes} for all courses for a given list of instructors
+     * except for courses in Recycle Bin.
      */
     public List<CourseAttributes> getCoursesForInstructor(List<InstructorAttributes> instructorList) {
         Assumption.assertNotNull("Supplied parameter was null", instructorList);
-        List<String> courseIdList = new ArrayList<>();
 
-        for (InstructorAttributes instructor : instructorList) {
-            courseIdList.add(instructor.courseId);
-        }
+        List<String> courseIdList = instructorList.stream()
+                .filter(instructor -> !coursesDb.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
 
         List<CourseAttributes> courseList = coursesDb.getCourses(courseIdList);
 
@@ -523,6 +528,41 @@ public final class CoursesLogic {
         }
 
         return courseList;
+    }
+
+    /**
+     * Returns a list of {@link CourseAttributes} for soft-deleted courses for a given list of instructors.
+     */
+    public List<CourseAttributes> getRecoveryCoursesForInstructors(List<InstructorAttributes> instructorList) {
+        Assumption.assertNotNull("Supplied parameter was null", instructorList);
+
+        List<String> recoveryCourseIdList = instructorList.stream()
+                .filter(instructor -> coursesDb.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
+
+        List<CourseAttributes> recoveryCourseList = coursesDb.getCourses(recoveryCourseIdList);
+
+        if (recoveryCourseIdList.size() > recoveryCourseList.size()) {
+            for (CourseAttributes ca : recoveryCourseList) {
+                recoveryCourseIdList.remove(ca.getId());
+            }
+            log.severe("Course(s) was deleted but the instructor still exists: " + System.lineSeparator()
+                    + recoveryCourseIdList.toString());
+        }
+
+        return recoveryCourseList;
+    }
+
+    public CourseAttributes getRecoveryCourseForInstructor(InstructorAttributes instructor) {
+        Assumption.assertNotNull("Supplied parameter was null", instructor);
+
+        CourseAttributes recoveryCourse = coursesDb.getCourse(instructor.courseId);
+
+        if (recoveryCourse.isCourseDeleted()) {
+            return null;
+        }
+        return recoveryCourse;
     }
 
     /**
@@ -614,7 +654,7 @@ public final class CoursesLogic {
     }
 
     /**
-     * Delete a course from its given corresponding ID.
+     * Permanently deletes a course in Recycle Bin by its given corresponding ID.
      * This will also cascade the data in other databases which are related to this course.
      */
     public void deleteCourseCascade(String courseId) {
@@ -624,16 +664,70 @@ public final class CoursesLogic {
         coursesDb.deleteCourse(courseId);
     }
 
+    /**
+     * Permanently deletes all courses in Recycle Bin.
+     * This will also cascade the data in other databases which are related to these courses.
+     */
+    public void deleteAllCoursesCascade(List<InstructorAttributes> instructorList) {
+        Assumption.assertNotNull("Supplied parameter was null", instructorList);
+
+        List<String> recoveryCourseIdList = instructorList.stream()
+                .filter(instructor -> coursesDb.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
+
+        for (String courseId : recoveryCourseIdList) {
+            deleteCourseCascade(courseId);
+        }
+    }
+
+    /**
+     * Moves a course to Recycle Bin by its given corresponding ID.
+     */
+    public void moveCourseToRecovery(String courseId)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        CourseAttributes course = coursesDb.getCourse(courseId);
+        course.setDeletedAt();
+        coursesDb.updateCourse(course);
+    }
+
+    /**
+     * Restores a course from Recycle Bin by its given corresponding ID.
+     */
+    public void restoreCourseFromRecovery(String courseId)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        CourseAttributes course = coursesDb.getCourse(courseId);
+        course.resetDeletedAt();
+        coursesDb.updateCourse(course);
+    }
+
+    /**
+     * Restores all courses from Recycle Bin.
+     */
+    public void restoreAllCoursesFromRecovery(List<InstructorAttributes> instructorList)
+            throws InvalidParametersException, EntityDoesNotExistException {
+        Assumption.assertNotNull("Supplied parameter was null", instructorList);
+
+        List<String> recoveryCourseIdList = instructorList.stream()
+                .filter(instructor -> coursesDb.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
+
+        for (String courseId : recoveryCourseIdList) {
+            restoreCourseFromRecovery(courseId);
+        }
+    }
+
     private Map<String, CourseSummaryBundle> getCourseSummaryWithoutStatsForInstructor(
             List<InstructorAttributes> instructorAttributesList) {
 
         HashMap<String, CourseSummaryBundle> courseSummaryList = new HashMap<>();
 
-        List<String> courseIdList = new ArrayList<>();
+        List<String> courseIdList = instructorAttributesList.stream()
+                .filter(instructor -> !coursesDb.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
 
-        for (InstructorAttributes ia : instructorAttributesList) {
-            courseIdList.add(ia.courseId);
-        }
         List<CourseAttributes> courseList = coursesDb.getCourses(courseIdList);
 
         // Check that all courseIds queried returned a course.

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -1,5 +1,6 @@
 package teammates.logic.core;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -559,7 +560,7 @@ public final class CoursesLogic {
 
         CourseAttributes recoveryCourse = coursesDb.getCourse(instructor.courseId);
 
-        if (recoveryCourse.isCourseDeleted()) {
+        if (!recoveryCourse.isCourseDeleted()) {
             return null;
         }
         return recoveryCourse;
@@ -684,11 +685,13 @@ public final class CoursesLogic {
     /**
      * Moves a course to Recycle Bin by its given corresponding ID.
      */
-    public void moveCourseToRecovery(String courseId)
+    public Instant moveCourseToRecovery(String courseId)
             throws InvalidParametersException, EntityDoesNotExistException {
         CourseAttributes course = coursesDb.getCourse(courseId);
         course.setDeletedAt();
         coursesDb.updateCourse(course);
+
+        return course.deletedAt;
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -256,9 +257,13 @@ public final class FeedbackSessionsLogic {
     public List<FeedbackSessionAttributes> getFeedbackSessionsListForInstructor(
             List<InstructorAttributes> instructorList) {
 
+        List<InstructorAttributes> courseNotDeletedInstructorList = instructorList.stream()
+                .filter(instructor -> !coursesLogic.getCourse(instructor.courseId).isCourseDeleted())
+                .collect(Collectors.toList());
+
         List<FeedbackSessionAttributes> fsList = new ArrayList<>();
 
-        for (InstructorAttributes instructor : instructorList) {
+        for (InstructorAttributes instructor : courseNotDeletedInstructorList) {
             fsList.addAll(getFeedbackSessionsListForCourse(instructor.courseId));
         }
 
@@ -267,6 +272,9 @@ public final class FeedbackSessionsLogic {
 
     public List<FeedbackSessionAttributes> getFeedbackSessionListForInstructor(
             InstructorAttributes instructor) {
+        if (coursesLogic.getCourse(instructor.courseId).isCourseDeleted()) {
+            return null;
+        }
         return getFeedbackSessionsListForCourse(instructor.courseId);
     }
 

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -76,7 +76,7 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
 
     /**
      * Updates the course.<br>
-     * Updates only name and course archive status.<br>
+     * Updates only name, deletion date and course archive status.<br>
      * Preconditions: <br>
      * * {@code courseToUpdate} is non-null.<br>
      */
@@ -97,13 +97,16 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
         }
 
         courseEntityToUpdate.setName(courseToUpdate.getName());
+        courseEntityToUpdate.setDeletedAt(courseToUpdate.deletedAt);
         courseEntityToUpdate.setTimeZone(courseToUpdate.getTimeZone().getId());
 
         saveEntity(courseEntityToUpdate, courseToUpdate);
     }
 
     /**
-     * Note: This is a non-cascade delete.<br>
+     * Permanently deletes the course from the Datastore.
+     *
+     * <p>Note: This is a non-cascade delete.<br>
      *   <br> Fails silently if there is no such object.
      * <br> Preconditions:
      * <br> * {@code courseId} is not null.
@@ -159,6 +162,8 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
             courseTimeZone = Const.DEFAULT_TIME_ZONE;
         }
         return CourseAttributes.builder(entity.getUniqueId(), entity.getName(), courseTimeZone)
-                .withCreatedAt(entity.getCreatedAt()).build();
+                .withCreatedAt(entity.getCreatedAt())
+                .withDeletedAt(entity.getDeletedAt())
+                .build();
     }
 }

--- a/src/main/java/teammates/storage/entity/Course.java
+++ b/src/main/java/teammates/storage/entity/Course.java
@@ -25,6 +25,8 @@ public class Course extends BaseEntity {
     // TODO: change to `java.time.Instant` once we have upgraded to Objectify 6
     private Date createdAt;
 
+    private Date deletedAt;
+
     private String timeZone;
 
     @SuppressWarnings("unused")
@@ -32,7 +34,7 @@ public class Course extends BaseEntity {
         // required by Objectify
     }
 
-    public Course(String courseId, String courseName, String courseTimeZone, Instant createdAt) {
+    public Course(String courseId, String courseName, String courseTimeZone, Instant createdAt, Instant deletedAt) {
         this.setUniqueId(courseId);
         this.setName(courseName);
         if (courseTimeZone == null) {
@@ -45,6 +47,7 @@ public class Course extends BaseEntity {
         } else {
             this.setCreatedAt(createdAt);
         }
+        this.setDeletedAt(deletedAt);
     }
 
     public String getUniqueId() {
@@ -64,11 +67,19 @@ public class Course extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return TimeHelper.convertDateToInstant(this.createdAt);
+        return TimeHelper.convertDateToInstant(createdAt);
     }
 
     public void setCreatedAt(Instant createdAt) {
         this.createdAt = TimeHelper.convertInstantToDate(createdAt);
+    }
+
+    public Instant getDeletedAt() {
+        return TimeHelper.convertDateToInstant(deletedAt);
+    }
+
+    public void setDeletedAt(Instant deletedAt) {
+        this.deletedAt = TimeHelper.convertInstantToDate(deletedAt);
     }
 
     public String getTimeZone() {

--- a/src/main/java/teammates/ui/controller/ActionFactory.java
+++ b/src/main/java/teammates/ui/controller/ActionFactory.java
@@ -53,6 +53,10 @@ public class ActionFactory {
         map(INSTRUCTOR_COURSE_ADD, InstructorCourseAddAction.class);
         map(INSTRUCTOR_COURSE_DELETE, InstructorCourseDeleteAction.class);
         map(INSTRUCTOR_COURSE_ARCHIVE, InstructorCourseArchiveAction.class);
+        map(INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE, InstructorCourseRestoreRecoveryCourseAction.class);
+        map(INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE_ALL, InstructorCourseRestoreAllRecoveryCoursesAction.class);
+        map(INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE, InstructorCourseDeleteRecoveryCourseAction.class);
+        map(INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE_ALL, InstructorCourseDeleteAllRecoveryCoursesAction.class);
         map(INSTRUCTOR_COURSE_DETAILS_PAGE, InstructorCourseDetailsPageAction.class);
         map(INSTRUCTOR_COURSE_JOIN, InstructorCourseJoinAction.class);
         map(INSTRUCTOR_COURSE_JOIN_AUTHENTICATED, InstructorCourseJoinAuthenticatedAction.class);

--- a/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseAddAction.java
@@ -53,6 +53,7 @@ public class InstructorCourseAddAction extends Action {
 
         // Get corresponding courses of the instructors.
         List<CourseAttributes> allCourses = logic.getCoursesForInstructor(instructorList);
+        List<CourseAttributes> recoveryCourses = logic.getRecoveryCoursesForInstructors(instructorList);
 
         List<String> archivedCourseIds = logic.getArchivedCourseIds(allCourses, instructorsForCourses);
         for (CourseAttributes course : allCourses) {
@@ -66,6 +67,7 @@ public class InstructorCourseAddAction extends Action {
         // Sort CourseDetailsBundle lists by course id
         CourseAttributes.sortById(activeCourses);
         CourseAttributes.sortById(archivedCourses);
+        CourseAttributes.sortById(recoveryCourses);
 
         String courseIdToShowParam = "";
         String courseNameToShowParam = "";
@@ -86,7 +88,8 @@ public class InstructorCourseAddAction extends Action {
             statusToAdmin += "<br>Total courses: " + allCourses.size();
         }
 
-        data.init(activeCourses, archivedCourses, instructorsForCourses, courseIdToShowParam, courseNameToShowParam);
+        data.init(activeCourses, archivedCourses, recoveryCourses, instructorsForCourses, courseIdToShowParam,
+                courseNameToShowParam);
 
         return isError ? createShowPageResult(Const.ViewURIs.INSTRUCTOR_COURSES, data)
                 : createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);

--- a/src/main/java/teammates/ui/controller/InstructorCourseDeleteAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDeleteAction.java
@@ -6,7 +6,7 @@ import teammates.common.util.StatusMessage;
 import teammates.common.util.StatusMessageColor;
 
 /**
- * Action: Delete a course for an instructor.
+ * Action: Move a course to Recycle Bin (soft-delete) for an instructor.
  */
 public class InstructorCourseDeleteAction extends Action {
 
@@ -20,11 +20,23 @@ public class InstructorCourseDeleteAction extends Action {
                                     logic.getCourse(idOfCourseToDelete),
                                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
 
-        /* Delete the course and setup status to be shown to user and admin */
-        logic.deleteCourse(idOfCourseToDelete);
-        String statusMessage = String.format(Const.StatusMessages.COURSE_DELETED, idOfCourseToDelete);
-        statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
-        statusToAdmin = "Course deleted: " + idOfCourseToDelete;
+        try {
+            /* Move the course to recycle bin and setup status to be shown to user and admin */
+            logic.moveCourseToRecovery(idOfCourseToDelete);
+
+            String statusMessage;
+            if (isRedirectedToHomePage()) {
+                statusMessage = String.format(Const.StatusMessages.COURSE_MOVED_TO_RECYCLE_BIN_FROM_HOMEPAGE,
+                        idOfCourseToDelete);
+            } else {
+                statusMessage = String.format(Const.StatusMessages.COURSE_MOVED_TO_RECYCLE_BIN,
+                        idOfCourseToDelete);
+            }
+            statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
+            statusToAdmin = "Course moved to recycle bin: " + idOfCourseToDelete;
+        } catch (Exception e) {
+            setStatusForException(e);
+        }
 
         if (isRedirectedToHomePage()) {
             return createRedirectResult(Const.ActionURIs.INSTRUCTOR_HOME_PAGE);

--- a/src/main/java/teammates/ui/controller/InstructorCourseDeleteAllRecoveryCoursesAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDeleteAllRecoveryCoursesAction.java
@@ -1,0 +1,44 @@
+package teammates.ui.controller;
+
+import java.util.List;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.StatusMessage;
+import teammates.common.util.StatusMessageColor;
+import teammates.ui.pagedata.InstructorCoursesPageData;
+
+/**
+ * Action: Permanently delete all courses from Recycle Bin for an instructor.
+ */
+public class InstructorCourseDeleteAllRecoveryCoursesAction extends Action {
+
+    @Override
+    public ActionResult execute() {
+
+        InstructorCoursesPageData data = new InstructorCoursesPageData(account, sessionToken);
+        List<InstructorAttributes> instructorList = logic.getInstructorsForGoogleId(data.account.googleId);
+
+        for (InstructorAttributes instructor : instructorList) {
+            CourseAttributes course = logic.getRecoveryCourseForInstructor(instructor);
+            if (course != null) {
+                gateKeeper.verifyAccessible(instructor,
+                        course,
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
+            }
+        }
+
+        try {
+            /* Permanently delete all courses and setup status to be shown to user and admin */
+            logic.deleteAllCourses(instructorList);
+            String statusMessage = Const.StatusMessages.COURSE_ALL_DELETED;
+            statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
+            statusToAdmin = "All courses deleted";
+        } catch (Exception e) {
+            setStatusForException(e);
+        }
+
+        return createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+    }
+}

--- a/src/main/java/teammates/ui/controller/InstructorCourseDeleteRecoveryCourseAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDeleteRecoveryCourseAction.java
@@ -1,0 +1,35 @@
+package teammates.ui.controller;
+
+import teammates.common.util.Assumption;
+import teammates.common.util.Const;
+import teammates.common.util.StatusMessage;
+import teammates.common.util.StatusMessageColor;
+
+/**
+ * Action: Permanently delete a course from Recycle Bin for an instructor.
+ */
+public class InstructorCourseDeleteRecoveryCourseAction extends Action {
+
+    @Override
+    public ActionResult execute() {
+
+        String idOfCourseToDelete = getRequestParamValue(Const.ParamsNames.COURSE_ID);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, idOfCourseToDelete);
+
+        gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(idOfCourseToDelete, account.googleId),
+                logic.getCourse(idOfCourseToDelete),
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
+
+        try {
+            /* Permanently delete the course and setup status to be shown to user and admin */
+            logic.deleteCourse(idOfCourseToDelete);
+            String statusMessage = String.format(Const.StatusMessages.COURSE_DELETED, idOfCourseToDelete);
+            statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
+            statusToAdmin = "Course deleted: " + idOfCourseToDelete;
+        } catch (Exception e) {
+            setStatusForException(e);
+        }
+
+        return createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+    }
+}

--- a/src/main/java/teammates/ui/controller/InstructorCourseRestoreAllRecoveryCoursesAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseRestoreAllRecoveryCoursesAction.java
@@ -1,0 +1,44 @@
+package teammates.ui.controller;
+
+import java.util.List;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.Const;
+import teammates.common.util.StatusMessage;
+import teammates.common.util.StatusMessageColor;
+import teammates.ui.pagedata.InstructorCoursesPageData;
+
+/**
+ * Action: Restore all courses from Recycle Bin for an instructor.
+ */
+public class InstructorCourseRestoreAllRecoveryCoursesAction extends Action {
+
+    @Override
+    public ActionResult execute() {
+
+        InstructorCoursesPageData data = new InstructorCoursesPageData(account, sessionToken);
+        List<InstructorAttributes> instructorList = logic.getInstructorsForGoogleId(data.account.googleId);
+
+        for (InstructorAttributes instructor : instructorList) {
+            CourseAttributes course = logic.getRecoveryCourseForInstructor(instructor);
+            if (course != null) {
+                gateKeeper.verifyAccessible(instructor,
+                        course,
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
+            }
+        }
+
+        try {
+            /* Restore all courses and setup status to be shown to user and admin */
+            logic.restoreAllCoursesFromRecovery(instructorList);
+            String statusMessage = Const.StatusMessages.COURSE_ALL_RESTORED;
+            statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
+            statusToAdmin = "All courses restored";
+        } catch (Exception e) {
+            setStatusForException(e);
+        }
+
+        return createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+    }
+}

--- a/src/main/java/teammates/ui/controller/InstructorCourseRestoreRecoveryCourseAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseRestoreRecoveryCourseAction.java
@@ -1,0 +1,35 @@
+package teammates.ui.controller;
+
+import teammates.common.util.Assumption;
+import teammates.common.util.Const;
+import teammates.common.util.StatusMessage;
+import teammates.common.util.StatusMessageColor;
+
+/**
+ * Action: Restore a deleted course from Recycle Bin for an instructor.
+ */
+public class InstructorCourseRestoreRecoveryCourseAction extends Action {
+
+    @Override
+    public ActionResult execute() {
+
+        String idOfCourseToRestore = getRequestParamValue(Const.ParamsNames.COURSE_ID);
+        Assumption.assertPostParamNotNull(Const.ParamsNames.COURSE_ID, idOfCourseToRestore);
+
+        gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(idOfCourseToRestore, account.googleId),
+                logic.getCourse(idOfCourseToRestore),
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
+
+        try {
+            /* Restore the deleted course and setup status to be shown to user and admin */
+            logic.restoreCourseFromRecovery(idOfCourseToRestore);
+            String statusMessage = String.format(Const.StatusMessages.COURSE_RESTORED, idOfCourseToRestore);
+            statusToUser.add(new StatusMessage(statusMessage, StatusMessageColor.SUCCESS));
+            statusToAdmin = "Course restored: " + idOfCourseToRestore;
+        } catch (Exception e) {
+            setStatusForException(e);
+        }
+
+        return createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+    }
+}

--- a/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCoursesPageAction.java
@@ -39,6 +39,7 @@ public class InstructorCoursesPageAction extends Action {
         List<CourseAttributes> allCourses = new ArrayList<>();
         List<CourseAttributes> activeCourses = new ArrayList<>();
         List<CourseAttributes> archivedCourses = new ArrayList<>();
+        List<CourseAttributes> recoveryCourses = new ArrayList<>();
 
         if (data.isUsingAjax()) {
             // Get list of InstructorAttributes that belong to the user.
@@ -49,6 +50,7 @@ public class InstructorCoursesPageAction extends Action {
 
             // Get corresponding courses of the instructors.
             allCourses = logic.getCoursesForInstructor(instructorList);
+            recoveryCourses = logic.getRecoveryCoursesForInstructors(instructorList);
 
             List<String> archivedCourseIds = logic.getArchivedCourseIds(allCourses, instructorsForCourses);
             for (CourseAttributes course : allCourses) {
@@ -62,9 +64,10 @@ public class InstructorCoursesPageAction extends Action {
             // Sort CourseDetailsBundle lists by course id
             CourseAttributes.sortById(activeCourses);
             CourseAttributes.sortById(archivedCourses);
+            CourseAttributes.sortById(recoveryCourses);
         }
 
-        data.init(activeCourses, archivedCourses, instructorsForCourses);
+        data.init(activeCourses, archivedCourses, recoveryCourses, instructorsForCourses);
 
         /* Explanation: Set any status messages that should be shown to the user.*/
         if (data.isUsingAjax() && allCourses.isEmpty()) {

--- a/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCourseEditPageData.java
@@ -175,11 +175,11 @@ public class InstructorCourseEditPageData extends PageData {
         String buttonId = "courseDeleteLink";
         String href = getInstructorCourseDeleteLink(course.getId(), false);
 
-        ElementTag button = createBasicButton(buttonContent, buttonId, href, Const.Tooltips.COURSE_DELETE,
+        ElementTag button = createBasicButton(buttonContent, buttonId, href, Const.Tooltips.COURSE_MOVE_TO_RECOVERY,
                                               isDisabled);
         button.setAttribute("data-course-id", course.getId());
         String existingClasses = button.removeAttribute("class");
-        button.setAttribute("class", existingClasses + " course-delete-link");
+        button.setAttribute("class", existingClasses);
 
         return button;
     }

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -14,6 +14,8 @@ import teammates.ui.template.ActiveCoursesTableRow;
 import teammates.ui.template.ArchivedCoursesTable;
 import teammates.ui.template.ArchivedCoursesTableRow;
 import teammates.ui.template.ElementTag;
+import teammates.ui.template.RecoveryCoursesTable;
+import teammates.ui.template.RecoveryCoursesTableRow;
 
 /**
  * This is the PageData object for the 'Courses' page.
@@ -26,6 +28,7 @@ public class InstructorCoursesPageData extends PageData {
 
     private ArchivedCoursesTable archivedCourses;
     private ActiveCoursesTable activeCourses;
+    private RecoveryCoursesTable recoveryCourses;
     private String courseIdToShow;
     private String courseNameToShow;
     private Map<String, InstructorAttributes> instructorsForCourses;
@@ -35,16 +38,19 @@ public class InstructorCoursesPageData extends PageData {
     }
 
     public void init(List<CourseAttributes> activeCoursesParam, List<CourseAttributes> archivedCoursesParam,
+                     List<CourseAttributes> recoveryCoursesParam,
                      Map<String, InstructorAttributes> instructorsForCoursesParam) {
-        init(activeCoursesParam, archivedCoursesParam, instructorsForCoursesParam, "", "");
+        init(activeCoursesParam, archivedCoursesParam, recoveryCoursesParam, instructorsForCoursesParam, "", "");
     }
 
     public void init(List<CourseAttributes> activeCoursesParam, List<CourseAttributes> archivedCoursesParam,
+                     List<CourseAttributes> recoveryCoursesParam,
                      Map<String, InstructorAttributes> instructorsForCoursesParam, String courseIdToShowParam,
                      String courseNameToShowParam) {
         this.instructorsForCourses = instructorsForCoursesParam;
         this.activeCourses = convertToActiveCoursesTable(activeCoursesParam);
         this.archivedCourses = convertToArchivedCoursesTable(archivedCoursesParam);
+        this.recoveryCourses = convertToRecoveryCoursesTable(recoveryCoursesParam);
         this.courseIdToShow = courseIdToShowParam;
         this.courseNameToShow = courseNameToShowParam;
     }
@@ -73,6 +79,10 @@ public class InstructorCoursesPageData extends PageData {
         return archivedCourses;
     }
 
+    public RecoveryCoursesTable getRecoveryCourses() {
+        return recoveryCourses;
+    }
+
     private ArchivedCoursesTable convertToArchivedCoursesTable(List<CourseAttributes> archivedCourses) {
         ArchivedCoursesTable archivedCoursesTable = new ArchivedCoursesTable();
 
@@ -90,9 +100,9 @@ public class InstructorCoursesPageData extends PageData {
             String deleteLink = getInstructorCourseDeleteLink(course.getId(), false);
             Boolean hasDeletePermission = instructorsForCourses.get(course.getId()).isAllowedForPrivilege(
                                                   Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
-            ElementTag deleteButton = createButton("Delete", "btn btn-default btn-xs course-delete-link",
-                                                   "t_course_delete" + idx, deleteLink, Const.Tooltips.COURSE_DELETE,
-                                                   !hasDeletePermission);
+            ElementTag deleteButton = createButton("Delete", "btn btn-default btn-xs",
+                                                   "t_course_delete" + idx, deleteLink,
+                                                   Const.Tooltips.COURSE_MOVE_TO_RECOVERY, !hasDeletePermission);
             deleteButton.setAttribute("data-course-id", course.getId());
 
             actionsParam.add(unarchivedButton);
@@ -142,9 +152,9 @@ public class InstructorCoursesPageData extends PageData {
             String deleteLink = getInstructorCourseDeleteLink(course.getId(), false);
             Boolean hasDeletePermission = instructorsForCourses.get(course.getId()).isAllowedForPrivilege(
                                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
-            ElementTag deleteButton = createButton("Delete", "btn btn-default btn-xs course-delete-link "
-                                                   + "t_course_delete" + idx, "", deleteLink, Const.Tooltips.COURSE_DELETE,
-                                                   !hasDeletePermission);
+            ElementTag deleteButton = createButton("Delete", "btn btn-default btn-xs "
+                                                   + "t_course_delete" + idx, "", deleteLink,
+                                                   Const.Tooltips.COURSE_MOVE_TO_RECOVERY, !hasDeletePermission);
             deleteButton.setAttribute("data-course-id", course.getId());
 
             actionsParam.add(enrollButton);
@@ -164,6 +174,48 @@ public class InstructorCoursesPageData extends PageData {
         }
 
         return activeCourses;
+    }
+
+    private RecoveryCoursesTable convertToRecoveryCoursesTable(List<CourseAttributes> courses) {
+        RecoveryCoursesTable recoveryCourses = new RecoveryCoursesTable();
+
+        int idx = -1;
+
+        for (CourseAttributes course : courses) {
+            idx++;
+
+            List<ElementTag> actionsParam = new ArrayList<>();
+
+            String restoreLink = getInstructorCourseRestoreRecoveryCourseLink(course.getId());
+            ElementTag restoreButton = createButton("Restore", "btn btn-default btn-xs t_course_restore" + idx, "",
+                    restoreLink, Const.Tooltips.COURSE_RESTORE, false);
+
+            String deleteLink = getInstructorCourseDeleteRecoveryCourseLink(course.getId());
+            Boolean hasDeletePermission = instructorsForCourses.get(course.getId()).isAllowedForPrivilege(
+                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
+            ElementTag deleteButton = createButton("Delete Permanently", "btn btn-default btn-xs course-delete-link "
+                            + "t_course_delete" + idx, "", deleteLink, Const.Tooltips.COURSE_DELETE,
+                    !hasDeletePermission);
+            deleteButton.setAttribute("data-course-id", course.getId());
+            deleteButton.setAttribute("style", "color: red");
+
+            actionsParam.add(restoreButton);
+            actionsParam.add(deleteButton);
+
+            RecoveryCoursesTableRow row = new RecoveryCoursesTableRow(SanitizationHelper.sanitizeForHtml(course.getId()),
+                    SanitizationHelper.sanitizeForHtml(course.getName()),
+                    course.getCreatedAtDateString(),
+                    course.getCreatedAtDateStamp(),
+                    course.getCreatedAtFullDateTimeString(),
+                    course.getDeletedAtDateString(),
+                    course.getDeletedAtDateStamp(),
+                    course.getDeletedAtFullDateTimeString(),
+                    this.getInstructorCourseStatsLink(course.getId()),
+                    actionsParam);
+            recoveryCourses.getRows().add(row);
+        }
+
+        return recoveryCourses;
     }
 
     private ElementTag createButton(String content, String buttonClass, String id, String href, String title,

--- a/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorCoursesPageData.java
@@ -83,6 +83,12 @@ public class InstructorCoursesPageData extends PageData {
         return recoveryCourses;
     }
 
+    public boolean isInstructorAllowedToModify() {
+        return getRecoveryCourses().getRows().stream()
+                .allMatch(course -> instructorsForCourses.get(course.getCourseId())
+                        .isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE));
+    }
+
     private ArchivedCoursesTable convertToArchivedCoursesTable(List<CourseAttributes> archivedCourses) {
         ArchivedCoursesTable archivedCoursesTable = new ArchivedCoursesTable();
 
@@ -187,14 +193,16 @@ public class InstructorCoursesPageData extends PageData {
             List<ElementTag> actionsParam = new ArrayList<>();
 
             String restoreLink = getInstructorCourseRestoreRecoveryCourseLink(course.getId());
+            Boolean hasRestorePermission = instructorsForCourses.get(course.getId()).isAllowedForPrivilege(
+                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
             ElementTag restoreButton = createButton("Restore", "btn btn-default btn-xs t_course_restore" + idx, "",
-                    restoreLink, Const.Tooltips.COURSE_RESTORE, false);
+                    restoreLink, Const.Tooltips.COURSE_RESTORE, !hasRestorePermission);
 
             String deleteLink = getInstructorCourseDeleteRecoveryCourseLink(course.getId());
             Boolean hasDeletePermission = instructorsForCourses.get(course.getId()).isAllowedForPrivilege(
                     Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE);
             ElementTag deleteButton = createButton("Delete Permanently", "btn btn-default btn-xs course-delete-link "
-                            + "t_course_delete" + idx, "", deleteLink, Const.Tooltips.COURSE_DELETE,
+                            + "t_course_delete_permanently" + idx, "", deleteLink, Const.Tooltips.COURSE_DELETE,
                     !hasDeletePermission);
             deleteButton.setAttribute("data-course-id", course.getId());
             deleteButton.setAttribute("style", "color: red");

--- a/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorHomeCourseAjaxPageData.java
@@ -91,9 +91,9 @@ public class InstructorHomeCourseAjaxPageData extends PageData {
         addAttributeIf(true, archive, "data-course-id", courseId);
 
         ElementTag delete = createButton("Delete",
-                                         className + "delete-for-test course-delete-link",
+                                         className + "delete-for-test course-move-to-recovery-link",
                                          getInstructorCourseDeleteLink(courseId, true),
-                                         Const.Tooltips.COURSE_DELETE);
+                                         Const.Tooltips.COURSE_MOVE_TO_RECOVERY);
         addAttributeIf(true, delete, "data-course-id", courseId);
 
         if (instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT)) {

--- a/src/main/java/teammates/ui/pagedata/PageData.java
+++ b/src/main/java/teammates/ui/pagedata/PageData.java
@@ -366,6 +366,44 @@ public class PageData {
         return link;
     }
 
+    public String getInstructorCourseRestoreRecoveryCourseLink(String courseId) {
+        String link = Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+        link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
+
+        return link;
+    }
+
+    public String getInstructorCourseRestoreAllRecoveryCoursesLink() {
+        String link = Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE_ALL;
+        link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+        link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
+
+        return link;
+    }
+
+    public String getInstructorCourseDeleteRecoveryCourseLink(String courseId) {
+        String link = Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE;
+        link = Url.addParamToUrl(link, Const.ParamsNames.COURSE_ID, courseId);
+        link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+        link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
+
+        return link;
+    }
+
+    public String getInstructorCourseDeleteAllRecoveryCoursesLink() {
+        String link = Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE_ALL;
+        link = Url.addParamToUrl(link, Const.ParamsNames.NEXT_URL, Const.ActionURIs.INSTRUCTOR_COURSES_PAGE);
+        link = addUserIdToUrl(link);
+        link = addSessionTokenToUrl(link);
+
+        return link;
+    }
+
     public String getInstructorFeedbackSessionsLink() {
         String link = Const.ActionURIs.INSTRUCTOR_FEEDBACK_SESSIONS_PAGE;
         link = addUserIdToUrl(link);

--- a/src/main/java/teammates/ui/template/CourseEditInstructorPanel.java
+++ b/src/main/java/teammates/ui/template/CourseEditInstructorPanel.java
@@ -240,7 +240,7 @@ public class CourseEditInstructorPanel {
     private List<ElementTag> createPermissionInputGroup1ForInstructorPanel() {
         List<ElementTag> permissionInputGroup = new ArrayList<>();
 
-        permissionInputGroup.add(createCheckBox("Edit/Delete Course",
+        permissionInputGroup.add(createCheckBox("Edit/Delete/Restore Course",
                                                 Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE));
 
         permissionInputGroup.add(createCheckBox("Add/Edit/Delete Instructors",

--- a/src/main/java/teammates/ui/template/RecoveryCoursesTable.java
+++ b/src/main/java/teammates/ui/template/RecoveryCoursesTable.java
@@ -1,0 +1,20 @@
+package teammates.ui.template;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecoveryCoursesTable {
+    private List<RecoveryCoursesTableRow> rows;
+
+    public RecoveryCoursesTable() {
+        rows = new ArrayList<>();
+    }
+
+    public List<RecoveryCoursesTableRow> getRows() {
+        return rows;
+    }
+
+    public void setRows(List<RecoveryCoursesTableRow> rows) {
+        this.rows = rows;
+    }
+}

--- a/src/main/java/teammates/ui/template/RecoveryCoursesTableRow.java
+++ b/src/main/java/teammates/ui/template/RecoveryCoursesTableRow.java
@@ -1,0 +1,73 @@
+package teammates.ui.template;
+
+import java.util.List;
+
+public class RecoveryCoursesTableRow {
+    private String courseId;
+    private String courseName;
+    private String createdAtDateString;
+    private String createdAtDateStamp;
+    private String createdAtFullDateTimeString;
+    private String deletedAtDateString;
+    private String deletedAtDateStamp;
+    private String deletedAtFullDateTimeString;
+    private String href;
+    private List<ElementTag> actions;
+
+    public RecoveryCoursesTableRow(String courseIdParam, String courseNameParam,
+            String createdAtDateStringParam, String createdAtDateStampParam, String createdAtFullDateTimeStringParam,
+            String deletedAtDateStringParam, String deletedAtDateStampParam, String deletedAtFullDateTimeStringParam,
+            String href, List<ElementTag> actionsParam) {
+        this.courseId = courseIdParam;
+        this.courseName = courseNameParam;
+        this.createdAtDateString = createdAtDateStringParam;
+        this.createdAtDateStamp = createdAtDateStampParam;
+        this.createdAtFullDateTimeString = createdAtFullDateTimeStringParam;
+        this.deletedAtDateString = deletedAtDateStringParam;
+        this.deletedAtDateStamp = deletedAtDateStampParam;
+        this.deletedAtFullDateTimeString = deletedAtFullDateTimeStringParam;
+        this.href = href;
+        this.actions = actionsParam;
+    }
+
+    public String getCourseId() {
+        return courseId;
+    }
+
+    public String getCourseName() {
+        return courseName;
+    }
+
+    public String getCreatedAtDateString() {
+        return createdAtDateString;
+    }
+
+    public String getCreatedAtDateStamp() {
+        return createdAtDateStamp;
+    }
+
+    public String getCreatedAtFullDateTimeString() {
+        return createdAtFullDateTimeString;
+    }
+
+    public String getDeletedAtDateString() {
+        return deletedAtDateString;
+    }
+
+    public String getDeletedAtDateStamp() {
+        return deletedAtDateStamp;
+    }
+
+    public String getDeletedAtFullDateTimeString() {
+        return deletedAtFullDateTimeString;
+    }
+
+    public String getHref() {
+        return href;
+    }
+
+    public List<ElementTag> getActions() {
+        return actions;
+    }
+
+}

--- a/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/activeCoursesTable.tag
@@ -75,6 +75,7 @@
       <td></td>
       <td></td>
       <td></td>
+      <td></td>
     </tr>
   </c:if>
 </table>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/archivedCoursesTable.tag
@@ -5,14 +5,16 @@
 <%@ attribute name="archivedCourses" type="teammates.ui.template.ArchivedCoursesTable" required="true" %>
 <%@ attribute name="activeCourses" type="teammates.ui.template.ActiveCoursesTable" required="true" %>
 
-<h2 class="text-muted">Archived courses</h2>
+<h2 class="text-muted">
+  <span class="glyphicon glyphicon-floppy-disk"></span> Archived courses
+</h2>
 <table class="table table-bordered table-striped" id="tableArchivedCourses">
   <thead>
-    <tr class="fill-default">
+    <tr class="fill-info">
       <th id="button_sortid" class="button-sort-none toggle-sort">
         Course ID<span class="icon-sort unsorted"></span>
       </th>
-      <th id="button_sortid" class="button-sort-none toggle-sort">
+      <th id="button_sortname" class="button-sort-none toggle-sort">
         Course Name<span class="icon-sort unsorted"></span>
       </th>
       <th id="button_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAccessControlEditDivForInstr.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAccessControlEditDivForInstr.tag
@@ -26,7 +26,7 @@
         <input type="radio" name="<%=Const.ParamsNames.INSTRUCTOR_ROLE_NAME%>"
             id="<%=Const.ParamsNames.INSTRUCTOR_ROLE_NAME%>forinstructor${instructorPanel.index}"
             value="<%=Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER%>">
-        &nbsp;Manager: Can do everything except for deleting the course&nbsp;
+        &nbsp;Manager: Can do everything except for deleting/restoring the course&nbsp;
         <a href="javascript:;" class="view-role-details" data-role="<%= Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER %>">
           View Details
         </a>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditAddInstructorPanel.tag
@@ -86,7 +86,7 @@
               <input type="radio" name="<%=Const.ParamsNames.INSTRUCTOR_ROLE_NAME%>"
                   id="<%=Const.ParamsNames.INSTRUCTOR_ROLE_NAME%>forinstructor${addInstructorPanel.index}"
                   value="<%=Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER%>" >
-              &nbsp;Manager: Can do everything except for deleting the course
+              &nbsp;Manager: Can do everything except for deleting/restoring the course
               <a href="javascript:;" class="view-role-details"
                   data-role="<%= Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER%>">
                 View Details

--- a/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorRoleModal.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/courseEditInstructorRoleModal.tag
@@ -16,7 +16,7 @@
         <div class="row">
           <div class="col-sm-6">
             <input type="checkbox" name="<%=Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE%>"
-                value="true" checked disabled> Edit/Delete Course
+                value="true" checked disabled> Edit/Delete/Restore Course
           </div>
 
           <div class="col-sm-6">

--- a/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursePanel.tag
@@ -13,7 +13,7 @@
     <div class="pull-right margin-left-7px">
       <span class="glyphicon ajax_submit glyphicon-chevron-down"></span>
     </div>
-    <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative"
+    <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative<c:if test="${not data.instructorAllowedToModify}"> disabled</c:if>"
        id="btn-course-deleteall"
        href="${data.instructorCourseDeleteAllRecoveryCoursesLink}"
        title="<%= Const.Tooltips.COURSE_DELETE_ALL %>"
@@ -22,7 +22,7 @@
       <span class="glyphicon glyphicon-remove"></span>
       <strong>Delete All</strong>
     </a>
-    <a class="btn btn-default btn-xs pull-right pull-down"
+    <a class="btn btn-default btn-xs pull-right pull-down<c:if test="${not data.instructorAllowedToModify}"> disabled</c:if>"
        id="btn-course-restoreall"
        href="${data.instructorCourseRestoreAllRecoveryCoursesLink}"
        title="<%= Const.Tooltips.COURSE_RESTORE_ALL %>"

--- a/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursePanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursePanel.tag
@@ -1,0 +1,43 @@
+<%@ tag trimDirectiveWhitespaces="true" %>
+<%@ tag description="instructorCourses - Recovery courses table panel" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib tagdir="/WEB-INF/tags/instructor/course" prefix="course" %>
+<%@ tag import="teammates.common.util.Const" %>
+
+<h2 class="text-muted">
+  <span class="glyphicon glyphicon-trash"></span> Deleted courses
+</h2>
+<div class="panel">
+  <div class="panel-heading ajax_submit fill-default">
+    <div class="pull-right margin-left-7px">
+      <span class="glyphicon ajax_submit glyphicon-chevron-down"></span>
+    </div>
+    <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative"
+       id="btn-course-deleteall"
+       href="${data.instructorCourseDeleteAllRecoveryCoursesLink}"
+       title="<%= Const.Tooltips.COURSE_DELETE_ALL %>"
+       data-toggle="tooltip"
+       data-placement="top">
+      <span class="glyphicon glyphicon-remove"></span>
+      <strong>Delete All</strong>
+    </a>
+    <a class="btn btn-default btn-xs pull-right pull-down"
+       id="btn-course-restoreall"
+       href="${data.instructorCourseRestoreAllRecoveryCoursesLink}"
+       title="<%= Const.Tooltips.COURSE_RESTORE_ALL %>"
+       data-toggle="tooltip"
+       data-placement="top">
+      <span class="glyphicon glyphicon-ok"></span>
+      <strong>Restore All</strong>
+    </a>
+    <strong class="ajax_submit">
+      Recycle Bin
+    </strong>
+  </div>
+  <div class="panel-collapse collapse">
+    <div class="panel-body padding-0">
+      <course:recoveryCoursesTable recoveryCourses="${data.recoveryCourses}"/>
+    </div>
+  </div>
+</div>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursesTable.tag
@@ -25,17 +25,17 @@
   </thead>
   <c:forEach items="${recoveryCourses.rows}" var="recoveryCourse" varStatus="i">
     <tr>
-      <td id="recoverycourseid${i.index + fn:length(recoveryCourses.rows)}">${recoveryCourse.courseId}</td>
-      <td id="recoverycoursename${i.index + fn:length(recoveryCourses.rows)}">${recoveryCourse.courseName}</td>
+      <td id="recoverycourseid${i.index}">${recoveryCourse.courseId}</td>
+      <td id="recoverycoursename${i.index}">${recoveryCourse.courseName}</td>
       <td
-          id="recoverycoursecreateddate${i.index + fn:length(recoveryCourses.rows)}"
+          id="recoverycoursecreateddate${i.index}"
           data-date-stamp="${recoveryCourse.createdAtDateStamp}"
           data-toggle="tooltip"
           data-original-title="${recoveryCourse.createdAtFullDateTimeString}">
           ${recoveryCourse.createdAtDateString}
       </td>
       <td
-          id="recoverycoursedeleteddate${i.index + fn:length(recoveryCourses.rows)}"
+          id="recoverycoursedeleteddate${i.index}"
           data-date-stamp="${recoveryCourse.deletedAtDateStamp}"
           data-toggle="tooltip"
           data-original-title="${recoveryCourse.deletedAtFullDateTimeString}">

--- a/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursesTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/recoveryCoursesTable.tag
@@ -1,0 +1,53 @@
+<%@ tag trimDirectiveWhitespaces="true" %>
+<%@ tag description="instructorCourse - Recovery courses table" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ attribute name="recoveryCourses" type="teammates.ui.template.RecoveryCoursesTable" required="true" %>
+
+<c:set var="tableHeaderClass" value="background-color-medium-gray text-color-gray font-weight-normal" />
+<table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+  <thead class="${tableHeaderClass}">
+    <tr>
+      <th id="btn_sortid" class="button-sort-none toggle-sort">
+        Course ID<span class="icon-sort unsorted"></span>
+      </th>
+      <th id="btn_sortname" class="button-sort-none toggle-sort">
+        Course Name<span class="icon-sort unsorted"></span>
+      </th>
+      <th id="btn_sortcoursecreateddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
+        Creation Date<span class="icon-sort unsorted"></span>
+      </th>
+      <th id="btn_sortcoursedeleteddate" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" class="button-sort-none toggle-sort">
+        Deletion Date<span class="icon-sort unsorted"></span>
+      </th>
+      <th class="align-center no-print">Action(s)</th>
+    </tr>
+  </thead>
+  <c:forEach items="${recoveryCourses.rows}" var="recoveryCourse" varStatus="i">
+    <tr>
+      <td id="recoverycourseid${i.index + fn:length(recoveryCourses.rows)}">${recoveryCourse.courseId}</td>
+      <td id="recoverycoursename${i.index + fn:length(recoveryCourses.rows)}">${recoveryCourse.courseName}</td>
+      <td
+          id="recoverycoursecreateddate${i.index + fn:length(recoveryCourses.rows)}"
+          data-date-stamp="${recoveryCourse.createdAtDateStamp}"
+          data-toggle="tooltip"
+          data-original-title="${recoveryCourse.createdAtFullDateTimeString}">
+          ${recoveryCourse.createdAtDateString}
+      </td>
+      <td
+          id="recoverycoursedeleteddate${i.index + fn:length(recoveryCourses.rows)}"
+          data-date-stamp="${recoveryCourse.deletedAtDateStamp}"
+          data-toggle="tooltip"
+          data-original-title="${recoveryCourse.deletedAtFullDateTimeString}">
+          ${recoveryCourse.deletedAtDateString}
+      </td>
+      <td class="align-center no-print">
+        <c:forEach items="${recoveryCourse.actions}" var="button">
+          <a ${button.attributesToString}>
+              ${button.content}
+          </a>
+        </c:forEach>
+      </td>
+    </tr>
+  </c:forEach>
+</table>

--- a/src/main/webapp/WEB-INF/tags/instructor/navBar.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/navBar.tag
@@ -30,9 +30,7 @@
           <a class='nav students' data-link="instructorStudent" href="${data.instructorStudentListLink}">Students</a>
         </li>
         <li<c:if test="${fn:contains(data.getClass(), 'Search')}"> class="active"</c:if>>
-          <a class='nav search' data-link="instructorSearch" href="${data.instructorSearchLink}">
-            Search
-          </a>
+          <a class='nav search' data-link="instructorSearch" href="${data.instructorSearchLink}">Search</a>
         </li>
         <li>
           <a class="nav help" href="/instructorHelp.jsp" target="_blank" rel="noopener noreferrer">Help</a>

--- a/src/main/webapp/dev/js/common/instructor.js
+++ b/src/main/webapp/dev/js/common/instructor.js
@@ -310,7 +310,7 @@ function bindDeleteButtons() {
         const courseId = $button.data('courseid');
         const feedbackSessionName = $button.data('fsname');
 
-        const messageText = `Are you want to delete the feedback session ${feedbackSessionName} in ${courseId}?`;
+        const messageText = `Are you sure you want to delete the feedback session ${feedbackSessionName} in ${courseId}?`;
         const okCallback = function () {
             window.location = $button.attr('href');
         };
@@ -320,12 +320,28 @@ function bindDeleteButtons() {
     });
 }
 
+function bindCourseMoveToRecoveryLinks() {
+    $('body').on('click', '.course-move-to-recovery-link', (event) => {
+        event.preventDefault();
+
+        const $clickedLink = $(event.currentTarget);
+        const messageText = `Are you sure you want to delete the course: ${$clickedLink.data('courseId')}? `
+                + 'This action can be reverted by going to the "courses" tab and restoring the desired course(s).';
+        const okCallback = function () {
+            window.location = $clickedLink.attr('href');
+        };
+
+        showModalConfirmation('Confirm moving course to recovery', messageText, okCallback, null,
+                null, null, BootstrapContextualColors.WARNING);
+    });
+}
+
 function bindCourseDeleteLinks() {
     $('body').on('click', '.course-delete-link', (event) => {
         event.preventDefault();
 
         const $clickedLink = $(event.currentTarget);
-        const messageText = `Are you sure you want to delete the course: ${$clickedLink.data('courseId')}? `
+        const messageText = `Are you sure you want to permanently delete the course: ${$clickedLink.data('courseId')}? `
                           + 'This operation will delete all students and sessions in this course. '
                           + 'All instructors of this course will not be able to access it hereafter as well.';
         const okCallback = function () {
@@ -333,6 +349,23 @@ function bindCourseDeleteLinks() {
         };
 
         showModalConfirmation('Confirm deleting course', messageText, okCallback, null,
+                null, null, BootstrapContextualColors.DANGER);
+    });
+}
+
+function bindCourseDeleteAllLinks() {
+    $('body').on('click', '.course-delete-all-link', (event) => {
+        event.preventDefault();
+
+        const $clickedLink = $(event.currentTarget);
+        const messageText = 'Are you sure you want to permanently delete all the courses? '
+                + 'This operation will delete all students and sessions in these courses. '
+                + 'All instructors of these courses will not be able to access them hereafter as well.';
+        const okCallback = function () {
+            window.location = $clickedLink.attr('href');
+        };
+
+        showModalConfirmation('Confirm deleting all courses', messageText, okCallback, null,
                 null, null, BootstrapContextualColors.DANGER);
     });
 }
@@ -548,7 +581,9 @@ function prepareInstructorPages() {
     bindStudentPhotoHoverLink('.profile-pic-icon-hover');
 
     // bind the event handler to show confirmation modal
+    bindCourseMoveToRecoveryLinks();
     bindCourseDeleteLinks();
+    bindCourseDeleteAllLinks();
     bindSessionDeleteLinks();
 }
 

--- a/src/main/webapp/dev/js/main/instructorCourses.js
+++ b/src/main/webapp/dev/js/main/instructorCourses.js
@@ -58,6 +58,33 @@ function linkAjaxForCourseStats() {
     $('td[id^="course-stats"] > a').click(courseStatsClickHandler);
 }
 
+function bindCollapseEvents() {
+    const tables = $('div.courses-tables');
+    const panels = $(tables[0]).children('.panel');
+    const heading = $(panels[0]).children('.panel-heading');
+    const bodyCollapse = $(panels[0]).children('.panel-collapse');
+    if (heading.length !== 0 && bodyCollapse.length !== 0) {
+        $(heading[0]).attr('data-target', '#recoveryPanelBodyCollapse');
+        $(heading[0]).attr('id', 'recoveryPanelHeading');
+        $(heading[0]).css('cursor', 'pointer');
+        $(bodyCollapse[0]).attr('id', 'recoveryPanelBodyCollapse');
+    }
+
+    $(heading[0]).click((e) => {
+        if ($(e.target).hasClass('ajax_submit')) {
+            const toggleChevronDown = $(panels[0]).find('.glyphicon-chevron-down');
+            const toggleChevronUp = $(panels[0]).find('.glyphicon-chevron-up');
+            if (toggleChevronDown.length === 0) {
+                $(bodyCollapse).collapse('toggle');
+                $(toggleChevronUp[0]).addClass('glyphicon-chevron-down').removeClass('glyphicon-chevron-up');
+            } else {
+                $(bodyCollapse).collapse('toggle');
+                $(toggleChevronDown[0]).addClass('glyphicon-chevron-up').removeClass('glyphicon-chevron-down');
+            }
+        }
+    });
+}
+
 $(document).ready(() => {
     prepareInstructorPages();
 
@@ -106,6 +133,8 @@ $(document).ready(() => {
                         .html(appendedCoursesTable);
                 toggleSort($('#button_sortcourseid'));
                 linkAjaxForCourseStats();
+
+                bindCollapseEvents();
             },
         });
     };

--- a/src/main/webapp/jsp/instructorCourses.jsp
+++ b/src/main/webapp/jsp/instructorCourses.jsp
@@ -24,7 +24,7 @@
   <t:statusMessage statusMessagesToUser="${data.statusMessagesToUser}"/>
   <br>
 
-  <div id="coursesList" class="align-center">
+  <div id="coursesList" class="courses-tables align-center">
     <c:if test="${data.usingAjax}">
       <course:activeCoursesTable activeCourses="${data.activeCourses}"/>
       <br>
@@ -39,6 +39,14 @@
       <c:if test="${not empty data.archivedCourses.rows}">
         <course:archivedCoursesTable archivedCourses="${data.archivedCourses}"
             activeCourses="${data.activeCourses}"/>
+        <br>
+        <br>
+        <br>
+        <br>
+      </c:if>
+
+      <c:if test="${not empty data.recoveryCourses.rows}">
+        <course:recoveryCoursePanel />
         <br>
         <br>
         <br>

--- a/src/main/webapp/partials/instructorHelpCourses.jsp
+++ b/src/main/webapp/partials/instructorHelpCourses.jsp
@@ -228,27 +228,27 @@
                           <label class="control-label pull-right">Access-level</label>
                         </div>
                         <div class="col-sm-9">
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor2" value="Co-owner" checked="">&nbsp;Co-owner: Can do everything
+                          <input type="radio" name="instructorrole" id="instructorrole1forinstructor2" value="Co-owner" checked="">&nbsp;Co-owner: Can do everything
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor2" value="Manager">&nbsp;Manager: Can do everything except for deleting the course
+                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor2" value="Manager">&nbsp;Manager: Can do everything except for deleting the course
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor2" value="Observer">&nbsp;Observer: Can only view information(students, submissions, comments etc.). &nbsp;Cannot edit/delete/submit anything.
+                          <input type="radio" name="instructorrole" id="instructorrole3forinstructor2" value="Observer">&nbsp;Observer: Can only view information(students, submissions, comments etc.). &nbsp;Cannot edit/delete/submit anything.
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor2" value="Tutor">&nbsp;Tutor: Can view student details, give/view comments, submit/view responses for sessions
+                          <input type="radio" name="instructorrole" id="instructorrole4forinstructor2" value="Tutor">&nbsp;Tutor: Can view student details, give/view comments, submit/view responses for sessions
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor2" value="Custom">&nbsp;Custom: No access by default. Any access needs to be granted explicitly.
+                          <input type="radio" name="instructorrole" id="instructorrole5forinstructor2" value="Custom">&nbsp;Custom: No access by default. Any access needs to be granted explicitly.
                         </div>
                       </div>
                     </div>
@@ -415,27 +415,27 @@
                           <label class="control-label pull-right">Access-level</label>
                         </div>
                         <div class="col-sm-9">
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor1" value="Co-owner"> &nbsp;Co-owner: Can do everything &nbsp;
+                          <input type="radio" name="instructorrole" id="instructorrole1forinstructor1" value="Co-owner"> &nbsp;Co-owner: Can do everything &nbsp;
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor1" value="Manager"> &nbsp;Manager: Can do everything except for deleting the course &nbsp;
+                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor1" value="Manager"> &nbsp;Manager: Can do everything except for deleting the course &nbsp;
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor1" value="Observer"> &nbsp;Observer: Can only view information(students, submissions, comments etc.). &nbsp;Cannot edit/delete/submit anything. &nbsp;
+                          <input type="radio" name="instructorrole" id="instructorrole3forinstructor1" value="Observer"> &nbsp;Observer: Can only view information(students, submissions, comments etc.). &nbsp;Cannot edit/delete/submit anything. &nbsp;
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor1" value="Tutor"> &nbsp;Tutor: Can view student details, give/view comments, submit/view responses for sessions &nbsp;
+                          <input type="radio" name="instructorrole" id="instructorrole4forinstructor1" value="Tutor"> &nbsp;Tutor: Can view student details, give/view comments, submit/view responses for sessions &nbsp;
                           <a href="javascript:;">
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorroleforinstructor1" value="Custom" checked=""> &nbsp;Custom: No access by default. Any access needs to be granted explicitly.
+                          <input type="radio" name="instructorrole" id="instructorrole5forinstructor1" value="Custom" checked=""> &nbsp;Custom: No access by default. Any access needs to be granted explicitly.
                           <br>
                         </div>
                       </div>
@@ -750,18 +750,23 @@
         <div class="panel-body">
           <p>
             You can view all your archived courses by navigating to the <b>Courses</b> page.<br>
-            Scroll to the <b>Archived Courses</b> heading, which looks similar to this:
+            Scroll to the <b>Archived courses</b> heading, which looks similar to this:
           </p>
           <div class="bs-example">
-            <h2 class="text-muted">Archived courses</h2>
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-floppy-disk"></span> Archived courses
+            </h2>
             <table class="table table-bordered table-striped">
               <thead>
-              <tr class="fill-default">
+              <tr class="fill-info">
                 <th onclick="toggleSort(this);" class="button-sort-none">
                   Course ID<span class="icon-sort unsorted"></span>
                 </th>
                 <th onclick="toggleSort(this);" class="button-sort-none">
                   Course Name<span class="icon-sort unsorted"></span>
+                </th>
+                <th onclick="toggleSort(this);" class="button-sort-none">
+                  Creation Date<span class="icon-sort unsorted"></span>
                 </th>
                 <th class="align-center no-print">Action(s)</th>
               </tr>
@@ -769,6 +774,7 @@
               <tr>
                 <td>AI532</td>
                 <td>Artificial Intelligence</td>
+                <td>20 Jan 2018</td>
                 <td class="align-center no-print">
                   <button href="#" class="btn btn-default btn-xs" type="button">Unarchive</button>
                   <button href="#" class="btn btn-default btn-xs" type="button">Delete</button>
@@ -794,15 +800,20 @@
             Then, click on the <button href="#" class="btn btn-default btn-xs" type="button">Unarchive</button> button corresponding to the course you want to unarchive.
           </p>
           <div class="bs-example">
-            <h2 class="text-muted">Archived courses</h2>
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-floppy-disk"></span> Archived courses
+            </h2>
             <table class="table table-bordered table-striped">
               <thead>
-              <tr class="fill-default">
+              <tr class="fill-info">
                 <th onclick="toggleSort(this);" class="button-sort-none">
                   Course ID<span class="icon-sort unsorted"></span>
                 </th>
                 <th onclick="toggleSort(this);" class="button-sort-none">
                   Course Name<span class="icon-sort unsorted"></span>
+                </th>
+                <th onclick="toggleSort(this);" class="button-sort-none">
+                  Creation Date<span class="icon-sort unsorted"></span>
                 </th>
                 <th class="align-center no-print">Action(s)</th>
               </tr>
@@ -810,12 +821,290 @@
               <tr>
                 <td>AI532</td>
                 <td>Artificial Intelligence</td>
+                <td>20 Jan 2018</td>
                 <td class="align-center no-print">
                   <button href="#" class="btn btn-default btn-xs" type="button">Unarchive</button>
                   <button href="#" class="btn btn-default btn-xs" type="button">Delete</button>
                 </td>
               </tr>
             </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <h3>Restoring Deleted Courses</h3>
+  <div class="panel-group">
+    <div class="panel panel-default" id="course-view-deleted">
+      <div class="panel-heading cursor-pointer" data-toggle="collapse" data-target="#course-view-deleted-body">
+        <h3 class="panel-title">How do I view courses I have deleted?</h3>
+      </div>
+      <div id="course-view-deleted-body" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p>
+            You can view all your deleted courses by navigating to the <b>Courses</b> page.<br>
+            Scroll to the <b>Deleted courses</b> heading, which looks similar to this:
+          </p>
+          <div class="bs-example">
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-trash"></span> Deleted courses
+            </h2>
+            <div class="panel">
+              <div class="panel-heading fill-default">
+                <div class="pull-right margin-left-7px">
+                  <span class="glyphicon glyphicon-chevron-up"></span>
+                </div>
+                <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px color-negative"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <strong>Delete All</strong>
+                </a>
+                <a class="btn btn-default btn-xs pull-right pull-down"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-ok"></span>
+                  <strong>Restore All</strong>
+                </a>
+                <strong>
+                  Recycle Bin
+                </strong>
+              </div>
+              <div class="panel-collapse">
+                <div class="panel-body padding-0">
+                  <table class="table table-bordered table-striped margin-0">
+                    <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+                      <tr>
+                        <th onclick="toggleSort(this);" class="button-sort-none">
+                          Course ID<span class="icon-sort unsorted"></span>
+                        </th>
+                        <th onclick="toggleSort(this);" class="button-sort-none">
+                          Course Name<span class="icon-sort unsorted"></span>
+                        </th>
+                        <th onclick="toggleSort(this);" class="button-sort-none">
+                          Creation Date<span class="icon-sort unsorted"></span>
+                        </th>
+                        <th onclick="toggleSort(this);" class="button-sort-none">
+                          Deletion Date<span class="icon-sort unsorted"></span>
+                        </th>
+                        <th class="align-center no-print">Action(s)</th>
+                      </tr>
+                    </thead>
+                    <tr>
+                      <td>AI532</td>
+                      <td>Artificial Intelligence</td>
+                      <td>20 Jan 2018</td>
+                      <td>10 Mar 2018</td>
+                      <td class="align-center no-print">
+                        <button href="#" class="btn btn-default btn-xs" type="button">Restore</button>
+                        <button href="#" class="btn btn-default btn-xs color-negative" type="button">Delete Permanently</button>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p>
+            The courses you have previously deleted are listed here.
+            In order to access information in a deleted course, <a class="collapse-link" data-target="#course-restore-body" href="#course-restore">restore the course</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default" id="course-restore">
+      <div class="panel-heading cursor-pointer" data-toggle="collapse" data-target="#course-restore-body">
+        <h3 class="panel-title">How do I restore a deleted course?</h3>
+      </div>
+      <div id="course-restore-body" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p>
+            To restore a deleted course, first <a class="collapse-link" data-target="#course-view-deleted-body" href="#course-view-deleted">view the course</a> that you would like to restore in the <b>Courses</b> page.<br>
+            Then, click on the <button href="#" class="btn btn-default btn-xs" type="button">Restore</button> button corresponding to the course you want to restore.
+          </p>
+          <div class="bs-example">
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-trash"></span> Deleted courses
+            </h2>
+            <div class="panel">
+              <div class="panel-heading fill-default">
+                <div class="pull-right margin-left-7px">
+                  <span class="glyphicon glyphicon-chevron-up"></span>
+                </div>
+                <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px color-negative"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <strong>Delete All</strong>
+                </a>
+                <a class="btn btn-default btn-xs pull-right pull-down"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-ok"></span>
+                  <strong>Restore All</strong>
+                </a>
+                <strong>
+                  Recycle Bin
+                </strong>
+              </div>
+              <div class="panel-collapse">
+                <div class="panel-body padding-0">
+                  <table class="table table-bordered table-striped margin-0">
+                    <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+                    <tr>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Course ID<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Course Name<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Creation Date<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Deletion Date<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th class="align-center no-print">Action(s)</th>
+                    </tr>
+                    </thead>
+                    <tr>
+                      <td>AI532</td>
+                      <td>Artificial Intelligence</td>
+                      <td>20 Jan 2018</td>
+                      <td>10 Mar 2018</td>
+                      <td class="align-center no-print">
+                        <button href="#" class="btn btn-default btn-xs" type="button">Restore</button>
+                        <button href="#" class="btn btn-default btn-xs color-negative" type="button">Delete Permanently</button>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p>
+            After restoring the course, all the information relevant to the course (e.g. instructors, sessions, students) will also be restored.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default" id="course-delete">
+      <div class="panel-heading cursor-pointer" data-toggle="collapse" data-target="#course-delete-body">
+        <h3 class="panel-title">How do I permanently delete a course?</h3>
+      </div>
+      <div id="course-delete-body" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p>
+            To permanently delete a course, first <a class="collapse-link" data-target="#course-view-deleted-body" href="#course-view-deleted">view the course</a> that you would like to permanently delete in the <b>Courses</b> page.<br>
+            Then, click on the <button href="#" class="btn btn-default btn-xs color-negative" type="button">Delete Permanently</button> button corresponding to the course you want to delete.
+          </p>
+          <div class="bs-example">
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-trash"></span> Deleted courses
+            </h2>
+            <div class="panel">
+              <div class="panel-heading fill-default">
+                <div class="pull-right margin-left-7px">
+                  <span class="glyphicon glyphicon-chevron-up"></span>
+                </div>
+                <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px color-negative"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <strong>Delete All</strong>
+                </a>
+                <a class="btn btn-default btn-xs pull-right pull-down"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-ok"></span>
+                  <strong>Restore All</strong>
+                </a>
+                <strong>
+                  Recycle Bin
+                </strong>
+              </div>
+              <div class="panel-collapse">
+                <div class="panel-body padding-0">
+                  <table class="table table-bordered table-striped margin-0">
+                    <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+                    <tr>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Course ID<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Course Name<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Creation Date<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th onclick="toggleSort(this);" class="button-sort-none">
+                        Deletion Date<span class="icon-sort unsorted"></span>
+                      </th>
+                      <th class="align-center no-print">Action(s)</th>
+                    </tr>
+                    </thead>
+                    <tr>
+                      <td>AI532</td>
+                      <td>Artificial Intelligence</td>
+                      <td>20 Jan 2018</td>
+                      <td>10 Mar 2018</td>
+                      <td class="align-center no-print">
+                        <button href="#" class="btn btn-default btn-xs" type="button">Restore</button>
+                        <button href="#" class="btn btn-default btn-xs color-negative" type="button">Delete Permanently</button>
+                      </td>
+                    </tr>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p>
+            After deleting the course, all the information relevant to the course (e.g. instructors, sessions, students) will also be permanently deleted.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="panel panel-default" id="course-all-action">
+      <div class="panel-heading cursor-pointer" data-toggle="collapse" data-target="#course-all-action-body">
+        <h3 class="panel-title">How do I restore/delete all courses from Recycle Bin?</h3>
+      </div>
+      <div id="course-all-action-body" class="panel-collapse collapse">
+        <div class="panel-body">
+          <p>
+            First <a class="collapse-link" data-target="#course-view-deleted-body" href="#course-view-deleted">view the course</a> and check for courses in Recycle Bin.<br>
+            To restore all courses, click on the <a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top"><span class="glyphicon glyphicon-ok"></span><strong> Restore All</strong></a> button in <b>Deleted courses</b> heading;
+            to delete all courses, click on the <a class="btn btn-default btn-xs color-negative" data-toggle="tooltip" data-placement="top"><span class="glyphicon glyphicon-remove"></span><strong> Delete All</strong></a> button in <b>Deleted courses</b> heading.
+          </p>
+          <div class="bs-example">
+            <h2 class="text-muted">
+              <span class="glyphicon glyphicon-trash"></span> Deleted courses
+            </h2>
+            <div class="panel">
+              <div class="panel-heading fill-default">
+                <div class="pull-right margin-left-7px">
+                  <span class="glyphicon glyphicon-chevron-down"></span>
+                </div>
+                <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px color-negative"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-remove"></span>
+                  <strong>Delete All</strong>
+                </a>
+                <a class="btn btn-default btn-xs pull-right pull-down"
+                   data-toggle="tooltip"
+                   data-placement="top">
+                  <span class="glyphicon glyphicon-ok"></span>
+                  <strong>Restore All</strong>
+                </a>
+                <strong>
+                  Recycle Bin
+                </strong>
+              </div>
+              <div class="panel-collapse">
+                <div class="panel-body padding-0">
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/main/webapp/partials/instructorHelpCourses.jsp
+++ b/src/main/webapp/partials/instructorHelpCourses.jsp
@@ -233,7 +233,7 @@
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor2" value="Manager">&nbsp;Manager: Can do everything except for deleting the course
+                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor2" value="Manager">&nbsp;Manager: Can do everything except for deleting/restoring the course
                           <a href="javascript:;">
                             View Details
                           </a>
@@ -420,7 +420,7 @@
                             View Details
                           </a>
                           <br>
-                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor1" value="Manager"> &nbsp;Manager: Can do everything except for deleting the course &nbsp;
+                          <input type="radio" name="instructorrole" id="instructorrole2forinstructor1" value="Manager"> &nbsp;Manager: Can do everything except for deleting/restoring the course &nbsp;
                           <a href="javascript:;">
                             View Details
                           </a>
@@ -448,7 +448,7 @@
                               </div>
                               <div class="panel-body">
                                 <div class="col-sm-3">
-                                  <input type="checkbox" name="canmodifycourse" value="true"> Edit/Delete Course
+                                  <input type="checkbox" name="canmodifycourse" value="true"> Edit/Delete/Restore Course
                                 </div>
                                 <div class="col-sm-3">
                                   <input type="checkbox" name="canmodifyinstructor" value="true"> Add/Edit/Delete Instructors

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDeleteActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDeleteActionTest.java
@@ -48,7 +48,8 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
                 getPageResultDestination(Const.ActionURIs.INSTRUCTOR_HOME_PAGE, false, "idOfInstructor1OfCourse1"),
                 redirectResult.getDestinationWithParams());
         assertFalse(redirectResult.isError);
-        assertEquals("The course idOfTypicalCourse1 has been deleted.", redirectResult.getStatusMessage());
+        assertEquals("The course idOfTypicalCourse1 has been deleted. You can restore it from the 'Courses' tab.",
+                redirectResult.getStatusMessage());
 
         List<CourseAttributes> courseList = CoursesLogic.inst().getCoursesForInstructor(instructorId);
         assertEquals(1, courseList.size());
@@ -56,7 +57,7 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
 
         String expectedLogMessage = "TEAMMATESLOG|||instructorCourseDelete|||instructorCourseDelete|||true|||"
                                     + "Instructor|||Instructor 1 of Course 1|||idOfInstructor1OfCourse1|||"
-                                    + "instr1@course1.tmt|||Course deleted: idOfTypicalCourse1|||"
+                                    + "instr1@course1.tmt|||Course moved to recycle bin: idOfTypicalCourse1|||"
                                     + "/page/instructorCourseDelete";
         AssertHelper.assertLogMessageEquals(expectedLogMessage, deleteAction.getLogMessage());
 
@@ -75,14 +76,15 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
         assertEquals(getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse1"),
                      redirectResult.getDestinationWithParams());
         assertFalse(redirectResult.isError);
-        assertEquals("The course icdct.tpa.id1 has been deleted.", redirectResult.getStatusMessage());
+        assertEquals("The course icdct.tpa.id1 has been deleted. You can restore it from the deleted courses table below.",
+                redirectResult.getStatusMessage());
 
         courseList = CoursesLogic.inst().getCoursesForInstructor(instructorId);
         assertEquals(0, courseList.size());
 
         expectedLogMessage = "TEAMMATESLOG|||instructorCourseDelete|||instructorCourseDelete|||true|||Instructor(M)|||"
                              + "Instructor 1 of Course 1|||idOfInstructor1OfCourse1|||instr1@course1.tmt|||"
-                             + "Course deleted: icdct.tpa.id1|||/page/instructorCourseDelete";
+                             + "Course moved to recycle bin: icdct.tpa.id1|||/page/instructorCourseDelete";
         AssertHelper.assertLogMessageEqualsInMasqueradeMode(expectedLogMessage, deleteAction.getLogMessage(), adminUserId);
 
         ______TS("Masquerade mode, delete last course, no next URL, redirect to Courses page");
@@ -97,14 +99,15 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
         assertEquals(getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse1"),
                      redirectResult.getDestinationWithParams());
         assertFalse(redirectResult.isError);
-        assertEquals("The course icdct.tpa.id2 has been deleted.", redirectResult.getStatusMessage());
+        assertEquals("The course icdct.tpa.id2 has been deleted. You can restore it from the deleted courses table below.",
+                redirectResult.getStatusMessage());
 
         courseList = CoursesLogic.inst().getCoursesForInstructor(instructorId);
         assertEquals(0, courseList.size());
 
         expectedLogMessage = "TEAMMATESLOG|||instructorCourseDelete|||instructorCourseDelete|||true|||Instructor(M)|||"
                              + "Instructor 1 of Course 1|||idOfInstructor1OfCourse1|||instr1@course1.tmt|||"
-                             + "Course deleted: icdct.tpa.id2|||/page/instructorCourseDelete";
+                             + "Course moved to recycle bin: icdct.tpa.id2|||/page/instructorCourseDelete";
         AssertHelper.assertLogMessageEqualsInMasqueradeMode(expectedLogMessage, deleteAction.getLogMessage(), adminUserId);
 
     }
@@ -134,6 +137,8 @@ public class InstructorCourseDeleteActionTest extends BaseActionTest {
         verifyUnaccessibleForInstructorsOfOtherCourses(submissionParams);
         verifyUnaccessibleWithoutModifyCoursePrivilege(submissionParams);
         verifyAccessibleForInstructorsOfTheSameCourse(submissionParams);
+
+        CoursesLogic.inst().deleteCourseCascade("icdat.owncourse");
 
         /* Test access for admin in masquerade mode */
         CoursesLogic.inst().createCourseAndInstructor(

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDeleteAllRecoveryCoursesActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDeleteAllRecoveryCoursesActionTest.java
@@ -1,0 +1,132 @@
+package teammates.test.cases.action;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.logic.core.CoursesLogic;
+import teammates.logic.core.InstructorsLogic;
+import teammates.test.driver.AssertHelper;
+import teammates.ui.controller.InstructorCourseDeleteAllRecoveryCoursesAction;
+import teammates.ui.controller.RedirectResult;
+
+/**
+ * SUT: {@link InstructorCourseDeleteAllRecoveryCoursesAction}.
+ */
+public class InstructorCourseDeleteAllRecoveryCoursesActionTest extends BaseActionTest {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE_ALL;
+    }
+
+    @Override
+    @Test
+    public void testExecuteAndPostProcess() throws Exception {
+
+        ______TS("Typical case, delete all courses from Recycle Bin, without privilege");
+
+        InstructorAttributes instructor2OfCourse3 = typicalBundle.instructors.get("instructor2OfCourse3");
+        String instructor2Id = instructor2OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor2Id);
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+        InstructorCourseDeleteAllRecoveryCoursesAction deleteAllAction;
+
+        try {
+            deleteAllAction = getAction();
+            getRedirectResult(deleteAllAction);
+        } catch (UnauthorizedAccessException e) {
+            assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
+                    + "for privilege [canmodifycourse]", e.getMessage());
+        }
+
+        List<InstructorAttributes> instructorList = new ArrayList<>();
+        instructorList.add(instructor2OfCourse3);
+        List<CourseAttributes> courseList = CoursesLogic.inst().getRecoveryCoursesForInstructors(instructorList);
+        assertEquals(1, courseList.size());
+        assertEquals(instructor2OfCourse3.courseId, courseList.get(0).getId());
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+
+        ______TS("Typical case, delete all courses from Recycle Bin, with privilege for only some courses");
+
+        InstructorAttributes instructor1OfCourse3 = typicalBundle.instructors.get("instructor1OfCourse3");
+        InstructorAttributes newInstructor = InstructorAttributes
+                .builder(instructor1OfCourse3.getGoogleId(), "icdat.owncourse", "Instructor1 Course3",
+                        "instructor1@course3.tmt")
+                .build();
+        gaeSimulation.loginAsInstructor(instructor1OfCourse3.googleId);
+        instructorList.remove(instructor2OfCourse3);
+        instructorList.add(instructor1OfCourse3);
+        instructorList.add(newInstructor);
+        courseList = CoursesLogic.inst().getCoursesForInstructor(instructorList);
+        assertEquals(1, courseList.size());
+        CoursesLogic.inst().moveCourseToRecovery("icdat.owncourse");
+        courseList = CoursesLogic.inst().getRecoveryCoursesForInstructors(instructorList);
+        assertEquals(2, courseList.size());
+        newInstructor.privileges.updatePrivilege("canmodifycourse", false);
+        InstructorsLogic.inst().updateInstructorByGoogleId(instructor1OfCourse3.getGoogleId(), newInstructor);
+
+        try {
+            deleteAllAction = getAction();
+            getRedirectResult(deleteAllAction);
+        } catch (UnauthorizedAccessException e) {
+            assertEquals("Course [icdat.owncourse] is not accessible to instructor [instructor1@course3.tmt] "
+                    + "for privilege [canmodifycourse]", e.getMessage());
+        }
+
+        courseList = CoursesLogic.inst().getRecoveryCoursesForInstructors(instructorList);
+        assertEquals(2, courseList.size());
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+        assertTrue(CoursesLogic.inst().isCoursePresent(newInstructor.courseId));
+
+        ______TS("Typical case, delete all courses from Recycle Bin, with privilege");
+
+        String instructor1Id = instructor1OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor1Id);
+        newInstructor.privileges.updatePrivilege("canmodifycourse", true);
+        InstructorsLogic.inst().updateInstructorByGoogleId(instructor1OfCourse3.getGoogleId(), newInstructor);
+
+        deleteAllAction = getAction();
+        RedirectResult redirectResult = getRedirectResult(deleteAllAction);
+
+        assertEquals(
+                getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse3"),
+                redirectResult.getDestinationWithParams());
+        assertFalse(redirectResult.isError);
+        assertEquals("All courses have been permanently deleted.", redirectResult.getStatusMessage());
+        assertFalse(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+        assertFalse(CoursesLogic.inst().isCoursePresent("icdat.owncourse"));
+        String expectedLogMessage = "TEAMMATESLOG|||instructorRecoveryDeleteAllCourses|||"
+                + "instructorRecoveryDeleteAllCourses|||true|||Instructor|||Instructor 1 of Course 3|||"
+                + "idOfInstructor1OfCourse3|||instr1@course3.tmt|||All courses deleted|||"
+                + "/page/instructorRecoveryDeleteAllCourses";
+        AssertHelper.assertLogMessageEquals(expectedLogMessage, deleteAllAction.getLogMessage());
+
+    }
+
+    @Override
+    protected InstructorCourseDeleteAllRecoveryCoursesAction getAction(String... params) {
+        return (InstructorCourseDeleteAllRecoveryCoursesAction) gaeSimulation.getActionObject(getActionUri(), params);
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws Exception {
+        CoursesLogic.inst().createCourseAndInstructor(
+                typicalBundle.instructors.get("instructor1OfCourse3").googleId,
+                "icdat.owncourse", "New course", "UTC");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, "icdat.owncourse"
+        };
+
+        //  Test access for users
+        verifyUnaccessibleWithoutLogin(submissionParams);
+        verifyUnaccessibleForUnregisteredUsers(submissionParams);
+    }
+}

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDeleteRecoveryCourseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDeleteRecoveryCourseActionTest.java
@@ -1,0 +1,111 @@
+package teammates.test.cases.action;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.logic.core.CoursesLogic;
+import teammates.test.driver.AssertHelper;
+import teammates.ui.controller.InstructorCourseDeleteRecoveryCourseAction;
+import teammates.ui.controller.RedirectResult;
+
+/**
+ * SUT: {@link InstructorCourseDeleteRecoveryCourseAction}.
+ */
+public class InstructorCourseDeleteRecoveryCourseActionTest extends BaseActionTest {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_DELETE;
+    }
+
+    @Override
+    @Test
+    public void testExecuteAndPostProcess() throws Exception {
+
+        ______TS("Not enough parameters");
+
+        verifyAssumptionFailure();
+
+        ______TS("Typical case, delete 1 course from Recycle Bin, without privilege");
+
+        InstructorAttributes instructor2OfCourse3 = typicalBundle.instructors.get("instructor2OfCourse3");
+        String instructor2Id = instructor2OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor2Id);
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor2OfCourse3.courseId
+        };
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+        InstructorCourseDeleteRecoveryCourseAction deleteAction;
+
+        try {
+            deleteAction = getAction(submissionParams);
+            getRedirectResult(deleteAction);
+        } catch (UnauthorizedAccessException e) {
+            assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
+                    + "for privilege [canmodifycourse]", e.getMessage());
+        }
+
+        List<InstructorAttributes> instructorList = new ArrayList<>();
+        instructorList.add(instructor2OfCourse3);
+        List<CourseAttributes> courseList = CoursesLogic.inst().getRecoveryCoursesForInstructors(instructorList);
+        assertEquals(1, courseList.size());
+        assertEquals(instructor2OfCourse3.courseId, courseList.get(0).getId());
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+
+        ______TS("Typical case, delete 1 course from Recycle Bin, with privilege");
+
+        InstructorAttributes instructor1OfCourse3 = typicalBundle.instructors.get("instructor1OfCourse3");
+        String instructor1Id = instructor1OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor1Id);
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor1OfCourse3.courseId
+        };
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+
+        deleteAction = getAction(submissionParams);
+        RedirectResult redirectResult = getRedirectResult(deleteAction);
+
+        assertEquals(
+                getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse3"),
+                redirectResult.getDestinationWithParams());
+        assertFalse(redirectResult.isError);
+        assertEquals("The course idOfTypicalCourse3 has been permanently deleted.", redirectResult.getStatusMessage());
+        assertFalse(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+        String expectedLogMessage = "TEAMMATESLOG|||instructorRecoveryDeleteCourse|||instructorRecoveryDeleteCourse|||"
+                + "true|||Instructor|||Instructor 1 of Course 3|||idOfInstructor1OfCourse3|||"
+                + "instr1@course3.tmt|||Course deleted: idOfTypicalCourse3|||"
+                + "/page/instructorRecoveryDeleteCourse";
+        AssertHelper.assertLogMessageEquals(expectedLogMessage, deleteAction.getLogMessage());
+
+    }
+
+    @Override
+    protected InstructorCourseDeleteRecoveryCourseAction getAction(String... params) {
+        return (InstructorCourseDeleteRecoveryCourseAction) gaeSimulation.getActionObject(getActionUri(), params);
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws Exception {
+        CoursesLogic.inst().createCourseAndInstructor(
+                typicalBundle.instructors.get("instructor1OfCourse3").googleId,
+                "icdat.owncourse", "New course", "UTC");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, "icdat.owncourse"
+        };
+
+        //  Test access for users
+        verifyUnaccessibleWithoutLogin(submissionParams);
+        verifyUnaccessibleForUnregisteredUsers(submissionParams);
+        verifyUnaccessibleForInstructorsOfOtherCourses(submissionParams);
+        verifyUnaccessibleForStudentsOfOtherCourses(submissionParams);
+        verifyUnaccessibleWithoutModifyCoursePrivilege(submissionParams);
+    }
+}

--- a/src/test/java/teammates/test/cases/action/InstructorCourseRestoreAllRecoveryCoursesActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseRestoreAllRecoveryCoursesActionTest.java
@@ -1,0 +1,95 @@
+package teammates.test.cases.action;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.logic.core.CoursesLogic;
+import teammates.test.driver.AssertHelper;
+import teammates.ui.controller.InstructorCourseRestoreAllRecoveryCoursesAction;
+import teammates.ui.controller.RedirectResult;
+
+/**
+ * SUT: {@link InstructorCourseRestoreAllRecoveryCoursesAction}.
+ */
+public class InstructorCourseRestoreAllRecoveryCoursesActionTest extends BaseActionTest {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE_ALL;
+    }
+
+    @Override
+    @Test
+    public void testExecuteAndPostProcess() throws Exception {
+
+        ______TS("Typical case, restore all courses from Recycle Bin, with privilege");
+
+        InstructorAttributes instructor1OfCourse3 = typicalBundle.instructors.get("instructor1OfCourse3");
+        String instructor1Id = instructor1OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor1Id);
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+
+        InstructorCourseRestoreAllRecoveryCoursesAction restoreAllAction = getAction();
+        RedirectResult redirectResult = getRedirectResult(restoreAllAction);
+
+        assertEquals(
+                getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse3"),
+                redirectResult.getDestinationWithParams());
+        assertFalse(redirectResult.isError);
+        assertEquals("All courses have been restored.", redirectResult.getStatusMessage());
+        List<CourseAttributes> courseList = CoursesLogic.inst().getCoursesForInstructor(instructor1Id);
+        assertEquals(2, courseList.size());
+        assertEquals(instructor1OfCourse3.courseId, courseList.get(1).getId());
+        String expectedLogMessage = "TEAMMATESLOG|||instructorRecoveryRestoreAllCourses|||"
+                + "instructorRecoveryRestoreAllCourses|||true|||Instructor|||Instructor 1 of Course 3|||"
+                + "idOfInstructor1OfCourse3|||instr1@course3.tmt|||All courses restored|||"
+                + "/page/instructorRecoveryRestoreAllCourses";
+        AssertHelper.assertLogMessageEquals(expectedLogMessage, restoreAllAction.getLogMessage());
+
+        ______TS("Typical case, restore all courses from Recycle Bin, without privilege");
+
+        InstructorAttributes instructor2OfCourse3 = typicalBundle.instructors.get("instructor2OfCourse3");
+        String instructor2Id = instructor2OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor2Id);
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+
+        try {
+            restoreAllAction = getAction();
+            getRedirectResult(restoreAllAction);
+        } catch (UnauthorizedAccessException e) {
+            assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
+                    + "for privilege [canmodifycourse]", e.getMessage());
+        }
+
+        courseList = CoursesLogic.inst().getCoursesForInstructor(instructor2Id);
+        assertEquals(1, courseList.size());
+        assertEquals(instructor2OfCourse3.courseId, courseList.get(0).getId());
+
+    }
+
+    @Override
+    protected InstructorCourseRestoreAllRecoveryCoursesAction getAction(String... params) {
+        return (InstructorCourseRestoreAllRecoveryCoursesAction) gaeSimulation.getActionObject(getActionUri(), params);
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws Exception {
+        CoursesLogic.inst().createCourseAndInstructor(
+                typicalBundle.instructors.get("instructor1OfCourse3").googleId,
+                "icdat.owncourse", "New course", "UTC");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, "icdat.owncourse"
+        };
+
+        //  Test access for users
+        verifyUnaccessibleWithoutLogin(submissionParams);
+        verifyUnaccessibleForUnregisteredUsers(submissionParams);
+    }
+}

--- a/src/test/java/teammates/test/cases/action/InstructorCourseRestoreRecoveryCourseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseRestoreRecoveryCourseActionTest.java
@@ -1,0 +1,109 @@
+package teammates.test.cases.action;
+
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.logic.core.CoursesLogic;
+import teammates.test.driver.AssertHelper;
+import teammates.ui.controller.InstructorCourseRestoreRecoveryCourseAction;
+import teammates.ui.controller.RedirectResult;
+
+/**
+ * SUT: {@link InstructorCourseRestoreRecoveryCourseAction}.
+ */
+public class InstructorCourseRestoreRecoveryCourseActionTest extends BaseActionTest {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ActionURIs.INSTRUCTOR_COURSE_RECOVERY_COURSE_RESTORE;
+    }
+
+    @Override
+    @Test
+    public void testExecuteAndPostProcess() throws Exception {
+
+        ______TS("Not enough parameters");
+
+        verifyAssumptionFailure();
+
+        ______TS("Typical case, restore 1 course from Recycle Bin, with privilege");
+
+        InstructorAttributes instructor1OfCourse3 = typicalBundle.instructors.get("instructor1OfCourse3");
+        String instructor1Id = instructor1OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor1Id);
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor1OfCourse3.courseId
+        };
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor1OfCourse3.courseId));
+
+        InstructorCourseRestoreRecoveryCourseAction restoreAction = getAction(submissionParams);
+        RedirectResult redirectResult = getRedirectResult(restoreAction);
+
+        assertEquals(
+                getPageResultDestination(Const.ActionURIs.INSTRUCTOR_COURSES_PAGE, false, "idOfInstructor1OfCourse3"),
+                redirectResult.getDestinationWithParams());
+        assertFalse(redirectResult.isError);
+        assertEquals("The course idOfTypicalCourse3 has been restored.", redirectResult.getStatusMessage());
+        List<CourseAttributes> courseList = CoursesLogic.inst().getCoursesForInstructor(instructor1Id);
+        assertEquals(2, courseList.size());
+        assertEquals(instructor1OfCourse3.courseId, courseList.get(1).getId());
+        String expectedLogMessage = "TEAMMATESLOG|||instructorRecoveryRestoreCourse|||instructorRecoveryRestoreCourse|||"
+                + "true|||Instructor|||Instructor 1 of Course 3|||idOfInstructor1OfCourse3|||"
+                + "instr1@course3.tmt|||Course restored: idOfTypicalCourse3|||"
+                + "/page/instructorRecoveryRestoreCourse";
+        AssertHelper.assertLogMessageEquals(expectedLogMessage, restoreAction.getLogMessage());
+
+        ______TS("Typical case, restore 1 course from Recycle Bin, without privilege");
+
+        InstructorAttributes instructor2OfCourse3 = typicalBundle.instructors.get("instructor2OfCourse3");
+        String instructor2Id = instructor2OfCourse3.googleId;
+        gaeSimulation.loginAsInstructor(instructor2Id);
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor2OfCourse3.courseId
+        };
+        assertTrue(CoursesLogic.inst().isCoursePresent(instructor2OfCourse3.courseId));
+        courseList = CoursesLogic.inst().getCoursesForInstructor(instructor2Id);
+        assertEquals(1, courseList.size());
+
+        try {
+            restoreAction = getAction(submissionParams);
+            getRedirectResult(restoreAction);
+        } catch (UnauthorizedAccessException e) {
+            assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
+                    + "for privilege [canmodifycourse]", e.getMessage());
+        }
+
+        assertEquals(1, courseList.size());
+        assertEquals(instructor2OfCourse3.courseId, courseList.get(0).getId());
+
+    }
+
+    @Override
+    protected InstructorCourseRestoreRecoveryCourseAction getAction(String... params) {
+        return (InstructorCourseRestoreRecoveryCourseAction) gaeSimulation.getActionObject(getActionUri(), params);
+    }
+
+    @Override
+    @Test
+    protected void testAccessControl() throws Exception {
+        CoursesLogic.inst().createCourseAndInstructor(
+                typicalBundle.instructors.get("instructor1OfCourse3").googleId,
+                "icdat.owncourse", "New course", "UTC");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, "icdat.owncourse"
+        };
+
+        //  Test access for users
+        verifyUnaccessibleWithoutLogin(submissionParams);
+        verifyUnaccessibleForUnregisteredUsers(submissionParams);
+        verifyUnaccessibleForInstructorsOfOtherCourses(submissionParams);
+        verifyUnaccessibleForStudentsOfOtherCourses(submissionParams);
+        verifyUnaccessibleWithoutModifyCoursePrivilege(submissionParams);
+    }
+}

--- a/src/test/java/teammates/test/cases/action/InstructorCoursesPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCoursesPageActionTest.java
@@ -68,6 +68,7 @@ public class InstructorCoursesPageActionTest extends BaseActionTest {
         assertEquals(instructorId, pageData.account.googleId);
         assertEquals(2, pageData.getActiveCourses().getRows().size() + pageData.getArchivedCourses().getRows().size());
         assertEquals(0, pageData.getArchivedCourses().getRows().size());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
         assertEquals("", pageData.getCourseIdToShow());
         assertEquals("", pageData.getCourseNameToShow());
 
@@ -98,6 +99,7 @@ public class InstructorCoursesPageActionTest extends BaseActionTest {
         assertEquals(instructorId, pageData.account.googleId);
         assertEquals(0, pageData.getArchivedCourses().getRows().size());
         assertEquals(0, pageData.getActiveCourses().getRows().size());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
         assertEquals("", pageData.getCourseIdToShow());
         assertEquals("", pageData.getCourseNameToShow());
 

--- a/src/test/java/teammates/test/cases/browsertests/AdminHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminHomePageUiTest.java
@@ -265,7 +265,7 @@ public class AdminHomePageUiTest extends BaseUiTestCase {
 
         instructorHomePage.clickAndConfirm(instructorHomePage.getDeleteCourseLink(demoCourseId));
         assertTrue(instructorHomePage.getTextsForAllStatusMessagesToUser()
-                .contains("The course " + demoCourseId + " has been deleted."));
+                .contains("The course " + demoCourseId + " has been deleted. You can restore it from the 'Courses' tab."));
 
         instructorHomePage.logout();
 

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCourseEditPageUiTest.java
@@ -801,16 +801,12 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         // TODO: use navigateTo instead
         courseEditPage = getCourseEditPage();
 
-        ______TS("delete course then cancel");
+        ______TS("delete course");
 
-        courseEditPage.clickDeleteCourseLinkAndCancel();
+        InstructorCoursesPage coursePage = courseEditPage.clickDeleteCourseLink();
         assertNotNull(BackDoor.getCourse(courseId));
-
-        ______TS("delete course then proceed");
-
-        InstructorCoursesPage coursePage = courseEditPage.clickDeleteCourseLinkAndConfirm();
         assertTrue(coursePage.getTextsForAllStatusMessagesToUser()
-                .contains(String.format(Const.StatusMessages.COURSE_DELETED, courseId)));
+                .contains(String.format(Const.StatusMessages.COURSE_MOVED_TO_RECYCLE_BIN, courseId)));
     }
 
     private void testUnregisteredInstructorEmailNotEditable() {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -281,15 +281,11 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
 
     private void testDeleteAction() throws Exception {
 
-        /* Explanation: We test both 'confirm' and 'cancel' cases here.
-         */
-
         String courseId = "CCAddUiTest.course1";
-        coursesPage.clickAndCancel(coursesPage.getDeleteLink(courseId));
-        assertNotNull(BackDoor.getCourse(courseId));
 
-        coursesPage.clickAndConfirm(coursesPage.getDeleteLink(courseId))
-                   .verifyHtmlMainContent("/instructorCoursesDeleteSuccessful.html");
+        coursesPage.deleteCourse(courseId);
+        assertNotNull(BackDoor.getCourse(courseId));
+        coursesPage.verifyHtmlMainContent("/instructorCoursesDeleteSuccessful.html");
     }
 
     private void testArchiveAction() throws Exception {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorCoursesPageUiTest.java
@@ -97,8 +97,12 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
         // Explanation: Checks 'actions' that can be performed using the page.
         testAddAction();
         testSortCourses();
-        testDeleteAction();
+        testMoveToRecycleBinAction();
+        testRestoreAction();
+        testRestoreAllAction();
         testArchiveAction();
+        testDeleteAction();
+        testDeleteAllAction();
 
         /* Explanation: The above categorization of test cases is useful in
          * identifying test cases. However, do not follow it blindly.
@@ -279,13 +283,49 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
         coursesPage.sortByCourseId().verifyTablePattern(0, patternString);
     }
 
-    private void testDeleteAction() throws Exception {
+    private void testMoveToRecycleBinAction() throws Exception {
+
+        ______TS("move course to Recycle Bin action success");
 
         String courseId = "CCAddUiTest.course1";
+        assertFalse(validCourse.isCourseDeleted());
 
-        coursesPage.deleteCourse(courseId);
+        coursesPage.moveCourseToRecovery(courseId);
+        validCourse.setDeletedAt();
+
         assertNotNull(BackDoor.getCourse(courseId));
-        coursesPage.verifyHtmlMainContent("/instructorCoursesDeleteSuccessful.html");
+        assertTrue(validCourse.isCourseDeleted());
+        coursesPage.verifyHtmlMainContent("/instructorCoursesMoveToRecoverySuccessful.html");
+    }
+
+    private void testRestoreAction() throws Exception {
+
+        ______TS("restore action success");
+
+        String courseId = "CCAddUiTest.course1";
+        assertTrue(validCourse.isCourseDeleted());
+
+        coursesPage.restoreCourse(courseId);
+        validCourse.resetDeletedAt();
+
+        assertNotNull(BackDoor.getCourse(courseId));
+        assertFalse(validCourse.isCourseDeleted());
+        coursesPage.verifyHtmlMainContent("/instructorCoursesRestoreSuccessful.html");
+    }
+
+    private void testRestoreAllAction() throws Exception {
+
+        ______TS("restore all action success");
+
+        CourseAttributes courseCS2105 = testData.courses.get("CS2105");
+        assertTrue(courseCS2105.isCourseDeleted());
+
+        coursesPage.restoreAllCourses();
+        courseCS2105.resetDeletedAt();
+
+        assertNotNull(BackDoor.getCourse(courseCS2105.getId()));
+        assertFalse(courseCS2105.isCourseDeleted());
+        coursesPage.verifyHtmlMainContent("/instructorCoursesRestoreAllSuccessful.html");
     }
 
     private void testArchiveAction() throws Exception {
@@ -352,6 +392,50 @@ public class InstructorCoursesPageUiTest extends BaseUiTestCase {
         coursesPage.unarchiveCourse(courseId);
         coursesPage.verifyContains("You are not authorized to view this page.");
 
+    }
+
+    private void testDeleteAction() throws Exception {
+
+        ______TS("delete action success");
+
+        instructorId = testData.accounts.get("OtherInstructorWithCourses").googleId;
+        coursesPage = getCoursesPage();
+        coursesPage.verifyHtmlMainContent("/otherInstructorCoursesMultipleRecoveryCourses.html");
+
+        CourseAttributes courseCS2106 = testData.courses.get("CS2106");
+        assertTrue(courseCS2106.isCourseDeleted());
+
+        // Delete and cancel
+        coursesPage.deleteCourseAndCancel(courseCS2106.getId());
+
+        assertNotNull(BackDoor.getCourse(courseCS2106.getId()));
+
+        // Delete and confirm
+        coursesPage = getCoursesPage();
+        coursesPage.deleteCourseAndConfirm(courseCS2106.getId());
+
+        assertNull(BackDoor.getCourse(courseCS2106.getId()));
+        coursesPage.verifyHtmlMainContent("/instructorCoursesDeleteSuccessful.html");
+    }
+
+    private void testDeleteAllAction() throws Exception {
+
+        ______TS("delete all action success");
+
+        CourseAttributes courseCS2107 = testData.courses.get("CS2107");
+        assertTrue(courseCS2107.isCourseDeleted());
+
+        // Delete all and cancel
+        coursesPage.deleteAllCoursesAndCancel();
+
+        assertNotNull(BackDoor.getCourse(courseCS2107.getId()));
+
+        // Delete all and confirm
+        coursesPage = getCoursesPage();
+        coursesPage.deleteAllCoursesAndConfirm();
+
+        assertNull(BackDoor.getCourse(courseCS2107.getId()));
+        coursesPage.verifyHtmlMainContent("/instructorCoursesDeleteAllSuccessful.html");
     }
 
     private InstructorCoursesPage getCoursesPage() {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorHomePageUiTest.java
@@ -546,8 +546,11 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         assertNotNull(BackDoor.getCourse(courseId));
 
         homePage.clickAndConfirm(homePage.getDeleteCourseLink(courseId));
-        assertNull(BackDoor.getCourse(courseId));
+        assertNotNull(BackDoor.getCourse(courseId));
+
         homePage.verifyHtmlMainContent("/instructorHomeCourseDeleteSuccessful.html");
+
+        BackDoor.deleteCourse(courseId);
 
         //delete the other course as well
         courseId = testData.courses.get("CHomeUiT.CS1101").getId();

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -20,6 +20,7 @@ public class CourseAttributesTest extends BaseTestCase {
     private String validId = "validId";
     private ZoneId validTimeZone = ZoneId.of("UTC");
     private Instant validCreatedAt = Instant.ofEpochMilli(98765);
+    private Instant validDeletedAt = validCreatedAt.plusSeconds(1000);
 
     @Test
     public void testStandardBuilder() {
@@ -27,6 +28,7 @@ public class CourseAttributesTest extends BaseTestCase {
                 .builder(validId, validName, validTimeZone)
                 .build();
         assertEquals(Instant.now(), courseAttributes.createdAt);
+        assertEquals(null, courseAttributes.deletedAt);
         assertEquals(validId, courseAttributes.getId());
         assertEquals(validName, courseAttributes.getName());
         assertEquals(validTimeZone, courseAttributes.getTimeZone());
@@ -42,6 +44,34 @@ public class CourseAttributesTest extends BaseTestCase {
         assertEquals(validName, caWithCreatedAt.getName());
         assertEquals(validTimeZone, caWithCreatedAt.getTimeZone());
         assertEquals(validCreatedAt, caWithCreatedAt.createdAt);
+        assertEquals(null, caWithCreatedAt.deletedAt);
+    }
+
+    @Test
+    public void testBuilderWithDeletedAt() {
+        CourseAttributes caWithDeletedAt = CourseAttributes
+                .builder(validId, validName, validTimeZone)
+                .withDeletedAt(validDeletedAt)
+                .build();
+        assertEquals(validId, caWithDeletedAt.getId());
+        assertEquals(validName, caWithDeletedAt.getName());
+        assertEquals(validTimeZone, caWithDeletedAt.getTimeZone());
+        assertEquals(Instant.now(), caWithDeletedAt.createdAt);
+        assertEquals(validDeletedAt, caWithDeletedAt.deletedAt);
+    }
+
+    @Test
+    public void testBuilderWithCreatedAtAndDeletedAt() {
+        CourseAttributes caWithCreatedAtAndDeletedAt = CourseAttributes
+                .builder(validId, validName, validTimeZone)
+                .withCreatedAt(validCreatedAt)
+                .withDeletedAt(validDeletedAt)
+                .build();
+        assertEquals(validId, caWithCreatedAtAndDeletedAt.getId());
+        assertEquals(validName, caWithCreatedAtAndDeletedAt.getName());
+        assertEquals(validTimeZone, caWithCreatedAtAndDeletedAt.getTimeZone());
+        assertEquals(validCreatedAt, caWithCreatedAtAndDeletedAt.createdAt);
+        assertEquals(validDeletedAt, caWithCreatedAtAndDeletedAt.deletedAt);
     }
 
     @Test
@@ -84,6 +114,15 @@ public class CourseAttributesTest extends BaseTestCase {
                 .withCreatedAt(null)
                 .build();
         assertEquals(Instant.now(), courseAttributes.createdAt);
+    }
+
+    @Test
+    public void testBuilderWithNullDeletedAt() {
+        CourseAttributes courseAttributes = CourseAttributes
+                .builder(validId, validName, validTimeZone)
+                .withDeletedAt(null)
+                .build();
+        assertEquals(null, courseAttributes.deletedAt);
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
@@ -120,7 +120,7 @@ public class AccountsLogicTest extends BaseLogicTest {
             ______TS(aa.toString());
         }
 
-        assertEquals(12, accountsLogic.getInstructorAccounts().size());
+        assertEquals(14, accountsLogic.getInstructorAccounts().size());
 
         ______TS("test updateAccount");
 

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -1,5 +1,6 @@
 package teammates.test.cases.logic;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +44,8 @@ public class CoursesLogicTest extends BaseLogicTest {
     public void testAll() throws Exception {
         testGetCourse();
         testGetCoursesForInstructor();
+        testGetRecoveryCoursesForInstructors();
+        testGetRecoveryCourseForInstructor();
         testIsSampleCourse();
         testIsCoursePresent();
         testVerifyCourseIsPresent();
@@ -58,7 +61,11 @@ public class CoursesLogicTest extends BaseLogicTest {
         testHasIndicatedSections();
         testCreateCourse();
         testCreateCourseAndInstructor();
+        testMoveCourseToRecovery();
+        testRestoreCourseFromRecovery();
+        testRestoreAllCoursesFromRecovery();
         testDeleteCourse();
+        testDeleteAllCourses();
         testUpdateCourse();
     }
 
@@ -128,6 +135,67 @@ public class CoursesLogicTest extends BaseLogicTest {
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null", e.getMessage());
+        }
+    }
+
+    private void testGetRecoveryCoursesForInstructors() {
+
+        ______TS("success: instructors with deleted courses");
+
+        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse3");
+
+        List<InstructorAttributes> instructors = new ArrayList<>();
+        instructors.add(instructor);
+
+        List<CourseAttributes> courses = coursesLogic.getRecoveryCoursesForInstructors(instructors);
+
+        assertEquals(1, courses.size());
+
+        ______TS("boundary: instructor without any courses");
+
+        instructors.remove(0);
+        instructor = dataBundle.instructors.get("instructor5");
+        instructors.add(instructor);
+
+        courses = coursesLogic.getRecoveryCoursesForInstructors(instructors);
+
+        assertEquals(0, courses.size());
+
+        ______TS("Null parameter");
+
+        try {
+            coursesLogic.getRecoveryCoursesForInstructors(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
+    private void testGetRecoveryCourseForInstructor() {
+
+        ______TS("success: instructor with deleted course");
+
+        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse3");
+
+        CourseAttributes course = coursesLogic.getRecoveryCourseForInstructor(instructor);
+
+        assertNotNull(course);
+
+        ______TS("boundary: instructor without any deleted courses");
+
+        instructor = dataBundle.instructors.get("instructor5");
+
+        course = coursesLogic.getRecoveryCourseForInstructor(instructor);
+
+        assertNull(course);
+
+        ______TS("Null parameter");
+
+        try {
+            coursesLogic.getRecoveryCourseForInstructor(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
         }
     }
 
@@ -943,6 +1011,127 @@ public class CoursesLogicTest extends BaseLogicTest {
         }
     }
 
+    private void testMoveCourseToRecovery() throws InvalidParametersException, EntityDoesNotExistException {
+
+        ______TS("typical case");
+
+        CourseAttributes course1OfInstructor = dataBundle.courses.get("typicalCourse1");
+
+        // Ensure there are entities in the datastore under this course
+        verifyPresentInDatastore(course1OfInstructor);
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse1"));
+        verifyPresentInDatastore(dataBundle.students.get("student5InCourse1"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse1"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session2InCourse1"));
+
+        // Ensure the course is not in Recycle Bin
+        assertFalse(course1OfInstructor.isCourseDeleted());
+
+        Instant deletedAt = coursesLogic.moveCourseToRecovery(course1OfInstructor.getId());
+        course1OfInstructor.setDeletedAt(deletedAt);
+
+        // Ensure the course and related entities still exist in datastore
+        verifyPresentInDatastore(course1OfInstructor);
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse1"));
+        verifyPresentInDatastore(dataBundle.students.get("student5InCourse1"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse1"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session2InCourse1"));
+
+        // Ensure the course is moved to Recycle Bin
+        assertTrue(course1OfInstructor.isCourseDeleted());
+
+        ______TS("null parameter");
+
+        try {
+            coursesLogic.moveCourseToRecovery(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
+    private void testRestoreCourseFromRecovery() throws InvalidParametersException, EntityDoesNotExistException {
+
+        ______TS("typical case");
+
+        CourseAttributes course3OfInstructor = dataBundle.courses.get("typicalCourse3");
+
+        // Ensure there are entities in the datastore under this course
+        verifyPresentInDatastore(course3OfInstructor);
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        // Ensure the course is currently in Recycle Bin
+        assertTrue(course3OfInstructor.isCourseDeleted());
+
+        coursesLogic.restoreCourseFromRecovery(course3OfInstructor.getId());
+        course3OfInstructor.resetDeletedAt();
+
+        // Ensure the course and related entities still exist in datastore
+        verifyPresentInDatastore(course3OfInstructor);
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        // Ensure the course is restored from Recycle Bin
+        assertFalse(course3OfInstructor.isCourseDeleted());
+
+        // Move the course back to Recycle Bin for further testing
+        coursesLogic.moveCourseToRecovery(course3OfInstructor.getId());
+
+        ______TS("null parameter");
+
+        try {
+            coursesLogic.restoreCourseFromRecovery(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
+    private void testRestoreAllCoursesFromRecovery() throws InvalidParametersException, EntityDoesNotExistException {
+
+        ______TS("typical case");
+
+        InstructorAttributes instructor1OfCourse3 = dataBundle.instructors.get("instructor1OfCourse3");
+        CourseAttributes course3OfInstructor = coursesLogic.getRecoveryCourseForInstructor(instructor1OfCourse3);
+
+        List<InstructorAttributes> instructors = new ArrayList<>();
+        instructors.add(instructor1OfCourse3);
+
+        // Ensure there are entities in the datastore under this course
+        verifyPresentInDatastore(course3OfInstructor);
+        verifyPresentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        // Ensure the course is currently in Recycle Bin
+        assertTrue(course3OfInstructor.isCourseDeleted());
+
+        coursesLogic.restoreAllCoursesFromRecovery(instructors);
+        course3OfInstructor.resetDeletedAt();
+
+        // Ensure the course and related entities still exist in datastore
+        verifyPresentInDatastore(course3OfInstructor);
+        verifyPresentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        // Ensure the courses are restored from Recycle Bin
+        assertFalse(course3OfInstructor.isCourseDeleted());
+
+        // Move the course back to Recycle Bin for further testing
+        coursesLogic.moveCourseToRecovery(course3OfInstructor.getId());
+
+        ______TS("null parameter");
+
+        try {
+            coursesLogic.restoreAllCoursesFromRecovery(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
     private void testDeleteCourse() {
 
         ______TS("typical case");
@@ -984,6 +1173,37 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         try {
             coursesLogic.deleteCourseCascade(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
+    private void testDeleteAllCourses() {
+
+        ______TS("typical case");
+
+        InstructorAttributes instructor1OfCourse3 = dataBundle.instructors.get("instructor1OfCourse3");
+
+        List<InstructorAttributes> instructors = new ArrayList<>();
+        instructors.add(instructor1OfCourse3);
+
+        // Ensure there are entities in the datastore under this course
+        verifyPresentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
+        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        coursesLogic.deleteAllCoursesCascade(instructors);
+
+        // Ensure the course and related entities are deleted
+        verifyAbsentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
+        verifyAbsentInDatastore(dataBundle.students.get("student1InCourse3"));
+        verifyAbsentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
+
+        ______TS("null parameter");
+
+        try {
+            coursesLogic.deleteAllCoursesCascade(null);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
@@ -28,8 +28,9 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
                 new InstructorCoursesPageData(instructorAccountWithoutCourses, dummySessionToken);
         List<CourseAttributes> activeCourses = new ArrayList<>();
         List<CourseAttributes> archivedCourses = new ArrayList<>();
+        List<CourseAttributes> recoveryCourses = new ArrayList<>();
         Map<String, InstructorAttributes> instructorForCourses = new HashMap<>();
-        pageData.init(activeCourses, archivedCourses, instructorForCourses);
+        pageData.init(activeCourses, archivedCourses, recoveryCourses, instructorForCourses);
 
         assertNotNull(pageData.getActiveCourses());
         assertNotNull(pageData.getActiveCourses().getRows());
@@ -51,7 +52,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         archivedCourses = new ArrayList<>();
         instructorForCourses = new HashMap<>();
         instructorForCourses.put("idOfTypicalCourse1", dataBundle.instructors.get("instructor1OfCourse1"));
-        pageData.init(activeCourses, archivedCourses, instructorForCourses);
+        pageData.init(activeCourses, archivedCourses, recoveryCourses, instructorForCourses);
 
         assertNotNull(pageData.getActiveCourses());
         assertNotNull(pageData.getActiveCourses().getRows());
@@ -75,7 +76,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         instructorForCourses = new HashMap<>();
         instructorForCourses.put("idOfTypicalCourse1", dataBundle.instructors.get("instructor3OfCourse1"));
         instructorForCourses.put("idOfTypicalCourse2", dataBundle.instructors.get("instructor3OfCourse2"));
-        pageData.init(activeCourses, archivedCourses, instructorForCourses, "Id to show", "Name to show");
+        pageData.init(activeCourses, archivedCourses, recoveryCourses, instructorForCourses, "Id to show", "Name to show");
 
         assertNotNull(pageData.getActiveCourses());
         assertNotNull(pageData.getActiveCourses().getRows());
@@ -99,7 +100,7 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         instructorForCourses = new HashMap<>();
         instructorForCourses.put("idOfArchivedCourse", dataBundle.instructors.get("instructorOfArchivedCourse"));
 
-        pageData.init(activeCourses, archivedCourses, instructorForCourses);
+        pageData.init(activeCourses, archivedCourses, recoveryCourses, instructorForCourses);
 
         assertNotNull(pageData.getActiveCourses());
         assertNotNull(pageData.getActiveCourses().getRows());

--- a/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
+++ b/src/test/java/teammates/test/cases/pagedata/InstructorCoursesPageDataTest.java
@@ -40,8 +40,14 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         assertNotNull(pageData.getArchivedCourses().getRows());
         assertEquals(0, pageData.getArchivedCourses().getRows().size());
 
+        assertNotNull(pageData.getRecoveryCourses());
+        assertNotNull(pageData.getRecoveryCourses().getRows());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
+
         assertEquals("", pageData.getCourseIdToShow());
         assertEquals("", pageData.getCourseNameToShow());
+
+        assertTrue(pageData.isInstructorAllowedToModify());
 
         ______TS("test 1 active course");
         AccountAttributes instructorAccountWithOneActiveCourse = dataBundle.accounts.get("instructor1OfCourse1");
@@ -62,8 +68,14 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         assertNotNull(pageData.getArchivedCourses().getRows());
         assertEquals(0, pageData.getArchivedCourses().getRows().size());
 
+        assertNotNull(pageData.getRecoveryCourses());
+        assertNotNull(pageData.getRecoveryCourses().getRows());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
+
         assertEquals("", pageData.getCourseIdToShow());
         assertEquals("", pageData.getCourseNameToShow());
+
+        assertTrue(pageData.isInstructorAllowedToModify());
 
         ______TS("test 2 active courses");
         AccountAttributes instructorAccountWithTwoActiveCourses = dataBundle.accounts.get("instructor3");
@@ -86,8 +98,14 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         assertNotNull(pageData.getArchivedCourses().getRows());
         assertEquals(0, pageData.getArchivedCourses().getRows().size());
 
+        assertNotNull(pageData.getRecoveryCourses());
+        assertNotNull(pageData.getRecoveryCourses().getRows());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
+
         assertEquals("Id to show", pageData.getCourseIdToShow());
         assertEquals("Name to show", pageData.getCourseNameToShow());
+
+        assertTrue(pageData.isInstructorAllowedToModify());
 
         ______TS("test 1 archived course");
         AccountAttributes instructorAccountWithOneArchivedCourse = dataBundle.accounts.get("instructorOfArchivedCourse");
@@ -110,8 +128,44 @@ public class InstructorCoursesPageDataTest extends BaseTestCase {
         assertNotNull(pageData.getArchivedCourses().getRows());
         assertEquals(1, pageData.getArchivedCourses().getRows().size());
 
+        assertNotNull(pageData.getRecoveryCourses());
+        assertNotNull(pageData.getRecoveryCourses().getRows());
+        assertEquals(0, pageData.getRecoveryCourses().getRows().size());
+
         assertEquals("", pageData.getCourseIdToShow());
         assertEquals("", pageData.getCourseNameToShow());
+
+        assertTrue(pageData.isInstructorAllowedToModify());
+
+        ______TS("test 1 deleted course in Recycle Bin");
+        AccountAttributes instructorAccountWithOneDeletedCourse = dataBundle.accounts.get("instructor2OfCourse3");
+        pageData = new InstructorCoursesPageData(instructorAccountWithOneDeletedCourse, dummySessionToken);
+
+        activeCourses = new ArrayList<>();
+        archivedCourses = new ArrayList<>();
+        recoveryCourses.add(dataBundle.courses.get("typicalCourse3"));
+
+        instructorForCourses = new HashMap<>();
+        instructorForCourses.put("idOfTypicalCourse3", dataBundle.instructors.get("instructor2OfCourse3"));
+
+        pageData.init(activeCourses, archivedCourses, recoveryCourses, instructorForCourses);
+
+        assertNotNull(pageData.getActiveCourses());
+        assertNotNull(pageData.getActiveCourses().getRows());
+        assertEquals(0, pageData.getActiveCourses().getRows().size());
+
+        assertNotNull(pageData.getArchivedCourses());
+        assertNotNull(pageData.getArchivedCourses().getRows());
+        assertEquals(0, pageData.getArchivedCourses().getRows().size());
+
+        assertNotNull(pageData.getRecoveryCourses());
+        assertNotNull(pageData.getRecoveryCourses().getRows());
+        assertEquals(1, pageData.getRecoveryCourses().getRows().size());
+
+        assertEquals("", pageData.getCourseIdToShow());
+        assertEquals("", pageData.getCourseNameToShow());
+
+        assertFalse(pageData.isInstructorAllowedToModify());
 
     }
 }

--- a/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
@@ -25,6 +25,8 @@ public class InstructorSearchTest extends BaseSearchTest {
         InstructorAttributes ins1InCourse2 = dataBundle.instructors.get("instructor1OfCourse2");
         InstructorAttributes ins2InCourse2 = dataBundle.instructors.get("instructor2OfCourse2");
         InstructorAttributes ins3InCourse2 = dataBundle.instructors.get("instructor3OfCourse2");
+        InstructorAttributes ins1InCourse3 = dataBundle.instructors.get("instructor1OfCourse3");
+        InstructorAttributes ins2InCourse3 = dataBundle.instructors.get("instructor2OfCourse3");
         InstructorAttributes insInArchivedCourse = dataBundle.instructors.get("instructorOfArchivedCourse");
         InstructorAttributes insInUnregCourse = dataBundle.instructors.get("instructor5");
         InstructorAttributes ins1InTestingSanitizationCourse =
@@ -45,12 +47,12 @@ public class InstructorSearchTest extends BaseSearchTest {
         ______TS("success: search for instructors in whole system; query string matches some instructors");
 
         results = instructorsDb.searchInstructorsInWholeSystem("instructor1");
-        verifySearchResults(results, ins1InCourse1, ins1InCourse2, ins1InTestingSanitizationCourse);
+        verifySearchResults(results, ins1InCourse1, ins1InCourse2, ins1InCourse3, ins1InTestingSanitizationCourse);
 
         ______TS("success: search for instructors in whole system; query string should be case-insensitive");
 
         results = instructorsDb.searchInstructorsInWholeSystem("InStRuCtOr2");
-        verifySearchResults(results, ins2InCourse1, ins2InCourse2);
+        verifySearchResults(results, ins2InCourse1, ins2InCourse2, ins2InCourse3);
 
         ______TS("success: search for instructors in whole system; instructors in archived courses should be included");
 
@@ -107,20 +109,20 @@ public class InstructorSearchTest extends BaseSearchTest {
 
         instructorsDb.deleteInstructor(ins1InCourse1.courseId, ins1InCourse1.email);
         results = instructorsDb.searchInstructorsInWholeSystem("instructor1");
-        verifySearchResults(results, ins1InCourse2, ins1InTestingSanitizationCourse);
+        verifySearchResults(results, ins1InCourse2, ins1InCourse3, ins1InTestingSanitizationCourse);
 
         ______TS("success: search for instructors in whole system; instructors created without searchability unsearchable");
 
         instructorsDb.createEntitiesWithoutExistenceCheck(Arrays.asList(ins1InCourse1));
         results = instructorsDb.searchInstructorsInWholeSystem("instructor1");
-        verifySearchResults(results, ins1InCourse2, ins1InTestingSanitizationCourse);
+        verifySearchResults(results, ins1InCourse2, ins1InCourse3, ins1InTestingSanitizationCourse);
 
         ______TS("success: search for instructors in whole system; deleting instructor without deleting document:"
                 + "document deleted during search, instructor unsearchable");
 
         instructorsDb.deleteEntity(ins2InCourse1);
         results = instructorsDb.searchInstructorsInWholeSystem("instructor2");
-        verifySearchResults(results, ins2InCourse2);
+        verifySearchResults(results, ins2InCourse2, ins2InCourse3);
     }
 
     /*

--- a/src/test/java/teammates/test/cases/search/StudentSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/StudentSearchTest.java
@@ -27,6 +27,7 @@ public class StudentSearchTest extends BaseSearchTest {
         StudentAttributes stu2InCourse1 = dataBundle.students.get("student2InCourse1");
         StudentAttributes stu1InCourse2 = dataBundle.students.get("student1InCourse2");
         StudentAttributes stu2InCourse2 = dataBundle.students.get("student2InCourse2");
+        StudentAttributes stu1InCourse3 = dataBundle.students.get("student1InCourse3");
         StudentAttributes stu1InUnregCourse = dataBundle.students.get("student1InUnregisteredCourse");
         StudentAttributes stu2InUnregCourse = dataBundle.students.get("student2InUnregisteredCourse");
         StudentAttributes stu1InArchCourse = dataBundle.students.get("student1InArchivedCourse");
@@ -43,9 +44,9 @@ public class StudentSearchTest extends BaseSearchTest {
 
         bundle = studentsDb.searchStudentsInWholeSystem("student1");
 
-        assertEquals(4, bundle.numberOfResults);
+        assertEquals(5, bundle.numberOfResults);
         AssertHelper.assertSameContentIgnoreOrder(
-                     Arrays.asList(stu1InCourse1, stu1InCourse2, stu1InUnregCourse, stu1InArchCourse),
+                     Arrays.asList(stu1InCourse1, stu1InCourse2, stu1InCourse3, stu1InUnregCourse, stu1InArchCourse),
                      bundle.studentList);
 
         ______TS("success: search for students in whole system; query string should be case-insensitive");

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -1,6 +1,8 @@
 package teammates.test.cases.storage;
 
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.testng.annotations.Test;
 
@@ -112,6 +114,34 @@ public class CoursesDbTest extends BaseComponentTestCase {
     }
 
     @Test
+    public void testGetCourses() throws InvalidParametersException {
+        CourseAttributes c = createNewCourse();
+        List<String> courseIds = new ArrayList<>();
+
+        ______TS("Success: get an existent course");
+
+        courseIds.add(c.getId());
+        List<CourseAttributes> retrieved = coursesDb.getCourses(courseIds);
+        assertEquals(1, retrieved.size());
+
+        ______TS("Failure: get a non-existent course");
+
+        courseIds.remove(c.getId());
+        courseIds.add("non-existent-course");
+        retrieved = coursesDb.getCourses(courseIds);
+        assertEquals(0, retrieved.size());
+
+        ______TS("Failure: get null parameters");
+
+        try {
+            coursesDb.getCourse(null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
+        }
+    }
+
+    @Test
     public void testUpdateCourse() throws Exception {
 
         ______TS("Failure: null paramater");
@@ -155,13 +185,16 @@ public class CoursesDbTest extends BaseComponentTestCase {
         ______TS("success: typical case");
 
         CourseAttributes c = createNewCourse();
+        c.setDeletedAt();
         CourseAttributes updatedCourse = CourseAttributes
                 .builder(c.getId(), c.getName() + " updated", ZoneId.of("UTC"))
+                .withDeletedAt(c.deletedAt)
                 .build();
 
         coursesDb.updateCourse(updatedCourse);
         CourseAttributes retrieved = coursesDb.getCourse(c.getId());
         assertEquals(c.getName() + " updated", retrieved.getName());
+        assertEquals(c.deletedAt, retrieved.deletedAt);
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
@@ -197,7 +197,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         List<FeedbackSessionAttributes> fsaList = fsDb.getFeedbackSessionsPossiblyNeedingClosingEmail();
 
-        assertEquals(8, fsaList.size());
+        assertEquals(9, fsaList.size());
         for (FeedbackSessionAttributes fsa : fsaList) {
             assertFalse(fsa.isSentClosingEmail());
             assertTrue(fsa.isClosingEmailEnabled());
@@ -211,7 +211,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         List<FeedbackSessionAttributes> fsaList = fsDb.getFeedbackSessionsPossiblyNeedingClosedEmail();
 
-        assertEquals(8, fsaList.size());
+        assertEquals(9, fsaList.size());
         for (FeedbackSessionAttributes fsa : fsaList) {
             assertFalse(fsa.isSentClosedEmail());
             assertTrue(fsa.isClosingEmailEnabled());
@@ -225,7 +225,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         List<FeedbackSessionAttributes> fsaList = fsDb.getFeedbackSessionsPossiblyNeedingPublishedEmail();
 
-        assertEquals(10, fsaList.size());
+        assertEquals(11, fsaList.size());
         for (FeedbackSessionAttributes fsa : fsaList) {
             assertFalse(fsa.isSentPublishedEmail());
             assertTrue(fsa.isPublishedEmailEnabled());

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
@@ -443,14 +443,10 @@ public class InstructorCourseEditPage extends AppPage {
         fillTextBox(courseNameTextBox, value);
     }
 
-    public InstructorCoursesPage clickDeleteCourseLinkAndConfirm() {
-        clickAndConfirm(deleteCourseLink);
+    public InstructorCoursesPage clickDeleteCourseLink() {
+        click(deleteCourseLink);
         waitForPageToLoad();
         return changePageType(InstructorCoursesPage.class);
-    }
-
-    public void clickDeleteCourseLinkAndCancel() {
-        clickAndCancel(deleteCourseLink);
     }
 
     /**

--- a/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
@@ -35,6 +35,9 @@ public class InstructorCoursesPage extends AppPage {
     @FindBy(id = "btnAddCourse")
     private WebElement submitButton;
 
+    @FindBy(id = "recoveryPanelHeading")
+    private WebElement panelHeading;
+
     public InstructorCoursesPage(Browser browser) {
         super(browser);
     }
@@ -57,12 +60,6 @@ public class InstructorCoursesPage extends AppPage {
         return this;
     }
 
-    public InstructorCoursesPage deleteCourse(String courseId) {
-        click(getDeleteLink(courseId));
-        waitForPageToLoad();
-        return this;
-    }
-
     public InstructorCoursesPage archiveCourse(String courseId) {
         click(getArchiveLink(courseId));
         waitForPageToLoad();
@@ -71,6 +68,48 @@ public class InstructorCoursesPage extends AppPage {
 
     public InstructorCoursesPage unarchiveCourse(String courseId) {
         click(getUnarchiveLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage moveCourseToRecovery(String courseId) {
+        click(getMoveToRecoveryLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage restoreCourse(String courseId) {
+        click(getRestoreLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage restoreAllCourses() {
+        click(getRestoreAllLink());
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage deleteCourseAndCancel(String courseId) {
+        clickAndCancel(getDeleteLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage deleteCourseAndConfirm(String courseId) {
+        clickAndConfirm(getDeleteLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage deleteAllCoursesAndCancel() {
+        clickAndCancel(getDeleteAllLink());
+        waitForPageToLoad();
+        return this;
+    }
+
+    public InstructorCoursesPage deleteAllCoursesAndConfirm() {
+        clickAndConfirm(getDeleteAllLink());
         waitForPageToLoad();
         return this;
     }
@@ -95,9 +134,9 @@ public class InstructorCoursesPage extends AppPage {
         waitForPageToLoad();
     }
 
-    public WebElement getDeleteLink(String courseId) {
+    public WebElement getMoveToRecoveryLink(String courseId) {
         int courseRowNumber = getRowNumberOfCourse(courseId);
-        return getDeleteLinkInRow(courseRowNumber);
+        return getMoveToRecoveryLinkInRow(courseRowNumber);
     }
 
     public WebElement getArchiveLink(String courseId) {
@@ -108,6 +147,28 @@ public class InstructorCoursesPage extends AppPage {
     public WebElement getUnarchiveLink(String courseId) {
         int courseRowNumber = getRowNumberOfCourse(courseId);
         return getUnarchiveLinkInRow(courseRowNumber);
+    }
+
+    public WebElement getRestoreLink(String courseId) {
+        click(panelHeading);
+        waitForElementVisibility(browser.driver.findElement(By.id("recoverycourseid0")));
+        int courseRowNumber = getRowNumberOfRecoveryCourse(courseId);
+        return getRestoreLinkInRow(courseRowNumber);
+    }
+
+    public WebElement getRestoreAllLink() {
+        return browser.driver.findElement(By.id("btn-course-restoreall"));
+    }
+
+    public WebElement getDeleteLink(String courseId) {
+        click(panelHeading);
+        waitForElementVisibility(browser.driver.findElement(By.id("recoverycourseid0")));
+        int courseRowNumber = getRowNumberOfRecoveryCourse(courseId);
+        return getDeleteLinkInRow(courseRowNumber);
+    }
+
+    public WebElement getDeleteAllLink() {
+        return browser.driver.findElement(By.id("btn-course-deleteall"));
     }
 
     public InstructorCoursesPage sortByCourseName() {
@@ -182,9 +243,24 @@ public class InstructorCoursesPage extends AppPage {
         return browser.driver.findElement(activeCoursesTable).findElements(By.tagName("tr")).size();
     }
 
+    private int getRecoveryCourseCount() {
+        By recoveryCoursesTable = By.id("tableRecoveryCourses");
+        waitForElementPresence(recoveryCoursesTable);
+        return browser.driver.findElement(recoveryCoursesTable).findElements(By.tagName("tr")).size();
+    }
+
     private int getRowNumberOfCourse(String courseId) {
         for (int i = 0; i < getCourseCount(); i++) {
             if (getCourseIdCell(i).getText().equals(courseId)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int getRowNumberOfRecoveryCourse(String courseId) {
+        for (int i = 0; i < getRecoveryCourseCount(); i++) {
+            if (getRecoveryCourseIdCell(i).getText().equals(courseId)) {
                 return i;
             }
         }
@@ -195,9 +271,13 @@ public class InstructorCoursesPage extends AppPage {
         return browser.driver.findElement(By.id("courseid" + rowId));
     }
 
-    private WebElement getDeleteLinkInRow(int rowId) {
-        By deleteLink = By.className("t_course_delete" + rowId);
-        return browser.driver.findElement(deleteLink);
+    private WebElement getRecoveryCourseIdCell(int rowId) {
+        return browser.driver.findElement(By.id("recoverycourseid" + rowId));
+    }
+
+    private WebElement getMoveToRecoveryLinkInRow(int rowId) {
+        By moveToRecoveryLink = By.className("t_course_delete" + rowId);
+        return browser.driver.findElement(moveToRecoveryLink);
     }
 
     private WebElement getArchiveLinkInRow(int rowId) {
@@ -208,6 +288,16 @@ public class InstructorCoursesPage extends AppPage {
     private WebElement getUnarchiveLinkInRow(int rowId) {
         By archiveLink = By.id("t_course_unarchive" + rowId);
         return browser.driver.findElement(archiveLink);
+    }
+
+    private WebElement getRestoreLinkInRow(int rowId) {
+        By restoreLink = By.className("t_course_restore" + rowId);
+        return browser.driver.findElement(restoreLink);
+    }
+
+    private WebElement getDeleteLinkInRow(int rowId) {
+        By deleteLink = By.className("t_course_delete_permanently" + rowId);
+        return browser.driver.findElement(deleteLink);
     }
 
     private <T extends AppPage> T goToLinkInRow(By locator, Class<T> destinationPageType) {

--- a/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
@@ -57,6 +57,12 @@ public class InstructorCoursesPage extends AppPage {
         return this;
     }
 
+    public InstructorCoursesPage deleteCourse(String courseId) {
+        click(getDeleteLink(courseId));
+        waitForPageToLoad();
+        return this;
+    }
+
     public InstructorCoursesPage archiveCourse(String courseId) {
         click(getArchiveLink(courseId));
         waitForPageToLoad();

--- a/src/test/resources/data/InstructorCoursesPageUiTest.json
+++ b/src/test/resources/data/InstructorCoursesPageUiTest.json
@@ -7,6 +7,13 @@
       "email": "CCAddUiTest.instructor@gmail.tmt",
       "institute": "TEAMMATES Test Institute with Long Long Long Name"
     },
+    "OtherInstructorWithCourses": {
+      "googleId": "CCAddUiTest.instr1",
+      "name": "Teammates Demo Instr 1",
+      "isInstructor": true,
+      "email": "CCAddUiTest.instr1@gmail.tmt",
+      "institute": "TEAMMATES Test Institute with Long Long Long Name"
+    },
     "instructorWithoutCourses": {
       "googleId": "CCAddUiTest.instr2",
       "name": "Teammates Demo Instr 2",
@@ -31,6 +38,27 @@
     "CS2104": {
       "id": "CCAddUiTest.CS2104",
       "name": "Programming Language Concept",
+      "timeZone": "UTC"
+    },
+    "CS2105": {
+      "createdAt": "2012-04-02T23:58:00Z",
+      "deletedAt": "2012-04-12T23:58:00Z",
+      "id": "CCAddUiTest.CS2105",
+      "name": "Computer Networks",
+      "timeZone": "UTC"
+    },
+    "CS2106": {
+      "createdAt": "2012-04-02T23:58:00Z",
+      "deletedAt": "2012-04-12T23:58:00Z",
+      "id": "CCAddUiTest.CS2106",
+      "name": "Operating Systems",
+      "timeZone": "UTC"
+    },
+    "CS2107": {
+      "createdAt": "2012-04-02T23:58:00Z",
+      "deletedAt": "2012-04-12T23:58:00Z",
+      "id": "CCAddUiTest.CS2107",
+      "name": "Introduction to Information Security",
       "timeZone": "UTC"
     }
   },
@@ -87,6 +115,75 @@
       "courseId": "CCAddUiTest.CS2104",
       "name": "Teammates Demo Instr",
       "email": "CCAddUiTest.instructor@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1CS2105": {
+      "googleId": "CCAddUiTest.instructor",
+      "courseId": "CCAddUiTest.CS2105",
+      "name": "Teammates Demo Inst",
+      "email": "CCAddUiTest.instructor@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1CS2106": {
+      "googleId": "CCAddUiTest.instr1",
+      "courseId": "CCAddUiTest.CS2106",
+      "name": "Teammates Demo Inst 1",
+      "email": "CCAddUiTest.instr1@gmail.tmt",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1CS2107": {
+      "googleId": "CCAddUiTest.instr1",
+      "courseId": "CCAddUiTest.CS2107",
+      "name": "Teammates Demo Inst 1",
+      "email": "CCAddUiTest.instr1@gmail.tmt",
       "role": "Co-owner",
       "isDisplayedToStudents": true,
       "displayedName": "Instructor",

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -35,6 +35,20 @@
       "email": "instr2@course2.tmt",
       "institute": "TEAMMATES Test Institute 1"
     },
+    "instructor1OfCourse3": {
+      "googleId": "idOfInstructor1OfCourse3",
+      "name": "Instructor 1 of Course 3",
+      "isInstructor": true,
+      "email": "instr1@course3.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "instructor2OfCourse3": {
+      "googleId": "idOfInstructor2OfCourse3",
+      "name": "Instructor 2 of Course 3",
+      "isInstructor": true,
+      "email": "instr2@course3.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
     "instructor3": {
       "googleId": "idOfInstructor3",
       "name": "Instructor 3 of Course 1 and 2",
@@ -146,6 +160,13 @@
       "deletedAt": null,
       "id": "idOfTypicalCourse2",
       "name": "Typical Course 2 with 1 Evals",
+      "timeZone": "UTC"
+    },
+    "typicalCourse3": {
+      "createdAt": "2012-04-02T23:58:00Z",
+      "deletedAt": "2012-04-12T23:58:00Z",
+      "id": "idOfTypicalCourse3",
+      "name": "Typical Course 3 with 1 Evals",
       "timeZone": "UTC"
     },
     "courseNoEvals": {
@@ -312,6 +333,54 @@
           "cansubmitsessioninsection": true,
           "canmodifysessioncommentinsection": true,
           "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1OfCourse3": {
+      "googleId": "idOfInstructor1OfCourse3",
+      "courseId": "idOfTypicalCourse3",
+      "name": "Instructor1 Course3",
+      "email": "instructor1@course3.tmt",
+      "isArchived": false,
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor2OfCourse3": {
+      "googleId": "idOfInstructor2OfCourse3",
+      "courseId": "idOfTypicalCourse3",
+      "name": "Instructor2 Course3",
+      "email": "instructor2@course3.tmt",
+      "isArchived": false,
+      "role": "Manager",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": false,
           "canviewsessioninsection": true,
           "canmodifysession": true,
           "canmodifystudent": true,
@@ -578,6 +647,15 @@
       "team": "Team 2.1",
       "section": "None"
     },
+    "student1InCourse3": {
+      "googleId": "student1InCourse3",
+      "email": "student1InCourse3@gmail.tmt",
+      "course": "idOfTypicalCourse3",
+      "name": "student1 In Course3</td></div>'\"",
+      "comments": "comment for student1InCourse3</td></div>'\"",
+      "team": "Team 1.1</td></div>'\"",
+      "section": "Section 1"
+    },
     "student1InUnregisteredCourse": {
       "email": "student1InUnregisteredCourse@gmail.tmt",
       "course": "idOfUnregisteredCourse",
@@ -807,6 +885,28 @@
       "resultsVisibleFromTime": "1970-01-01T00:00:00Z",
       "timeZone": "Asia/Singapore",
       "gracePeriod": 0,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "session1InCourse3": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse3",
+      "creatorEmail": "instructor1@course3.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T21:59:00Z",
+      "endTime": "2027-04-30T21:59:00Z",
+      "sessionVisibleFromTime": "2012-03-28T21:59:00Z",
+      "resultsVisibleFromTime": "2027-05-01T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
       "sentOpenEmail": true,
       "sentClosingEmail": false,
       "sentClosedEmail": false,

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -136,12 +136,14 @@
   "courses": {
     "typicalCourse1": {
       "createdAt": "2012-04-01T23:58:00Z",
+      "deletedAt": null,
       "id": "idOfTypicalCourse1",
       "name": "Typical Course 1 with 2 Evals",
       "timeZone": "Africa/Johannesburg"
     },
     "typicalCourse2": {
       "createdAt": "2012-04-01T23:59:00Z",
+      "deletedAt": null,
       "id": "idOfTypicalCourse2",
       "name": "Typical Course 2 with 1 Evals",
       "timeZone": "UTC"
@@ -168,6 +170,7 @@
     },
     "testingSanitizationCourse": {
       "createdAt": "2012-04-01T23:58:00Z",
+      "deletedAt": null,
       "id": "idOfTestingSanitizationCourse",
       "name": "Testing<script> alert('hi!'); </script>",
       "timeZone": "UTC"

--- a/src/test/resources/pages/instructorArchiveStatusNotAffected.html
+++ b/src/test/resources/pages/instructorArchiveStatusNotAffected.html
@@ -59,7 +59,7 @@
   <div id="statusMessagesToUser" style="">
   </div>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -142,7 +142,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr3&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -392,7 +392,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor3" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course 
+                 Manager: Can do everything except for deleting/restoring the course 
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -426,7 +426,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input checked="" name="canmodifyinstructor" type="checkbox" value="true">
@@ -1377,7 +1377,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor9" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -1410,7 +1410,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1807,7 +1807,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditAddInstructor.html
+++ b/src/test/resources/pages/instructorCourseEditAddInstructor.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCoownerForm.html
@@ -69,7 +69,7 @@
           </a>
           <br>
           <input disabled="" id="instructorroleforinstructor7" name="instructorrole" type="radio" value="Manager">
-           Manager: Can do everything except for deleting the course 
+           Manager: Can do everything except for deleting/restoring the course 
           <a class="view-role-details" data-role="Manager" href="javascript:;">
             View Details
           </a>
@@ -103,7 +103,7 @@
               <div class="panel-body">
                 <div class="col-sm-3">
                   <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-                  Edit/Delete Course
+                  Edit/Delete/Restore Course
                 </div>
                 <div class="col-sm-3">
                   <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorForm.html
@@ -66,7 +66,7 @@
           </a>
           <br>
           <input disabled="" id="instructorroleforinstructor1" name="instructorrole" type="radio" value="Manager">
-           Manager: Can do everything except for deleting the course 
+           Manager: Can do everything except for deleting/restoring the course 
           <a class="view-role-details" data-role="Manager" href="javascript:;">
             View Details
           </a>
@@ -100,7 +100,7 @@
               <div class="panel-body">
                 <div class="col-sm-3">
                   <input disabled="" name="canmodifycourse" type="checkbox" value="true">
-                  Edit/Delete Course
+                  Edit/Delete/Restore Course
                 </div>
                 <div class="col-sm-3">
                   <input disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
+++ b/src/test/resources/pages/instructorCourseEditCancelEditCustomInstructorPermissionsForm.html
@@ -66,7 +66,7 @@
           </a>
           <br>
           <input disabled="" id="instructorroleforinstructor1" name="instructorrole" type="radio" value="Manager">
-           Manager: Can do everything except for deleting the course 
+           Manager: Can do everything except for deleting/restoring the course 
           <a class="view-role-details" data-role="Manager" href="javascript:;">
             View Details
           </a>
@@ -100,7 +100,7 @@
               <div class="panel-body">
                 <div class="col-sm-3">
                   <input disabled="" name="canmodifycourse" type="checkbox" value="true">
-                  Edit/Delete Course
+                  Edit/Delete/Restore Course
                 </div>
                 <div class="col-sm-3">
                   <input disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -856,7 +856,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor8" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -889,7 +889,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1286,7 +1286,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditCoowner.html
+++ b/src/test/resources/pages/instructorCourseEditCoowner.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -190,7 +190,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor1" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course 
+                 Manager: Can do everything except for deleting/restoring the course 
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -224,7 +224,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input checked="" name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input checked="" name="canmodifyinstructor" type="checkbox" value="true">
@@ -1385,7 +1385,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor9" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -1418,7 +1418,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1815,7 +1815,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesBeforeSubmit.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -190,7 +190,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor1" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course 
+                 Manager: Can do everything except for deleting/restoring the course 
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -224,7 +224,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input checked="" name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input checked="" name="canmodifyinstructor" type="checkbox" value="true">
@@ -1385,7 +1385,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor9" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -1418,7 +1418,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1815,7 +1815,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesModal.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessful.html
@@ -967,7 +967,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor9" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -1000,7 +1000,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1397,7 +1397,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.test&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
+++ b/src/test/resources/pages/instructorCourseEditEditInstructorPrivilegesSuccessfulAndCheckEditAgain.html
@@ -187,7 +187,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor1" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course 
+                 Manager: Can do everything except for deleting/restoring the course 
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -221,7 +221,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1382,7 +1382,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor9" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -1415,7 +1415,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1812,7 +1812,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -934,7 +934,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor8" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -967,7 +967,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1364,7 +1364,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -95,7 +95,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.Helper&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.Helper&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -856,7 +856,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor8" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -889,7 +889,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1286,7 +1286,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditManager.html
+++ b/src/test/resources/pages/instructorCourseEditManager.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.manager&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.manager&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.observer&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.observer&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditObserver.html
+++ b/src/test/resources/pages/instructorCourseEditObserver.html
@@ -856,7 +856,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor8" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -889,7 +889,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1286,7 +1286,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditTestingSanitization.html
+++ b/src/test/resources/pages/instructorCourseEditTestingSanitization.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.idOfTestingSanitizationCourse" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.idOfTestingSanitizationCourse&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.idOfInstructor1OfTestingSanitizationCourse&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.idOfTestingSanitizationCourse" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=InsCrsEdit.idOfTestingSanitizationCourse&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.idOfInstructor1OfTestingSanitizationCourse&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCourseEditTestingSanitization.html
+++ b/src/test/resources/pages/instructorCourseEditTestingSanitization.html
@@ -248,7 +248,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor2" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -281,7 +281,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -348,7 +348,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -856,7 +856,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor8" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -889,7 +889,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -1286,7 +1286,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/instructorCourseEditTutor.html
+++ b/src/test/resources/pages/instructorCourseEditTutor.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.tutor&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="InsCrsEdit.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=InsCrsEdit.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=InsCrsEdit.tutor&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddDupIdFailed.html
@@ -64,7 +64,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -195,7 +195,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -243,7 +243,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -64,7 +64,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -195,7 +195,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -243,7 +243,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddInvalidIdFailed.html
@@ -254,5 +254,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -64,7 +64,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -195,7 +195,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -243,7 +243,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
+++ b/src/test/resources/pages/instructorCoursesAddMissingParamsFailed.html
@@ -254,5 +254,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -264,5 +264,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesAddSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesAddSuccessful.html
@@ -74,7 +74,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -157,7 +157,7 @@
             <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -205,7 +205,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -253,7 +253,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -105,6 +105,54 @@
       </thead>
       <tbody>
         <tr>
+          <td id="courseid2">
+            CCAddUiTest.course1
+          </td>
+          <td id="coursename2">
+            Software Engineering $^&*()
+          </td>
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
+            ${datetime.now.courses}
+          </td>
+          <td id="course-stats-sectionNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-teamNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-totalStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-unregisteredStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td class="align-center no-print">
+            <a class="btn btn-default btn-xs t_course_enroll2" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              Enroll
+            </a>
+            <a class="btn btn-default btn-xs t_course_view2" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              View
+            </a>
+            <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              Edit
+            </a>
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Archive
+            </a>
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Delete
+            </a>
+          </td>
+        </tr>
+        <tr>
           <td id="courseid0">
             CCAddUiTest.CS2104
           </td>
@@ -152,6 +200,54 @@
             </a>
           </td>
         </tr>
+        <tr>
+          <td id="courseid1">
+            CCAddUiTest.CS2105
+          </td>
+          <td id="coursename1">
+            Computer Networks
+          </td>
+          <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="coursecreateddate1">
+            2 Apr 2012
+          </td>
+          <td id="course-stats-sectionNum-1">
+            <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-teamNum-1">
+            <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-totalStudentNum-1">
+            <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-unregisteredStudentNum-1">
+            <a class="course-stats-link-1" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td class="align-center no-print">
+            <a class="btn btn-default btn-xs t_course_enroll1" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Enroll
+            </a>
+            <a class="btn btn-default btn-xs t_course_view1" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              View
+            </a>
+            <a class="btn btn-default btn-xs t_course_edit1" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Edit
+            </a>
+            <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2105&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Archive
+            </a>
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2105" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Delete
+            </a>
+          </td>
+        </tr>
       </tbody>
     </table>
     <br>
@@ -188,117 +284,26 @@
       </thead>
       <tbody>
         <tr>
-          <td id="courseid1">
+          <td id="courseid3">
             CCAddUiTest.CS1101
           </td>
-          <td id="coursename1">
+          <td id="coursename3">
             Programming Methodology
           </td>
-          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate1">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate3">
             ${datetime.now.courses}
           </td>
           <td class="align-center no-print">
-            <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive1">
+            <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive3">
               Unarchive
             </a>
-            <a class="btn btn-default btn-xs" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_delete1" title="">
+            <a class="btn btn-default btn-xs" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_delete3" title="">
               Delete
             </a>
           </td>
         </tr>
       </tbody>
     </table>
-    <br>
-    <br>
-    <br>
-    <br>
-    <h2 class="text-muted">
-      <span class="glyphicon glyphicon-trash">
-      </span>
-      Deleted courses
-    </h2>
-    <div class="panel">
-      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
-        <div class="pull-right margin-left-7px">
-          <span class="glyphicon ajax_submit glyphicon-chevron-down">
-          </span>
-        </div>
-        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
-          <span class="glyphicon glyphicon-remove">
-          </span>
-          <strong>
-            Delete All
-          </strong>
-        </a>
-        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
-          <span class="glyphicon glyphicon-ok">
-          </span>
-          <strong>
-            Restore All
-          </strong>
-        </a>
-        <strong class="ajax_submit">
-          Recycle Bin
-        </strong>
-      </div>
-      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
-        <div class="panel-body padding-0">
-          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
-            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
-              <tr>
-                <th class="button-sort-none toggle-sort" id="btn_sortid">
-                  Course ID
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="btn_sortname">
-                  Course Name
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
-                  Creation Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
-                  Deletion Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="align-center no-print">
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td id="recoverycourseid1">
-                  CCAddUiTest.course1
-                </td>
-                <td id="recoverycoursename1">
-                  Software Engineering $^&*()
-                </td>
-                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
-                  ${datetime.now.courses}
-                </td>
-                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
-                  ${datetime.now.courses}
-                </td>
-                <td class="align-center no-print">
-                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
-                    Restore
-                  </a>
-                  <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
-                    Delete Permanently
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesArchiveSuccessful.html
@@ -64,7 +64,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -159,17 +159,19 @@
     <br>
     <br>
     <h2 class="text-muted">
+      <span class="glyphicon glyphicon-floppy-disk">
+      </span>
       Archived courses
     </h2>
     <table class="table table-bordered table-striped" id="tableArchivedCourses">
       <thead>
-        <tr class="fill-default">
+        <tr class="fill-info">
           <th class="button-sort-none toggle-sort" id="button_sortid">
             Course ID
             <span class="icon-sort unsorted">
             </span>
           </th>
-          <th class="button-sort-none toggle-sort" id="button_sortid">
+          <th class="button-sort-none toggle-sort" id="button_sortname">
             Course Name
             <span class="icon-sort unsorted">
             </span>
@@ -199,13 +201,104 @@
             <a class="btn btn-default btn-xs" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=false&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_unarchive1">
               Unarchive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_delete1" title="">
+            <a class="btn btn-default btn-xs" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="t_course_delete1" title="">
               Delete
             </a>
           </td>
         </tr>
       </tbody>
     </table>
+    <br>
+    <br>
+    <br>
+    <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid1">
+                  CCAddUiTest.course1
+                </td>
+                <td id="recoverycoursename1">
+                  Software Engineering $^&*()
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorCoursesDeleteAllSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteAllSuccessful.html
@@ -1,0 +1,138 @@
+<div class="container" id="mainContent">
+  <div id="topOfPage">
+  </div>
+  <h1>
+    Add New Course
+  </h1>
+  <br>
+  <div class="panel panel-primary">
+    <div class="panel-body fill-plain">
+      <form action="/page/instructorCourseAdd" class="form form-horizontal" method="get" name="form_addcourse">
+        <input id="instructorid" name="instructorid" type="hidden" value="CCAddUiTest.instr1">
+        <input name="token" type="hidden" value="${sessionToken}">
+        <input name="user" type="hidden" value="CCAddUiTest.instr1">
+        <div class="form-group">
+          <label class="col-sm-3 control-label">
+            Course ID:
+          </label>
+          <div class="col-sm-3">
+            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-3 control-label">
+            Course Name:
+          </label>
+          <div class="col-sm-9">
+            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="">
+          </div>
+        </div>
+        <div class="form-group">
+          <label class="col-sm-3 control-label">
+            Time Zone:
+          </label>
+          <div class="col-sm-9">
+            <div class="input-group">
+              <select class="form-control" data-original-title="The time zone for the course. You should not need to change this as it is auto-detected based on your
+                  device settings.<br><br> TEAMMATES automatically adjusts to match the current time offset in your area,
+                  including clock changes due to daylight saving time." data-placement="top" data-toggle="tooltip" id="coursetimezone" name="coursetimezone" title="">
+              </select>
+              <span class="input-group-btn">
+                <input class="btn btn-primary" id="auto-detect-time-zone" type="button" value="Auto-Detect">
+              </span>
+            </div>
+          </div>
+        </div>
+        <div class="form-group">
+          <div class="col-sm-offset-3 col-sm-9">
+            <input class="btn btn-primary" id="btnAddCourse" tabindex="3" type="submit" value="Add Course">
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+  <form action="/page/instructorCoursesPage" class="ajaxForCoursesForm" id="ajaxForCourses" style="display:none;">
+    <input name="user" type="hidden" value="CCAddUiTest.instr1">
+    <input name="isusingAjax" type="hidden" value="on">
+  </form>
+  <br>
+  <div id="statusMessagesToUser">
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
+      All courses have been permanently deleted.
+    </div>
+    <div class="overflow-auto alert alert-warning icon-warning statusMessage">
+      You do not seem to have any courses. Use the form above to create a course.
+    </div>
+  </div>
+  <script defer="" src="/js/statusMessage.js" type="text/javascript">
+  </script>
+  <br>
+  <div class="courses-tables" id="coursesList">
+    <h2>
+      Active courses
+    </h2>
+    <table class="table table-bordered table-striped" id="tableActiveCourses">
+      <thead class="fill-primary">
+        <tr>
+          <th class="button-sort-none toggle-sort button-sort-ascending" id="button_sortcourseid">
+            Course ID
+            <span class="icon-sort sorted-ascending">
+            </span>
+          </th>
+          <th class="button-sort-none toggle-sort" id="button_sortcoursename">
+            Course Name
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
+          <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="button_sortcoursecreateddate">
+            Creation Date
+            <span class="icon-sort unsorted">
+            </span>
+          </th>
+          <th>
+            Sections
+          </th>
+          <th>
+            Teams
+          </th>
+          <th>
+            Total Students
+          </th>
+          <th>
+            Total Unregistered
+          </th>
+          <th class="align-center no-print">
+            Action(s)
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <br>
+    <br>
+    No records found.
+    <br>
+    <br>
+    <br>
+    <br>
+  </div>
+</div>

--- a/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesDeleteSuccessful.html
@@ -58,13 +58,13 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-success icon-success statusMessage">
-      The course CCAddUiTest.course1 has been deleted.
+      The course CCAddUiTest.course1 has been deleted. You can restore it from the deleted courses table below.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -195,13 +195,104 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
         </tr>
       </tbody>
     </table>
+    <br>
+    <br>
+    <br>
+    <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid1">
+                  CCAddUiTest.course1
+                </td>
+                <td id="recoverycoursename1">
+                  Software Engineering $^&*()
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorCoursesMoveToRecoverySuccessful.html
+++ b/src/test/resources/pages/instructorCoursesMoveToRecoverySuccessful.html
@@ -16,7 +16,7 @@
             Course ID:
           </label>
           <div class="col-sm-3">
-            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="CCAddUiTest.course1">
+            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -24,7 +24,7 @@
             Course Name:
           </label>
           <div class="col-sm-9">
-            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="different course name">
+            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -57,8 +57,8 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
-      A course by the same ID already exists in the system, possibly created by another user. Please choose a different course ID
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
+      The course CCAddUiTest.course1 has been deleted. You can restore it from the deleted courses table below.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
@@ -104,54 +104,6 @@
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td id="courseid2">
-            CCAddUiTest.course1
-          </td>
-          <td id="coursename2">
-            Software Engineering $^&*()
-          </td>
-          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
-            ${datetime.now.courses}
-          </td>
-          <td id="course-stats-sectionNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
-              Show
-            </a>
-          </td>
-          <td id="course-stats-teamNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
-              Show
-            </a>
-          </td>
-          <td id="course-stats-totalStudentNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
-              Show
-            </a>
-          </td>
-          <td id="course-stats-unregisteredStudentNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
-              Show
-            </a>
-          </td>
-          <td class="align-center no-print">
-            <a class="btn btn-default btn-xs t_course_enroll2" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
-              Enroll
-            </a>
-            <a class="btn btn-default btn-xs t_course_view2" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
-              View
-            </a>
-            <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
-              Edit
-            </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
-              Archive
-            </a>
-            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
-              Delete
-            </a>
-          </td>
-        </tr>
         <tr>
           <td id="courseid0">
             CCAddUiTest.CS1101
@@ -332,6 +284,28 @@
                     Restore
                   </a>
                   <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td id="recoverycourseid1">
+                  CCAddUiTest.course1
+                </td>
+                <td id="recoverycoursename1">
+                  Software Engineering $^&*()
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore1" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently1" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
                     Delete Permanently
                   </a>
                 </td>

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -201,5 +201,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesMultipleCourses.html
+++ b/src/test/resources/pages/instructorCoursesMultipleCourses.html
@@ -59,7 +59,7 @@
   <div id="statusMessagesToUser" style="">
   </div>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -142,7 +142,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -190,7 +190,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -140,7 +140,7 @@
     </div>
   </div>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -181,6 +181,8 @@
       </thead>
       <tbody>
         <tr>
+          <td>
+          </td>
           <td>
           </td>
           <td>

--- a/src/test/resources/pages/instructorCoursesRestoreAllSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesRestoreAllSuccessful.html
@@ -16,7 +16,7 @@
             Course ID:
           </label>
           <div class="col-sm-3">
-            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="CCAddUiTest.course1">
+            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -24,7 +24,7 @@
             Course Name:
           </label>
           <div class="col-sm-9">
-            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="different course name">
+            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -57,8 +57,8 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
-      A course by the same ID already exists in the system, possibly created by another user. Please choose a different course ID
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
+      All courses have been restored.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
@@ -105,49 +105,49 @@
       </thead>
       <tbody>
         <tr>
-          <td id="courseid2">
+          <td id="courseid3">
             CCAddUiTest.course1
           </td>
-          <td id="coursename2">
+          <td id="coursename3">
             Software Engineering $^&*()
           </td>
-          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate2">
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate3">
             ${datetime.now.courses}
           </td>
-          <td id="course-stats-sectionNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+          <td id="course-stats-sectionNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
             </a>
           </td>
-          <td id="course-stats-teamNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+          <td id="course-stats-teamNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
             </a>
           </td>
-          <td id="course-stats-totalStudentNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+          <td id="course-stats-totalStudentNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
             </a>
           </td>
-          <td id="course-stats-unregisteredStudentNum-2">
-            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+          <td id="course-stats-unregisteredStudentNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
               Show
             </a>
           </td>
           <td class="align-center no-print">
-            <a class="btn btn-default btn-xs t_course_enroll2" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_enroll3" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Enroll
             </a>
-            <a class="btn btn-default btn-xs t_course_view2" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_view3" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               View
             </a>
-            <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+            <a class="btn btn-default btn-xs t_course_edit3" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
               Edit
             </a>
-            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_archive3" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete3" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -248,99 +248,56 @@
             </a>
           </td>
         </tr>
+        <tr>
+          <td id="courseid2">
+            CCAddUiTest.CS2105
+          </td>
+          <td id="coursename2">
+            Computer Networks
+          </td>
+          <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="coursecreateddate2">
+            2 Apr 2012
+          </td>
+          <td id="course-stats-sectionNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-teamNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-totalStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-unregisteredStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td class="align-center no-print">
+            <a class="btn btn-default btn-xs t_course_enroll2" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Enroll
+            </a>
+            <a class="btn btn-default btn-xs t_course_view2" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              View
+            </a>
+            <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Edit
+            </a>
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2105&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Archive
+            </a>
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.CS2105" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Delete
+            </a>
+          </td>
+        </tr>
       </tbody>
     </table>
-    <br>
-    <br>
-    <br>
-    <br>
-    <h2 class="text-muted">
-      <span class="glyphicon glyphicon-trash">
-      </span>
-      Deleted courses
-    </h2>
-    <div class="panel">
-      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
-        <div class="pull-right margin-left-7px">
-          <span class="glyphicon ajax_submit glyphicon-chevron-down">
-          </span>
-        </div>
-        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
-          <span class="glyphicon glyphicon-remove">
-          </span>
-          <strong>
-            Delete All
-          </strong>
-        </a>
-        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
-          <span class="glyphicon glyphicon-ok">
-          </span>
-          <strong>
-            Restore All
-          </strong>
-        </a>
-        <strong class="ajax_submit">
-          Recycle Bin
-        </strong>
-      </div>
-      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
-        <div class="panel-body padding-0">
-          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
-            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
-              <tr>
-                <th class="button-sort-none toggle-sort" id="btn_sortid">
-                  Course ID
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="btn_sortname">
-                  Course Name
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
-                  Creation Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
-                  Deletion Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="align-center no-print">
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td id="recoverycourseid0">
-                  CCAddUiTest.CS2105
-                </td>
-                <td id="recoverycoursename0">
-                  Computer Networks
-                </td>
-                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
-                  2 Apr 2012
-                </td>
-                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
-                  12 Apr 2012
-                </td>
-                <td class="align-center no-print">
-                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
-                    Restore
-                  </a>
-                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
-                    Delete Permanently
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorCoursesRestoreSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesRestoreSuccessful.html
@@ -16,7 +16,7 @@
             Course ID:
           </label>
           <div class="col-sm-3">
-            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="CCAddUiTest.course1">
+            <input class="form-control" data-original-title="Enter the identifier of the course, e.g.CS3215-2013Semester1." data-placement="top" data-toggle="tooltip" id="courseid" maxlength="40" name="courseid" placeholder="e.g. CS3215-2013Semester1" tabindex="1" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -24,7 +24,7 @@
             Course Name:
           </label>
           <div class="col-sm-9">
-            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="different course name">
+            <input class="form-control" data-original-title="Enter the name of the course, e.g. Software Engineering." data-placement="top" data-toggle="tooltip" id="coursename" maxlength="64" name="coursename" placeholder="e.g. Software Engineering" tabindex="2" title="" type="text" value="">
           </div>
         </div>
         <div class="form-group">
@@ -57,8 +57,8 @@
   </form>
   <br>
   <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-danger icon-danger statusMessage">
-      A course by the same ID already exists in the system, possibly created by another user. Please choose a different course ID
+    <div class="overflow-auto alert alert-success icon-success statusMessage">
+      The course CCAddUiTest.course1 has been restored.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -205,5 +205,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxFailure.html
@@ -59,7 +59,7 @@
   <div id="statusMessagesToUser" style="">
   </div>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -142,7 +142,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -194,7 +194,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -59,7 +59,7 @@
   <div id="statusMessagesToUser" style="">
   </div>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -142,7 +142,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -182,7 +182,7 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>

--- a/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesStatsAjaxSuccessful.html
@@ -193,5 +193,96 @@
     <br>
     <br>
     <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid0">
+                  CCAddUiTest.CS2105
+                </td>
+                <td id="recoverycoursename0">
+                  Computer Networks
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate0">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2105" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <br>
+    <br>
+    <br>
+    <br>
   </div>
 </div>

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -105,6 +105,54 @@
       </thead>
       <tbody>
         <tr>
+          <td id="courseid3">
+            CCAddUiTest.course1
+          </td>
+          <td id="coursename3">
+            Software Engineering $^&*()
+          </td>
+          <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="coursecreateddate3">
+            ${datetime.now.courses}
+          </td>
+          <td id="course-stats-sectionNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-teamNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-totalStudentNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-unregisteredStudentNum-3">
+            <a class="course-stats-link-3" href="/page/courseStatsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td class="align-center no-print">
+            <a class="btn btn-default btn-xs t_course_enroll3" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              Enroll
+            </a>
+            <a class="btn btn-default btn-xs t_course_view3" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              View
+            </a>
+            <a class="btn btn-default btn-xs t_course_edit3" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.course1&user=CCAddUiTest.instructor" title="">
+              Edit
+            </a>
+            <a class="btn btn-default btn-xs t_course_archive3" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.course1&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Archive
+            </a>
+            <a class="btn btn-default btn-xs t_course_delete3" data-course-id="CCAddUiTest.course1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Delete
+            </a>
+          </td>
+        </tr>
+        <tr>
           <td id="courseid0">
             CCAddUiTest.CS1101
           </td>
@@ -200,99 +248,56 @@
             </a>
           </td>
         </tr>
+        <tr>
+          <td id="courseid2">
+            CCAddUiTest.CS2105
+          </td>
+          <td id="coursename2">
+            Computer Networks
+          </td>
+          <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="coursecreateddate2">
+            2 Apr 2012
+          </td>
+          <td id="course-stats-sectionNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-teamNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-totalStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td id="course-stats-unregisteredStudentNum-2">
+            <a class="course-stats-link-2" href="/page/courseStatsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" oncontextmenu="return false;">
+              Show
+            </a>
+          </td>
+          <td class="align-center no-print">
+            <a class="btn btn-default btn-xs t_course_enroll2" data-original-title="Enroll student into the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEnrollPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Enroll
+            </a>
+            <a class="btn btn-default btn-xs t_course_view2" data-original-title="View, edit and send invitation emails to the students in the course" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDetailsPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              View
+            </a>
+            <a class="btn btn-default btn-xs t_course_edit2" data-original-title="Edit Course information and instructor list" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseEditPage?courseid=CCAddUiTest.CS2105&user=CCAddUiTest.instructor" title="">
+              Edit
+            </a>
+            <a class="btn btn-default btn-xs t_course_archive2" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2105&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Archive
+            </a>
+            <a class="btn btn-default btn-xs t_course_delete2" data-course-id="CCAddUiTest.CS2105" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2105&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+              Delete
+            </a>
+          </td>
+        </tr>
       </tbody>
     </table>
-    <br>
-    <br>
-    <br>
-    <br>
-    <h2 class="text-muted">
-      <span class="glyphicon glyphicon-trash">
-      </span>
-      Deleted courses
-    </h2>
-    <div class="panel">
-      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
-        <div class="pull-right margin-left-7px">
-          <span class="glyphicon ajax_submit glyphicon-chevron-down">
-          </span>
-        </div>
-        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
-          <span class="glyphicon glyphicon-remove">
-          </span>
-          <strong>
-            Delete All
-          </strong>
-        </a>
-        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
-          <span class="glyphicon glyphicon-ok">
-          </span>
-          <strong>
-            Restore All
-          </strong>
-        </a>
-        <strong class="ajax_submit">
-          Recycle Bin
-        </strong>
-      </div>
-      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
-        <div class="panel-body padding-0">
-          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
-            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
-              <tr>
-                <th class="button-sort-none toggle-sort" id="btn_sortid">
-                  Course ID
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" id="btn_sortname">
-                  Course Name
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
-                  Creation Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
-                  Deletion Date
-                  <span class="icon-sort unsorted">
-                  </span>
-                </th>
-                <th class="align-center no-print">
-                  Action(s)
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td id="recoverycourseid1">
-                  CCAddUiTest.course1
-                </td>
-                <td id="recoverycoursename1">
-                  Software Engineering $^&*()
-                </td>
-                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
-                  ${datetime.now.courses}
-                </td>
-                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
-                  ${datetime.now.courses}
-                </td>
-                <td class="align-center no-print">
-                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
-                    Restore
-                  </a>
-                  <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
-                    Delete Permanently
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
+++ b/src/test/resources/pages/instructorCoursesUnarchiveSuccessful.html
@@ -64,7 +64,7 @@
   <script defer="" src="/js/statusMessage.js" type="text/javascript">
   </script>
   <br>
-  <div class="" id="coursesList">
+  <div class="courses-tables" id="coursesList">
     <h2>
       Active courses
     </h2>
@@ -147,7 +147,7 @@
             <a class="btn btn-default btn-xs t_course_archive0" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS1101&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete0" data-course-id="CCAddUiTest.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" disabled="" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS1101&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
@@ -195,13 +195,104 @@
             <a class="btn btn-default btn-xs t_course_archive1" data-original-title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseArchive?courseid=CCAddUiTest.CS2104&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Archive
             </a>
-            <a class="btn btn-default btn-xs course-delete-link t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+            <a class="btn btn-default btn-xs t_course_delete1" data-course-id="CCAddUiTest.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CCAddUiTest.CS2104&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
               Delete
             </a>
           </td>
         </tr>
       </tbody>
     </table>
+    <br>
+    <br>
+    <br>
+    <br>
+    <h2 class="text-muted">
+      <span class="glyphicon glyphicon-trash">
+      </span>
+      Deleted courses
+    </h2>
+    <div class="panel">
+      <div class="panel-heading ajax_submit fill-default" data-target="#recoveryPanelBodyCollapse" id="recoveryPanelHeading" style="cursor: pointer;">
+        <div class="pull-right margin-left-7px">
+          <span class="glyphicon ajax_submit glyphicon-chevron-down">
+          </span>
+        </div>
+        <a class="btn btn-default btn-xs pull-right pull-down margin-left-7px course-delete-all-link color-negative" data-original-title="Permanently delete all courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-deleteall" title="">
+          <span class="glyphicon glyphicon-remove">
+          </span>
+          <strong>
+            Delete All
+          </strong>
+        </a>
+        <a class="btn btn-default btn-xs pull-right pull-down" data-original-title="Restore all deleted courses and their corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreAllCourses?next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" id="btn-course-restoreall" title="">
+          <span class="glyphicon glyphicon-ok">
+          </span>
+          <strong>
+            Restore All
+          </strong>
+        </a>
+        <strong class="ajax_submit">
+          Recycle Bin
+        </strong>
+      </div>
+      <div class="panel-collapse collapse" id="recoveryPanelBodyCollapse">
+        <div class="panel-body padding-0">
+          <table class="table table-bordered table-striped margin-0" id="tableRecoveryCourses">
+            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+              <tr>
+                <th class="button-sort-none toggle-sort" id="btn_sortid">
+                  Course ID
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" id="btn_sortname">
+                  Course Name
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursecreateddate">
+                  Creation Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="button-sort-none toggle-sort" data-toggle-sort-comparator="sortDate" data-toggle-sort-extractor="dateStampExtractor" id="btn_sortcoursedeleteddate">
+                  Deletion Date
+                  <span class="icon-sort unsorted">
+                  </span>
+                </th>
+                <th class="align-center no-print">
+                  Action(s)
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td id="recoverycourseid1">
+                  CCAddUiTest.course1
+                </td>
+                <td id="recoverycoursename1">
+                  Software Engineering $^&*()
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursecreateddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td data-date-stamp="${datetime.now.iso8601utc}" data-original-title="${datetime.now}" data-toggle="tooltip" id="recoverycoursedeleteddate1">
+                  ${datetime.now.courses}
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete0" data-course-id="CCAddUiTest.course1" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.course1&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instructor&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
     <br>
     <br>
     <br>

--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -210,7 +210,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseDeleteSuccessful.html
@@ -27,7 +27,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-success icon-success statusMessage">
-      The course CHomeUiT.CS2104 has been deleted.
+      The course CHomeUiT.CS2104 has been deleted. You can restore it from the 'Courses' tab.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/test/resources/pages/instructorHomeHTML.html
+++ b/src/test/resources/pages/instructorHomeHTML.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRateFail.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByDate.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortById.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortByName.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -766,7 +766,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByEndDate.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByName.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
+++ b/src/test/resources/pages/instructorHomeHTMLSortSessionsByStartDate.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS1101" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS1101&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithHelperView.html
@@ -330,7 +330,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.CS2104" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.CS2104&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
+++ b/src/test/resources/pages/instructorHomeHTMLWithUnloadedCourse.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo1&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="ins.wit-demo1" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo1&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -354,7 +354,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo2" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo2&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="ins.wit-demo2" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo2&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>
@@ -505,7 +505,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="ins.wit-demo3" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo3&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="ins.wit-demo3" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=ins.wit-demo3&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.unloaded&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/instructorHomeNewInstructorWithSampleCourse.html
@@ -218,7 +218,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="newIns.wit-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=newIns.wit-demo&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="newIns.wit-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=newIns.wit-demo&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.instructor.tmms.new&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/instructorHomeTestingSanitization.html
+++ b/src/test/resources/pages/instructorHomeTestingSanitization.html
@@ -203,7 +203,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="CHomeUiT.idOfTestingSanitizationCourse" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.idOfTestingSanitizationCourse&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.idOfInstructor1OfTestingSanitizationCourse&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="CHomeUiT.idOfTestingSanitizationCourse" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=CHomeUiT.idOfTestingSanitizationCourse&next=%2Fpage%2FinstructorHomePage&user=CHomeUiT.idOfInstructor1OfTestingSanitizationCourse&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -248,7 +248,7 @@
                 </a>
                 <br>
                 <input id="instructorroleforinstructor2" name="instructorrole" type="radio" value="Manager">
-                 Manager: Can do everything except for deleting the course
+                 Manager: Can do everything except for deleting/restoring the course
                 <a class="view-role-details" data-role="Manager" href="javascript:;">
                   View Details
                 </a>
@@ -281,7 +281,7 @@
                     <div class="panel-body">
                       <div class="col-sm-3">
                         <input name="canmodifycourse" type="checkbox" value="true">
-                        Edit/Delete Course
+                        Edit/Delete/Restore Course
                       </div>
                       <div class="col-sm-3">
                         <input name="canmodifyinstructor" type="checkbox" value="true">
@@ -617,7 +617,7 @@
           <div class="row">
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifycourse" type="checkbox" value="true">
-              Edit/Delete Course
+              Edit/Delete/Restore Course
             </div>
             <div class="col-sm-6">
               <input checked="" disabled="" name="canmodifyinstructor" type="checkbox" value="true">

--- a/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorCourseEditPage.html
@@ -17,7 +17,7 @@
           </span>
           Edit
         </a>
-        <a class="btn btn-primary btn-xs course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
+        <a class="btn btn-primary btn-xs" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorCoursesPage&user=${test.instructor}&token=${sessionToken}" id="courseDeleteLink" title="" type="button">
           <span class="glyphicon glyphicon-trash">
           </span>
           Delete

--- a/src/test/resources/pages/newlyJoinedInstructorHomePage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorHomePage.html
@@ -218,7 +218,7 @@
                   </a>
                 </li>
                 <li>
-                  <a class="btn-tm-actions course-delete-for-test course-delete-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
+                  <a class="btn-tm-actions course-delete-for-test course-move-to-recovery-link" data-course-id="AHPUiT____.instr1_.gma-demo" data-original-title="Delete the course and its corresponding students and sessions" data-placement="left" data-toggle="tooltip" href="/page/instructorCourseDelete?courseid=AHPUiT____.instr1_.gma-demo&next=%2Fpage%2FinstructorHomePage&user=${test.instructor}&token=${sessionToken}" title="">
                     Delete
                   </a>
                 </li>

--- a/src/test/resources/pages/otherInstructorCoursesMultipleRecoveryCourses.html
+++ b/src/test/resources/pages/otherInstructorCoursesMultipleRecoveryCourses.html
@@ -56,16 +56,11 @@
     <input name="isusingAjax" type="hidden" value="on">
   </form>
   <br>
-  <div id="statusMessagesToUser">
-    <div class="overflow-auto alert alert-success icon-success statusMessage">
-      The course CCAddUiTest.CS2106 has been permanently deleted.
-    </div>
+  <div id="statusMessagesToUser" style="">
     <div class="overflow-auto alert alert-warning icon-warning statusMessage">
       You do not seem to have any courses. Use the form above to create a course.
     </div>
   </div>
-  <script defer="" src="/js/statusMessage.js" type="text/javascript">
-  </script>
   <br>
   <div class="courses-tables" id="coursesList">
     <h2>
@@ -196,10 +191,10 @@
             <tbody>
               <tr>
                 <td id="recoverycourseid0">
-                  CCAddUiTest.CS2107
+                  CCAddUiTest.CS2106
                 </td>
                 <td id="recoverycoursename0">
-                  Introduction to Information Security
+                  Operating Systems
                 </td>
                 <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate0">
                   2 Apr 2012
@@ -208,10 +203,32 @@
                   12 Apr 2012
                 </td>
                 <td class="align-center no-print">
-                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2107&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" title="">
+                  <a class="btn btn-default btn-xs t_course_restore0" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2106&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" title="">
                     Restore
                   </a>
-                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2107" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2107&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" style="color: red" title="">
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently0" data-course-id="CCAddUiTest.CS2106" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2106&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" style="color: red" title="">
+                    Delete Permanently
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td id="recoverycourseid1">
+                  CCAddUiTest.CS2107
+                </td>
+                <td id="recoverycoursename1">
+                  Introduction to Information Security
+                </td>
+                <td data-date-stamp="2012-04-02T23:58:00Z" data-original-title="Mon, 02 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursecreateddate1">
+                  2 Apr 2012
+                </td>
+                <td data-date-stamp="2012-04-12T23:58:00Z" data-original-title="Thu, 12 Apr 2012, 11:58 PM" data-toggle="tooltip" id="recoverycoursedeleteddate1">
+                  12 Apr 2012
+                </td>
+                <td class="align-center no-print">
+                  <a class="btn btn-default btn-xs t_course_restore1" data-original-title="Restore the deleted course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryRestoreCourse?courseid=CCAddUiTest.CS2107&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" title="">
+                    Restore
+                  </a>
+                  <a class="btn btn-default btn-xs course-delete-link t_course_delete_permanently1" data-course-id="CCAddUiTest.CS2107" data-original-title="Permanently delete the course and its corresponding students and sessions" data-placement="top" data-toggle="tooltip" href="/page/instructorRecoveryDeleteCourse?courseid=CCAddUiTest.CS2107&next=%2Fpage%2FinstructorCoursesPage&user=CCAddUiTest.instr1&token=${sessionToken}" style="color: red" title="">
                     Delete Permanently
                   </a>
                 </td>


### PR DESCRIPTION
Fixes #9002 
Fixes #8852 
Fixes #8927 
Fixes #8952 
Fixes #8971 

**Content:**
- Allow instructors to restore/permanently delete single/all courses in Recycle Bin panel of the 'Courses' page
- Add instructions for managing deleted courses in `InstructorHelpPage`
- Add tests for deleting & restoring of courses in Recycle Bin

