### PR TITLE
[#8448] Complete migration of FeedbackSession entities

### DIFF
--- a/src/client/java/teammates/client/scripts/DataMigrationForSessions.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSessions.java
@@ -55,7 +55,7 @@ public class DataMigrationForSessions extends DataMigrationWithCheckpointForEnti
     protected boolean isMigrationNeeded(Key<FeedbackSession> sessionKey) {
         FeedbackSession session = ofy().load().key(sessionKey).now();
         try {
-            Field followingCourseTimeZoneField = session.getClass().getDeclaredField("isFollowingCourseTimeZone");
+            Field followingCourseTimeZoneField = session.getClass().getDeclaredField("wasFollowingCourseTimeZone");
             followingCourseTimeZoneField.setAccessible(true);
             return !followingCourseTimeZoneField.getBoolean(session);
         } catch (ReflectiveOperationException e) {

--- a/src/client/java/teammates/client/scripts/DataMigrationForSessions.java
+++ b/src/client/java/teammates/client/scripts/DataMigrationForSessions.java
@@ -27,6 +27,13 @@ import teammates.storage.entity.FeedbackSession;
  */
 public class DataMigrationForSessions extends DataMigrationWithCheckpointForEntities<FeedbackSession> {
 
+    public DataMigrationForSessions() {
+        super();
+        numberOfScannedKey.set(0L);
+        numberOfAffectedEntities.set(0L);
+        numberOfUpdatedEntities.set(0L);
+    }
+
     public static void main(String[] args) throws IOException {
         new DataMigrationForSessions().doOperationRemotely();
     }


### PR DESCRIPTION
Fixes #8448

- It turns out that `@OnLoad` will turn `isFollowingCourseTimeZone` to ture (although I don't know why it is written in this way :D). Therefore, we should use `wasFollowingCourseTimeZone`, `true` when `isFollowingCourseTimeZone` is ture, `false` when `isFollowingCourseTimeZone` has been changed from `true` to `false` by `OnLoad` method.

- Also, add the ability to change counting stats according to https://github.com/TEAMMATES/teammates/issues/9084#issuecomment-417996024

