### PR TITLE
[#9146] InstructorSearch: Error searching terms found in deleted sessions

### DIFF
--- a/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
+++ b/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
@@ -222,16 +222,27 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
                 frcDb.deleteDocumentByCommentId(feedbackResponseCommentId);
                 continue;
             }
-            // construct responseId to comment map
-            bundle.comments
-                    .computeIfAbsent(comment.feedbackResponseId, key -> new ArrayList<>())
-                    .add(comment);
-
             // get related response from results
             FeedbackResponseAttributes response = frDb.getFeedbackResponse(comment.feedbackResponseId);
             if (response == null) {
                 continue;
             }
+            // get related question from results
+            FeedbackQuestionAttributes question = fqDb.getFeedbackQuestion(comment.feedbackQuestionId);
+            if (question == null) {
+                continue;
+            }
+            // get related session from results
+            FeedbackSessionAttributes session = fsDb.getFeedbackSession(comment.courseId, comment.feedbackSessionName);
+            if (session == null) {
+                continue;
+            }
+
+            // construct responseId to comment map
+            bundle.comments
+                    .computeIfAbsent(comment.feedbackResponseId, key -> new ArrayList<>())
+                    .add(comment);
+
             // construct questionId to response map
             bundle.responses.putIfAbsent(response.feedbackQuestionId, new ArrayList<>());
             if (!isAdded.contains(response.getId())) {
@@ -239,11 +250,6 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
                 bundle.responses.get(response.feedbackQuestionId).add(response);
             }
 
-            // get related question from results
-            FeedbackQuestionAttributes question = fqDb.getFeedbackQuestion(comment.feedbackQuestionId);
-            if (question == null) {
-                continue;
-            }
             // construct session name to question map
             bundle.questions.putIfAbsent(question.feedbackSessionName, new ArrayList<>());
             if (!isAdded.contains(question.getId())) {
@@ -251,11 +257,6 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
                 bundle.questions.get(question.feedbackSessionName).add(question);
             }
 
-            // get related session from results
-            FeedbackSessionAttributes session = fsDb.getFeedbackSession(comment.courseId, comment.feedbackSessionName);
-            if (session == null) {
-                continue;
-            }
             // construct session name to session map
             if (!isAdded.contains(session.getFeedbackSessionName())) {
                 isAdded.add(session.getFeedbackSessionName());

--- a/src/test/java/teammates/test/cases/search/BaseSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/BaseSearchTest.java
@@ -1,6 +1,6 @@
 package teammates.test.cases.search;
 
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.test.cases.BaseComponentTestCase;
@@ -12,7 +12,7 @@ public abstract class BaseSearchTest extends BaseComponentTestCase {
 
     protected DataBundle dataBundle;
 
-    @BeforeClass
+    @BeforeMethod
     public void baseClassSetup() {
         prepareTestData();
     }


### PR DESCRIPTION
Fixes #9146 

Cause of the bug:

We should check the existence of `comment`, `response`, `question`, `session` before adding to the Map.

When a session is soft-deleted, its corresponding `comment`, `response`, `question` are still in the DB. In the old way, the corresponding `session` will not be in the map because it is deleted while the `comment`, `response` and `response` will be in the map. Therefore, when rendering the page,  it cannot find the corresponding sessions.

I should take care of this in #9102 😞 