### PR TITLE
[#9065] Fix unstable testToEntity() in StudentProfileAttributesTest

### DIFF
--- a/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
@@ -184,8 +184,6 @@ public class StudentProfileAttributesTest extends BaseAttributesTest {
         assertEquals(expectedEntity.getNationality(), actualEntity.getNationality());
         assertEquals(expectedEntity.getGender(), actualEntity.getGender());
         assertEquals(expectedEntity.getMoreInfo(), actualEntity.getMoreInfo());
-        assertEquals(expectedEntity.getModifiedDate().toString(),
-                     actualEntity.getModifiedDate().toString());
         assertEquals(expectedEntity.getPictureKey(), actualEntity.getPictureKey());
     }
 


### PR DESCRIPTION
Fixes #9065 

As `modifiedTime` is not carried over when creating a `StudentProfile` or calling 
 `StudentProfileAttributes.toEntity()`, the test will fail or pass depending on if lines 177 and 179 are executed fast enough to produce the same modifiedTime.

**Outline of Solution**

`assertsEquals(expectedEntity.getModifiedDate().toString(), actualEntity.getModifiedDate().toString());` was removed. It would hide the fact that `toEntity()` is setting the modifiedDate by also calling new `StudentProfile(...)` but it seems this is correct behaviour as I was encouraged to submit this change as a PR.