### PR TITLE
Data Migration: Able to resume/restart from where it fails/stops #9044

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForOrphanedStudentProfile.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForOrphanedStudentProfile.java
@@ -1,0 +1,52 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.storage.entity.StudentProfile;
+
+/**
+ * Script to delete all orphaned StudentProfile entity.
+ */
+public class DataMigrationForOrphanedStudentProfile extends DataMigrationWithCheckpointForEntities<StudentProfile> {
+
+    public static void main(String[] args) throws IOException {
+        new DataMigrationForOrphanedStudentProfile().doOperationRemotely();
+    }
+
+    @Override
+    protected Query<StudentProfile> getFilterQuery() {
+        return ofy().load().type(StudentProfile.class);
+    }
+
+    @Override
+    protected String getLastPositionOfCursor() {
+        return "";
+    }
+
+    @Override
+    protected int getCursorInformationPrintCycle() {
+        // Till 23/08/2018, we have around 61363 StudentProfile entities and therefore
+        // 500 could be a good batch size.
+        return 500;
+    }
+
+    @Override
+    protected boolean isPreview() {
+        return true;
+    }
+
+    @Override
+    protected boolean isMigrationNeeded(Key<StudentProfile> spKey) throws Exception {
+        // orphaned student profile doesn't have parent key
+        return spKey.getParent() == null;
+    }
+
+    @Override
+    protected void migrateEntity(Key<StudentProfile> spKey) throws Exception {
+        println("Deleting orphaned StudentProfile now! " + spKey);
+        ofy().delete().key(spKey).now();
+    }
+}

--- a/src/client/java/teammates/client/scripts/DataMigrationWithCheckpointForEntities.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationWithCheckpointForEntities.java
@@ -1,0 +1,154 @@
+package teammates.client.scripts;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.appengine.api.datastore.Cursor;
+import com.google.appengine.api.datastore.QueryResultIterator;
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.cmd.Query;
+
+import teammates.client.remoteapi.RemoteApiClient;
+import teammates.common.util.StringHelper;
+import teammates.storage.entity.BaseEntity;
+
+/**
+ * Base script to be used as a template for all data migration scripts.
+ *
+ * <ul>
+ * <li>Supports full scan of entities without {@code OutOfMemoryError}.</li>
+ * <li>Supports continuation from the last failure point (Checkpoint feature).</li>
+ * <li>Supports transaction between {@link #isMigrationNeeded(Key)} and {@link #migrateEntity(Key)}.</li>
+ * </ul>
+ *
+ * @param <T> The entity type to be migrated by the script.
+ */
+public abstract class DataMigrationWithCheckpointForEntities<T extends BaseEntity> extends RemoteApiClient {
+
+    protected AtomicLong numberOfScannedKey;
+    protected AtomicLong numberOfAffectedEntities;
+    protected AtomicLong numberOfUpdatedEntities;
+
+    public DataMigrationWithCheckpointForEntities() {
+        numberOfScannedKey = new AtomicLong();
+        numberOfAffectedEntities = new AtomicLong();
+        numberOfUpdatedEntities = new AtomicLong();
+    }
+
+    /**
+     * Gets the query for the entities that need data migration.
+     */
+    protected abstract Query<T> getFilterQuery();
+
+    /**
+     * If true, the script will not perform actual data migration.
+     *
+     * <p>Causation: this method might be called in multiple threads.</p>
+     */
+    protected abstract boolean isPreview();
+
+    /**
+     * Gets the last position of cursor where the migration script stopped.
+     *
+     * <p>Use empty string/null if no last position;
+     * Position can be obtained from the console output of the last script run.</p>
+     */
+    protected abstract String getLastPositionOfCursor();
+
+    /**
+     * Determines how often the cursor position information should be printed.
+     *
+     * <p>Should choose a reasonable value based on the number of entities in the server.</p>
+     */
+    protected abstract int getCursorInformationPrintCycle();
+
+    /**
+     * Checks whether data migration is needed.
+     *
+     * <p>Causation: this method might be called in multiple threads.</p>
+     */
+    protected abstract boolean isMigrationNeeded(Key<T> entity) throws Exception;
+
+    /**
+     * Migrates the entity.
+     *
+     * <p>Causation: this method might be called in multiple threads.</p>
+     */
+    protected abstract void migrateEntity(Key<T> entity) throws Exception;
+
+    /**
+     * Does data migration ({@link #isMigrationNeeded(Key)} and {@link #migrateEntity(Key)}) in transaction
+     * to ensure data consistency.
+     */
+    private void migrate(Key<T> entityKey) {
+        ofy().transact(() -> {
+            try {
+                if (!isMigrationNeeded(entityKey)) {
+                    return;
+                }
+                numberOfAffectedEntities.incrementAndGet();
+                if (!isPreview()) {
+                    migrateEntity(entityKey);
+                    numberOfUpdatedEntities.incrementAndGet();
+                }
+            } catch (Exception e) {
+                System.err.println("Problem migrating entity with key: " + entityKey);
+                System.err.println(e.getMessage());
+            }
+        });
+    }
+
+    @Override
+    protected void doOperation() {
+        println("Running " + getClass().getSimpleName() + "...");
+        println("Preview: " + isPreview());
+
+        Cursor cursor = null;
+        String cursorPosition = getLastPositionOfCursor();
+        if (StringHelper.isEmpty(cursorPosition)) {
+            println("Start from the beginning, you may want to record the cursor position\n"
+                    + "in order to start from the last stopped position when re-run the script.");
+        } else {
+            println("Start from cursor position: " + cursorPosition);
+            cursor = Cursor.fromWebSafeString(cursorPosition);
+        }
+
+        String entityType = "Unknown";
+        boolean shouldContinue = true;
+        while (shouldContinue) {
+            shouldContinue = false;
+            Query<T> filterQueryKeys = getFilterQuery().limit(getCursorInformationPrintCycle());
+            if (cursor != null) {
+                filterQueryKeys = filterQueryKeys.startAt(cursor);
+            }
+            QueryResultIterator<Key<T>> iterator = filterQueryKeys.keys().iterator();
+
+            while (iterator.hasNext()) {
+                shouldContinue = true;
+                Key<T> keyOfEntityToMigrate = iterator.next();
+
+                // get entity type
+                if ("Unknown".equals(entityType)) {
+                    entityType = keyOfEntityToMigrate.getKind();
+                }
+
+                // migrate
+                migrate(keyOfEntityToMigrate);
+                numberOfScannedKey.incrementAndGet();
+            }
+
+            if (shouldContinue) {
+                cursor = iterator.getCursor();
+                println(String.format("Cursor Position: %s", cursor.toWebSafeString()));
+                println(String.format("Number Of Entity Key Scanned: %d", numberOfScannedKey.get()));
+                println(String.format("Number Of Entity affected: %d", numberOfAffectedEntities.get()));
+                println(String.format("Number Of Entity updated: %d", numberOfUpdatedEntities.get()));
+            }
+        }
+
+        println(isPreview() ? "Preview Completed!" : "Migration Completed!");
+        println("Total number of " + entityType + "s: " + numberOfScannedKey.get());
+        println("Number of affected " + entityType + "s: " + numberOfAffectedEntities.get());
+        println("Number of updated " + entityType + "s: " + numberOfUpdatedEntities.get());
+    }
+
+}


### PR DESCRIPTION
Fixes #9044 

**Outline of Solution**

- In the script, data is fetch in batch (default to 100 entities each round) (so no chance to have `OutOfMemoryError`). In addition, the cursor position will also be printed after each batch. 

- By copying the cursor position printed on the console and paste it into the code, the script will start from the position specified instead of staring the query again.

<hr>

I have provided a sample script for #9060 

In order to create orphaned student profile. The following java code can be used:

```java
package teammates.client.scripts;

import java.io.IOException;
import java.lang.reflect.Field;

import teammates.client.remoteapi.RemoteApiClient;
import teammates.storage.entity.StudentProfile;

public class CreateOrphanedStudentProfile extends RemoteApiClient {
    public static void main(String[] args) throws IOException {
        new CreateOrphanedStudentProfile().doOperationRemotely();
    }

    @Override
    protected void doOperation() {
        try {
            StudentProfile sp = new StudentProfile("sp.test");
            Field accountField = sp.getClass().getDeclaredField("account");
            accountField.setAccessible(true);
            accountField.set(sp, null);
            ofy().save().entity(sp).now();
        } catch (Exception e) {
            e.printStackTrace();
        }
    }
}

``` 

<hr>

Here is the sample output when it is run

```
--- Starting remote operation ---
Going to connect to:6-10-2-dot-teammates-xiaopu.appspot.com:443
Running DataMigrationForOrphanedStudentProfile...
Preview: false
Start from the beginning, you may want to record the cursor position
in order to start from the last stopped position when re-run the script.
Cursor Position: Cm0SZ2oSc350ZWFtbWF0ZXMteGlhb3B1clELEgdBY2NvdW50IhhJQ0pDb25maXJtYXRpb25VaVQuaW5zdHIMCxIOU3R1ZGVudFByb2ZpbGUiGElDSkNvbmZpcm1hdGlvblVpVC5pbnN0cgwYACAA
Number Of Entity Key Scanned: 100
Number Of Entity affected: 0
Number Of Entity updated: 0
Deleting orphaned StudentProfile now! Key<?>(StudentProfile("xp.test"))
Deleting orphaned StudentProfile now! Key<?>(StudentProfile("xp1.test"))
Cursor Position: CjgSMmoSc350ZWFtbWF0ZXMteGlhb3B1chwLEg5TdHVkZW50UHJvZmlsZSIIeHAxLnRlc3QMGAAgAA
Number Of Entity Key Scanned: 198
Number Of Entity affected: 2
Number Of Entity updated: 2
Migration Completed!
Total number of StudentProfiles: 198
Number of affected StudentProfiles: 2
Number of updated StudentProfiles: 2
--- Remote operation completed ---
```

For example `Cm0SZ2oSc350ZWFtbWF0ZXMteGlhb3B1clELEgdBY2NvdW50IhhJQ0pDb25maXJtYXRpb25VaVQuaW5zdHIMCxIOU3R1ZGVudFByb2ZpbGUiGElDSkNvbmZpcm1hdGlvblVpVC5pbnN0cgwYACAA` should be pasted to `getLastPositionOfCursor()` if the administrator want to skip the first 100 entities.