### PR TITLE
[#9109] Deactivate deleted sessions

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1195,8 +1195,12 @@ public class Logic {
     }
 
     /**
-     * Preconditions: <br>
+     * Gets a feedback session from the data storage.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
+     *
+     * @return null if not found or in recycle bin.
      */
     public FeedbackSessionAttributes getFeedbackSession(String feedbackSessionName, String courseId) {
 
@@ -1204,6 +1208,21 @@ public class Logic {
         Assumption.assertNotNull(courseId);
 
         return feedbackSessionsLogic.getFeedbackSession(feedbackSessionName, courseId);
+    }
+
+    /**
+     * Gets a feedback session from the recycle bin.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return null if not found.
+     */
+    public FeedbackSessionAttributes getFeedbackSessionFromRecycleBin(String feedbackSessionName, String courseId) {
+        Assumption.assertNotNull(feedbackSessionName);
+        Assumption.assertNotNull(courseId);
+
+        return feedbackSessionsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName, courseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorLogic.java
@@ -210,6 +210,14 @@ public class BackDoorLogic extends Logic {
         return JsonUtils.toJson(fs);
     }
 
+    /**
+     * Gets an json serialized feedback session from the recycle bin.
+     */
+    public String getFeedbackSessionFromRecycleBinAsJson(String feedbackSessionName, String courseId) {
+        FeedbackSessionAttributes fs = getFeedbackSessionFromRecycleBin(feedbackSessionName, courseId);
+        return JsonUtils.toJson(fs);
+    }
+
     public String getFeedbackQuestionAsJson(String feedbackSessionName, String courseId, int qnNumber) {
         FeedbackQuestionAttributes fq =
                 feedbackQuestionsLogic.getFeedbackQuestion(feedbackSessionName, courseId, qnNumber);

--- a/src/main/java/teammates/logic/backdoor/BackDoorOperation.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorOperation.java
@@ -71,8 +71,11 @@ public enum BackDoorOperation {
     /** Operation type: getting a list of feedback response data for particular recipient from the datastore as JSON. */
     OPERATION_GET_FEEDBACK_RESPONSES_FOR_RECEIVER_AS_JSON,
 
-    /** Operation type: getting a feedback session data from the datastore as JSON. */
+    /** Operation type: getting a feedback session data from the data storage as JSON. */
     OPERATION_GET_FEEDBACK_SESSION_AS_JSON,
+
+    /** Operation type: getting a feedback session data from the recycle bin as JSON. */
+    OPERATION_GET_FEEDBACK_SESSION_FROM_RECYCLE_BIN_AS_JSON,
 
     /** Operation type: getting an instructor data for particular google ID from the datastore as JSON. */
     OPERATION_GET_INSTRUCTOR_AS_JSON_BY_ID,

--- a/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
+++ b/src/main/java/teammates/logic/backdoor/BackDoorServlet.java
@@ -166,6 +166,10 @@ public class BackDoorServlet extends HttpServlet {
             feedbackSessionName = req.getParameter(BackDoorOperation.PARAMETER_FEEDBACK_SESSION_NAME);
             courseId = req.getParameter(BackDoorOperation.PARAMETER_COURSE_ID);
             return backDoorLogic.getFeedbackSessionAsJson(feedbackSessionName, courseId);
+        case OPERATION_GET_FEEDBACK_SESSION_FROM_RECYCLE_BIN_AS_JSON:
+            feedbackSessionName = req.getParameter(BackDoorOperation.PARAMETER_FEEDBACK_SESSION_NAME);
+            courseId = req.getParameter(BackDoorOperation.PARAMETER_COURSE_ID);
+            return backDoorLogic.getFeedbackSessionFromRecycleBinAsJson(feedbackSessionName, courseId);
         case OPERATION_GET_INSTRUCTOR_AS_JSON_BY_ID:
             googleId = req.getParameter(BackDoorOperation.PARAMETER_GOOGLE_ID);
             courseId = req.getParameter(BackDoorOperation.PARAMETER_COURSE_ID);

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -111,10 +111,21 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * This method returns a single feedback session. Returns null if not found.
+     * Gets a feedback session from the data storage.
+     *
+     * @return null if not found or in recycle bin.
      */
     public FeedbackSessionAttributes getFeedbackSession(String feedbackSessionName, String courseId) {
         return fsDb.getFeedbackSession(courseId, feedbackSessionName);
+    }
+
+    /**
+     * Gets a feedback session from the recycle bin.
+     *
+     * @return null if not found.
+     */
+    public FeedbackSessionAttributes getFeedbackSessionFromRecycleBin(String feedbackSessionName, String courseId) {
+        return fsDb.getSoftDeletedFeedbackSession(courseId, feedbackSessionName);
     }
 
     public List<FeedbackSessionAttributes> getFeedbackSessionsForCourse(
@@ -1542,7 +1553,7 @@ public final class FeedbackSessionsLogic {
      */
     public void restoreFeedbackSessionFromRecycleBin(String feedbackSessionName, String courseId)
             throws InvalidParametersException, EntityDoesNotExistException {
-        FeedbackSessionAttributes feedbackSession = fsDb.getFeedbackSession(courseId, feedbackSessionName);
+        FeedbackSessionAttributes feedbackSession = fsDb.getSoftDeletedFeedbackSession(courseId, feedbackSessionName);
         feedbackSession.resetDeletedTime();
         fsDb.updateFeedbackSession(feedbackSession);
     }

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -117,31 +117,43 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
     }
 
     /**
-     * Returns An empty list if no sessions are found that have unsent open emails.
+     * Gets a list of undeleted feedback sessions which start within the last 2 hours
+     * and possibly need an open email to be sent.
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsPossiblyNeedingOpenEmail() {
-        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingOpenEmail());
+        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingOpenEmail()).stream()
+                .filter(session -> !session.isSessionDeleted())
+                .collect(Collectors.toList());
     }
 
     /**
-     * Returns An empty list if no sessions are found that have unsent closing emails.
+     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
+     * and possibly need a closing email to be sent.
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsPossiblyNeedingClosingEmail() {
-        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingClosingEmail());
+        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingClosingEmail()).stream()
+                .filter(session -> !session.isSessionDeleted())
+                .collect(Collectors.toList());
     }
 
     /**
-     * Returns An empty list if no sessions are found that have unsent closed emails.
+     * Gets a list of undeleted feedback sessions which end in the future (2 hour ago onward)
+     * and possibly need a closed email to be sent.
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsPossiblyNeedingClosedEmail() {
-        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingClosedEmail());
+        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingClosedEmail()).stream()
+                .filter(session -> !session.isSessionDeleted())
+                .collect(Collectors.toList());
     }
 
     /**
-     * Returns An empty list if no sessions are found that have unsent published emails.
+     * Gets a list of undeleted published feedback sessions which possibly need a published email
+     * to be sent.
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsPossiblyNeedingPublishedEmail() {
-        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingPublishedEmail());
+        return makeAttributes(getFeedbackSessionEntitiesPossiblyNeedingPublishedEmail()).stream()
+                .filter(session -> !session.isSessionDeleted())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -78,16 +78,50 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
     }
 
     /**
-     * Preconditions: <br>
+     * Gets a feedback session that is not soft-deleted.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
-     * @return Null if not found.
+     *
+     * @return null if not found or soft-deleted.
      */
     public FeedbackSessionAttributes getFeedbackSession(String courseId, String feedbackSessionName) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackSessionName);
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
 
-        return makeAttributesOrNull(getFeedbackSessionEntity(feedbackSessionName, courseId),
+        FeedbackSessionAttributes feedbackSession =
+                makeAttributesOrNull(getFeedbackSessionEntity(feedbackSessionName, courseId),
                 "Trying to get non-existent Session: " + feedbackSessionName + "/" + courseId);
+
+        if (feedbackSession != null && feedbackSession.isSessionDeleted()) {
+            log.info("Trying to access soft-deleted session: " + feedbackSessionName + "/" + courseId);
+            return null;
+        }
+        return feedbackSession;
+    }
+
+    /**
+     * Gets a soft-deleted feedback session.
+     *
+     * <br/>Preconditions: <br/>
+     * * All parameters are non-null.
+     *
+     * @return null if not found or not soft-deleted.
+     */
+    public FeedbackSessionAttributes getSoftDeletedFeedbackSession(String courseId, String feedbackSessionName) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackSessionName);
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
+
+        FeedbackSessionAttributes feedbackSession =
+                makeAttributesOrNull(getFeedbackSessionEntity(feedbackSessionName, courseId),
+                "Trying to get non-existent Session: " + feedbackSessionName + "/" + courseId);
+
+        if (feedbackSession != null && !feedbackSession.isSessionDeleted()) {
+            log.info(feedbackSessionName + "/" + courseId + " is not soft-deleted!");
+            return null;
+        }
+
+        return feedbackSession;
     }
 
     /**

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackDeleteSoftDeletedSessionAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackDeleteSoftDeletedSessionAction.java
@@ -20,7 +20,7 @@ public class InstructorFeedbackDeleteSoftDeletedSessionAction extends Action {
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, nameOfSessionToDelete);
 
         gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(idOfCourseToDelete, account.googleId),
-                logic.getFeedbackSession(nameOfSessionToDelete, idOfCourseToDelete),
+                logic.getFeedbackSessionFromRecycleBin(nameOfSessionToDelete, idOfCourseToDelete),
                 false,
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackRestoreSoftDeletedSessionAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackRestoreSoftDeletedSessionAction.java
@@ -20,7 +20,7 @@ public class InstructorFeedbackRestoreSoftDeletedSessionAction extends Action {
         Assumption.assertPostParamNotNull(Const.ParamsNames.FEEDBACK_SESSION_NAME, nameOfSessionToRestore);
 
         gateKeeper.verifyAccessible(logic.getInstructorForGoogleId(idOfCourseToRestore, account.googleId),
-                logic.getFeedbackSession(nameOfSessionToRestore, idOfCourseToRestore),
+                logic.getFeedbackSessionFromRecycleBin(nameOfSessionToRestore, idOfCourseToRestore),
                 false,
                 Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION);
 

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteActionTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
+import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.storage.api.FeedbackSessionsDb;
 import teammates.ui.controller.InstructorFeedbackDeleteAction;
 import teammates.ui.controller.RedirectResult;
@@ -38,7 +39,8 @@ public class InstructorFeedbackDeleteActionTest extends BaseActionTest {
         InstructorFeedbackDeleteAction a = getAction(submissionParams);
         RedirectResult r = getRedirectResult(a);
 
-        assertNotNull(fsDb.getFeedbackSession(fs.getCourseId(), fs.getFeedbackSessionName()));
+        assertNull(fsDb.getFeedbackSession(fs.getCourseId(), fs.getFeedbackSessionName()));
+        assertNotNull(fsDb.getSoftDeletedFeedbackSession(fs.getCourseId(), fs.getFeedbackSessionName()));
         assertEquals(
                 getPageResultDestination(
                         Const.ActionURIs.INSTRUCTOR_FEEDBACK_SESSIONS_PAGE,
@@ -58,6 +60,7 @@ public class InstructorFeedbackDeleteActionTest extends BaseActionTest {
     @Test
     protected void testAccessControl() throws Exception {
         FeedbackSessionAttributes fs = typicalBundle.feedbackSessions.get("session2InCourse1");
+        FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
 
         String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, fs.getCourseId(),
@@ -69,8 +72,11 @@ public class InstructorFeedbackDeleteActionTest extends BaseActionTest {
         verifyUnaccessibleForStudents(submissionParams);
         verifyUnaccessibleForInstructorsOfOtherCourses(submissionParams);
         verifyUnaccessibleWithoutModifySessionPrivilege(submissionParams);
+
         verifyAccessibleForInstructorsOfTheSameCourse(submissionParams);
+        fsLogic.restoreFeedbackSessionFromRecycleBin(fs.getFeedbackSessionName(), fs.getCourseId());
 
         verifyAccessibleForAdminToMasqueradeAsInstructor(submissionParams);
+        fsLogic.restoreFeedbackSessionFromRecycleBin(fs.getFeedbackSessionName(), fs.getCourseId());
     }
 }

--- a/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentFeedbackSubmissionEditSaveActionTest.java
@@ -4,8 +4,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
@@ -21,11 +21,13 @@ import teammates.common.datatransfer.questions.FeedbackMcqResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackNumericalScaleQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackQuestionType;
 import teammates.common.exception.NullPostParameterException;
+import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailType;
 import teammates.common.util.EmailWrapper;
 import teammates.common.util.StringHelper;
 import teammates.common.util.TimeHelper;
+import teammates.logic.api.Logic;
 import teammates.logic.core.CoursesLogic;
 import teammates.logic.core.StudentsLogic;
 import teammates.storage.api.FeedbackQuestionsDb;
@@ -41,19 +43,104 @@ import teammates.ui.controller.StudentFeedbackSubmissionEditSaveAction;
 public class StudentFeedbackSubmissionEditSaveActionTest extends BaseActionTest {
     private final CoursesLogic coursesLogic = CoursesLogic.inst();
 
-    @BeforeClass
-    public void classSetup() throws Exception {
+    @Override
+    protected void prepareTestData() {
+        // see setup()
+    }
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        removeAndRestoreTypicalDataBundle();
         addUnregStudentToCourse1();
     }
 
-    @AfterClass
-    public void classTearDown() {
+    @AfterMethod
+    public void tearDown() {
         StudentsLogic.inst().deleteStudentCascade("idOfTypicalCourse1", "student6InCourse1@gmail.tmt");
     }
 
     @Override
     protected String getActionUri() {
         return Const.ActionURIs.STUDENT_FEEDBACK_SUBMISSION_EDIT_SAVE;
+    }
+
+    @Test(expectedExceptions = UnauthorizedAccessException.class,
+            expectedExceptionsMessageRegExp = "Trying to access system using a non-existent feedback session entity")
+    public void testExecuteAndPostProcess_registeredStudentAccessSoftDeletedSession_shouldNotAccessAndExceptionThrow()
+            throws Exception {
+        Logic logic = new Logic();
+
+        logic.moveFeedbackSessionToRecycleBin("First feedback session", "idOfTypicalCourse1");
+
+        FeedbackQuestionsDb fqDb = new FeedbackQuestionsDb();
+        FeedbackQuestionAttributes fq =
+                fqDb.getFeedbackQuestion("First feedback session", "idOfTypicalCourse1", 1);
+        assertNotNull("Feedback question not found in database", fq);
+
+        FeedbackResponsesDb frDb = new FeedbackResponsesDb();
+        FeedbackResponseAttributes fr = typicalBundle.feedbackResponses.get("response1ForQ1S1C1");
+        // necessary to get the correct responseId
+        fr = frDb.getFeedbackResponse(fq.getId(), fr.giver, fr.recipient);
+        assertNotNull("Feedback response not found in database", fr);
+
+        StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+        gaeSimulation.loginAsStudent(student1InCourse1.googleId);
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL + "-1", "1",
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID + "-1-0", fr.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fr.feedbackSessionName,
+                Const.ParamsNames.COURSE_ID, fr.courseId,
+                Const.ParamsNames.FEEDBACK_QUESTION_ID + "-1", fr.feedbackQuestionId,
+                Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT + "-1-0", fr.recipient,
+                Const.ParamsNames.FEEDBACK_QUESTION_TYPE + "-1", fr.feedbackQuestionType.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_TEXT + "-1-0", "Edited" + fr.getResponseDetails().getAnswerString()
+        };
+
+        StudentFeedbackSubmissionEditSaveAction a = getAction(submissionParams);
+        getRedirectResult(a);
+    }
+
+    @Test(expectedExceptions = UnauthorizedAccessException.class,
+            expectedExceptionsMessageRegExp = "Trying to access system using a non-existent feedback session entity")
+    public void testExecuteAndPostProcess_unregisteredStudentAccessSoftDeletedSession_shouldNotAccessAndExceptionThrow()
+            throws Exception {
+        Logic logic = new Logic();
+
+        logic.moveFeedbackSessionToRecycleBin("First feedback session", "idOfTypicalCourse1");
+
+        FeedbackQuestionsDb fqDb = new FeedbackQuestionsDb();
+        FeedbackQuestionAttributes fq =
+                fqDb.getFeedbackQuestion("First feedback session", "idOfTypicalCourse1", 1);
+        assertNotNull("Feedback question not found in database", fq);
+
+        FeedbackResponsesDb frDb = new FeedbackResponsesDb();
+        FeedbackResponseAttributes fr = typicalBundle.feedbackResponses.get("response1ForQ1S1C1");
+        // necessary to get the correct responseId
+        fr = frDb.getFeedbackResponse(fq.getId(), fr.giver, fr.recipient);
+        assertNotNull("Feedback response not found in database", fr);
+
+        StudentAttributes unregisteredStudent =
+                logic.getStudentForEmail("idOfTypicalCourse1", "student6InCourse1@gmail.tmt");
+        String studentKey = logic.getEncryptedKeyForStudent(unregisteredStudent.course, unregisteredStudent.email);
+        gaeSimulation.logoutUser();
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL + "-1", "1",
+                Const.ParamsNames.FEEDBACK_RESPONSE_ID + "-1-0", fr.getId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, fr.feedbackSessionName,
+                Const.ParamsNames.COURSE_ID, fr.courseId,
+                Const.ParamsNames.FEEDBACK_QUESTION_ID + "-1", fr.feedbackQuestionId,
+                Const.ParamsNames.FEEDBACK_RESPONSE_RECIPIENT + "-1-0", fr.recipient,
+                Const.ParamsNames.FEEDBACK_QUESTION_TYPE + "-1", fr.feedbackQuestionType.toString(),
+                Const.ParamsNames.FEEDBACK_RESPONSE_TEXT + "-1-0", "Edited" + fr.getResponseDetails().getAnswerString(),
+
+                Const.ParamsNames.REGKEY, studentKey,
+                Const.ParamsNames.STUDENT_EMAIL, unregisteredStudent.email
+        };
+
+        StudentFeedbackSubmissionEditSaveAction a = getAction(submissionParams);
+        getRedirectResult(a);
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -1216,7 +1216,8 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         InstructorFeedbackSessionsPage feedbackPage = feedbackEditPage.deleteSession();
         assertTrue(feedbackPage.getTextsForAllStatusMessagesToUser()
                 .contains(Const.StatusMessages.FEEDBACK_SESSION_MOVED_TO_RECYCLE_BIN));
-        assertNotNull(getFeedbackSession(courseId, feedbackSessionName));
+
+        assertNotNull(BackDoor.getFeedbackSessionFromRecycleBin(courseId, feedbackSessionName));
     }
 
     private InstructorFeedbackEditPage getFeedbackEditPage() {

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSessionsPageUiTest.java
@@ -600,8 +600,8 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
 
         assertTrue(feedbackPage.getTextsForAllStatusMessagesToUser()
                 .contains(Const.StatusMessages.FEEDBACK_SESSION_MOVED_TO_RECYCLE_BIN));
-        assertNotNull("session should not have been deleted",
-                      BackDoor.getFeedbackSession(courseId, sessionName));
+        assertNotNull("session should be in recycle bin",
+                BackDoor.getFeedbackSessionFromRecycleBin(courseId, sessionName));
         assertTrue(newSession.isSessionDeleted());
         feedbackPage.verifyHtmlMainContent("/instructorFeedbackMoveToRecycleBinSuccessful.html");
 
@@ -661,7 +661,7 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         // Delete and cancel
         feedbackPage.deleteSessionAndCancel(session1OfCS2106.getCourseId(), session1OfCS2106.getFeedbackSessionName());
 
-        assertNotNull(BackDoor.getFeedbackSession(session1OfCS2106.getCourseId(),
+        assertNotNull(BackDoor.getFeedbackSessionFromRecycleBin(session1OfCS2106.getCourseId(),
                 session1OfCS2106.getFeedbackSessionName()));
 
         // Delete and confirm
@@ -684,9 +684,9 @@ public class InstructorFeedbackSessionsPageUiTest extends BaseUiTestCase {
         // Delete all and cancel
         feedbackPage.deleteAllSessionsAndCancel();
 
-        assertNotNull(BackDoor.getFeedbackSession(session2OfCS2106.getCourseId(),
+        assertNotNull(BackDoor.getFeedbackSessionFromRecycleBin(session2OfCS2106.getCourseId(),
                 session2OfCS2106.getFeedbackSessionName()));
-        assertNotNull(BackDoor.getFeedbackSession(session3OfCS2106.getCourseId(),
+        assertNotNull(BackDoor.getFeedbackSessionFromRecycleBin(session3OfCS2106.getCourseId(),
                 session3OfCS2106.getFeedbackSessionName()));
 
         // Delete all and confirm

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -33,6 +33,7 @@ import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
+import teammates.common.util.JsonUtils;
 import teammates.common.util.ThreadHelper;
 import teammates.common.util.TimeHelper;
 import teammates.logic.core.FeedbackQuestionsLogic;
@@ -2050,7 +2051,8 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         Instant deletedTime = fsLogic.moveFeedbackSessionToRecycleBin(feedbackSessionName, courseId);
         feedbackSession.setDeletedTime(deletedTime);
 
-        verifyPresentInDatastore(feedbackSession);
+        FeedbackSessionAttributes actualFs = fsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName, courseId);
+        assertEquals(JsonUtils.toJson(feedbackSession), JsonUtils.toJson(actualFs));
         assertTrue(feedbackSession.isSessionDeleted());
     }
 

--- a/src/test/java/teammates/test/driver/BackDoor.java
+++ b/src/test/java/teammates/test/driver/BackDoor.java
@@ -314,10 +314,22 @@ public final class BackDoor {
     }
 
     /**
-     * Gets a feedback session data from the datastore.
+     * Gets a feedback session data from the data storage.
      */
     public static FeedbackSessionAttributes getFeedbackSession(String courseId, String feedbackSessionName) {
         Map<String, String> params = createParamMap(BackDoorOperation.OPERATION_GET_FEEDBACK_SESSION_AS_JSON);
+        params.put(BackDoorOperation.PARAMETER_FEEDBACK_SESSION_NAME, feedbackSessionName);
+        params.put(BackDoorOperation.PARAMETER_COURSE_ID, courseId);
+        String feedbackSessionJson = makePostRequest(params);
+        return JsonUtils.fromJson(feedbackSessionJson, FeedbackSessionAttributes.class);
+    }
+
+    /**
+     * Gets a feedback session data from the recycle bin.
+     */
+    public static FeedbackSessionAttributes getFeedbackSessionFromRecycleBin(String courseId, String feedbackSessionName) {
+        Map<String, String> params =
+                createParamMap(BackDoorOperation.OPERATION_GET_FEEDBACK_SESSION_FROM_RECYCLE_BIN_AS_JSON);
         params.put(BackDoorOperation.PARAMETER_FEEDBACK_SESSION_NAME, feedbackSessionName);
         params.put(BackDoorOperation.PARAMETER_COURSE_ID, courseId);
         String feedbackSessionJson = makePostRequest(params);


### PR DESCRIPTION
Fixes #9109

@dalessr is busy right now so I am submitting the fix instead.

From this incident, I think we could further improve the design of soft delete. See https://github.com/TEAMMATES/teammates/projects/5#card-12752944 Will discuss with @dalessr later.

To reviewer:

It seems like the changes are a bit overkilled as we can simply add checks for every involved action. However, once you begin to think about the actions involved, you will give up XD (e.g. feedback submit + feedback result + student comment delete + instructor comment edit + instructor comment delete etc. maybe more in the future)).

Therefore, I decide to change `getFeedbackSession()` to ignore every soft-deleted session and provide a new method `getSoftDeletedFeedbackSession()` to retrieve soft-deleted session. There is still a lot of work to do and it's your turn @dalessr.

Here is the design:

- Storage should know whether the entity is permanently deleted, soft-deleted or existed in Datastore (It should also hide the information). 
    - If not specified, it should always give entities that existed in Datastore (**exclude soft-deleted state** -> in doing this, all the logic we have in existing code can be unchanged). 
    - Therefore, there is no point for `FeedbackSessionAttributes` to have `isSessionDeleted`. We should push the method to `FeedbackSession` entity and the attribute can just have a `deleteTime`.

- Logic should not mention the word `soft-delete` (as it is a word from database/storage). Instead, it should address the business logic and we should call it `recyleBin`. (`soft-delete` is an implementation of `recycle bin`, can think in this way.)



