### PR TITLE
Fix unstable test in FeedbackSessionsDbTest #9067

### DIFF
--- a/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
@@ -319,12 +319,18 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
     }
 
     private FeedbackSessionAttributes getNewFeedbackSession() {
+        Instant sessionStartTime = Instant.now();
+        try {
+            Thread.sleep(1);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         return FeedbackSessionAttributes.builder("fsTest1", "testCourse", "valid@email.com")
-                .withCreatedTime(Instant.now())
-                .withStartTime(Instant.now())
+                .withCreatedTime(sessionStartTime)
+                .withStartTime(sessionStartTime)
                 .withEndTime(Instant.now())
-                .withSessionVisibleFromTime(Instant.now())
-                .withResultsVisibleFromTime(Instant.now())
+                .withSessionVisibleFromTime(sessionStartTime)
+                .withResultsVisibleFromTime(sessionStartTime)
                 .withGracePeriodMinutes(5)
                 .withSentOpenEmail(true)
                 .withSentPublishedEmail(true)


### PR DESCRIPTION
Fixes #9067 

I generated a delay of at least 1 millisecond with a "Thread.sleep(1)". This will make sure that there will be at least a millisecond of difference between the instant StartTime and EndTime.

I'm not sure whether the delay has to be added only between the start and end time or even in other fields, also i'm new to the project so i'd love to hear anyone's opinion on this simple solution.