### PR TITLE
[#9139] -unstable testBuilderWithDeletedAt()

### DIFF
--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -56,7 +56,7 @@ public class CourseAttributesTest extends BaseTestCase {
         assertEquals(validId, caWithDeletedAt.getId());
         assertEquals(validName, caWithDeletedAt.getName());
         assertEquals(validTimeZone, caWithDeletedAt.getTimeZone());
-        assertEquals(Instant.now(), caWithDeletedAt.createdAt);
+        
         assertEquals(validDeletedAt, caWithDeletedAt.deletedAt);
     }
 


### PR DESCRIPTION
Fixes #9139

**Outline of Solution**
1. Removed unnecessary assertEquals
assertEquals(Instant.now(), caWithDeletedAt.createdAt)
