### PR TITLE
[#9090] Instructor edit email of student: send the correct link to student

### DIFF
--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -107,11 +107,12 @@ public class EmailGenerator {
      * Generates the email containing the summary of the feedback sessions
      * email for the given {@code courseId} for {@code student}.
      * @param courseId - ID of the course
-     * @param student - attributes of student to send feedback session summary to
+     * @param studentEmail - Email of student to send feedback session summary to
      */
-    public EmailWrapper generateFeedbackSessionSummaryOfCourse(String courseId, StudentAttributes student) {
+    public EmailWrapper generateFeedbackSessionSummaryOfCourse(String courseId, String studentEmail) {
 
         CourseAttributes course = coursesLogic.getCourse(courseId);
+        StudentAttributes student = studentsLogic.getStudentForEmail(courseId, studentEmail);
 
         List<FeedbackSessionAttributes> sessions = new ArrayList<>();
         List<FeedbackSessionAttributes> fsInCourse = fsLogic.getFeedbackSessionsForCourse(courseId);

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
@@ -78,7 +78,8 @@ public class InstructorCourseStudentDetailsEditSaveAction extends Action {
                 logic.resetStudentGoogleId(student.email, courseId);
                 if (isSessionSummarySendEmail) {
                     try {
-                        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(courseId, student);
+                        EmailWrapper email =
+                                new EmailGenerator().generateFeedbackSessionSummaryOfCourse(courseId, student.email);
                         emailSender.sendEmail(email);
                     } catch (Exception e) {
                         log.severe("Error while sending session summary email"

--- a/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailGeneratorTest.java
@@ -43,6 +43,12 @@ public class EmailGeneratorTest extends BaseLogicTest {
     private static final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
     private static final StudentsLogic studentsLogic = StudentsLogic.inst();
 
+    @Override
+    public void prepareTestData() {
+        dataBundle = loadDataBundle("/EmailGeneratorTest.json");
+        removeAndRestoreDataBundle(dataBundle);
+    }
+
     /**
      * Reminder to disable GodMode and re-run the test.
      */
@@ -62,8 +68,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
         CourseAttributes course = coursesLogic.getCourse(session.getCourseId());
 
         StudentAttributes student1 = studentsLogic.getStudentForEmail(course.getId(), "student1InCourse1@gmail.tmt");
-        StudentAttributes unregisteredStudent = studentsLogic.getStudentForEmail("idOfUnregisteredCourse",
-                "student1InUnregisteredCourse@gmail.tmt");
+        StudentAttributes unregisteredStudent = studentsLogic.getStudentForEmail("idOfTypicalCourse1",
+                "student1UnregisteredInCourse1@gmail.tmt");
 
         InstructorAttributes instructor1 =
                 instructorsLogic.getInstructorForEmail(course.getId(), "instructor1@course1.tmt");
@@ -76,7 +82,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("feedback session opening emails");
 
         List<EmailWrapper> emails = new EmailGenerator().generateFeedbackSessionOpeningEmails(session);
-        assertEquals(10, emails.size());
+        assertEquals(11, emails.size());
 
         String subject = String.format(EmailType.FEEDBACK_OPENING.getSubject(),
                                        course.getName(), session.getFeedbackSessionName());
@@ -88,8 +94,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         emails = new EmailGenerator().generateFeedbackSessionReminderEmails(session, students, instructors,
                 instructorToNotify);
-        // (5 instructors, 5 students reminded) and (1 instructor to be notified)
-        assertEquals(11, emails.size());
+        // (5 instructors, 6 students reminded) and (1 instructor to be notified)
+        assertEquals(12, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_SESSION_REMINDER.getSubject(),
                                 course.getName(), session.getFeedbackSessionName());
@@ -109,7 +115,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("feedback session closing alerts");
 
         emails = new EmailGenerator().generateFeedbackSessionClosingEmails(session);
-        assertEquals(8, emails.size());
+        assertEquals(9, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_CLOSING.getSubject(),
                                 course.getName(), session.getFeedbackSessionName());
@@ -129,7 +135,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("feedback session closed alerts");
 
         emails = new EmailGenerator().generateFeedbackSessionClosedEmails(session);
-        assertEquals(10, emails.size());
+        assertEquals(11, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_CLOSED.getSubject(),
                                 course.getName(), session.getFeedbackSessionName());
@@ -140,7 +146,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("feedback session published alerts");
 
         emails = new EmailGenerator().generateFeedbackSessionPublishedEmails(session);
-        assertEquals(10, emails.size());
+        assertEquals(11, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_PUBLISHED.getSubject(),
                                 course.getName(), session.getFeedbackSessionName());
@@ -151,7 +157,7 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("feedback session unpublished alerts");
 
         emails = new EmailGenerator().generateFeedbackSessionUnpublishedEmails(session);
-        assertEquals(10, emails.size());
+        assertEquals(11, emails.size());
 
         subject = String.format(EmailType.FEEDBACK_UNPUBLISHED.getSubject(),
                                 course.getName(), session.getFeedbackSessionName());
@@ -162,7 +168,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all feedback sessions of course email to new student. "
                 + "Edited student has joined the course");
 
-        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1);
+        EmailWrapper email =
+                new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1.email);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, student1.email, subject, "/summaryOfFeedbackSessionsOfCourseEmailForStudent.html");
@@ -170,7 +177,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
         ______TS("send summary of all feedback sessions of course email to new student. "
                 + "Edited student has not joined the course");
 
-        email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), unregisteredStudent);
+        email = new EmailGenerator()
+                .generateFeedbackSessionSummaryOfCourse(session.getCourseId(), unregisteredStudent.email);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
 
         verifyEmail(email, unregisteredStudent.email, subject,
@@ -257,7 +265,8 @@ public class EmailGeneratorTest extends BaseLogicTest {
 
         ______TS("feedback sessions summary of course email: sanitization required");
 
-        EmailWrapper email = new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1);
+        EmailWrapper email =
+                new EmailGenerator().generateFeedbackSessionSummaryOfCourse(session.getCourseId(), student1.email);
         subject = String.format(EmailType.STUDENT_EMAIL_CHANGED.getSubject(), course.getName(), course.getId());
         verifyEmail(email, student1.email, subject,
                 "/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html");

--- a/src/test/resources/data/EmailGeneratorTest.json
+++ b/src/test/resources/data/EmailGeneratorTest.json
@@ -1,0 +1,991 @@
+{
+  "accounts": {
+    "instructor1OfCourse1": {
+      "googleId": "idOfInstructor1OfCourse1",
+      "name": "Instructor 1 of Course 1",
+      "isInstructor": true,
+      "email": "instr1@course1.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "instructor2OfCourse1": {
+      "googleId": "idOfInstructor2OfCourse1",
+      "name": "Instructor 2 of Course 1",
+      "isInstructor": true,
+      "email": "instr2@course1.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "instructor3": {
+      "googleId": "idOfInstructor3",
+      "name": "Instructor 3 of Course 1",
+      "isInstructor": true,
+      "email": "instr3@course1n2.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "helperOfCourse1": {
+      "googleId": "idOfHelperOfCourse1",
+      "name": "Helper of Course 1",
+      "isInstructor": true,
+      "email": "helper@course1.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "instructor1OfCourse2": {
+      "googleId": "idOfInstructor1OfCourse2",
+      "name": "Instructor 1 of Course 2",
+      "isInstructor": true,
+      "email": "instr1@course2.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "instructor1OfTestingSanitizationCourse": {
+      "googleId": "idOfInstructor1OfTestingSanitizationCourse",
+      "name": "Instructor<script> alert('hi!'); </script>",
+      "isInstructor": true,
+      "email": "instructor1@sanitization.tmt",
+      "institute": "inst<script> alert('hi!'); </script>"
+    },
+    "student1InCourse1": {
+      "googleId": "student1InCourse1",
+      "name": "Student 1 in course 1",
+      "isInstructor": false,
+      "email": "student1InCourse1@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 1",
+      "studentProfile": {
+        "googleId": "student1InCourse1",
+        "shortName": "Stud1",
+        "email": "i.m.stud1@gmail.tmt",
+        "institute": "TEAMMATES Test Institute 3",
+        "nationality": "American",
+        "gender": "male",
+        "moreInfo": "I am just a student :P",
+        "pictureKey": "asdf34&hfn3!@"
+      }
+    },
+    "student2InCourse1": {
+      "googleId": "student2InCourse1",
+      "name": "Student in two courses",
+      "isInstructor": false,
+      "email": "student2InCourse1@gmail.tmt",
+      "institute": "TEAMMATES Test Institute 1"
+    },
+    "student1InTestingSanitizationCourse": {
+      "googleId": "student1InTestingSanitizationCourse",
+      "name": "Stud1<script> alert('hi!'); </script>",
+      "isInstructor": false,
+      "email": "normal@sanitization.tmt",
+      "institute": "inst<script> alert('hi!'); </script>",
+      "studentProfile": {
+        "googleId": "student1InTestingSanitizationCourse",
+        "shortName": "Stud1<script> alert('hi!'); </script>",
+        "email": "weird&'@gmail.tmt",
+        "institute": "inst<script> alert('hi!'); </script>",
+        "nationality": "American",
+        "gender": "other",
+        "moreInfo": "I am just a student :P<script> alert('hi!'); </script>",
+        "pictureKey": ""
+      }
+    }
+  },
+  "courses": {
+    "typicalCourse1": {
+      "createdAt": "2012-04-01T23:58:00Z",
+      "deletedAt": null,
+      "id": "idOfTypicalCourse1",
+      "name": "Typical Course 1 with 2 Evals",
+      "timeZone": "Africa/Johannesburg"
+    },
+    "typicalCourse2": {
+      "createdAt": "2012-04-01T23:59:00Z",
+      "deletedAt": null,
+      "id": "idOfTypicalCourse2",
+      "name": "Typical Course 2 with 1 Evals",
+      "timeZone": "UTC"
+    },
+    "testingSanitizationCourse": {
+      "createdAt": "2012-04-01T23:58:00Z",
+      "deletedAt": null,
+      "id": "idOfTestingSanitizationCourse",
+      "name": "Testing<script> alert('hi!'); </script>",
+      "timeZone": "UTC"
+    }
+  },
+  "instructors": {
+    "instructor1OfCourse1": {
+      "googleId": "idOfInstructor1OfCourse1",
+      "courseId": "idOfTypicalCourse1",
+      "name": "Instructor1 Course1",
+      "email": "instructor1@course1.tmt",
+      "isArchived": false,
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor2OfCourse1": {
+      "googleId": "idOfInstructor2OfCourse1",
+      "courseId": "idOfTypicalCourse1",
+      "name": "Instructor2 Course1",
+      "email": "instructor2@course1.tmt",
+      "isArchived": false,
+      "role": "Manager",
+      "isDisplayedToStudents": true,
+      "displayedName": "Manager",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": false,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "helperOfCourse1": {
+      "googleId": "idOfHelperOfCourse1",
+      "courseId": "idOfTypicalCourse1",
+      "name": "Helper Course1",
+      "email": "helper@course1.tmt",
+      "isArchived": false,
+      "role": "Custom",
+      "isDisplayedToStudents": false,
+      "displayedName": "Helper",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": false,
+          "cansubmitsessioninsection": false,
+          "canmodifysessioncommentinsection": false,
+          "canmodifycourse": false,
+          "canviewsessioninsection": false,
+          "canmodifysession": false,
+          "canmodifystudent": false,
+          "canmodifyinstructor": false
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructorNotYetJoinCourse1": {
+      "courseId": "idOfTypicalCourse1",
+      "name": "Instructor Not Yet Joined Course 1",
+      "email": "instructorNotYetJoinedCourse1@email.tmt",
+      "isArchived": false,
+      "key": "regKeyForInstrNotYetJoinCourse1",
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1OfCourse2": {
+      "googleId": "idOfInstructor1OfCourse2",
+      "courseId": "idOfTypicalCourse2",
+      "name": "Instructor1 Course2",
+      "email": "instructor1@course2.tmt",
+      "isArchived": false,
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor3OfCourse1": {
+      "googleId": "idOfInstructor3",
+      "courseId": "idOfTypicalCourse1",
+      "name": "Instructor3 Course1",
+      "email": "instructor3@course1.tmt",
+      "isArchived": false,
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "Instructor",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    },
+    "instructor1OfTestingSanitizationCourse": {
+      "googleId": "idOfInstructor1OfTestingSanitizationCourse",
+      "courseId": "idOfTestingSanitizationCourse",
+      "name": "Instructor<script> alert('hi!'); </script>",
+      "email": "instructor1@sanitization.tmt",
+      "isArchived": false,
+      "role": "Co-owner",
+      "isDisplayedToStudents": true,
+      "displayedName": "inst'\"/><script>alert('hi!');</script>",
+      "privileges": {
+        "courseLevel": {
+          "canviewstudentinsection": true,
+          "cansubmitsessioninsection": true,
+          "canmodifysessioncommentinsection": true,
+          "canmodifycourse": true,
+          "canviewsessioninsection": true,
+          "canmodifysession": true,
+          "canmodifystudent": true,
+          "canmodifyinstructor": true
+        },
+        "sectionLevel": {},
+        "sessionLevel": {}
+      }
+    }
+  },
+  "students": {
+    "student1InCourse1": {
+      "googleId": "student1InCourse1",
+      "email": "student1InCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "student1 In Course1</td></div>'\"",
+      "comments": "comment for student1InCourse1</td></div>'\"",
+      "team": "Team 1.1</td></div>'\"",
+      "section": "Section 1"
+    },
+    "student2InCourse1": {
+      "googleId": "student2InCourse1",
+      "email": "student2InCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "student2 In Course1",
+      "comments": "",
+      "team": "Team 1.1</td></div>'\"",
+      "section": "Section 1"
+    },
+    "student3InCourse1": {
+      "googleId": "student3InCourse1",
+      "email": "student3InCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "student3 In Course1",
+      "comments": "",
+      "team": "Team 1.1</td></div>'\"",
+      "section": "Section 1"
+    },
+    "student4InCourse1": {
+      "googleId": "student4InCourse1",
+      "email": "student4InCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "student4 In Course1",
+      "comments": "",
+      "team": "Team 1.1</td></div>'\"",
+      "section": "Section 1"
+    },
+    "student5InCourse1": {
+      "googleId": "student5InCourse1",
+      "email": "student5InCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "student5 In Course1",
+      "comments": "",
+      "team": "Team 1.2",
+      "section": "Section 2"
+    },
+    "student1UnregisteredInCourse1": {
+      "email": "student1UnregisteredInCourse1@gmail.tmt",
+      "course": "idOfTypicalCourse1",
+      "name": "unregistered student",
+      "comments": "",
+      "team": "Team 1.2",
+      "section": "Section 2",
+      "key": "regKeyForStuNotYetJoinCourse"
+    },
+    "student1InTestingSanitizationCourse": {
+      "googleId": "student1InTestingSanitizationCourse",
+      "email": "normal@sanitization.tmt",
+      "course": "idOfTestingSanitizationCourse",
+      "name": "Stud1<script> alert('hi!'); </script>",
+      "comments": "<script> alert('hi!'); </script>",
+      "team": "Team tags&\"</td>",
+      "section": "Section'</td>"
+    }
+  },
+  "feedbackSessions": {
+    "session1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T21:59:00Z",
+      "endTime": "2027-04-30T21:59:00Z",
+      "sessionVisibleFromTime": "2012-03-28T21:59:00Z",
+      "resultsVisibleFromTime": "2027-05-01T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "session2InCourse1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2013-03-20T23:59:00Z",
+      "startTime": "2013-06-01T21:59:00Z",
+      "endTime": "2026-04-28T21:59:00Z",
+      "sessionVisibleFromTime": "2013-03-20T21:59:00Z",
+      "resultsVisibleFromTime": "2026-04-29T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "gracePeriodSession": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2013-03-20T23:59:00Z",
+      "startTime": "2013-06-01T21:59:00Z",
+      "endTime": "2026-04-28T21:59:00Z",
+      "sessionVisibleFromTime": "2013-03-20T21:59:00Z",
+      "resultsVisibleFromTime": "2026-04-29T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 1440,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "closedSession": {
+      "feedbackSessionName": "Closed Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2013-03-20T23:59:00Z",
+      "startTime": "2013-06-01T21:58:00Z",
+      "endTime": "2013-06-01T21:59:00Z",
+      "sessionVisibleFromTime": "2013-03-20T21:59:00Z",
+      "resultsVisibleFromTime": "2013-04-29T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "empty.session": {
+      "feedbackSessionName": "Empty session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor2@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2013-01-20T23:57:00Z",
+      "startTime": "2013-02-01T23:57:00Z",
+      "endTime": "2013-04-28T23:57:00Z",
+      "sessionVisibleFromTime": "2013-01-20T23:57:00Z",
+      "resultsVisibleFromTime": "2013-04-29T23:57:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpenEmail": false,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "awaiting.session": {
+      "feedbackSessionName": "non visible session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor2@course1.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2013-01-20T23:00:00Z",
+      "startTime": "2026-04-01T23:00:00Z",
+      "endTime": "2026-04-28T23:00:00Z",
+      "sessionVisibleFromTime": "2026-04-01T23:00:00Z",
+      "resultsVisibleFromTime": "2026-04-29T23:00:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpenEmail": false,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "session2InCourse2": {
+      "feedbackSessionName": "Not answerable feedback session",
+      "courseId": "idOfTypicalCourse2",
+      "creatorEmail": "instructor1@course2.tmt",
+      "instructions": {
+        "value": "Please please fill in the following questions."
+      },
+      "createdTime": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T15:59:00Z",
+      "endTime": "2027-04-30T15:59:00Z",
+      "sessionVisibleFromTime": "1970-11-27T00:00:00Z",
+      "resultsVisibleFromTime": "1970-01-01T00:00:00Z",
+      "timeZone": "Asia/Singapore",
+      "gracePeriod": 0,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "session1InTestingSanitizationCourse": {
+      "feedbackSessionName": "Normal feedback session name",
+      "courseId": "idOfTestingSanitizationCourse",
+      "creatorEmail": "instructor1@sanitization.tmt",
+      "instructions": {
+        "value": "unclosed tags </td></div> Attempted script injection '\" <script>alert('hello');</script>"
+      },
+      "createdTime": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T21:59:00Z",
+      "endTime": "2027-04-30T21:59:00Z",
+      "sessionVisibleFromTime": "2012-03-28T21:59:00Z",
+      "resultsVisibleFromTime": "2027-05-01T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 10,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    }
+  },
+  "feedbackQuestions": {
+    "qn1InSession1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "What is the best selling point of your product?"
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    },
+    "qn2InSession1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Rate 1 other student's product"
+      },
+      "questionNumber": 2,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "STUDENTS",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS",
+        "RECEIVER"
+      ]
+    },
+    "qn3InSession1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "My comments on the class"
+      },
+      "questionNumber": 3,
+      "questionType": "TEXT",
+      "giverType": "SELF",
+      "recipientType": "NONE",
+      "numberOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ]
+    },
+    "qn4InSession1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Instructor comments on the class"
+      },
+      "questionNumber": 4,
+      "questionType": "TEXT",
+      "giverType": "INSTRUCTORS",
+      "recipientType": "NONE",
+      "numberOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER",
+        "OWN_TEAM_MEMBERS",
+        "STUDENTS",
+        "INSTRUCTORS"
+      ]
+    },
+    "qn5InSession1InCourse1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "{\"recommendedLength\":100,\"questionText\":\"New format Text question\",\"questionType\":\"TEXT\"}"
+      },
+      "questionNumber": 5,
+      "questionType": "TEXT",
+      "giverType": "SELF",
+      "recipientType": "NONE",
+      "numberOfEntitiesToGiveFeedbackTo": -100,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    },
+    "team.feedback": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to 2 other teams."
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "TEAMS",
+      "recipientType": "TEAMS",
+      "numberOfEntitiesToGiveFeedbackTo": 2,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "team.members.feedback": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to 1 of your team mates"
+      },
+      "questionNumber": 2,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "OWN_TEAM_MEMBERS",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "graceperiod.session.feedback": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to 2 other teams."
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "TEAMS",
+      "recipientType": "TEAMS",
+      "numberOfEntitiesToGiveFeedbackTo": 2,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "graceperiod.session.feedback2": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to yourself."
+      },
+      "questionNumber": 2,
+      "questionType": "TEXT",
+      "giverType": "INSTRUCTORS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "graceperiod.session.feedbackFromTeamToSelf": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback as a team to own team."
+      },
+      "questionNumber": 3,
+      "questionType": "TEXT",
+      "giverType": "TEAMS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "closed.session.feedback": {
+      "feedbackSessionName": "Closed Session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to yourself."
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "INSTRUCTORS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "qn1InSession4InCourse1": {
+      "feedbackSessionName": "non visible session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instructor1@course1.tmt",
+      "questionMetaData": {
+        "value": "Give feedback to 4 other students"
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "STUDENTS",
+      "numberOfEntitiesToGiveFeedbackTo": 4,
+      "showResponsesTo": [
+        "RECEIVER"
+      ],
+      "showGiverNameTo": [
+        "RECEIVER"
+      ],
+      "showRecipientNameTo": [
+        "RECEIVER"
+      ]
+    },
+    "qn1InSession1InTestingSanitizationCourse": {
+      "feedbackSessionName": "Normal feedback session name",
+      "courseId": "idOfTestingSanitizationCourse",
+      "creatorEmail": "instructor1@sanitization.tmt",
+      "questionMetaData": {
+        "value": "Testing quotation marks '\" Testing unclosed tags </td></div> Testing script injection <script> alert('hello'); </script>"
+      },
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    }
+  },
+  "feedbackResponses": {
+    "response1ForQ1S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student1InCourse1@gmail.tmt",
+      "recipient": "student1InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Student 1 self feedback."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response2ForQ1S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student2InCourse1@gmail.tmt",
+      "recipient": "student2InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "I'm cool'"
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response1ForQ2S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student2InCourse1@gmail.tmt",
+      "recipient": "student1InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Response from student 2 to student 1."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response2ForQ2S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student1InCourse1@gmail.tmt",
+      "recipient": "student2InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Response from student 1 to student 2."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response3ForQ2S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student3InCourse1@gmail.tmt",
+      "recipient": "student2InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Response from student 3 \"to\" student 2.\r\nMultiline test."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response1ForQ3S1C1": {
+      "feedbackSessionName": "First feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "3",
+      "feedbackQuestionType": "TEXT",
+      "giver": "instructor1@course1.tmt",
+      "recipient": "%GENERAL%",
+      "responseMetaData": {
+        "value": "Good work, keep it up!"
+      },
+      "giverSection": "None",
+      "recipientSection": "None"
+    },
+    "response1ForQ1S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student4InCourse1@gmail.tmt",
+      "recipient": "Team 1.2",
+      "responseMetaData": {
+        "value": "Response from team 1 by (student 4) to team 1.2."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 2"
+    },
+    "response1GracePeriodFeedback": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student4InCourse1@gmail.tmt",
+      "recipient": "Team 1.2",
+      "responseMetaData": {
+        "value": "Response from team 1 by (student 4) to team 1.2."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 2"
+    },
+    "response1Q2GracePeriodFeedback": {
+      "feedbackSessionName": "Grace Period Session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "instructor1@course1.tmt",
+      "recipient": "instructor1@course1.tmt",
+      "responseMetaData": {
+        "value": "Response from instructor to self."
+      },
+      "giverSection": "None",
+      "recipientSection": "None"
+    },
+    "response1Q1ClosedPeriodFeedback": {
+      "feedbackSessionName": "Closed Session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "instructor1@course1.tmt",
+      "recipient": "instructor1@course1.tmt",
+      "responseMetaData": {
+        "value": "Response from Inst1 to self."
+      },
+      "giverSection": "None",
+      "recipientSection": "None"
+    },
+    "response1ForQ2S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student4InCourse1@gmail.tmt",
+      "recipient": "student2InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Response from student 4 to team member (student 2)."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
+    "response2ForQ2S2C1": {
+      "feedbackSessionName": "Second feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "2",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student1InCourse1@gmail.tmt",
+      "recipient": "student4InCourse1@gmail.tmt",
+      "responseMetaData": {
+        "value": "Response from student 1 to team member (student 4)."
+      },
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    }
+  },
+  "feedbackResponseComments": {},
+  "profiles": {}
+}

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -1,8 +1,8 @@
-<p>Hello student1 In unregisteredCourse,</p>
+<p>Hello unregistered student,</p>
 
 <p>
   An instructor has updated your email address in the course [Course name: Typical Course 1 with 2 Evals] [Course ID: idOfTypicalCourse1].
-  Given below are the relevant links for the course, updated to work with your new email address student1InUnregisteredCourse@gmail.tmt.
+  Given below are the relevant links for the course, updated to work with your new email address student1UnregisteredInCourse1@gmail.tmt.
 </p>
 
 <p>
@@ -10,7 +10,7 @@
 </p>
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt&courseid=idOfUnregisteredCourse">${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt&courseid=idOfUnregisteredCourse</a>
+  <a href="${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt&courseid=idOfTypicalCourse1">${app.url}/page/studentCourseJoinAuthentication?key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt&courseid=idOfTypicalCourse1</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -38,16 +38,16 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt</a>
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+To view the responses for this session, please go to this Web address: <a href="${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt">${app.url}/page/studentFeedbackResultsPage?courseid=idOfTypicalCourse1&fsname=Closed+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt</a>
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=First+feedback+session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt</a>
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -56,7 +56,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Grace+Period+Session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt</a>
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
@@ -65,7 +65,7 @@ To view the responses for this session, please go to this Web address: (Feedback
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1InUnregisteredCourse%40gmail.tmt</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt">${app.url}/page/studentFeedbackSubmissionEditPage?courseid=idOfTypicalCourse1&fsname=Second+feedback+session&key=${regkey.enc}&studentemail=student1UnregisteredInCourse1%40gmail.tmt</a>
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)


### PR DESCRIPTION
Fixes #9090

When student email is updated, its registration Key should be updated also.

`InstructorCourseStudentDetailsEditSaveAction` doesn't do the the job correctly.

There are two solutions to fix this.

1. Write `logic.getStudentForEmail()` in `InstructorCourseStudentDetailsEditSaveAction` to get the updated student. ---- However, it is really hard to test the behavior as we ignore comparision of registrationKey.

1. Push the logic of getting updated student to `EmailGenerator` (which is our logic API) ---- `registrationKey` still no verified but less likely to cause regression in the future.
