### PR TITLE
[#9082] Objectify: Use java.time.Instant instead of java.util.Date for entity

### DIFF
--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneRulesProvider;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -414,38 +413,6 @@ public final class TimeHelper {
                 || instant.equals(Const.TIME_REPRESENTS_FOLLOW_VISIBLE)
                 || instant.equals(Const.TIME_REPRESENTS_LATER)
                 || instant.equals(Const.TIME_REPRESENTS_NOW);
-    }
-
-    /**
-     * Temporary method for transition from storing time zone as double.
-     */
-    @Deprecated
-    public static ZoneId convertToZoneId(double timeZone) {
-        return ZoneId.ofOffset("UTC", ZoneOffset.ofTotalSeconds((int) (timeZone * 60 * 60)));
-    }
-
-    /**
-     * Temporary method for transition from java.util.Date.
-     */
-    @Deprecated
-    public static LocalDateTime convertDateToLocalDateTime(Date date) {
-        return date == null ? null : date.toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime();
-    }
-
-    /**
-     * Temporary method for transition from java.util.Date.
-     */
-    @Deprecated
-    public static Date convertInstantToDate(Instant instant) {
-        return instant == null ? null : Date.from(instant);
-    }
-
-    /**
-     * Temporary method for transition from java.util.Date.
-     */
-    @Deprecated
-    public static Instant convertDateToInstant(Date date) {
-        return date == null ? null : date.toInstant();
     }
 
     /**

--- a/src/main/java/teammates/storage/api/AdminEmailsDb.java
+++ b/src/main/java/teammates/storage/api/AdminEmailsDb.java
@@ -19,7 +19,6 @@ import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.GoogleCloudStorageHelper;
 import teammates.common.util.ThreadHelper;
-import teammates.common.util.TimeHelper;
 import teammates.storage.entity.AdminEmail;
 
 /**
@@ -208,7 +207,7 @@ public class AdminEmailsDb extends EntitiesDb<AdminEmail, AdminEmailAttributes> 
     private AdminEmail getAdminEmailEntity(String subject, Instant createDate) {
         return load()
                 .filter("subject =", subject)
-                .filter("createDate =", TimeHelper.convertInstantToDate(createDate))
+                .filter("createDate =", createDate)
                 .first().now();
     }
 
@@ -238,7 +237,7 @@ public class AdminEmailsDb extends EntitiesDb<AdminEmail, AdminEmailAttributes> 
         if (key == null) {
             query = load()
                     .filter("subject =", attributes.subject)
-                    .filter("createDate =", TimeHelper.convertInstantToDate(attributes.createDate));
+                    .filter("createDate =", attributes.createDate);
         } else {
             query = load().filterKey(key);
         }

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -26,7 +26,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.Logger;
-import teammates.common.util.TimeHelper;
 import teammates.storage.entity.FeedbackResponseComment;
 import teammates.storage.search.FeedbackResponseCommentSearchDocument;
 import teammates.storage.search.FeedbackResponseCommentSearchQuery;
@@ -311,7 +310,7 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
     private FeedbackResponseComment getFeedbackResponseCommentEntity(String courseId, Instant createdAt, String giverEmail) {
         return load()
                 .filter("courseId =", courseId)
-                .filter("createdAt =", TimeHelper.convertInstantToDate(createdAt))
+                .filter("createdAt =", createdAt)
                 .filter("giverEmail =", giverEmail)
                 .first().now();
     }
@@ -325,7 +324,7 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
         return load()
                 .filter("feedbackResponseId =", feedbackResponseId)
                 .filter("giverEmail =", giverEmail)
-                .filter("createdAt =", TimeHelper.convertInstantToDate(createdAt))
+                .filter("createdAt =", createdAt)
                 .first().now();
     }
 
@@ -414,7 +413,7 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
         }
         return load()
                 .filter("feedbackResponseId =", attributes.feedbackResponseId)
-                .filter("createdAt =", TimeHelper.convertInstantToDate(attributes.createdAt))
+                .filter("createdAt =", attributes.createdAt)
                 .filter("giverEmail =", attributes.commentGiver)
                 .keys();
     }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -37,13 +37,13 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
      */
     public List<FeedbackSessionAttributes> getAllOpenFeedbackSessions(Instant rangeStart, Instant rangeEnd) {
         List<FeedbackSession> endEntities = load()
-                .filter("endTime >", TimeHelper.convertInstantToDate(rangeStart))
-                .filter("endTime <=", TimeHelper.convertInstantToDate(rangeEnd))
+                .filter("endTime >", rangeStart)
+                .filter("endTime <=", rangeEnd)
                 .list();
 
         List<FeedbackSession> startEntities = load()
-                .filter("startTime >=", TimeHelper.convertInstantToDate(rangeStart))
-                .filter("startTime <", TimeHelper.convertInstantToDate(rangeEnd))
+                .filter("startTime >=", rangeStart)
+                .filter("startTime <", rangeEnd)
                 .list();
 
         // remove duplications
@@ -511,14 +511,14 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
 
     private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingOpenEmail() {
         return load()
-                .filter("startTime >", TimeHelper.convertInstantToDate(TimeHelper.getInstantDaysOffsetFromNow(-2)))
+                .filter("startTime >", TimeHelper.getInstantDaysOffsetFromNow(-2))
                 .filter("sentOpenEmail =", false)
                 .list();
     }
 
     private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosingEmail() {
         return load()
-                .filter("endTime >", TimeHelper.convertInstantToDate(TimeHelper.getInstantDaysOffsetFromNow(-2)))
+                .filter("endTime >", TimeHelper.getInstantDaysOffsetFromNow(-2))
                 .filter("sentClosingEmail =", false)
                 .filter("isClosingEmailEnabled =", true)
                 .list();
@@ -526,7 +526,7 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
 
     private List<FeedbackSession> getFeedbackSessionEntitiesPossiblyNeedingClosedEmail() {
         return load()
-                .filter("endTime >", TimeHelper.convertInstantToDate(TimeHelper.getInstantDaysOffsetFromNow(-2)))
+                .filter("endTime >", TimeHelper.getInstantDaysOffsetFromNow(-2))
                 .filter("sentClosedEmail =", false)
                 .filter("isClosingEmailEnabled =", true)
                 .list();

--- a/src/main/java/teammates/storage/api/OfyHelper.java
+++ b/src/main/java/teammates/storage/api/OfyHelper.java
@@ -7,6 +7,7 @@ import com.googlecode.objectify.ObjectifyService;
 
 import teammates.storage.entity.Account;
 import teammates.storage.entity.AdminEmail;
+import teammates.storage.entity.BaseEntity;
 import teammates.storage.entity.Course;
 import teammates.storage.entity.CourseStudent;
 import teammates.storage.entity.FeedbackQuestion;
@@ -35,6 +36,8 @@ public class OfyHelper implements ServletContextListener {
         ObjectifyService.register(FeedbackSession.class);
         ObjectifyService.register(Instructor.class);
         ObjectifyService.register(StudentProfile.class);
+        // enable the ability to use java.time.Instant to issue query
+        ObjectifyService.factory().getTranslators().add(new BaseEntity.InstantTranslatorFactory());
     }
 
     @Override

--- a/src/main/java/teammates/storage/entity/Account.java
+++ b/src/main/java/teammates/storage/entity/Account.java
@@ -1,15 +1,13 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
-import java.util.Date;
 
 import com.googlecode.objectify.Ref;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
-
-import teammates.common.util.TimeHelper;
+import com.googlecode.objectify.annotation.Translate;
 
 /**
  * Represents a unique user in the system.
@@ -29,7 +27,8 @@ public class Account extends BaseEntity {
 
     private String institute;
 
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
     private Ref<StudentProfile> studentProfile;
 
@@ -115,11 +114,11 @@ public class Account extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return TimeHelper.convertDateToInstant(createdAt);
+        return createdAt;
     }
 
     public void setCreatedAt(Instant createdAt) {
-        this.createdAt = TimeHelper.convertInstantToDate(createdAt);
+        this.createdAt = createdAt;
     }
 
     /**

--- a/src/main/java/teammates/storage/entity/AdminEmail.java
+++ b/src/main/java/teammates/storage/entity/AdminEmail.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.google.appengine.api.datastore.Text;
@@ -10,9 +9,8 @@ import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
-
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents emails composed by Admin.
@@ -33,9 +31,11 @@ public class AdminEmail extends BaseEntity {
     private String subject;
 
     //For draft emails,this is null. For sent emails, this is not null;
-    private Date sendDate;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant sendDate;
 
-    private Date createDate;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createDate;
 
     @Unindex
     private Text content;
@@ -61,8 +61,8 @@ public class AdminEmail extends BaseEntity {
         this.groupReceiver = groupReceiver == null ? new ArrayList<String>() : groupReceiver;
         this.subject = subject;
         this.content = content;
-        this.sendDate = TimeHelper.convertInstantToDate(sendDate);
-        this.createDate = new Date();
+        this.sendDate = sendDate;
+        this.createDate = Instant.now();
         this.isInTrashBin = false;
     }
 
@@ -87,7 +87,7 @@ public class AdminEmail extends BaseEntity {
     }
 
     public void setSendDate(Instant sendDate) {
-        this.sendDate = TimeHelper.convertInstantToDate(sendDate);
+        this.sendDate = sendDate;
     }
 
     public String getEmailId() {
@@ -107,7 +107,7 @@ public class AdminEmail extends BaseEntity {
     }
 
     public Instant getSendDate() {
-        return TimeHelper.convertDateToInstant(this.sendDate);
+        return this.sendDate;
     }
 
     public Text getContent() {
@@ -119,6 +119,6 @@ public class AdminEmail extends BaseEntity {
     }
 
     public Instant getCreateDate() {
-        return TimeHelper.convertDateToInstant(this.createDate);
+        return this.createDate;
     }
 }

--- a/src/main/java/teammates/storage/entity/BaseEntity.java
+++ b/src/main/java/teammates/storage/entity/BaseEntity.java
@@ -1,7 +1,47 @@
 package teammates.storage.entity;
 
+import java.time.Instant;
+import java.util.Date;
+
+import com.googlecode.objectify.impl.Path;
+import com.googlecode.objectify.impl.translate.CreateContext;
+import com.googlecode.objectify.impl.translate.LoadContext;
+import com.googlecode.objectify.impl.translate.SaveContext;
+import com.googlecode.objectify.impl.translate.SkipException;
+import com.googlecode.objectify.impl.translate.TypeKey;
+import com.googlecode.objectify.impl.translate.ValueTranslator;
+import com.googlecode.objectify.impl.translate.ValueTranslatorFactory;
+
 /**
  * Base class for all entities persisted to the Datastore.
  */
 public abstract class BaseEntity { // NOPMD
+
+    /**
+     * Translates between `java.time.Instant` in entity class and `java.util.Date` in Google Cloud Datastore.
+     *
+     * <p>See <a href="https://github.com/objectify/objectify/blob/v5.2/src/main/java/com/googlecode/objectify/annotation/Translate.java">@Translate annotation</a>
+     * and <a href="https://github.com/objectify/objectify/blob/v5.2/src/main/java/com/googlecode/objectify/impl/translate/TranslatorFactory.java">TranslatorFactory</a></p>
+     */
+    public static class InstantTranslatorFactory extends ValueTranslatorFactory<Instant, Date> {
+
+        public InstantTranslatorFactory() {
+            super(Instant.class);
+        }
+
+        @Override
+        protected ValueTranslator<Instant, Date> createValueTranslator(TypeKey<Instant> tk, CreateContext ctx, Path path) {
+            return new ValueTranslator<Instant, Date>(Date.class) {
+                @Override
+                protected Instant loadValue(Date value, LoadContext ctx, Path path) throws SkipException {
+                    return value == null ? null : value.toInstant();
+                }
+
+                @Override
+                protected Date saveValue(Instant value, boolean index, SaveContext ctx, Path path) throws SkipException {
+                    return value == null ? null : Date.from(value);
+                }
+            };
+        }
+    }
 }

--- a/src/main/java/teammates/storage/entity/Course.java
+++ b/src/main/java/teammates/storage/entity/Course.java
@@ -1,14 +1,13 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
-import java.util.Date;
 
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Translate;
 
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents a course entity.
@@ -22,10 +21,11 @@ public class Course extends BaseEntity {
 
     private String name;
 
-    // TODO: change to `java.time.Instant` once we have upgraded to Objectify 6
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
-    private Date deletedAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant deletedAt;
 
     private String timeZone;
 
@@ -67,19 +67,19 @@ public class Course extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return TimeHelper.convertDateToInstant(createdAt);
+        return createdAt;
     }
 
     public void setCreatedAt(Instant createdAt) {
-        this.createdAt = TimeHelper.convertInstantToDate(createdAt);
+        this.createdAt = createdAt;
     }
 
     public Instant getDeletedAt() {
-        return TimeHelper.convertDateToInstant(deletedAt);
+        return deletedAt;
     }
 
     public void setDeletedAt(Instant deletedAt) {
-        this.deletedAt = TimeHelper.convertInstantToDate(deletedAt);
+        this.deletedAt = deletedAt;
     }
 
     public String getTimeZone() {

--- a/src/main/java/teammates/storage/entity/CourseStudent.java
+++ b/src/main/java/teammates/storage/entity/CourseStudent.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.security.SecureRandom;
 import java.time.Instant;
-import java.util.Date;
 
 import com.google.gson.annotations.SerializedName;
 import com.googlecode.objectify.annotation.Entity;
@@ -10,11 +9,11 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
 
 import teammates.common.util.Assumption;
 import teammates.common.util.StringHelper;
-import teammates.common.util.TimeHelper;
 
 /**
  * An association class that represents the association Account -->
@@ -40,9 +39,11 @@ public class CourseStudent extends BaseEntity {
     @Id
     private String id;
 
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
-    private Date updatedAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant updatedAt;
 
     private transient String registrationKey;
 
@@ -105,21 +106,21 @@ public class CourseStudent extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return TimeHelper.convertDateToInstant(createdAt);
+        return createdAt;
     }
 
     public void setCreatedAt(Instant created) {
-        this.createdAt = TimeHelper.convertInstantToDate(created);
+        this.createdAt = created;
         setLastUpdate(created);
     }
 
     public Instant getUpdatedAt() {
-        return TimeHelper.convertDateToInstant(updatedAt);
+        return updatedAt;
     }
 
     public void setLastUpdate(Instant updatedAt) {
         if (!keepUpdateTimestamp) {
-            this.updatedAt = TimeHelper.convertInstantToDate(updatedAt);
+            this.updatedAt = updatedAt;
         }
     }
 

--- a/src/main/java/teammates/storage/entity/FeedbackQuestion.java
+++ b/src/main/java/teammates/storage/entity/FeedbackQuestion.java
@@ -2,7 +2,6 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.google.appengine.api.datastore.Text;
@@ -12,11 +11,11 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.Translate;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents a feedback question.
@@ -68,9 +67,11 @@ public class FeedbackQuestion extends BaseEntity {
 
     private List<FeedbackParticipantType> showRecipientNameTo = new ArrayList<>();
 
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
-    private Date updatedAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant updatedAt;
 
     @SuppressWarnings("unused")
     private FeedbackQuestion() {
@@ -106,21 +107,21 @@ public class FeedbackQuestion extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : TimeHelper.convertDateToInstant(createdAt);
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Instant getUpdatedAt() {
-        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : TimeHelper.convertDateToInstant(updatedAt);
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
 
     public void setCreatedAt(Instant newDate) {
-        this.createdAt = TimeHelper.convertInstantToDate(newDate);
+        this.createdAt = newDate;
         setLastUpdate(newDate);
     }
 
     public void setLastUpdate(Instant newDate) {
         if (!keepUpdateTimestamp) {
-            this.updatedAt = TimeHelper.convertInstantToDate(newDate);
+            this.updatedAt = newDate;
         }
     }
 

--- a/src/main/java/teammates/storage/entity/FeedbackResponse.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponse.java
@@ -1,7 +1,6 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
-import java.util.Date;
 
 import com.google.appengine.api.datastore.Text;
 import com.googlecode.objectify.annotation.Entity;
@@ -9,10 +8,10 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnSave;
+import com.googlecode.objectify.annotation.Translate;
 
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents a feedback response.
@@ -53,9 +52,11 @@ public class FeedbackResponse extends BaseEntity {
 
     private Text answer; //TODO: rename to responseMetaData, will require database conversion
 
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
-    private Date updatedAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant updatedAt;
 
     @SuppressWarnings("unused")
     private FeedbackResponse() {
@@ -157,21 +158,21 @@ public class FeedbackResponse extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : TimeHelper.convertDateToInstant(createdAt);
+        return createdAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Instant getUpdatedAt() {
-        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : TimeHelper.convertDateToInstant(updatedAt);
+        return updatedAt == null ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
 
     public void setCreatedAt(Instant newDate) {
-        this.createdAt = TimeHelper.convertInstantToDate(newDate);
+        this.createdAt = newDate;
         setLastUpdate(newDate);
     }
 
     public void setLastUpdate(Instant newDate) {
         if (!keepUpdateTimestamp) {
-            this.updatedAt = TimeHelper.convertInstantToDate(newDate);
+            this.updatedAt = newDate;
         }
     }
 

--- a/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
+++ b/src/main/java/teammates/storage/entity/FeedbackResponseComment.java
@@ -2,18 +2,17 @@ package teammates.storage.entity;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 import com.google.appengine.api.datastore.Text;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
 
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.util.SanitizationHelper;
-import teammates.common.util.TimeHelper;
 
 /**
  * An association class that represents the association
@@ -63,7 +62,8 @@ public class FeedbackResponseComment extends BaseEntity {
     private boolean isCommentFromFeedbackParticipant;
 
     /** The creation time of this comment. */
-    private Date createdAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdAt;
 
     /** The comment from giver about the feedback response. */
     @Unindex
@@ -73,7 +73,8 @@ public class FeedbackResponseComment extends BaseEntity {
     private String lastEditorEmail;
 
     /** The time in which the comment is last edited. */
-    private Date lastEditedAt;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant lastEditedAt;
 
     @SuppressWarnings("unused")
     private FeedbackResponseComment() {
@@ -92,7 +93,7 @@ public class FeedbackResponseComment extends BaseEntity {
         this.giverEmail = giverEmail;
         this.commentGiverType = commentGiverType;
         this.feedbackResponseId = feedbackResponseId;
-        this.createdAt = TimeHelper.convertInstantToDate(createdAt);
+        this.createdAt = createdAt;
         this.commentText = SanitizationHelper.sanitizeForRichText(commentText);
         this.giverSection = giverSection;
         this.receiverSection = receiverSection;
@@ -100,7 +101,7 @@ public class FeedbackResponseComment extends BaseEntity {
         this.showGiverNameTo = showGiverNameTo == null ? new ArrayList<FeedbackParticipantType>() : showGiverNameTo;
         this.isVisibilityFollowingFeedbackQuestion = isVisibilityFollowingFeedbackQuestion;
         this.lastEditorEmail = lastEditorEmail == null ? giverEmail : lastEditorEmail;
-        this.lastEditedAt = lastEditedAt == null ? this.createdAt : TimeHelper.convertInstantToDate(lastEditedAt);
+        this.lastEditedAt = lastEditedAt == null ? this.createdAt : lastEditedAt;
         this.isCommentFromFeedbackParticipant = isCommentFromFeedbackParticipant;
     }
 
@@ -199,11 +200,11 @@ public class FeedbackResponseComment extends BaseEntity {
     }
 
     public Instant getCreatedAt() {
-        return TimeHelper.convertDateToInstant(createdAt);
+        return createdAt;
     }
 
     public void setCreatedAt(Instant createdAt) {
-        this.createdAt = TimeHelper.convertInstantToDate(createdAt);
+        this.createdAt = createdAt;
     }
 
     public Text getCommentText() {
@@ -239,11 +240,11 @@ public class FeedbackResponseComment extends BaseEntity {
     }
 
     public Instant getLastEditedAt() {
-        return TimeHelper.convertDateToInstant(this.lastEditedAt);
+        return this.lastEditedAt;
     }
 
     public void setLastEditedAt(Instant lastEditedAt) {
-        this.lastEditedAt = TimeHelper.convertInstantToDate(lastEditedAt);
+        this.lastEditedAt = lastEditedAt;
     }
 
     public boolean getIsCommentFromFeedbackParticipant() {

--- a/src/main/java/teammates/storage/entity/FeedbackSession.java
+++ b/src/main/java/teammates/storage/entity/FeedbackSession.java
@@ -1,7 +1,6 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -9,9 +8,8 @@ import com.google.appengine.api.datastore.Text;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
-
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents an instructor-created Feedback Session.
@@ -43,19 +41,25 @@ public class FeedbackSession extends BaseEntity {
     private Text instructions;
 
     @Unindex
-    private Date createdTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant createdTime;
 
-    private Date deletedTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant deletedTime;
 
-    private Date startTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant startTime;
 
-    private Date endTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant endTime;
 
     @Unindex
-    private Date sessionVisibleFromTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant sessionVisibleFromTime;
 
     @Unindex
-    private Date resultsVisibleFromTime;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant resultsVisibleFromTime;
 
     private String timeZone;
 
@@ -104,12 +108,12 @@ public class FeedbackSession extends BaseEntity {
         this.courseId = courseId;
         this.creatorEmail = creatorEmail;
         this.instructions = instructions;
-        this.createdTime = TimeHelper.convertInstantToDate(createdTime);
-        this.deletedTime = TimeHelper.convertInstantToDate(deletedTime);
-        this.startTime = TimeHelper.convertInstantToDate(startTime);
-        this.endTime = TimeHelper.convertInstantToDate(endTime);
-        this.sessionVisibleFromTime = TimeHelper.convertInstantToDate(sessionVisibleFromTime);
-        this.resultsVisibleFromTime = TimeHelper.convertInstantToDate(resultsVisibleFromTime);
+        this.createdTime = createdTime;
+        this.deletedTime = deletedTime;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.sessionVisibleFromTime = sessionVisibleFromTime;
+        this.resultsVisibleFromTime = resultsVisibleFromTime;
         this.timeZone = timeZone;
         this.gracePeriod = gracePeriod;
         this.sentOpenEmail = sentOpenEmail;
@@ -157,51 +161,51 @@ public class FeedbackSession extends BaseEntity {
     }
 
     public Instant getCreatedTime() {
-        return TimeHelper.convertDateToInstant(createdTime);
+        return createdTime;
     }
 
     public void setCreatedTime(Instant createdTime) {
-        this.createdTime = TimeHelper.convertInstantToDate(createdTime);
+        this.createdTime = createdTime;
     }
 
     public Instant getDeletedTime() {
-        return TimeHelper.convertDateToInstant(deletedTime);
+        return deletedTime;
     }
 
     public void setDeletedTime(Instant deletedTime) {
-        this.deletedTime = TimeHelper.convertInstantToDate(deletedTime);
+        this.deletedTime = deletedTime;
     }
 
     public Instant getStartTime() {
-        return TimeHelper.convertDateToInstant(startTime);
+        return startTime;
     }
 
     public void setStartTime(Instant startTime) {
-        this.startTime = TimeHelper.convertInstantToDate(startTime);
+        this.startTime = startTime;
     }
 
     public Instant getEndTime() {
-        return TimeHelper.convertDateToInstant(endTime);
+        return endTime;
     }
 
     public void setEndTime(Instant endTime) {
-        this.endTime = TimeHelper.convertInstantToDate(endTime);
+        this.endTime = endTime;
     }
 
     public Instant getSessionVisibleFromTime() {
-        return TimeHelper.convertDateToInstant(sessionVisibleFromTime);
+        return sessionVisibleFromTime;
     }
 
     public void setSessionVisibleFromTime(Instant sessionVisibleFromTime) {
-        this.sessionVisibleFromTime = TimeHelper.convertInstantToDate(sessionVisibleFromTime);
+        this.sessionVisibleFromTime = sessionVisibleFromTime;
     }
 
     public Instant getResultsVisibleFromTime() {
-        return TimeHelper.convertDateToInstant(resultsVisibleFromTime);
+        return resultsVisibleFromTime;
     }
 
     public void setResultsVisibleFromTime(Instant resultsVisibleFromTime) {
-        this.resultsVisibleFromTime = TimeHelper.convertInstantToDate(resultsVisibleFromTime);
+        this.resultsVisibleFromTime = resultsVisibleFromTime;
     }
 
     public String getTimeZone() {

--- a/src/main/java/teammates/storage/entity/StudentProfile.java
+++ b/src/main/java/teammates/storage/entity/StudentProfile.java
@@ -1,7 +1,6 @@
 package teammates.storage.entity;
 
 import java.time.Instant;
-import java.util.Date;
 
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.datastore.Text;
@@ -10,9 +9,8 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.Parent;
+import com.googlecode.objectify.annotation.Translate;
 import com.googlecode.objectify.annotation.Unindex;
-
-import teammates.common.util.TimeHelper;
 
 /**
  * Represents profile details for student entities associated with an
@@ -45,7 +43,8 @@ public class StudentProfile extends BaseEntity {
     private BlobKey pictureKey;
 
     @Index
-    private Date modifiedDate;
+    @Translate(value = InstantTranslatorFactory.class)
+    private Instant modifiedDate;
 
     @SuppressWarnings("unused")
     private StudentProfile() {
@@ -163,11 +162,11 @@ public class StudentProfile extends BaseEntity {
     }
 
     public Instant getModifiedDate() {
-        return TimeHelper.convertDateToInstant(this.modifiedDate);
+        return this.modifiedDate;
     }
 
     public void setModifiedDate(Instant modifiedDate) {
-        this.modifiedDate = TimeHelper.convertInstantToDate(modifiedDate);
+        this.modifiedDate = modifiedDate;
     }
 
 }

--- a/static-analysis/teammates-macker.xml
+++ b/static-analysis/teammates-macker.xml
@@ -476,6 +476,21 @@
                     </deny>
                 </access-rule>
             </ruleset>
+            <ruleset name="java.util.Date/java.util.Calendar should not be used">
+                <access-rule>
+                    <deny>
+                        <to>
+                            <include class="java.util.Date" />
+                            <include class="java.util.Calendar" />
+                        </to>
+                        <allow>
+                            <!-- allow data type translator in BaseEntity -->
+                            <!-- this exception can be removed after upgrading to Objectify V6 -->
+                            <from class="${storage}.entity.BaseEntity$InstantTranslatorFactory**" />
+                        </allow>
+                    </deny>
+                </access-rule>
+            </ruleset>
         </ruleset>
     </ruleset>
 </macker>


### PR DESCRIPTION
Fixes #9082 

**Outline of Solution**

This step is necessary to prepare for upgrade to Objectify V6.

We shall wait for #9081 to get merged before removal of `Date` of `FeedbackSession` can be done. Or, we can release a version with the changes first. Up to the reviewer to decide.
