### PR TITLE
[#8527] Migrate to JUnit 5 Assertions API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ dependencies {
                     "com.google.appengine:appengine-remote-api:${appengineVersion}",
                     "com.google.appengine:appengine-testing:${appengineVersion}",
                     "org.httpunit:httpunit:1.7.2",
+                    "org.junit.jupiter:junit-jupiter-api:5.3.1",
                     "org.seleniumhq.selenium:selenium-java:2.53.1",
                     testng,
                     "org.kohsuke:wordnet-random-name:1.3",

--- a/src/main/java/teammates/common/util/Assumption.java
+++ b/src/main/java/teammates/common/util/Assumption.java
@@ -8,9 +8,7 @@ import teammates.common.exception.NullPostParameterException;
  * an unchecked {@link AssertionError} will be thrown at runtime.
  *
  * <p>Normally, we use Java assertion to do runtime checking, but GAE does not support the assertions.
- * The methods of this file is adapted from org.junit.Assert v4.10.
- *
- * @see org.junit.Assert
+ * The methods of this file are adapted from org.junit.jupiter.api.Assertions v5.3.1.
  */
 public final class Assumption {
 
@@ -20,116 +18,110 @@ public final class Assumption {
     }
 
     /**
-     * Asserts that a condition is true. If it isn't it throws an
-     * AssertionFailedError with the given message.
+     * <em>Asserts</em> that the supplied {@code condition} is {@code true}.
+     *
+     * <p>Fails with the supplied failure {@code message}.
      */
     public static void assertTrue(String message, boolean condition) {
         if (!condition) {
-            fail(message);
+            fail(buildPrefix(message) + "expected: <true> but was: <false>");
         }
     }
 
     /**
-     * Asserts that a condition is true. If it isn't it throws an
-     * AssertionFailedError.
+     * <em>Asserts</em> that the supplied {@code condition} is {@code true}.
      */
     public static void assertTrue(boolean condition) {
         assertTrue(null, condition);
     }
 
     /**
-     * Asserts that a condition is false. If it isn't it throws an
-     * AssertionFailedError with the given message.
+     * <em>Asserts</em> that the supplied {@code condition} is not {@code true}.
+     *
+     * <p>Fails with the supplied failure {@code message}.
      */
     public static void assertFalse(String message, boolean condition) {
-        assertTrue(message, !condition);
+        if (condition) {
+            fail(buildPrefix(message) + "expected: <false> but was: <true>");
+        }
     }
 
     /**
-     * Asserts that a condition is false. If it isn't it throws an
-     * AssertionFailedError.
+     * <em>Asserts</em> that the supplied {@code condition} is not {@code true}.
      */
     public static void assertFalse(boolean condition) {
         assertFalse(null, condition);
     }
 
     /**
-     * Fails a test with the given message.
+     * <em>Fails</em> a test with the given failure {@code message}.
      */
     public static void fail(String message) {
         throw new AssertionError(message);
     }
 
     /**
-     * Fails a test with no message.
+     * <em>Fails</em> a test <em>without</em> a failure message.
+     *
+     * <p>Although failing <em>with</em> an explicit failure message is recommended,
+     * this method may be useful when maintaining legacy code.
+     *
+     * @deprecated Use the version that makes failure message compulsory
      */
+    @Deprecated
     public static void fail() {
-        fail(null);
+        throw new AssertionError();
     }
 
     /**
-     * Asserts that two Strings are equal.
+     * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+     *
+     * <p>If both are {@code null}, they are considered equal.
+     *
+     * <p>Fails with the supplied failure {@code message}.
      */
-    public static void assertEquals(String message, String expected,
-            String actual) {
-        if (expected == null && actual == null) {
-            return;
+    public static void assertEquals(String message, String expected, String actual) {
+        if (!objectsAreEqual(expected, actual)) {
+            failNotEqual(expected, actual, message);
         }
-
-        if (expected != null && expected.equals(actual)) {
-            return;
-        }
-
-        throw new AssertionError(format(message, expected, actual));
     }
 
     /**
-     * Asserts that two longs are equal. If they are not an AssertionFailedError
-     * is thrown with the given message.
+     * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
+     *
+     * <p>Fails with the supplied failure {@code message}.
      */
     public static void assertEquals(String message, long expected, long actual) {
-        if (expected == actual) {
-            return;
+        if (expected != actual) {
+            failNotEqual(String.valueOf(expected), String.valueOf(actual), message);
         }
-
-        failNotEquals(message, expected, actual);
     }
 
     /**
-     * Asserts that two longs are equal.
+     * <em>Asserts</em> that {@code expected} and {@code actual} are equal.
      */
     public static void assertEquals(long expected, long actual) {
         assertEquals(null, expected, actual);
     }
 
     /**
-     * Asserts that an object isn't null.
+     * <em>Asserts</em> that {@code actual} is not {@code null}.
      */
     public static void assertNotNull(Object object) {
         assertNotNull(null, object);
     }
 
     /**
-     * Asserts that all objects aren't null. If it is an AssertionFailedError is
-     * thrown with the given message.
+     * <em>Asserts</em> that {@code objects} are all not {@code null}.
+     *
+     * <p>Fails with the supplied failure {@code message}.
      */
     public static void assertNotNull(String message, Object... objects) {
         for (Object object : objects) {
-            assertTrue(message, object != null);
+            if (object == null) {
+                fail(message);
+            }
         }
-    }
-
-    public static void failNotEquals(String message, Object expected,
-            Object actual) {
-        fail(format(message, expected, actual));
-    }
-
-    private static String format(String message, Object expected, Object actual) {
-        String formatted = "";
-        if (message != null) {
-            formatted = message + " ";
-        }
-        return formatted + "expected:<" + expected + "> but was:<" + actual + ">";
     }
 
     public static <T> void assertPostParamNotNull(String parameterName, T postParameter) {
@@ -139,12 +131,43 @@ public final class Assumption {
         }
     }
 
+    /**
+     * <em>Asserts</em> that the given string is neither {@code null} nor empty.
+     */
     public static void assertNotEmpty(String str) {
-        assertFalse(str.isEmpty());
+        assertFalse(StringHelper.isEmpty(str));
     }
 
+    /**
+     * <em>Asserts</em> that the given string is neither {@code null} nor empty.
+     *
+     * <p>Fails with the supplied failure {@code message}.
+     */
     public static void assertNotEmpty(String message, String str) {
-        assertFalse(message, str.isEmpty());
+        assertFalse(message, StringHelper.isEmpty(str));
+    }
+
+    private static String format(String expected, String actual, String message) {
+        return buildPrefix(message) + formatValues(expected, actual);
+    }
+
+    private static boolean objectsAreEqual(Object obj1, Object obj2) {
+        if (obj1 == null) {
+            return obj2 == null;
+        }
+        return obj1.equals(obj2);
+    }
+
+    private static void failNotEqual(String expected, String actual, String message) {
+        fail(format(expected, actual, message));
+    }
+
+    private static String buildPrefix(String message) {
+        return StringHelper.isEmpty(message) ? "" : message + " ==> ";
+    }
+
+    private static String formatValues(String expected, String actual) {
+        return String.format("expected: <%s> but was: <%s>", expected, actual);
     }
 
 }

--- a/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/AdminSearchPageData.java
@@ -221,7 +221,7 @@ public class AdminSearchPageData extends PageData {
                                     StudentAttributes student, FeedbackSessionState fsState) {
 
         List<AdminSearchStudentFeedbackSession> sessions = new ArrayList<>();
-        List<String> links = new ArrayList<>();
+        List<String> links;
 
         switch (fsState) {
         case OPEN:
@@ -235,6 +235,7 @@ public class AdminSearchPageData extends PageData {
             break;
         default:
             Assumption.fail();
+            links = new ArrayList<>(); // will not be reached; this is to prevent compile error
             break;
         }
 

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import org.junit.Assert;
-import org.testng.AssertJUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -124,87 +124,79 @@ public class BaseTestCase {
      */
 
     protected static void assertTrue(boolean condition) {
-        AssertJUnit.assertTrue(condition);
+        Assertions.assertTrue(condition);
     }
 
     protected static void assertTrue(String message, boolean condition) {
-        AssertJUnit.assertTrue(message, condition);
+        Assertions.assertTrue(condition, message);
     }
 
     protected static void assertFalse(boolean condition) {
-        AssertJUnit.assertFalse(condition);
+        Assertions.assertFalse(condition);
     }
 
     protected static void assertFalse(String message, boolean condition) {
-        AssertJUnit.assertFalse(message, condition);
-    }
-
-    protected static void assertEquals(String expected, String actual) {
-        AssertJUnit.assertEquals(expected, actual);
-    }
-
-    protected static void assertEquals(String message, String expected, String actual) {
-        AssertJUnit.assertEquals(message, expected, actual);
+        Assertions.assertFalse(condition, message);
     }
 
     protected static void assertEquals(int expected, int actual) {
-        AssertJUnit.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     protected static void assertEquals(String message, int expected, int actual) {
-        AssertJUnit.assertEquals(message, expected, actual);
-    }
-
-    protected static void assertEquals(boolean expected, boolean actual) {
-        AssertJUnit.assertEquals(expected, actual);
-    }
-
-    protected static void assertEquals(String message, boolean expected, boolean actual) {
-        AssertJUnit.assertEquals(message, expected, actual);
+        Assertions.assertEquals(expected, actual, message);
     }
 
     protected static void assertEquals(long expected, long actual) {
-        AssertJUnit.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     protected static void assertEquals(double expected, double actual, double delta) {
-        AssertJUnit.assertEquals(expected, actual, delta);
+        Assertions.assertEquals(expected, actual, delta);
     }
 
     protected static void assertEquals(Object expected, Object actual) {
-        AssertJUnit.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
-    protected static void assertNotEquals(long first, long second) {
-        Assert.assertNotEquals(first, second);
+    protected static void assertEquals(String message, Object expected, Object actual) {
+        Assertions.assertEquals(expected, actual, message);
     }
 
-    protected static void assertNotEquals(String first, String second) {
-        Assert.assertNotEquals(first, second);
+    protected static void assertNotEquals(Object unexpected, Object actual) {
+        Assertions.assertNotEquals(unexpected, actual);
     }
 
-    protected static void assertNotSame(Object expected, Object actual) {
-        AssertJUnit.assertNotSame(expected, actual);
+    protected static void assertNotSame(Object unexpected, Object actual) {
+        Assertions.assertNotSame(unexpected, actual);
     }
 
-    protected static void assertNull(Object object) {
-        AssertJUnit.assertNull(object);
+    protected static void assertNull(Object actual) {
+        Assertions.assertNull(actual);
     }
 
-    protected static void assertNull(String message, Object object) {
-        AssertJUnit.assertNull(message, object);
+    protected static void assertNull(String message, Object actual) {
+        Assertions.assertNull(actual, message);
     }
 
-    protected static void assertNotNull(Object object) {
-        AssertJUnit.assertNotNull(object);
+    protected static void assertNotNull(Object actual) {
+        Assertions.assertNotNull(actual);
     }
 
-    protected static void assertNotNull(String message, Object object) {
-        AssertJUnit.assertNotNull(message, object);
+    protected static void assertNotNull(String message, Object actual) {
+        Assertions.assertNotNull(actual, message);
     }
 
     protected static void fail(String message) {
-        AssertJUnit.fail(message);
+        Assertions.fail(message);
+    }
+
+    protected static void assertArrayEquals(Object[] expected, Object[] actual) {
+        Assertions.assertArrayEquals(expected, actual);
+    }
+
+    protected static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
+        return Assertions.assertThrows(expectedType, executable);
     }
 
 }

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -2,7 +2,6 @@ package teammates.test.cases;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
@@ -70,14 +69,6 @@ public class BaseTestCase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    protected void signalFailureToDetectException(String... messages) {
-        throw new RuntimeException("Expected exception not detected." + Arrays.toString(messages));
-    }
-
-    protected void ignoreExpectedException() {
-        assertTrue(true);
     }
 
     protected static void ignorePossibleException() {

--- a/src/test/java/teammates/test/cases/action/BaseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/BaseActionTest.java
@@ -67,6 +67,16 @@ public abstract class BaseActionTest extends BaseComponentTestCase {
         removeAndRestoreTypicalDataBundle();
     }
 
+    @Deprecated
+    protected void signalFailureToDetectException(String... messages) {
+        throw new RuntimeException("Expected exception not detected." + Arrays.toString(messages));
+    }
+
+    @Deprecated
+    protected void ignoreExpectedException() {
+        assertTrue(true);
+    }
+
     /** Executes the action and returns the result.
      * Assumption: The action returns a ShowPageResult.
      */
@@ -459,7 +469,7 @@ public abstract class BaseActionTest extends BaseComponentTestCase {
             Action c = gaeSimulation.getActionObject(getActionUri(), params);
             assertFalse(c.isValidUser());
         } catch (UnauthorizedAccessException ue) {
-            ignoreExpectedException();
+            ignorePossibleException();
         }
     }
 
@@ -665,7 +675,7 @@ public abstract class BaseActionTest extends BaseComponentTestCase {
             assertEquals(classNameOfResult, result.getClass().getName());
             AssertHelper.assertContains("You are not registered in the course ", result.getStatusMessage());
         } catch (UnauthorizedAccessException e) {
-            ignoreExpectedException();
+            ignorePossibleException();
         }
     }
 

--- a/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/FeedbackSessionStatsPageActionTest.java
@@ -56,20 +56,15 @@ public class FeedbackSessionStatsPageActionTest extends BaseActionTest {
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId
         };
 
-        boolean hasThrownUnauthorizedAccessException = false;
-        String exceptionMessage = "";
-
         a = getAction(addUserIdToParams(instructorId, submissionParams));
 
         try {
-            r = getAjaxResult(a);
+            getAjaxResult(a);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
-            hasThrownUnauthorizedAccessException = true;
-            exceptionMessage = e.getMessage();
+            assertEquals("Trying to access system using a non-existent feedback session entity", e.getMessage());
         }
 
-        assertTrue(hasThrownUnauthorizedAccessException);
-        assertEquals("Trying to access system using a non-existent feedback session entity", exceptionMessage);
         assertEquals("", r.getStatusMessage());
     }
 

--- a/src/test/java/teammates/test/cases/action/InstructorCourseArchiveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseArchiveActionTest.java
@@ -21,8 +21,6 @@ public class InstructorCourseArchiveActionTest extends BaseActionTest {
     @Override
     @Test
     public void testExecuteAndPostProcess() {
-        String[] submissionParams = new String[] {};
-
         InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         String instructorId = instructor1OfCourse1.googleId;
         String courseId = instructor1OfCourse1.courseId;
@@ -36,7 +34,7 @@ public class InstructorCourseArchiveActionTest extends BaseActionTest {
 
         ______TS("Typical case: archive a course, redirect to homepage");
 
-        submissionParams = new String[] {
+        String[] submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId,
                 Const.ParamsNames.COURSE_ARCHIVE_STATUS, "true",
                 Const.ParamsNames.NEXT_URL, Const.ActionURIs.INSTRUCTOR_HOME_PAGE

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDeleteAllSoftDeletedCoursesActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDeleteAllSoftDeletedCoursesActionTest.java
@@ -40,6 +40,7 @@ public class InstructorCourseDeleteAllSoftDeletedCoursesActionTest extends BaseA
         try {
             deleteAllAction = getAction();
             getRedirectResult(deleteAllAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
                     + "for privilege [canmodifycourse]", e.getMessage());
@@ -74,6 +75,7 @@ public class InstructorCourseDeleteAllSoftDeletedCoursesActionTest extends BaseA
         try {
             deleteAllAction = getAction();
             getRedirectResult(deleteAllAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Course [icdat.owncourse] is not accessible to instructor [instructor1@course3.tmt] "
                     + "for privilege [canmodifycourse]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseDeleteSoftDeletedCourseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseDeleteSoftDeletedCourseActionTest.java
@@ -46,6 +46,7 @@ public class InstructorCourseDeleteSoftDeletedCourseActionTest extends BaseActio
         try {
             deleteAction = getAction(submissionParams);
             getRedirectResult(deleteAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
                     + "for privilege [canmodifycourse]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseEditPageActionTest.java
@@ -119,7 +119,7 @@ public class InstructorCourseEditPageActionTest extends BaseActionTest {
 
         try {
             editAction = getAction(submissionParams);
-            pageResult = getShowPageResult(editAction);
+            getShowPageResult(editAction);
             signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Trying to access system using a non-existent instructor entity", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseInstructorEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseInstructorEditSaveActionTest.java
@@ -177,6 +177,7 @@ public class InstructorCourseInstructorEditSaveActionTest extends BaseActionTest
         try {
             saveAction = getAction(submissionParams);
             getRedirectResult(saveAction);
+            signalFailureToDetectException();
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
                     Const.ParamsNames.COURSE_ID), e.getMessage());
@@ -203,6 +204,7 @@ public class InstructorCourseInstructorEditSaveActionTest extends BaseActionTest
         try {
             saveAction = getAction(submissionParams);
             getRedirectResult(saveAction);
+            signalFailureToDetectException();
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
                     Const.ParamsNames.INSTRUCTOR_NAME), e.getMessage());
@@ -229,6 +231,7 @@ public class InstructorCourseInstructorEditSaveActionTest extends BaseActionTest
         try {
             saveAction = getAction(submissionParams);
             getRedirectResult(saveAction);
+            signalFailureToDetectException();
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
                     Const.ParamsNames.INSTRUCTOR_EMAIL), e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseRestoreSoftDeletedCourseActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseRestoreSoftDeletedCourseActionTest.java
@@ -73,6 +73,7 @@ public class InstructorCourseRestoreSoftDeletedCourseActionTest extends BaseActi
         try {
             restoreAction = getAction(submissionParams);
             getRedirectResult(restoreAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Course [idOfTypicalCourse3] is not accessible to instructor [instructor2@course3.tmt] "
                     + "for privilege [canmodifycourse]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorCourseStudentDetailsEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorCourseStudentDetailsEditSaveActionTest.java
@@ -277,7 +277,7 @@ public class InstructorCourseStudentDetailsEditSaveActionTest extends BaseAction
 
         try {
             a = getAction(submissionParams);
-            r = getRedirectResult(a);
+            getRedirectResult(a);
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
@@ -291,7 +291,7 @@ public class InstructorCourseStudentDetailsEditSaveActionTest extends BaseAction
 
         try {
             a = getAction(submissionParams);
-            r = getRedirectResult(a);
+            getRedirectResult(a);
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,

--- a/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackPageActionTest.java
@@ -153,7 +153,8 @@ public class InstructorEditStudentFeedbackPageActionTest extends BaseActionTest 
 
         try {
             editPageAction = getAction(submissionParams);
-            showPageResult = getShowPageResult(editPageAction);
+            getShowPageResult(editPageAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals(
                     "Feedback session [First feedback session] is not accessible to instructor ["
@@ -177,7 +178,7 @@ public class InstructorEditStudentFeedbackPageActionTest extends BaseActionTest 
 
         try {
             editPageAction = getAction(submissionParams);
-            showPageResult = getShowPageResult(editPageAction);
+            getShowPageResult(editPageAction);
             signalFailureToDetectException();
         } catch (EntityNotFoundException enfe) {
             assertEquals("An entity with the identifier "

--- a/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorEditStudentFeedbackSaveActionTest.java
@@ -294,6 +294,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         try {
             getAction(submissionParams).executeAndPostProcess();
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                                  + instructorHelper.email + "] for privilege "
@@ -321,6 +322,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         try {
             getAction(submissionParams).executeAndPostProcess();
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                                  + instructorHelper.email + "] for privilege "
@@ -392,6 +394,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         try {
             getAction(submissionParams).executeAndPostProcess();
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                              + instructorHelper2.email + "] for privilege [canmodifysessioncommentinsection] "
@@ -502,6 +505,7 @@ public class InstructorEditStudentFeedbackSaveActionTest extends BaseActionTest 
 
         try {
             getAction(submissionParams).executeAndPostProcess();
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [Another feedback session] is not accessible to instructor ["
                              + instructorHelper3.email + "] for privilege ["

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackAddActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackAddActionTest.java
@@ -253,6 +253,7 @@ public class InstructorFeedbackAddActionTest extends BaseActionTest {
         try {
             a = getAction(params);
             getRedirectResult(a);
+            signalFailureToDetectException();
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER, Const.ParamsNames.COURSE_ID),
                          e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteAllSoftDeletedSessionsActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteAllSoftDeletedSessionsActionTest.java
@@ -67,6 +67,7 @@ public class InstructorFeedbackDeleteAllSoftDeletedSessionsActionTest extends Ba
         try {
             deleteAllAction = getAction();
             getRedirectResult(deleteAllAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor "
                     + "[instructor1@course3.tmt] for privilege [canmodifysession]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteSoftDeletedSessionActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackDeleteSoftDeletedSessionActionTest.java
@@ -44,6 +44,7 @@ public class InstructorFeedbackDeleteSoftDeletedSessionActionTest extends BaseAc
         InstructorFeedbackDeleteSoftDeletedSessionAction deleteAction = getAction(submissionParams);
         try {
             getRedirectResult(deleteAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [Second feedback session] is not accessible to instructor "
                     + "[instructor2@course3.tmt] for privilege [canmodifysession]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackEditPageActionTest.java
@@ -72,7 +72,7 @@ public class InstructorFeedbackEditPageActionTest extends BaseActionTest {
 
         instructorFeedbackEditPageAction = getAction(submissionParams);
         try {
-            showPageResult = getShowPageResult(instructorFeedbackEditPageAction);
+            getShowPageResult(instructorFeedbackEditPageAction);
             signalFailureToDetectException();
         } catch (UnauthorizedAccessException uae) {
             assertEquals("Trying to access system using a non-existent feedback session entity",

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackPreviewAsInstructorActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackPreviewAsInstructorActionTest.java
@@ -111,7 +111,8 @@ public class InstructorFeedbackPreviewAsInstructorActionTest extends BaseActionT
 
         try {
             paia = getAction(submissionParams);
-            showPageResult = getShowPageResult(paia);
+            getShowPageResult(paia);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                          + instructorHelper.email + "] for privilege [canmodifysession]", e.getMessage());
@@ -131,7 +132,7 @@ public class InstructorFeedbackPreviewAsInstructorActionTest extends BaseActionT
 
         try {
             paia = getAction(submissionParams);
-            showPageResult = getShowPageResult(paia);
+            getShowPageResult(paia);
             signalFailureToDetectException();
         } catch (EntityNotFoundException enfe) {
             assertEquals("Instructor Email " + previewAsEmail + " does not exist in " + courseId + ".",

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackPreviewAsStudentActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackPreviewAsStudentActionTest.java
@@ -77,7 +77,8 @@ public class InstructorFeedbackPreviewAsStudentActionTest extends BaseActionTest
 
         try {
             paia = getAction(submissionParams);
-            showPageResult = getShowPageResult(paia);
+            getShowPageResult(paia);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor ["
                          + instructorHelper.email + "] for privilege [canmodifysession]", e.getMessage());
@@ -97,7 +98,7 @@ public class InstructorFeedbackPreviewAsStudentActionTest extends BaseActionTest
 
         try {
             paia = getAction(submissionParams);
-            showPageResult = getShowPageResult(paia);
+            getShowPageResult(paia);
             signalFailureToDetectException();
         } catch (EntityNotFoundException enfe) {
             assertEquals("Student Email " + previewAsEmail + " does not exist in " + courseId + ".",

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackQuestionCopyPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackQuestionCopyPageActionTest.java
@@ -53,7 +53,7 @@ public class InstructorFeedbackQuestionCopyPageActionTest extends BaseActionTest
 
         action = getAction(submissionParams);
         try {
-            result = getShowPageResult(action);
+            getShowPageResult(action);
             signalFailureToDetectException();
         } catch (UnauthorizedAccessException uae) {
             assertEquals("Trying to access system using a non-existent feedback session entity",
@@ -70,7 +70,7 @@ public class InstructorFeedbackQuestionCopyPageActionTest extends BaseActionTest
 
         action = getAction(submissionParams);
         try {
-            result = getShowPageResult(action);
+            getShowPageResult(action);
             signalFailureToDetectException();
         } catch (UnauthorizedAccessException uae) {
             assertEquals("Feedback session [First feedback session] is not accessible "

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackQuestionEditActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackQuestionEditActionTest.java
@@ -359,7 +359,7 @@ public class InstructorFeedbackQuestionEditActionTest extends BaseActionTest {
 
         try {
             a = getAction(submissionParams);
-            r = getRedirectResult(a);
+            getRedirectResult(a);
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,
@@ -386,7 +386,7 @@ public class InstructorFeedbackQuestionEditActionTest extends BaseActionTest {
 
         try {
             a = getAction(submissionParams);
-            r = getRedirectResult(a);
+            getRedirectResult(a);
             signalFailureToDetectException("Did not detect that parameters are null.");
         } catch (NullPostParameterException e) {
             assertEquals(String.format(Const.StatusCodes.NULL_POST_PARAMETER,

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackResponseCommentEditActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackResponseCommentEditActionTest.java
@@ -251,7 +251,8 @@ public class InstructorFeedbackResponseCommentEditActionTest extends BaseActionT
 
         try {
             action = getAction(submissionParams);
-            result = getAjaxResult(action);
+            getAjaxResult(action);
+            signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("FeedbackResponseComment should not be null", e.getMessage());
         }

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackRestoreAllSoftDeletedSessionsActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackRestoreAllSoftDeletedSessionsActionTest.java
@@ -67,6 +67,7 @@ public class InstructorFeedbackRestoreAllSoftDeletedSessionsActionTest extends B
         try {
             restoreAllAction = getAction();
             getRedirectResult(restoreAllAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [First feedback session] is not accessible to instructor "
                     + "[instructor1@course3.tmt] for privilege [canmodifysession]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorFeedbackRestoreSoftDeletedSessionActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorFeedbackRestoreSoftDeletedSessionActionTest.java
@@ -44,6 +44,7 @@ public class InstructorFeedbackRestoreSoftDeletedSessionActionTest extends BaseA
         InstructorFeedbackRestoreSoftDeletedSessionAction restoreAction = getAction(submissionParams);
         try {
             getRedirectResult(restoreAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException e) {
             assertEquals("Feedback session [Second feedback session] is not accessible to instructor "
                     + "[instructor2@course3.tmt] for privilege [canmodifysession]", e.getMessage());

--- a/src/test/java/teammates/test/cases/action/InstructorHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/InstructorHomePageActionTest.java
@@ -56,8 +56,6 @@ public class InstructorHomePageActionTest extends BaseActionTest {
                                      + "|||/page/instructorHomePage";
         AssertHelper.assertLogMessageEquals(expectedLogMessage, a.getLogMessage());
 
-        submissionParams = new String[] {};
-
         ______TS("instructor with multiple courses, sort by course id, masquerade mode");
 
         submissionParams = new String[] {

--- a/src/test/java/teammates/test/cases/action/StudentCourseJoinAuthenticatedActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentCourseJoinAuthenticatedActionTest.java
@@ -63,6 +63,7 @@ public class StudentCourseJoinAuthenticatedActionTest extends BaseActionTest {
         try {
             StudentCourseJoinAuthenticatedAction authenticatedAction = getAction(submissionParams);
             getRedirectResult(authenticatedAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException uae) {
             assertEquals("No student with given registration key:" + invalidKey, uae.getMessage());
         }

--- a/src/test/java/teammates/test/cases/action/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentFeedbackResultsPageActionTest.java
@@ -178,6 +178,11 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
 
         ______TS("access a closed session");
 
+        Instant originalResultVisibleTime = closedSession.getResultsVisibleFromTime();
+        // Session is closed but not published; modify result visible time
+        closedSession.setResultsVisibleFromTime(Instant.now().plus(Duration.ofDays(1L)));
+        FeedbackSessionsLogic.inst().updateFeedbackSession(closedSession);
+
         submissionParams = new String[] {
                 Const.ParamsNames.COURSE_ID, closedSession.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME,
@@ -188,9 +193,14 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
 
         try {
             getShowPageResult(pageAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException exception) {
             assertEquals("This feedback session is not yet visible.", exception.getMessage());
         }
+
+        // Restore original result visible time
+        closedSession.setResultsVisibleFromTime(originalResultVisibleTime);
+        FeedbackSessionsLogic.inst().updateFeedbackSession(closedSession);
 
         ______TS("access a non-existent session");
 

--- a/src/test/java/teammates/test/cases/action/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/action/StudentFeedbackResultsPageActionTest.java
@@ -141,6 +141,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
 
         try {
             getShowPageResult(pageAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException exception) {
             assertEquals("This feedback session is not yet visible.", exception.getMessage());
         }
@@ -169,7 +170,8 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         pageAction = getAction(submissionParams);
 
         try {
-            pageResult = getShowPageResult(pageAction);
+            getShowPageResult(pageAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException exception) {
             assertEquals("This feedback session is not yet visible.", exception.getMessage());
         }
@@ -185,7 +187,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         pageAction = getAction(submissionParams);
 
         try {
-            pageResult = getShowPageResult(pageAction);
+            getShowPageResult(pageAction);
         } catch (UnauthorizedAccessException exception) {
             assertEquals("This feedback session is not yet visible.", exception.getMessage());
         }
@@ -200,7 +202,8 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         pageAction = getAction(submissionParams);
 
         try {
-            pageResult = getShowPageResult(pageAction);
+            getShowPageResult(pageAction);
+            signalFailureToDetectException();
         } catch (UnauthorizedAccessException exception) {
             assertEquals("Trying to access system using a non-existent feedback session entity",
                          exception.getMessage());

--- a/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/AdminActivityLogPageUiTest.java
@@ -135,12 +135,8 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
         logPage.navigateTo(createUrl(Const.ActionURIs.ADMIN_ACTIVITY_LOG_PAGE));
         logPage.waitForPageToLoad();
 
-        try {
-            browser.driver.switchTo().alert();
-            signalFailureToDetectException("Script managed to get injected");
-        } catch (NoAlertPresentException e) {
-            // this is what we expect, since we expect the script injection to fail
-        }
+        // Expect no alert to appear since the script injection should fail
+        assertThrows(NoAlertPresentException.class, () -> browser.driver.switchTo().alert());
     }
 
     private void assertEqualsIfQueryStringNotEmpty(String expected, String actual) {

--- a/src/test/java/teammates/test/cases/browsertests/GodModeTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/GodModeTest.java
@@ -62,26 +62,16 @@ public class GodModeTest extends BaseUiTestCase {
 
     private void testGodMode(boolean isPart) throws Exception {
 
-        try {
-            // should fail as the expected output file does not exist
-            verifyHtml(OUTPUT_FILENAME, isPart);
-            signalFailureToDetectException();
-        } catch (IOException e) {
-            ignoreExpectedException();
-        }
+        // Should fail as the expected output file does not exist
+        assertThrows(IOException.class, () -> verifyHtml(OUTPUT_FILENAME, isPart));
 
         // run the God mode with non-existent expected file
         runGodModeRoutine(isPart);
 
         FileHelper.saveFile(OUTPUT_FILEPATH, PLACEHOLDER_CONTENT);
 
-        try {
-            // should fail as the expected output file has the wrong content
-            verifyHtml(OUTPUT_FILENAME, isPart);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            ignoreExpectedException();
-        }
+        // Should fail as the expected output file has the wrong content
+        assertThrows(AssertionError.class, () -> verifyHtml(OUTPUT_FILENAME, isPart));
 
         // run the God mode with wrong content in expected file
         runGodModeRoutine(isPart);

--- a/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AccountAttributesTest.java
@@ -31,12 +31,9 @@ public class AccountAttributesTest extends BaseAttributesTest {
         ______TS("null studentProfile");
 
         account.studentProfile = null;
-        try {
-            account.isValid();
-            signalFailureToDetectException(" - AssertionError");
-        } catch (AssertionError ae) {
-            assertEquals("Non-null value expected for studentProfile", ae.getMessage());
-        }
+        AccountAttributes[] finalAccount = new AccountAttributes[] { account };
+        AssertionError ae = assertThrows(AssertionError.class, () -> finalAccount[0].isValid());
+        assertEquals("Non-null value expected for studentProfile", ae.getMessage());
 
         ______TS("invalid account");
 

--- a/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AdminEmailAttributesTest.java
@@ -66,40 +66,40 @@ public class AdminEmailAttributesTest extends BaseAttributesTest {
         assertEquals(null, attributesWithNullOptionalArguments.getSendDate());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = Const.StatusCodes.NULL_PARAMETER)
+    @Test
     public void testBuilderWithNullRequiredSubjectParam() {
         ______TS("failure: subject cannot be null)");
 
-        AdminEmailAttributes
-                .builder(null, addressReceiverListString, groupReceiverListFileKey, content)
-                .build();
+        AssertionError ae = assertThrows(AssertionError.class, () ->
+                AdminEmailAttributes.builder(null, addressReceiverListString, groupReceiverListFileKey, content).build());
+        assertEquals(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = Const.StatusCodes.NULL_PARAMETER)
+    @Test
     public void testBuilderWithNullRequiredAddressReceiverParam() {
         ______TS("failure: addressReceiverListString cannot be null)");
 
-        AdminEmailAttributes
-                .builder(subject, null, groupReceiverListFileKey, content)
-                .build();
+        AssertionError ae = assertThrows(AssertionError.class, () ->
+                AdminEmailAttributes.builder(subject, null, groupReceiverListFileKey, content).build());
+        assertEquals(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = Const.StatusCodes.NULL_PARAMETER)
+    @Test
     public void testBuilderWithNullRequiredGroupReceiverParam() {
         ______TS("failure: groupReceiverListFileKey cannot be null)");
 
-        AdminEmailAttributes
-                .builder(subject, addressReceiverListString, null, content)
-                .build();
+        AssertionError ae = assertThrows(AssertionError.class, () ->
+                AdminEmailAttributes.builder(subject, addressReceiverListString, null, content).build());
+        assertEquals(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
     }
 
-    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = Const.StatusCodes.NULL_PARAMETER)
+    @Test
     public void testBuilderWithNullRequiredContentParam() {
         ______TS("failure: content cannot be null)");
 
-        AdminEmailAttributes
-                .builder(subject, addressReceiverListString, groupReceiverListFileKey, null)
-                .build();
+        AssertionError ae = assertThrows(AssertionError.class, () ->
+                AdminEmailAttributes.builder(subject, addressReceiverListString, groupReceiverListFileKey, null).build());
+        assertEquals(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/CourseAttributesTest.java
@@ -76,35 +76,23 @@ public class CourseAttributesTest extends BaseTestCase {
 
     @Test
     public void testBuilderWithNullId() {
-        try {
-            CourseAttributes.builder(null, validName, validTimeZone)
-                    .build();
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Non-null value expected", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> CourseAttributes.builder(null, validName, validTimeZone).build());
+        assertEquals("Non-null value expected", ae.getMessage());
     }
 
     @Test
     public void testBuilderWithNullName() {
-        try {
-            CourseAttributes.builder(validId, null, validTimeZone)
-                    .build();
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Non-null value expected", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> CourseAttributes.builder(validId, null, validTimeZone).build());
+        assertEquals("Non-null value expected", ae.getMessage());
     }
 
     @Test
     public void testBuilderWithNullTimeZone() {
-        try {
-            CourseAttributes.builder(validId, validName, null)
-                    .build();
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Non-null value expected", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> CourseAttributes.builder(validId, validName, null).build());
+        assertEquals("Non-null value expected", ae.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMcqQuestionDetailsTest.java
@@ -255,7 +255,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         assertEquals(0.0, mcqDetails.getMcqOtherWeight());
     }
 
-    @Test(expectedExceptions = AssertionError.class)
+    @Test
     public void testGetMcqOtherWeight_nullOtherWeight_exceptionThrown() {
         FeedbackMcqQuestionDetails mcqDetails = new FeedbackMcqQuestionDetails();
         HashMap<String, String[]> requestParams = new HashMap<>();
@@ -273,7 +273,7 @@ public class FeedbackMcqQuestionDetailsTest extends BaseTestCase {
         // Removed to send null as otherWeight parameter
         // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MCQ_OTHER_WEIGHT, new String[] { "" });
 
-        mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ);
+        assertThrows(AssertionError.class, () -> mcqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MCQ));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/FeedbackMsqQuestionDetailsTest.java
@@ -255,7 +255,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         assertEquals(0.0, msqDetails.getMsqOtherWeight());
     }
 
-    @Test(expectedExceptions = AssertionError.class)
+    @Test
     public void testGetMsqOtherWeight_nullOtherWeight_exceptionThrown() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
         HashMap<String, String[]> requestParams = new HashMap<>();
@@ -273,7 +273,7 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         // The following line is commented out, so otherWeight parameter is missing from the requestParams.
         // requestParams.put(Const.ParamsNames.FEEDBACK_QUESTION_MSQ_OTHER_WEIGHT, new String[] { "" });
 
-        msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ);
+        assertThrows(AssertionError.class, () -> msqDetails.extractQuestionDetails(requestParams, FeedbackQuestionType.MSQ));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesFactoryTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesFactoryTest.java
@@ -15,110 +15,102 @@ import teammates.test.cases.BaseTestCase;
 public class StudentAttributesFactoryTest extends BaseTestCase {
 
     @Test
-    public void testConstructor() throws Exception {
+    public void testConstructor_nullParameter_fail() throws Exception {
 
         ______TS("Failure case: null parameter");
-        try {
-            new StudentAttributesFactory(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> new StudentAttributesFactory(null));
+    }
+
+    @Test
+    public void testConstructor_tooFewColumns_fail() throws Exception {
 
         ______TS("Failure case: not satisfy the minimum requirement of fields");
         String headerRow = "name \t email";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
-                         e.getMessage());
-        }
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
+                ee.getMessage());
+    }
+
+    @Test
+    public void testConstructor_missingNameField_fail() throws Exception {
 
         ______TS("Failure case: missing 'Name' field");
-        headerRow = "section \t team \t email";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Name</mark>",
-                         e.getMessage());
-        }
+        String headerRow = "section \t team \t email";
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Name</mark>",
+                ee.getMessage());
+    }
+
+    @Test
+    public void testConstructor_missingTeamField_fail() throws Exception {
 
         ______TS("Failure case: missing 'Team' field");
-        headerRow = "section \t name \t email";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
-                         e.getMessage());
-        }
+        String headerRow = "section \t name \t email";
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Team</mark>",
+                ee.getMessage());
+    }
+
+    @Test
+    public void testConstructor_missingEmailField_fail() throws Exception {
 
         ______TS("Failure case: missing 'Email' field");
-        headerRow = "section \t team \t name";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Email</mark>",
-                         e.getMessage());
-        }
+        String headerRow = "section \t team \t name";
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_MISSED + ": <mark>Email</mark>",
+                ee.getMessage());
+    }
+
+    @Test
+    public void testConstructor_repeatedSingleColumn_fail() throws Exception {
 
         ______TS("Failure case: repeated required columns");
-        headerRow = "name \t email \t team \t comments \t name";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, e.getMessage());
-        }
+        String headerRow = "name \t email \t team \t comments \t name";
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, ee.getMessage());
+    }
+
+    @Test
+    public void testConstructor_repeatedMultipleColumns_fail() throws Exception {
 
         // adding this for complete coverage
         ______TS("Failure case: repeated required columns");
-        headerRow = "name \t email \t team \t comments \t section \t email \t team \t comments \t section ";
-        try {
-            new StudentAttributesFactory(headerRow);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, e.getMessage());
-        }
+        String headerRow = "name \t email \t team \t comments \t section \t email \t team \t comments \t section ";
+        EnrollException ee = assertThrows(EnrollException.class, () -> new StudentAttributesFactory(headerRow));
+        assertEquals(StudentAttributesFactory.ERROR_HEADER_ROW_FIELD_REPEATED, ee.getMessage());
 
         // remaining cases have been implicitly tested in testMakeStudent()
     }
 
     @Test
-    public void testMakeStudent() throws EnrollException {
-        StudentAttributesFactory saf = new StudentAttributesFactory();
-        String line = null;
-        String courseId = null;
-
-        StudentAttributes studentCreated;
-
+    public void testMakeStudent_emptyRow_fail() throws EnrollException {
         ______TS("Failure case: empty row");
-        line = "";
-        courseId = "SAFT.courseId";
-        try {
-            saf.makeStudent(line, courseId);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_ENROLL_LINE_EMPTY, e.getMessage());
-        }
+        StudentAttributesFactory saf = new StudentAttributesFactory();
+        String line = "";
+        String courseId = "SAFT.courseId";
+        EnrollException ee = assertThrows(EnrollException.class, () -> saf.makeStudent(line, courseId));
+        assertEquals(StudentAttributesFactory.ERROR_ENROLL_LINE_EMPTY, ee.getMessage());
+    }
 
+    @Test
+    public void testMakeStudent_tooFewColumns_fail() throws EnrollException {
         ______TS("Failure case: too few columns");
-        line = "name|email";
-        try {
-            saf.makeStudent(line, courseId);
-            signalFailureToDetectException();
-        } catch (EnrollException e) {
-            assertEquals(StudentAttributesFactory.ERROR_ENROLL_LINE_TOOFEWPARTS, e.getMessage());
-        }
+        StudentAttributesFactory saf = new StudentAttributesFactory();
+        String line = "name|email";
+        String courseId = "SAFT.courseId";
+        EnrollException ee = assertThrows(EnrollException.class, () -> saf.makeStudent(line, courseId));
+        assertEquals(StudentAttributesFactory.ERROR_ENROLL_LINE_TOOFEWPARTS, ee.getMessage());
+    }
+
+    @Test
+    public void testMakeStudent() throws EnrollException {
+        String courseId = "SAFT.courseId";
 
         ______TS("Typical case: normal column order with comment");
-        saf = new StudentAttributesFactory("TEAMS|Names|Email|comments");
-        line = "team 1|SAFT.name|SAFT@email.com|some comment...";
+        StudentAttributesFactory saf = new StudentAttributesFactory("TEAMS|Names|Email|comments");
+        String line = "team 1|SAFT.name|SAFT@email.com|some comment...";
 
-        studentCreated = saf.makeStudent(line, courseId);
+        StudentAttributes studentCreated = saf.makeStudent(line, courseId);
         assertEquals(studentCreated.team, "team 1");
         assertEquals(studentCreated.name, "SAFT.name");
         assertEquals(studentCreated.email, "SAFT@email.com");
@@ -193,12 +185,7 @@ public class StudentAttributesFactoryTest extends BaseTestCase {
     public void testSplitLineIntoColumns() throws Exception {
 
         ______TS("Failure case: null parameter");
-        try {
-            splitLineIntoColumns(null);
-            signalFailureToDetectException();
-        } catch (InvocationTargetException e) {
-            ignoreExpectedException();
-        }
+        assertThrows(InvocationTargetException.class, () -> splitLineIntoColumns(null));
 
         ______TS("Typical case: line with pipe symbol as separators");
         String line = "name | email |  | team";

--- a/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentAttributesTest.java
@@ -57,10 +57,9 @@ public class StudentAttributesTest extends BaseTestCaseWithMinimalGaeEnvironment
         assertNull(sd.comments);
     }
 
-    @Test(expectedExceptions = AssertionError.class)
+    @Test
     public void testBuilderWithNullValuesForRequiredFields() {
-        StudentAttributes.builder(null, null, null)
-                .build();
+        assertThrows(AssertionError.class, () -> StudentAttributes.builder(null, null, null).build());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/StudentProfileAttributesTest.java
@@ -37,10 +37,9 @@ public class StudentProfileAttributesTest extends BaseAttributesTest {
                 .build();
     }
 
-    @Test(expectedExceptions = AssertionError.class)
+    @Test
     public void testBuilderWithNullValuesForRequiredFields() {
-        StudentProfileAttributes.builder(null)
-                .build();
+        assertThrows(AssertionError.class, () -> StudentProfileAttributes.builder(null).build());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
@@ -87,12 +87,8 @@ public class AccountsLogicTest extends BaseLogicTest {
                 .withIsInstructor(true)
                 .withStudentProfileAttributes(spa)
                 .build();
-        try {
-            accountsLogic.createAccount(accountToCreate);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            ignoreExpectedException();
-        }
+        AccountAttributes[] finalAccount = new AccountAttributes[] { accountToCreate };
+        assertThrows(InvalidParametersException.class, () -> accountsLogic.createAccount(finalAccount[0]));
 
     }
 
@@ -160,12 +156,10 @@ public class AccountsLogicTest extends BaseLogicTest {
                 .withIsInstructor(true)
                 .withStudentProfileAttributes(spa)
                 .build();
-        try {
-            accountsLogic.updateAccount(expectedAccount);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            AssertHelper.assertContains(AccountsDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT, edne.getMessage());
-        }
+        AccountAttributes finalAccount = expectedAccount;
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsLogic.updateAccount(finalAccount));
+        AssertHelper.assertContains(AccountsDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT, ednee.getMessage());
 
         ______TS("test downgradeInstructorToStudentCascade");
 
@@ -206,29 +200,21 @@ public class AccountsLogicTest extends BaseLogicTest {
         studentsLogic.createStudentCascadeWithoutDocument(studentData);
         studentData = StudentsLogic.inst().getStudentForEmail(courseId,
                 originalEmail);
+        StudentAttributes finalStudent = studentData;
 
         verifyPresentInDatastore(studentData);
 
         ______TS("failure: wrong key");
 
-        try {
-            accountsLogic.joinCourseForStudent(StringHelper.encrypt("wrongkey"), correctStudentId);
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals(
-                    "You have used an invalid join link: %s",
-                    e.getMessage());
-        }
+        JoinCourseException jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForStudent(StringHelper.encrypt("wrongkey"), correctStudentId));
+        assertEquals("You have used an invalid join link: %s", jce.getMessage());
 
         ______TS("failure: invalid parameters");
 
-        try {
-            accountsLogic.joinCourseForStudent(StringHelper.encrypt(studentData.key), "wrong student");
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(FieldValidator.REASON_INCORRECT_FORMAT,
-                    e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> accountsLogic.joinCourseForStudent(StringHelper.encrypt(finalStudent.key), "wrong student"));
+        AssertHelper.assertContains(FieldValidator.REASON_INCORRECT_FORMAT, ipe.getMessage());
 
         ______TS("failure: googleID belongs to an existing student in the course");
 
@@ -242,13 +228,10 @@ public class AccountsLogicTest extends BaseLogicTest {
                 .build();
         studentsLogic.createStudentCascadeWithoutDocument(existingStudent);
 
-        try {
-            accountsLogic.joinCourseForStudent(StringHelper.encrypt(studentData.key), existingId);
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals(String.format(Const.StatusMessages.JOIN_COURSE_GOOGLE_ID_BELONGS_TO_DIFFERENT_USER,
-                    existingId), e.getMessage());
-        }
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForStudent(StringHelper.encrypt(finalStudent.key), existingId));
+        assertEquals(String.format(Const.StatusMessages.JOIN_COURSE_GOOGLE_ID_BELONGS_TO_DIFFERENT_USER, existingId),
+                jce.getMessage());
 
         ______TS("success: without encryption and account already exists");
 
@@ -276,30 +259,24 @@ public class AccountsLogicTest extends BaseLogicTest {
 
         ______TS("failure: already joined");
 
-        try {
-            accountsLogic.joinCourseForStudent(StringHelper.encrypt(studentData.key), correctStudentId);
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals("You (" + correctStudentId + ") have already joined this course",
-                    e.getMessage());
-        }
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForStudent(StringHelper.encrypt(finalStudent.key), correctStudentId));
+        assertEquals("You (" + correctStudentId + ") have already joined this course",
+                jce.getMessage());
 
         ______TS("failure: valid key belongs to a different user");
 
-        try {
-            accountsLogic.joinCourseForStudent(StringHelper.encrypt(studentData.key), "wrongstudent");
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals("The join link used belongs to a different user whose "
-                                 + "Google ID is corre..dentId (only part of the Google ID is "
-                                 + "shown to protect privacy). If that Google ID is owned by you, "
-                                 + "please logout and re-login using that Google account. "
-                                 + "If it doesn’t belong to you, please "
-                                 + "<a href=\"mailto:" + Config.SUPPORT_EMAIL + "?"
-                                 + "body=Your name:%0AYour course:%0AYour university:\">"
-                                 + "contact us</a> so that we can investigate.",
-                         e.getMessage());
-        }
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForStudent(StringHelper.encrypt(finalStudent.key), "wrongstudent"));
+        assertEquals("The join link used belongs to a different user whose "
+                        + "Google ID is corre..dentId (only part of the Google ID is "
+                        + "shown to protect privacy). If that Google ID is owned by you, "
+                        + "please logout and re-login using that Google account. "
+                        + "If it doesn’t belong to you, please "
+                        + "<a href=\"mailto:" + Config.SUPPORT_EMAIL + "?"
+                        + "body=Your name:%0AYour course:%0AYour university:\">"
+                        + "contact us</a> so that we can investigate.",
+                jce.getMessage());
 
         ______TS("success: with encryption and new account to be created");
 
@@ -359,21 +336,22 @@ public class AccountsLogicTest extends BaseLogicTest {
 
         InstructorAttributes instructor = dataBundle.instructors.get("instructorNotYetJoinCourse");
         String loggedInGoogleId = "AccLogicT.instr.id";
-        String encryptedKey = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, instructor.email);
+        String[] encryptedKey = new String[] {
+                instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, instructor.email)
+        };
 
         ______TS("failure: googleID belongs to an existing instructor in the course");
 
-        try {
-            accountsLogic.joinCourseForInstructor(encryptedKey, "idOfInstructorWithOnlyOneSampleCourse");
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals(String.format(Const.StatusMessages.JOIN_COURSE_GOOGLE_ID_BELONGS_TO_DIFFERENT_USER,
-                    "idOfInstructorWithOnlyOneSampleCourse"), e.getMessage());
-        }
+        JoinCourseException jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForInstructor(encryptedKey[0], "idOfInstructorWithOnlyOneSampleCourse"));
+        assertEquals(
+                String.format(Const.StatusMessages.JOIN_COURSE_GOOGLE_ID_BELONGS_TO_DIFFERENT_USER,
+                        "idOfInstructorWithOnlyOneSampleCourse"),
+                jce.getMessage());
 
         ______TS("success: instructor joined and new account be created");
 
-        accountsLogic.joinCourseForInstructor(encryptedKey, loggedInGoogleId);
+        accountsLogic.joinCourseForInstructor(encryptedKey[0], loggedInGoogleId);
 
         InstructorAttributes joinedInstructor =
                 instructorsLogic.getInstructorForEmail(instructor.courseId, instructor.email);
@@ -389,7 +367,7 @@ public class AccountsLogicTest extends BaseLogicTest {
         accountsDb.deleteAccount(loggedInGoogleId);
 
         //Try to join course again, Account object should be recreated
-        accountsLogic.joinCourseForInstructor(encryptedKey, loggedInGoogleId);
+        accountsLogic.joinCourseForInstructor(encryptedKey[0], loggedInGoogleId);
 
         joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, instructor.email);
         assertEquals(loggedInGoogleId, joinedInstructor.googleId);
@@ -407,10 +385,10 @@ public class AccountsLogicTest extends BaseLogicTest {
                 .build();
 
         instructorsLogic.createInstructor(newIns);
-        encryptedKey = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
+        encryptedKey[0] = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
         assertFalse(accountsLogic.getAccount(nonInstrAccount.googleId).isInstructor);
 
-        accountsLogic.joinCourseForInstructor(encryptedKey, nonInstrAccount.googleId);
+        accountsLogic.joinCourseForInstructor(encryptedKey[0], nonInstrAccount.googleId);
 
         joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, nonInstrAccount.email);
         assertEquals(nonInstrAccount.googleId, joinedInstructor.googleId);
@@ -434,9 +412,9 @@ public class AccountsLogicTest extends BaseLogicTest {
                 .build();
 
         instructorsLogic.createInstructor(newIns);
-        encryptedKey = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
+        encryptedKey[0] = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
 
-        accountsLogic.joinCourseForInstructor(encryptedKey, nonInstrAccount.googleId);
+        accountsLogic.joinCourseForInstructor(encryptedKey[0], nonInstrAccount.googleId);
 
         joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, nonInstrAccount.email);
         assertEquals(nonInstrAccount.googleId, joinedInstructor.googleId);
@@ -452,46 +430,35 @@ public class AccountsLogicTest extends BaseLogicTest {
         nonInstrAccount = dataBundle.accounts.get("student1InCourse1");
         instructor = dataBundle.instructors.get("instructorNotYetJoinCourse");
 
-        encryptedKey = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
+        encryptedKey[0] = instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, nonInstrAccount.email);
         joinedInstructor = instructorsLogic.getInstructorForEmail(instructor.courseId, nonInstrAccount.email);
-
-        try {
-            accountsLogic.joinCourseForInstructor(encryptedKey, joinedInstructor.googleId);
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals(joinedInstructor.googleId + " has already joined this course",
-                    e.getMessage());
-        }
+        InstructorAttributes[] finalInstructor = new InstructorAttributes[] { joinedInstructor };
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForInstructor(encryptedKey[0], finalInstructor[0].googleId));
+        assertEquals(joinedInstructor.googleId + " has already joined this course",
+                jce.getMessage());
 
         ______TS("failure: key belongs to a different user");
 
-        try {
-            accountsLogic.joinCourseForInstructor(encryptedKey, "otherUserId");
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals("The join link used belongs to a different user whose "
-                                 + "Google ID is stude..ourse1 (only part of the Google ID is "
-                                 + "shown to protect privacy). If that Google ID is owned by you, "
-                                 + "please logout and re-login using that Google account. "
-                                 + "If it doesn’t belong to you, please "
-                                 + "<a href=\"mailto:" + Config.SUPPORT_EMAIL + "?"
-                                 + "body=Your name:%0AYour course:%0AYour university:\">"
-                                 + "contact us</a> so that we can investigate.",
-                         e.getMessage());
-        }
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForInstructor(encryptedKey[0], "otherUserId"));
+        assertEquals("The join link used belongs to a different user whose "
+                        + "Google ID is stude..ourse1 (only part of the Google ID is "
+                        + "shown to protect privacy). If that Google ID is owned by you, "
+                        + "please logout and re-login using that Google account. "
+                        + "If it doesn’t belong to you, please "
+                        + "<a href=\"mailto:" + Config.SUPPORT_EMAIL + "?"
+                        + "body=Your name:%0AYour course:%0AYour university:\">"
+                        + "contact us</a> so that we can investigate.",
+                jce.getMessage());
 
         ______TS("failure: invalid key");
         String invalidKey = StringHelper.encrypt("invalidKey");
 
-        try {
-            accountsLogic.joinCourseForInstructor(invalidKey, loggedInGoogleId);
-            signalFailureToDetectException();
-        } catch (JoinCourseException e) {
-            assertEquals(
-                    "You have used an invalid join link: "
-                    + "/page/instructorCourseJoin?key=" + invalidKey,
-                    e.getMessage());
-        }
+        jce = assertThrows(JoinCourseException.class,
+                () -> accountsLogic.joinCourseForInstructor(invalidKey, loggedInGoogleId));
+        assertEquals("You have used an invalid join link: /page/instructorCourseJoin?key=" + invalidKey,
+                jce.getMessage());
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/BackDoorLogicTest.java
@@ -38,12 +38,9 @@ public class BackDoorLogicTest extends BaseLogicTest {
         verifyPresentInDatastore(loadDataBundle("/FeedbackSessionResultsTest.json"));
 
         ______TS("null parameter");
-        try {
-            backDoorLogic.persistDataBundle(null);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(Const.StatusCodes.NULL_PARAMETER, e.errorCode);
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> backDoorLogic.persistDataBundle(null));
+        assertEquals(Const.StatusCodes.NULL_PARAMETER, ipe.errorCode);
 
         ______TS("invalid parameters in an entity");
         CourseAttributes invalidCourse = CourseAttributes
@@ -51,15 +48,12 @@ public class BackDoorLogicTest extends BaseLogicTest {
                 .build();
         dataBundle = new DataBundle();
         dataBundle.courses.put("invalid", invalidCourse);
-        try {
-            backDoorLogic.persistDataBundle(dataBundle);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertTrue(e.getMessage().equals(
-                    getPopulatedErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE, "invalid id",
-                            FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
-                            FieldValidator.COURSE_ID_MAX_LENGTH)));
-        }
+        ipe = assertThrows(InvalidParametersException.class, () -> backDoorLogic.persistDataBundle(dataBundle));
+        assertEquals(
+                getPopulatedErrorMessage(FieldValidator.COURSE_ID_ERROR_MESSAGE, "invalid id",
+                        FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
+                        FieldValidator.COURSE_ID_MAX_LENGTH),
+                ipe.getMessage());
 
         // Not checking for invalid values in other entities because they
         // should be checked at lower level methods

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -88,12 +88,8 @@ public class CoursesLogicTest extends BaseLogicTest {
         coursesDb.deleteEntity(c);
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCoursesForInstructor() throws Exception {
@@ -123,19 +119,12 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getCoursesForInstructor((String) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCoursesForInstructor((String) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            coursesLogic.getCoursesForInstructor((List<InstructorAttributes>) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.getCoursesForInstructor((List<InstructorAttributes>) null));
+        assertEquals("Supplied parameter was null", ae.getMessage());
     }
 
     private void testGetSoftDeletedCoursesForInstructors() {
@@ -163,12 +152,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getSoftDeletedCoursesForInstructors(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getSoftDeletedCoursesForInstructors(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetSoftDeletedCourseForInstructor() {
@@ -191,12 +176,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getSoftDeletedCourseForInstructor(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getSoftDeletedCourseForInstructor(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testIsSampleCourse() {
@@ -225,12 +206,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.isSampleCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Course ID is null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.isSampleCourse(null));
+        assertEquals("Course ID is null", ae.getMessage());
     }
 
     private void testIsCoursePresent() {
@@ -253,12 +230,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.isCoursePresent(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.isCoursePresent(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testVerifyCourseIsPresent() throws Exception {
@@ -269,12 +242,9 @@ public class CoursesLogicTest extends BaseLogicTest {
                 .builder("non-existent-course", "non existent course", ZoneId.of("UTC"))
                 .build();
 
-        try {
-            coursesLogic.verifyCourseIsPresent(nonExistentCourse.getId());
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("Course does not exist: ", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.verifyCourseIsPresent(nonExistentCourse.getId()));
+        AssertHelper.assertContains("Course does not exist: ", ednee.getMessage());
 
         ______TS("typical case: verify an existent course");
 
@@ -285,12 +255,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.verifyCourseIsPresent(null);
-            signalFailureToDetectException();
-        } catch (AssertionError | EntityDoesNotExistException e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.verifyCourseIsPresent(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseSummary() throws Exception {
@@ -337,28 +303,17 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("non-existent");
 
-        try {
-            coursesLogic.getCourseSummary("non-existent-course");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("The course does not exist:", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseSummary("non-existent-course"));
+        AssertHelper.assertContains("The course does not exist:", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getCourseSummary((CourseAttributes) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourseSummary((String) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            coursesLogic.getCourseSummary((String) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourseSummary((CourseAttributes) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseSummaryWithoutStats() throws Exception {
@@ -393,28 +348,18 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("non-existent");
 
-        try {
-            coursesLogic.getCourseSummaryWithoutStats("non-existent-course");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("The course does not exist:", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseSummaryWithoutStats("non-existent-course"));
+        AssertHelper.assertContains("The course does not exist:", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getCourseSummaryWithoutStats((CourseAttributes) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.getCourseSummaryWithoutStats((CourseAttributes) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            coursesLogic.getCourseSummaryWithoutStats((String) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourseSummaryWithoutStats((String) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseDetails() throws Exception {
@@ -464,21 +409,14 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("non-existent");
 
-        try {
-            coursesLogic.getCourseSummary("non-existent-course");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("The course does not exist:", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseSummary("non-existent-course"));
+        AssertHelper.assertContains("The course does not exist:", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getCourseSummary((String) null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourseSummary((String) null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetTeamsForCourse() throws Exception {
@@ -514,21 +452,14 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("non-existent");
 
-        try {
-            coursesLogic.getTeamsForCourse("non-existent-course");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getTeamsForCourse("non-existent-course"));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getTeamsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getTeamsForCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCoursesForStudentAccount() throws Exception {
@@ -571,22 +502,14 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("non-existent student");
 
-        try {
-            coursesLogic.getCoursesForStudentAccount("non-existent-student");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCoursesForStudentAccount("non-existent-student"));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getCoursesForStudentAccount(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCoursesForStudentAccount(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseDetailsListForStudent() throws Exception {
@@ -613,22 +536,14 @@ public class CoursesLogicTest extends BaseLogicTest {
         // student with no courses is not applicable
         ______TS("non-existent student");
 
-        try {
-            coursesLogic.getCourseDetailsListForStudent("non-existent-student");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseDetailsListForStudent("non-existent-student"));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.getCourseDetailsListForStudent(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourseDetailsListForStudent(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseSummariesForInstructor() throws Exception {
@@ -657,22 +572,15 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Non-existent instructor");
 
-        try {
-            coursesLogic.getCourseSummariesForInstructor("non-existent-instructor", false);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseSummariesForInstructor("non-existent-instructor", false));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getCourseSummariesForInstructor(null, false);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.getCourseSummariesForInstructor(null, false));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
     }
 
@@ -699,12 +607,9 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.getCoursesSummaryWithoutStatsForInstructor(null, false);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.getCoursesSummaryWithoutStatsForInstructor(null, false));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testGetCourseStudentListAsCsv() throws Exception {
@@ -781,34 +686,26 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         assertEquals(StringUtils.join(expectedCsvString, System.lineSeparator()), csvString);
 
+        String finalCourseId = courseId;
+        String finalInstructorId = instructorId;
+
         ______TS("Failure case: non existent instructor");
 
-        try {
-            coursesLogic.getCourseStudentListAsCsv(courseId, "non-existent-instructor");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseStudentListAsCsv(finalCourseId, "non-existent-instructor"));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("Failure case: non existent course in the list of courses of the instructor");
 
-        try {
-            coursesLogic.getCourseStudentListAsCsv("non-existent-course", instructorId);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.getCourseStudentListAsCsv("non-existent-course", finalInstructorId));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("Failure case: null parameter");
 
-        try {
-            coursesLogic.getCourseStudentListAsCsv(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.getCourseStudentListAsCsv(finalCourseId, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testHasIndicatedSections() throws Exception {
@@ -825,22 +722,14 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Failure case: course does not exists");
 
-        try {
-            coursesLogic.hasIndicatedSections("non-existent-course");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("does not exist",
-                                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesLogic.hasIndicatedSections("non-existent-course"));
+        AssertHelper.assertContains("does not exist", ednee.getMessage());
 
         ______TS("Failure case: null parameter");
 
-        try {
-            coursesLogic.hasIndicatedSections(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.hasIndicatedSections(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
     }
 
@@ -856,24 +745,18 @@ public class CoursesLogicTest extends BaseLogicTest {
         coursesLogic.deleteCourseCascade(c.getId());
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.createCourse(null, c.getName(), c.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals("Non-null value expected", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourse(null, c.getName(), c.getTimeZone().getId()));
+        assertEquals("Non-null value expected", ae.getMessage());
         ______TS("Invalid time zone");
 
         String invalidTimeZone = "Invalid Timezone";
-        try {
-            coursesLogic.createCourse(c.getId(), c.getName(), invalidTimeZone);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            String expectedErrorMessage = getPopulatedErrorMessage(
-                    FieldValidator.TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
-                    FieldValidator.TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
-            assertEquals(expectedErrorMessage, e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesLogic.createCourse(c.getId(), c.getName(), invalidTimeZone));
+        String expectedErrorMessage = getPopulatedErrorMessage(
+                FieldValidator.TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
+                FieldValidator.TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+        assertEquals(expectedErrorMessage, ipe.getMessage());
     }
 
     private void testCreateCourseAndInstructor() throws Exception {
@@ -898,12 +781,9 @@ public class CoursesLogicTest extends BaseLogicTest {
                 .builder("instructor-for-tccai", c.getId(), "Instructor for tccai", "ins.for.iccai@gmail.tmt")
                 .build();
 
-        try {
-            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("for a non-existent instructor", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId()));
+        AssertHelper.assertContains("for a non-existent instructor", ae.getMessage());
         verifyAbsentInDatastore(c);
         verifyAbsentInDatastore(i);
 
@@ -919,12 +799,9 @@ public class CoursesLogicTest extends BaseLogicTest {
                 .build();
 
         accountsDb.createAccount(a);
-        try {
-            coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("doesn't have instructor privileges", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourseAndInstructor(i.googleId, c.getId(), c.getName(), c.getTimeZone().getId()));
+        AssertHelper.assertContains("doesn't have instructor privileges", ae.getMessage());
         verifyAbsentInDatastore(c);
         verifyAbsentInDatastore(i);
 
@@ -943,13 +820,10 @@ public class CoursesLogicTest extends BaseLogicTest {
                 + "A course ID can contain letters, numbers, fullstops, hyphens, underscores, and dollar signs. "
                 + "It cannot be longer than 40 characters, cannot be empty and cannot contain spaces.";
 
-        try {
-            coursesLogic.createCourseAndInstructor(i.googleId, invalidCourse.getId(), invalidCourse.getName(),
-                                                   invalidCourse.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(expectedError, e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesLogic.createCourseAndInstructor(
+                        i.googleId, invalidCourse.getId(), invalidCourse.getName(), invalidCourse.getTimeZone().getId()));
+        assertEquals(expectedError, ipe.getMessage());
         verifyAbsentInDatastore(invalidCourse);
         verifyAbsentInDatastore(i);
 
@@ -960,30 +834,26 @@ public class CoursesLogicTest extends BaseLogicTest {
                 .build();
         instructorsDb.createEntity(i); //create a duplicate instructor
 
-        try {
-            coursesLogic.createCourseAndInstructor(i.googleId, courseWithDuplicateInstructor.getId(),
-                                                   courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Unexpected exception while trying to create instructor for a new course",
-                                        e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourseAndInstructor(
+                        i.googleId, courseWithDuplicateInstructor.getId(), courseWithDuplicateInstructor.getName(),
+                        courseWithDuplicateInstructor.getTimeZone().getId()));
+        AssertHelper.assertContains(
+                "Unexpected exception while trying to create instructor for a new course",
+                ae.getMessage());
         verifyAbsentInDatastore(courseWithDuplicateInstructor);
 
         ______TS("fails: error during instructor creation due to invalid parameters");
 
         i.email = "ins.for.iccai.gmail.tmt";
 
-        try {
-            coursesLogic.createCourseAndInstructor(i.googleId, courseWithDuplicateInstructor.getId(),
-                                                   courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Unexpected exception while trying to create instructor for a new course",
-                                        e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourseAndInstructor(
+                        i.googleId, courseWithDuplicateInstructor.getId(), courseWithDuplicateInstructor.getName(),
+                        courseWithDuplicateInstructor.getTimeZone().getId()));
+        AssertHelper.assertContains(
+                "Unexpected exception while trying to create instructor for a new course",
+                ae.getMessage());
         verifyAbsentInDatastore(courseWithDuplicateInstructor);
 
         ______TS("success: typical case");
@@ -1001,14 +871,11 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("Null parameter");
 
-        try {
-            coursesLogic.createCourseAndInstructor(null, courseWithDuplicateInstructor.getId(),
-                                                   courseWithDuplicateInstructor.getName(),
-                                                   courseWithDuplicateInstructor.getTimeZone().getId());
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.createCourseAndInstructor(
+                        null, courseWithDuplicateInstructor.getId(), courseWithDuplicateInstructor.getName(),
+                        courseWithDuplicateInstructor.getTimeZone().getId()));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testMoveCourseToRecycleBin() throws InvalidParametersException, EntityDoesNotExistException {
@@ -1042,12 +909,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.moveCourseToRecycleBin(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.moveCourseToRecycleBin(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testRestoreCourseFromRecycleBin() throws InvalidParametersException, EntityDoesNotExistException {
@@ -1080,12 +943,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.restoreCourseFromRecycleBin(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.restoreCourseFromRecycleBin(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testRestoreAllCoursesFromRecycleBin() throws InvalidParametersException, EntityDoesNotExistException {
@@ -1124,12 +983,9 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.restoreAllCoursesFromRecycleBin(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> coursesLogic.restoreAllCoursesFromRecycleBin(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testDeleteCourse() {
@@ -1171,12 +1027,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.deleteCourseCascade(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.deleteCourseCascade(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testDeleteAllCourses() {
@@ -1202,12 +1054,8 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         ______TS("null parameter");
 
-        try {
-            coursesLogic.deleteAllCoursesCascade(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.deleteAllCoursesCascade(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testUpdateCourse() throws Exception {
@@ -1228,21 +1076,18 @@ public class CoursesLogicTest extends BaseLogicTest {
 
         String emptyName = "";
         String invalidTimeZone = "Invalid Timezone";
-        try {
-            coursesLogic.updateCourse(c.getId(), emptyName, invalidTimeZone);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            String expectedErrorMessage =
-                    getPopulatedEmptyStringErrorMessage(
-                            FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                            FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH)
-                    + System.lineSeparator()
-                    + getPopulatedErrorMessage(
-                            FieldValidator.TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
-                            FieldValidator.TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
-            assertEquals(expectedErrorMessage, e.getMessage());
-            verifyPresentInDatastore(c);
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesLogic.updateCourse(c.getId(), emptyName, invalidTimeZone));
+        String expectedErrorMessage =
+                getPopulatedEmptyStringErrorMessage(
+                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                        FieldValidator.COURSE_NAME_FIELD_NAME, FieldValidator.COURSE_NAME_MAX_LENGTH)
+                        + System.lineSeparator()
+                        + getPopulatedErrorMessage(
+                        FieldValidator.TIME_ZONE_ERROR_MESSAGE, invalidTimeZone,
+                        FieldValidator.TIME_ZONE_FIELD_NAME, FieldValidator.REASON_UNAVAILABLE_AS_CHOICE);
+        assertEquals(expectedErrorMessage, ipe.getMessage());
+        verifyPresentInDatastore(c);
     }
 
 }

--- a/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
@@ -200,23 +200,17 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         FeedbackQuestionAttributes question = getQuestionFromDatastore("qn1InSession1InCourse1");
         question.feedbackSessionName = "non-existent Feedback Session";
         question.setId(null);
-        try {
-            fqLogic.createFeedbackQuestion(question);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(e.getMessage(), "Session disappeared.");
-        }
+        FeedbackQuestionAttributes[] finalFq = new FeedbackQuestionAttributes[] { question };
+        AssertionError ae = assertThrows(AssertionError.class, () -> fqLogic.createFeedbackQuestion(finalFq[0]));
+        assertEquals("Session disappeared.", ae.getMessage());
 
         ______TS("Add question for course that does not exist");
         question = getQuestionFromDatastore("qn1InSession1InCourse1");
         question.courseId = "non-existent course id";
         question.setId(null);
-        try {
-            fqLogic.createFeedbackQuestion(question);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(e.getMessage(), "Session disappeared.");
-        }
+        finalFq[0] = question;
+        ae = assertThrows(AssertionError.class, () -> fqLogic.createFeedbackQuestion(finalFq[0]));
+        assertEquals("Session disappeared.", ae.getMessage());
 
         ______TS("Add questions sequentially");
         List<FeedbackQuestionAttributes> expectedList = new ArrayList<>();
@@ -384,28 +378,26 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         ______TS("failure: question does not exist");
 
         questionToUpdate = getQuestionFromDatastore("qn3InSession1InCourse1");
+        FeedbackQuestionAttributes[] finalFq = new FeedbackQuestionAttributes[] { questionToUpdate };
         fqLogic.deleteFeedbackQuestionCascade(questionToUpdate.getId());
 
-        try {
-            fqLogic.updateFeedbackQuestion(questionToUpdate);
-            signalFailureToDetectException("Expected EntityDoesNotExistException not caught.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals(e.getMessage(), "Trying to update a feedback question that does not exist.");
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fqLogic.updateFeedbackQuestion(finalFq[0]));
+        assertEquals("Trying to update a feedback question that does not exist.", ednee.getMessage());
 
         ______TS("failure: invalid parameters");
 
         questionToUpdate = getQuestionFromDatastore("qn3InSession1InCourse1");
         questionToUpdate.giverType = FeedbackParticipantType.TEAMS;
         questionToUpdate.recipientType = FeedbackParticipantType.OWN_TEAM_MEMBERS;
-        try {
-            fqLogic.updateFeedbackQuestion(questionToUpdate);
-            signalFailureToDetectException("Expected InvalidParametersException not caught.");
-        } catch (InvalidParametersException e) {
-            assertEquals(e.getMessage(), String.format(FieldValidator.PARTICIPANT_TYPE_TEAM_ERROR_MESSAGE,
-                                                       questionToUpdate.recipientType.toDisplayRecipientName(),
-                                                       questionToUpdate.giverType.toDisplayGiverName()));
-        }
+        finalFq[0] = questionToUpdate;
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> fqLogic.updateFeedbackQuestion(finalFq[0]));
+        assertEquals(
+                String.format(FieldValidator.PARTICIPANT_TYPE_TEAM_ERROR_MESSAGE,
+                        questionToUpdate.recipientType.toDisplayRecipientName(),
+                        questionToUpdate.giverType.toDisplayGiverName()),
+                ipe.getMessage());
     }
 
     private void testDeleteQuestion() {
@@ -506,13 +498,10 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
 
         ______TS("Failure: Getting questions for a non-existent session");
 
-        try {
-            fqLogic.getFeedbackQuestionsForInstructor("Instructor feedback session", "idOfTypicalCourse1",
-                                                      "instructor1@course1.tmt");
-            signalFailureToDetectException("Allowed to get questions for a feedback session that does not exist.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals(e.getMessage(), "Trying to get questions for a feedback session that does not exist.");
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fqLogic.getFeedbackQuestionsForInstructor(
+                        "Instructor feedback session", "idOfTypicalCourse1", "instructor1@course1.tmt"));
+        assertEquals("Trying to get questions for a feedback session that does not exist.", ednee.getMessage());
 
         ______TS("Get questions created for self from list of all questions");
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -39,31 +39,40 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
     @Test
     public void testCreateFeedbackResponseComment() throws Exception {
         FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
+        FeedbackResponseCommentAttributes[] finalFrc = new FeedbackResponseCommentAttributes[] { frComment };
 
         ______TS("fail: non-existent course");
 
         frComment.courseId = "no-such-course";
 
-        verifyExceptionThrownFromCreateFrComment(frComment,
-                "Trying to create feedback response comments for a course that does not exist.");
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frcLogic.createFeedbackResponseComment(finalFrc[0]));
+        assertEquals("Trying to create feedback response comments for a course that does not exist.",
+                ednee.getMessage());
         frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
+        finalFrc[0] = frComment;
 
         ______TS("fail: giver is not an instructor for the course");
 
         frComment.commentGiver = "instructor1@course2.com";
 
-        verifyExceptionThrownFromCreateFrComment(frComment,
-                "User " + frComment.commentGiver + " is not a registered instructor for course "
-                + frComment.courseId + ".");
+        ednee = assertThrows(EntityDoesNotExistException.class, () -> frcLogic.createFeedbackResponseComment(finalFrc[0]));
+        assertEquals(
+                "User " + frComment.commentGiver + " is not a registered instructor for course " + frComment.courseId + ".",
+                ednee.getMessage());
         frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
+        finalFrc[0] = frComment;
 
         ______TS("fail: feedback session is not a session for the course");
 
         frComment.feedbackSessionName = "Instructor feedback session";
 
-        verifyExceptionThrownFromCreateFrComment(frComment,
+        ednee = assertThrows(EntityDoesNotExistException.class, () -> frcLogic.createFeedbackResponseComment(finalFrc[0]));
+        assertEquals(
                 "Feedback session " + frComment.feedbackSessionName + " is not a session for course "
-                + frComment.courseId + ".");
+                        + frComment.courseId + ".",
+                ednee.getMessage());
+
         frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
 
         ______TS("typical successful case");
@@ -99,7 +108,9 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
         frComment.commentGiverType = FeedbackParticipantType.SELF;
         frComment.isCommentFromFeedbackParticipant = true;
-        verifyExceptionThrownFromCreateFrComment(frComment, "Unknown giver type: " + FeedbackParticipantType.SELF);
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frcLogic.createFeedbackResponseComment(frComment));
+        assertEquals("Unknown giver type: " + FeedbackParticipantType.SELF, ednee.getMessage());
     }
 
     @Test
@@ -108,8 +119,9 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         frComment.commentGiverType = FeedbackParticipantType.STUDENTS;
         frComment.isCommentFromFeedbackParticipant = true;
         frComment.commentGiver = "XYZ";
-        verifyExceptionThrownFromCreateFrComment(frComment,
-                "User XYZ is not a registered student for course idOfTypicalCourse1.");
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frcLogic.createFeedbackResponseComment(frComment));
+        assertEquals("User XYZ is not a registered student for course idOfTypicalCourse1.", ednee.getMessage());
     }
 
     @Test
@@ -117,8 +129,10 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
         frComment.isCommentFromFeedbackParticipant = true;
         frComment.isVisibilityFollowingFeedbackQuestion = false;
-        verifyExceptionThrownFromCreateFrComment(frComment, "Comment by feedback participant not following "
-                + "visibility setting of the question.");
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> frcLogic.createFeedbackResponseComment(frComment));
+        assertEquals("Comment by feedback participant not following visibility setting of the question.",
+                ipe.getMessage());
     }
 
     @Test
@@ -202,12 +216,15 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         ______TS("fail: invalid params");
 
         frComment.courseId = "invalid course name";
+        FeedbackResponseCommentAttributes finalFrca = frComment;
         String expectedError =
                 "\"" + frComment.courseId + "\" is not acceptable to TEAMMATES as a/an course ID "
                 + "because it is not in the correct format. A course ID can contain letters, "
                 + "numbers, fullstops, hyphens, underscores, and dollar signs. It cannot be longer "
                 + "than 40 characters, cannot be empty and cannot contain spaces.";
-        verifyExceptionThrownWhenUpdateFrComment(frComment, expectedError);
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> frcLogic.updateFeedbackResponseComment(finalFrca));
+        assertEquals(expectedError, ipe.getMessage());
         frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
 
         ______TS("typical success case");
@@ -314,16 +331,6 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         assertEquals(0, frcList.size());
     }
 
-    private void verifyExceptionThrownFromCreateFrComment(
-            FeedbackResponseCommentAttributes frComment, String expectedMessage) {
-        try {
-            frcLogic.createFeedbackResponseComment(frComment);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException | InvalidParametersException e) {
-            assertEquals(expectedMessage, e.getMessage());
-        }
-    }
-
     private void verifyNullFromGetFrCommentForSession(FeedbackResponseCommentAttributes frComment) {
         List<FeedbackResponseCommentAttributes> frCommentsGot =
                 frcLogic.getFeedbackResponseCommentForSession(frComment.courseId, frComment.feedbackSessionName);
@@ -335,17 +342,6 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
                 frcLogic.getFeedbackResponseComment(
                                  frComment.feedbackResponseId, frComment.commentGiver, frComment.createdAt);
         assertNull(frCommentGot);
-    }
-
-    private void verifyExceptionThrownWhenUpdateFrComment(
-            FeedbackResponseCommentAttributes frComment, String expectedString)
-            throws EntityDoesNotExistException {
-        try {
-            frcLogic.updateFeedbackResponseComment(frComment);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(expectedString, e.getMessage());
-        }
     }
 
     private FeedbackResponseCommentAttributes restoreFrCommentFromDataBundle(String existingFrCommentInDataBundle) {

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
@@ -146,12 +146,10 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         responseToUpdate.recipient = "student3InCourse1@gmail.tmt";
 
-        try {
-            frLogic.updateFeedbackResponse(responseToUpdate);
-            signalFailureToDetectException("Should have detected that same giver->recipient response alr exists");
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains("Trying to create a Feedback Response that exists", e.getMessage());
-        }
+        FeedbackResponseAttributes[] finalResponse = new FeedbackResponseAttributes[] { responseToUpdate };
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> frLogic.updateFeedbackResponse(finalResponse[0]));
+        AssertHelper.assertContains("Trying to create a Feedback Response that exists", eaee.getMessage());
 
         ______TS("success: standard update with carried params - using createFeedbackResponse");
 
@@ -207,14 +205,12 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         responseToUpdate.setId("invalidId");
 
-        try {
-            frLogic.updateFeedbackResponse(responseToUpdate);
-            signalFailureToDetectException("Should have detected that this response does not exist");
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(
-                        "Trying to update a feedback response that does not exist.",
-                        e.getMessage());
-        }
+        finalResponse[0] = responseToUpdate;
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frLogic.updateFeedbackResponse(finalResponse[0]));
+        AssertHelper.assertContains(
+                "Trying to update a feedback response that does not exist.",
+                ednee.getMessage());
     }
 
     private void testUpdateFeedbackResponsesForChangingTeam() throws Exception {
@@ -498,12 +494,11 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
 
         ______TS("failure: GetViewableResponsesForQuestion invalid role");
 
-        try {
-            frLogic.getViewableFeedbackResponsesForQuestionInSection(fq, instructor.email, UserRole.ADMIN, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(e.getMessage(), "The role of the requesting use has to be Student or Instructor");
-        }
+        FeedbackQuestionAttributes finalFq = fq;
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frLogic.getViewableFeedbackResponsesForQuestionInSection(
+                        finalFq, instructor.email, UserRole.ADMIN, null));
+        assertEquals("The role of the requesting use has to be Student or Instructor", ae.getMessage());
     }
 
     private void testIsNameVisibleTo() {

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -157,14 +157,10 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("non-existent session/courseId");
 
-        try {
-            fsLogic.isFeedbackSessionHasQuestionForStudents("nOnEXistEnT session", "someCourse");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Trying to check a non-existent feedback session: "
-                         + "someCourse" + "/" + "nOnEXistEnT session",
-                         edne.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.isFeedbackSessionHasQuestionForStudents("nOnEXistEnT session", "someCourse"));
+        assertEquals("Trying to check a non-existent feedback session: someCourse/nOnEXistEnT session",
+                ednee.getMessage());
 
         ______TS("session contains students");
 
@@ -370,29 +366,24 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         fsLogic.createFeedbackSession(fs);
         verifyPresentInDatastore(fs);
 
+        FeedbackSessionAttributes finalFs = fs;
         ______TS("test create with invalid session name");
         fs.setFeedbackSessionName("test & test");
-        try {
-            fsLogic.createFeedbackSession(fs);
-            signalFailureToDetectException();
-        } catch (Exception e) {
-            assertEquals("The provided feedback session name is not acceptable to TEAMMATES "
-                             + "as it cannot contain the following special html characters in brackets: "
-                             + "(&lt; &gt; &quot; &#x2f; &#39; &amp;)",
-                         e.getMessage());
-        }
+        Exception e = assertThrows(Exception.class, () -> fsLogic.createFeedbackSession(finalFs));
+        assertEquals(
+                "The provided feedback session name is not acceptable to TEAMMATES "
+                        + "as it cannot contain the following special html characters in brackets: "
+                        + "(&lt; &gt; &quot; &#x2f; &#39; &amp;)",
+                e.getMessage());
 
         fs.setFeedbackSessionName("test %| test");
-        try {
-            fsLogic.createFeedbackSession(fs);
-            signalFailureToDetectException();
-        } catch (Exception e) {
-            assertEquals("\"test %| test\" is not acceptable to TEAMMATES as a/an feedback session name "
-                             + "because it contains invalid characters. A/An feedback session name "
-                             + "must start with an alphanumeric character, and cannot contain "
-                             + "any vertical bar (|) or percent sign (%).",
-                         e.getMessage());
-        }
+        e = assertThrows(Exception.class, () -> fsLogic.createFeedbackSession(finalFs));
+        assertEquals(
+                "\"test %| test\" is not acceptable to TEAMMATES as a/an feedback session name "
+                        + "because it contains invalid characters. A/An feedback session name "
+                        + "must start with an alphanumeric character, and cannot contain "
+                        + "any vertical bar (|) or percent sign (%).",
+                e.getMessage());
 
         ______TS("test delete");
         fs = getNewFeedbackSession();
@@ -458,15 +449,11 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("Failure case: duplicate session");
 
-        try {
-            fsLogic.copyFeedbackSession(
-                    session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId(),
-                    session1InCourse1.getTimeZone(), session1InCourse1.getFeedbackSessionName(),
-                    session1InCourse1.getCourseId(), instructor2OfCourse1.email);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            ignoreExpectedException();
-        }
+        assertThrows(EntityAlreadyExistsException.class,
+                () -> fsLogic.copyFeedbackSession(
+                        session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId(),
+                        session1InCourse1.getTimeZone(), session1InCourse1.getFeedbackSessionName(),
+                        session1InCourse1.getCourseId(), instructor2OfCourse1.email));
 
         fsLogic.deleteFeedbackSessionCascade(copiedSession.getFeedbackSessionName(), copiedSession.getCourseId());
     }
@@ -541,12 +528,9 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("non-existent course");
 
-        try {
-            fsLogic.getFeedbackSessionsForUserInCourse("NonExistentCourseId", "randomUserId");
-            signalFailureToDetectException("Did not detect that course does not exist.");
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Error getting feedback session(s): Course does not exist.", edne.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionsForUserInCourse("NonExistentCourseId", "randomUserId"));
+        assertEquals("Error getting feedback session(s): Course does not exist.", ednee.getMessage());
 
         ______TS("Student viewing: 2 visible, 1 awaiting, 1 no questions");
 
@@ -696,25 +680,18 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: invalid session");
 
-        try {
-            fsLogic.getFeedbackSessionQuestionsForStudent(
-                    "invalid session", "idOfTypicalCourse1", "student3InCourse1@gmail.tmt");
-            signalFailureToDetectException("Did not detect that session does not exist.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Trying to get a non-existent feedback session: "
-                         + "idOfTypicalCourse1" + "/" + "invalid session",
-                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionQuestionsForStudent(
+                        "invalid session", "idOfTypicalCourse1", "student3InCourse1@gmail.tmt"));
+        assertEquals("Trying to get a non-existent feedback session: idOfTypicalCourse1/invalid session",
+                ednee.getMessage());
 
         ______TS("failure: non-existent student");
 
-        try {
-            fsLogic.getFeedbackSessionQuestionsForStudent(
-                    "Second feedback session", "idOfTypicalCourse1", "randomUserId");
-            signalFailureToDetectException("Did not detect that student does not exist.");
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Error getting feedback session(s): Student does not exist.", edne.getMessage());
-        }
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionQuestionsForStudent(
+                        "Second feedback session", "idOfTypicalCourse1", "randomUserId"));
+        assertEquals("Error getting feedback session(s): Student does not exist.", ednee.getMessage());
 
     }
 
@@ -761,15 +738,11 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: invalid session");
 
-        try {
-            fsLogic.getFeedbackSessionQuestionsForInstructor(
-                    "invalid session", "idOfTypicalCourse1", "instructor1@course1.tmt");
-            signalFailureToDetectException("Did not detect that session does not exist.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Trying to get a non-existent feedback session: "
-                         + "idOfTypicalCourse1" + "/" + "invalid session",
-                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionQuestionsForInstructor(
+                        "invalid session", "idOfTypicalCourse1", "instructor1@course1.tmt"));
+        assertEquals("Trying to get a non-existent feedback session: idOfTypicalCourse1/invalid session",
+                ednee.getMessage());
     }
 
     private void testGetFeedbackSessionResultsForUser() throws Exception {
@@ -1069,14 +1042,11 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: no session");
 
-        try {
-            fsLogic.getFeedbackSessionResultsForInstructor("invalid session", session.getCourseId(), instructor.email);
-            signalFailureToDetectException("Did not detect that session does not exist.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Trying to view a non-existent feedback session: "
-                         + session.getCourseId() + "/" + "invalid session",
-                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionResultsForInstructor(
+                        "invalid session", session.getCourseId(), instructor.email));
+        assertEquals("Trying to view a non-existent feedback session: " + session.getCourseId() + "/invalid session",
+                ednee.getMessage());
         //TODO: check for cases where a person is both a student and an instructor
     }
 
@@ -1876,15 +1846,12 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("Non-existent Course/Session");
 
-        try {
-            fsLogic.getFeedbackSessionResultsSummaryAsCsv("non.existent", "no course",
-                    instructor.email, null, true, true);
-            signalFailureToDetectException("Failed to detect non-existent feedback session.");
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Trying to view a non-existent feedback session: "
-                         + "no course" + "/" + "non.existent",
-                         e.getMessage());
-        }
+        InstructorAttributes finalInstructor = instructor;
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.getFeedbackSessionResultsSummaryAsCsv(
+                        "non.existent", "no course", finalInstructor.email, null, true, true));
+        assertEquals("Trying to view a non-existent feedback session: no course/non.existent",
+                ednee.getMessage());
     }
 
     private String getStudentAnonEmail(DataBundle dataBundle, String studentKey) {
@@ -1917,26 +1884,21 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     private void testUpdateFeedbackSession() throws Exception {
 
         ______TS("failure 1: null object");
-        try {
-            fsLogic.updateFeedbackSession(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            AssertHelper.assertContains(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fsLogic.updateFeedbackSession(null));
+        AssertHelper.assertContains(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
 
         ______TS("failure 2: non-existent session name");
         FeedbackSessionAttributes fsa = FeedbackSessionAttributes
                 .builder("asdf_randomName1423", "idOfTypicalCourse1", "")
                 .build();
 
-        try {
-            fsLogic.updateFeedbackSession(fsa);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Trying to update a non-existent feedback session: "
-                         + fsa.getCourseId() + "/" + fsa.getFeedbackSessionName(),
-                         edne.getMessage());
-        }
+        FeedbackSessionAttributes finalFsa = fsa;
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.updateFeedbackSession(finalFsa));
+        assertEquals(
+                "Trying to update a non-existent feedback session: "
+                        + fsa.getCourseId() + "/" + fsa.getFeedbackSessionName(),
+                ednee.getMessage());
 
         ______TS("success 1: all changeable values sent are null");
         fsa = dataBundle.feedbackSessions.get("session1InCourse1");
@@ -1972,13 +1934,9 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: already published");
 
-        try {
-            fsLogic.publishFeedbackSession(sessionUnderTest);
-            signalFailureToDetectException(
-                    "Did not catch exception signalling that session is already published.");
-        } catch (InvalidParametersException e) {
-            assertEquals("Error publishing feedback session: Session has already been published.", e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> fsLogic.publishFeedbackSession(sessionUnderTest));
+        assertEquals("Error publishing feedback session: Session has already been published.", ipe.getMessage());
 
         ______TS("success: unpublish");
 
@@ -1993,13 +1951,8 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: not published");
 
-        try {
-            fsLogic.unpublishFeedbackSession(sessionUnderTest);
-            signalFailureToDetectException(
-                    "Did not catch exception signalling that session is not published.");
-        } catch (InvalidParametersException e) {
-            assertEquals("Error unpublishing feedback session: Session has already been unpublished.", e.getMessage());
-        }
+        ipe = assertThrows(InvalidParametersException.class, () -> fsLogic.unpublishFeedbackSession(sessionUnderTest));
+        assertEquals("Error unpublishing feedback session: Session has already been unpublished.", ipe.getMessage());
 
     }
 
@@ -2031,14 +1984,11 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
 
         ______TS("failure: non-existent feedback session for student");
 
-        try {
-            fsLogic.isFeedbackSessionFullyCompletedByStudent("nonExistentFSName", fs.getCourseId(), "random.student@email");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Trying to check a non-existent feedback session: "
-                         + fs.getCourseId() + "/" + "nonExistentFSName",
-                         edne.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsLogic.isFeedbackSessionFullyCompletedByStudent(
+                        "nonExistentFSName", fs.getCourseId(), "random.student@email"));
+        assertEquals("Trying to check a non-existent feedback session: " + fs.getCourseId() + "/nonExistentFSName",
+                ednee.getMessage());
 
         ______TS("success case: fully done by student 1");
         assertTrue(fsLogic.isFeedbackSessionFullyCompletedByStudent(fs.getFeedbackSessionName(), fs.getCourseId(),

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -78,12 +78,9 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: instructor already exists");
 
-        try {
-            instructorsLogic.createInstructor(instr);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains("Trying to create a Instructor that exists", e.getMessage());
-        }
+        EntityAlreadyExistsException ednee = assertThrows(EntityAlreadyExistsException.class,
+                () -> instructorsLogic.createInstructor(instr));
+        AssertHelper.assertContains("Trying to create a Instructor that exists", ednee.getMessage());
 
         instructorsLogic.deleteInstructorCascade(instr.courseId, instr.email);
 
@@ -96,21 +93,14 @@ public class InstructorsLogicTest extends BaseLogicTest {
                 + "some text followed by one '@' sign followed by some more text. "
                 + "It cannot be longer than 254 characters, cannot be empty and "
                 + "cannot contain spaces.";
-        try {
-            instructorsLogic.createInstructor(instr);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(expectedError, e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> instructorsLogic.createInstructor(instr));
+        assertEquals(expectedError, ipe.getMessage());
 
         ______TS("failure: null parameters");
 
-        try {
-            instructorsLogic.createInstructor(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.createInstructor(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testGetInstructorForEmail() {
@@ -133,19 +123,11 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameters");
 
-        try {
-            instructorsLogic.getInstructorForEmail(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.getInstructorForEmail(null, email));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.getInstructorForEmail(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.getInstructorForEmail(courseId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -169,19 +151,12 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameters");
 
-        try {
-            instructorsLogic.getInstructorForGoogleId(null, googleId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.getInstructorForGoogleId(null, googleId));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.getInstructorForGoogleId(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.getInstructorForGoogleId(courseId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -206,12 +181,9 @@ public class InstructorsLogicTest extends BaseLogicTest {
         assertEquals(instr.email, retrieved.email);
 
         ______TS("failure: null parameter");
-        try {
-            instructorsLogic.getInstructorForRegistrationKey(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.getInstructorForRegistrationKey(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testGetInstructorsForCourse() throws Exception {
@@ -246,12 +218,8 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameters");
 
-        try {
-            instructorsLogic.getInstructorsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.getInstructorsForCourse(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testGetInstructorsForGoogleId() {
@@ -278,12 +246,8 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.getInstructorsForGoogleId(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.getInstructorsForGoogleId(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testGetKeyForInstructor() throws Exception {
@@ -301,29 +265,19 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: non-existent instructor");
 
-        try {
-            instructorsLogic.getEncryptedKeyForInstructor(courseId, "non-existent@email.tmt");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Instructor " + "non-existent@email.tmt"
-                    + " does not belong to course " + courseId, e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.getEncryptedKeyForInstructor(courseId, "non-existent@email.tmt"));
+        assertEquals("Instructor non-existent@email.tmt does not belong to course " + courseId,
+                ednee.getMessage());
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.getEncryptedKeyForInstructor(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.getEncryptedKeyForInstructor(courseId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.getEncryptedKeyForInstructor(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.getEncryptedKeyForInstructor(null, email));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -332,15 +286,14 @@ public class InstructorsLogicTest extends BaseLogicTest {
         ______TS("success: is an instructor of a given course");
 
         String instructorId = "idOfInstructor1OfCourse1";
-        String courseId = "idOfTypicalCourse1";
 
-        boolean result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, courseId);
+        boolean result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, "idOfTypicalCourse1");
 
         assertTrue(result);
 
         ______TS("failure: not an instructor of a given course");
 
-        courseId = "idOfTypicalCourse2";
+        String courseId = "idOfTypicalCourse2";
 
         result = instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, courseId);
 
@@ -348,19 +301,12 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.isGoogleIdOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.isGoogleIdOfInstructorOfCourse(null, courseId));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.isGoogleIdOfInstructorOfCourse(instructorId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testIsEmailOfInstructorOfCourse() {
@@ -368,15 +314,14 @@ public class InstructorsLogicTest extends BaseLogicTest {
         ______TS("success: is an instructor of a given course");
 
         String instructorEmail = "instructor1@course1.tmt";
-        String courseId = "idOfTypicalCourse1";
 
-        boolean result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, courseId);
+        boolean result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, "idOfTypicalCourse1");
 
         assertTrue(result);
 
         ______TS("failure: not an instructor of a given course");
 
-        courseId = "idOfTypicalCourse2";
+        String courseId = "idOfTypicalCourse2";
 
         result = instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, courseId);
 
@@ -384,19 +329,12 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.isEmailOfInstructorOfCourse(instructorEmail, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.isEmailOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.isEmailOfInstructorOfCourse(null, courseId));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -404,63 +342,43 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("success: instructor does exist");
 
-        String instructorId = "idOfInstructor1OfCourse1";
-        instructorsLogic.verifyInstructorExists(instructorId);
+        instructorsLogic.verifyInstructorExists("idOfInstructor1OfCourse1");
 
         ______TS("failure: instructor doesn't exist");
 
-        instructorId = "nonExistingInstructor";
-
-        try {
-            instructorsLogic.verifyInstructorExists(instructorId);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains("Instructor does not exist", e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.verifyInstructorExists("nonExistingInstructor"));
+        AssertHelper.assertContains("Instructor does not exist", ednee.getMessage());
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.verifyInstructorExists(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.verifyInstructorExists(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testVerifyIsEmailOfInstructorOfCourse() throws Exception {
 
         ______TS("success: instructor belongs to course");
 
-        String instructorEmail = "instructor1@course1.tmt";
         String courseId = "idOfTypicalCourse1";
-        instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, courseId);
+        instructorsLogic.verifyIsEmailOfInstructorOfCourse("instructor1@course1.tmt", courseId);
 
         ______TS("failure: instructor doesn't belong to course");
-        instructorEmail = "nonExistingInstructor@email.tmt";
+        String instructorEmail = "nonExistingInstructor@email.tmt";
 
-        try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, courseId);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Instructor " + instructorEmail
-                    + " does not belong to course " + courseId, e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, courseId));
+        assertEquals("Instructor " + instructorEmail + " does not belong to course " + courseId,
+                ednee.getMessage());
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.verifyIsEmailOfInstructorOfCourse(null, courseId));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.verifyIsEmailOfInstructorOfCourse(instructorEmail, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
     }
 
     private void testIsNewInstructor() {
@@ -487,12 +405,8 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.isNewInstructor(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.isNewInstructor(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -516,33 +430,24 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         instructorsLogic.deleteInstructorCascade(courseId, instructorUpdated.email);
 
-        try {
-            instructorsLogic.updateInstructorByGoogleId(googleId, instructorUpdated);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Instructor " + googleId + " does not belong to course " + courseId, e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.updateInstructorByGoogleId(googleId, instructorUpdated));
+        assertEquals("Instructor " + googleId + " does not belong to course " + courseId, ednee.getMessage());
 
         ______TS("failure: course doesn't exist");
 
         courseId = "random-course";
         instructorToBeUpdated.courseId = courseId;
 
-        try {
-            instructorsLogic.updateInstructorByGoogleId(googleId, instructorToBeUpdated);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Course does not exist: " + courseId, e.getMessage());
-        }
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.updateInstructorByGoogleId(googleId, instructorToBeUpdated));
+        assertEquals("Course does not exist: " + courseId, ednee.getMessage());
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.updateInstructorByGoogleId(googleId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.updateInstructorByGoogleId(googleId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -569,33 +474,24 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         instructorsLogic.deleteInstructorCascade(courseId, instructorToBeUpdated.email);
 
-        try {
-            instructorsLogic.updateInstructorByEmail(email, instructorToBeUpdated);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Instructor " + email + " does not belong to course " + courseId, e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.updateInstructorByEmail(email, instructorToBeUpdated));
+        assertEquals("Instructor " + email + " does not belong to course " + courseId, ednee.getMessage());
 
         ______TS("failure: course doesn't exist");
 
         courseId = "random-course";
         instructorToBeUpdated.courseId = courseId;
 
-        try {
-            instructorsLogic.updateInstructorByEmail(email, instructorToBeUpdated);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals("Course does not exist: " + courseId, e.getMessage());
-        }
+        ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsLogic.updateInstructorByEmail(email, instructorToBeUpdated));
+        assertEquals("Course does not exist: " + courseId, ednee.getMessage());
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.updateInstructorByEmail(email, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.updateInstructorByEmail(email, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 
@@ -618,19 +514,12 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.deleteInstructorCascade(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.deleteInstructorCascade(courseId, null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
-        try {
-            instructorsLogic.deleteInstructorCascade(null, email);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructorCascade(null, email));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
         // restore deleted instructor
         instructorsLogic.createInstructor(instructorDeleted);
@@ -654,12 +543,9 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure: null parameter");
 
-        try {
-            instructorsLogic.deleteInstructorsForGoogleIdAndCascade(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsLogic.deleteInstructorsForGoogleIdAndCascade(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
         // restore deleted instructors
         for (InstructorAttributes instructor : instructors) {
@@ -685,12 +571,8 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         ______TS("failure case: null parameter");
 
-        try {
-            instructorsLogic.deleteInstructorsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructorsForCourse(null));
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
     }
 

--- a/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
@@ -48,12 +48,8 @@ public class AccountsDbTest extends BaseComponentTestCase {
         assertNull(retrieved);
 
         ______TS("failure: null parameter");
-        try {
-            accountsDb.getAccount(null);
-            signalFailureToDetectException(" - AssertionError");
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> accountsDb.getAccount(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     @Test
@@ -157,25 +153,18 @@ public class AccountsDbTest extends BaseComponentTestCase {
         // Should we not allow empty fields?
         ______TS("failure case: invalid parameter");
         a.email = "invalid email";
-        try {
-            accountsDb.createAccount(a);
-            signalFailureToDetectException(" - InvalidParametersException");
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> accountsDb.createAccount(a));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.EMAIL_ERROR_MESSAGE, "invalid email",
                         FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.EMAIL_MAX_LENGTH),
-                    e.getMessage());
-        }
+                ipe.getMessage());
 
         ______TS("failure: null parameter");
-        try {
-            accountsDb.createAccount(null);
-            signalFailureToDetectException(" - AssertionError");
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> accountsDb.createAccount(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     @Test
@@ -231,13 +220,11 @@ public class AccountsDbTest extends BaseComponentTestCase {
 
         ______TS("non-existent account");
 
-        try {
-            a.googleId = "non.existent";
-            accountsDb.updateAccount(a);
-            signalFailureToDetectException(" - EntityDoesNotExistException");
-        } catch (EntityDoesNotExistException edne) {
-            AssertHelper.assertContains(AccountsDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT, edne.getMessage());
-        }
+        a.googleId = "non.existent";
+        AccountAttributes[] finalAccount = new AccountAttributes[] { a };
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> accountsDb.updateAccount(finalAccount[0]));
+        AssertHelper.assertContains(AccountsDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT, ednee.getMessage());
 
         ______TS("failure: invalid parameters");
 
@@ -247,22 +234,16 @@ public class AccountsDbTest extends BaseComponentTestCase {
         a.institute = StringHelperExtension.generateStringOfLength(65);
         a.studentProfile.shortName = "??";
 
-        try {
-            accountsDb.updateAccount(a);
-            signalFailureToDetectException(" - InvalidParametersException");
-        } catch (InvalidParametersException ipe) {
-            assertEquals(StringHelper.toString(a.getInvalidityInfo()), ipe.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> accountsDb.updateAccount(finalAccount[0]));
+        assertEquals(StringHelper.toString(a.getInvalidityInfo()), ipe.getMessage());
 
         // Only check first 2 parameters (course & email) which are used to identify the student entry.
         // The rest are actually allowed to be null.
         ______TS("failure: null parameter");
-        try {
-            accountsDb.updateAccount(null);
-            signalFailureToDetectException(" - AssertionError");
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> accountsDb.updateAccount(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     @Test
@@ -290,12 +271,9 @@ public class AccountsDbTest extends BaseComponentTestCase {
 
         ______TS("failure null paramter");
 
-        try {
-            accountsDb.deleteAccount(null);
-            signalFailureToDetectException(" - AssertionError");
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> accountsDb.deleteAccount(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private AccountAttributes createNewAccount() throws Exception {

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -44,48 +44,35 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: create duplicate course");
 
-        try {
-            coursesDb.createEntity(c);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(EntitiesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, "Course"),
-                                        e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> coursesDb.createEntity(c));
+        AssertHelper.assertContains(
+                String.format(EntitiesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, "Course"),
+                eaee.getMessage());
 
         ______TS("Failure: create a course with invalid parameter");
 
         CourseAttributes invalidIdCourse = CourseAttributes
                 .builder("Invalid id", "Basic Computing", ZoneId.of("UTC"))
                 .build();
-        try {
-            coursesDb.createEntity(invalidIdCourse);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    "not acceptable to TEAMMATES as a/an course ID because it is not in the correct format",
-                    e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesDb.createEntity(invalidIdCourse));
+        AssertHelper.assertContains(
+                "not acceptable to TEAMMATES as a/an course ID because it is not in the correct format",
+                ipe.getMessage());
 
         String longCourseName = StringHelperExtension.generateStringOfLength(FieldValidator.COURSE_NAME_MAX_LENGTH + 1);
         CourseAttributes invalidNameCourse = CourseAttributes
                 .builder("CDbT.tCC.newCourse", longCourseName, ZoneId.of("UTC"))
                 .build();
-        try {
-            coursesDb.createEntity(invalidNameCourse);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is too long",
-                                        e.getMessage());
-        }
+        ipe = assertThrows(InvalidParametersException.class, () -> coursesDb.createEntity(invalidNameCourse));
+        AssertHelper.assertContains("not acceptable to TEAMMATES as a/an course name because it is too long",
+                ipe.getMessage());
 
         ______TS("Failure: null parameter");
 
-        try {
-            coursesDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.createEntity(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
     }
 
@@ -105,12 +92,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: get null parameters");
 
-        try {
-            coursesDb.getCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.getCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -133,12 +117,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: get null parameters");
 
-        try {
-            coursesDb.getCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.getCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -146,12 +127,8 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null paramater");
 
-        try {
-            coursesDb.updateCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.updateCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("Failure: update course with invalid parameters");
 
@@ -159,15 +136,10 @@ public class CoursesDbTest extends BaseComponentTestCase {
                 .builder("", "", ZoneId.of("UTC"))
                 .build();
 
-        try {
-            coursesDb.updateCourse(invalidCourse);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("The field 'course ID' is empty",
-                                        e.getMessage());
-            AssertHelper.assertContains("The field 'course name' is empty",
-                                        e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesDb.updateCourse(invalidCourse));
+        AssertHelper.assertContains("The field 'course ID' is empty", ipe.getMessage());
+        AssertHelper.assertContains("The field 'course name' is empty", ipe.getMessage());
 
         ______TS("fail: non-exisitng course");
 
@@ -175,12 +147,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
                 .builder("CDbT.non-exist-course", "Non existing course", ZoneId.of("UTC"))
                 .build();
 
-        try {
-            coursesDb.updateCourse(nonExistentCourse);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals(CoursesDb.ERROR_UPDATE_NON_EXISTENT_COURSE, e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> coursesDb.updateCourse(nonExistentCourse));
+        assertEquals(CoursesDb.ERROR_UPDATE_NON_EXISTENT_COURSE, ednee.getMessage());
 
         ______TS("success: typical case");
 
@@ -215,12 +184,9 @@ public class CoursesDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameter");
 
-        try {
-            coursesDb.deleteCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.deleteCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     private CourseAttributes createNewCourse() throws InvalidParametersException {
@@ -233,7 +199,7 @@ public class CoursesDbTest extends BaseComponentTestCase {
             coursesDb.createEntity(c);
         } catch (EntityAlreadyExistsException e) {
             //It is ok if it already exists.
-            ignoreExpectedException();
+            ignorePossibleException();
         }
 
         return c;

--- a/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
@@ -41,40 +41,30 @@ public class EntitiesDbTest extends BaseComponentTestCase {
         verifyPresentInDatastore(c);
 
         ______TS("fails: entity already exists");
-        try {
-            coursesDb.createEntity(c);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(CoursesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                                                      c.getEntityTypeAsString())
-                                                + c.getIdentificationString(),
-                                        e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> coursesDb.createEntity(c));
+        AssertHelper.assertContains(String.format(CoursesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
+                c.getEntityTypeAsString())
+                        + c.getIdentificationString(),
+                eaee.getMessage());
         coursesDb.deleteEntity(c);
 
         ______TS("fails: invalid parameters");
         CourseAttributes invalidCourse = CourseAttributes
                 .builder("invalid id spaces", "Basic Computing", ZoneId.of("UTC"))
                 .build();
-        try {
-            coursesDb.createEntity(invalidCourse);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> coursesDb.createEntity(invalidCourse));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         COURSE_ID_ERROR_MESSAGE, invalidCourse.getId(),
                         FieldValidator.COURSE_ID_FIELD_NAME, REASON_INCORRECT_FORMAT,
                         FieldValidator.COURSE_ID_MAX_LENGTH),
-                    e.getMessage());
-        }
+                ipe.getMessage());
 
         ______TS("fails: null parameter");
-        try {
-            coursesDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> coursesDb.createEntity(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
 }

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -88,14 +88,11 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("duplicate - with same id.");
 
-        try {
-            fqDb.createEntity(fqa);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(FeedbackQuestionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                                                      fqa.getEntityTypeAsString()) + fqa.getIdentificationString(),
-                                                      e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class, () -> fqDb.createEntity(fqa));
+        AssertHelper.assertContains(
+                String.format(FeedbackQuestionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
+                        fqa.getEntityTypeAsString()) + fqa.getIdentificationString(),
+                eaee.getMessage());
 
         ______TS("delete - with id specified");
 
@@ -104,22 +101,14 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fqDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fqDb.createEntity(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("invalid params");
 
-        try {
-            fqa.creatorEmail = "haha";
-            fqDb.createEntity(fqa);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("Invalid creator's email", e.getLocalizedMessage());
-        }
+        fqa.creatorEmail = "invalidemail";
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class, () -> fqDb.createEntity(fqa));
+        AssertHelper.assertContains("Invalid creator's email", ipe.getLocalizedMessage());
     }
 
     @Test
@@ -145,21 +134,14 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("null fsName");
 
-        try {
-            fqDb.getFeedbackQuestion(null, expected.courseId, 1);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestion(null, expected.courseId, 1));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("null courseId");
 
-        try {
-            fqDb.getFeedbackQuestion(expected.feedbackSessionName, null, 1);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> fqDb.getFeedbackQuestion(expected.feedbackSessionName, null, 1));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("get by id");
 
@@ -193,19 +175,13 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fqDb.getFeedbackQuestionsForSession(null, expected.get(0).courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestionsForSession(null, expected.get(0).courseId));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            fqDb.getFeedbackQuestionsForSession(expected.get(0).feedbackSessionName, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestionsForSession(expected.get(0).feedbackSessionName, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent session");
 
@@ -248,26 +224,18 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fqDb.getFeedbackQuestionsForGiverType(null, fqa.courseId, FeedbackParticipantType.STUDENTS);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestionsForGiverType(null, fqa.courseId, FeedbackParticipantType.STUDENTS));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, null, FeedbackParticipantType.STUDENTS);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestionsForGiverType(
+                        fqa.feedbackSessionName, null, FeedbackParticipantType.STUDENTS));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> fqDb.getFeedbackQuestionsForGiverType(fqa.feedbackSessionName, fqa.courseId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existant session");
 
@@ -287,12 +255,8 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fqDb.updateFeedbackQuestion(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fqDb.updateFeedbackQuestion(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("invalid feedback question attributes");
 
@@ -303,24 +267,18 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
                                                   invalidFqa.questionNumber).getId());
         invalidFqa.creatorEmail = "haha";
 
-        try {
-            fqDb.updateFeedbackQuestion(invalidFqa);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains("Invalid creator's email", e.getLocalizedMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> fqDb.updateFeedbackQuestion(invalidFqa));
+        AssertHelper.assertContains("Invalid creator's email", ipe.getLocalizedMessage());
 
         ______TS("feedback session does not exist");
 
         FeedbackQuestionAttributes nonexistantFq = getNewFeedbackQuestionAttributes();
         nonexistantFq.setId("non-existent fq id");
 
-        try {
-            fqDb.updateFeedbackQuestion(nonexistantFq);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(FeedbackQuestionsDb.ERROR_UPDATE_NON_EXISTENT, e.getLocalizedMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fqDb.updateFeedbackQuestion(nonexistantFq));
+        AssertHelper.assertContains(FeedbackQuestionsDb.ERROR_UPDATE_NON_EXISTENT, ednee.getLocalizedMessage());
 
         ______TS("standard success case");
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
@@ -91,12 +91,8 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.getFeedbackResponseComment(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> frcDb.getFeedbackResponseComment(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("typical success case");
 
@@ -117,26 +113,17 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.getFeedbackResponseComment(null, "", Instant.now());
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseComment(null, "", Instant.now()));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.getFeedbackResponseComment("", null, Instant.now());
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseComment("", null, Instant.now()));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.getFeedbackResponseComment("", "", null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseComment("", "", null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("typical success case");
 
@@ -166,19 +153,13 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.getFeedbackResponseCommentForGiver(null, frcaData.commentGiver);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseCommentForGiver(null, frcaData.commentGiver));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.getFeedbackResponseCommentForGiver(frcaData.courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseCommentForGiver(frcaData.courseId, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("typical success case");
 
@@ -212,12 +193,8 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.updateFeedbackResponseComment(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> frcDb.updateFeedbackResponseComment(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("typical success case");
 
@@ -249,12 +226,9 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         frcaExpected.setId(-1L);
 
-        try {
-            frcDb.updateFeedbackResponseComment(frcaExpected);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals(EntitiesDb.ERROR_UPDATE_NON_EXISTENT + frcaExpected.toString(), edne.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frcDb.updateFeedbackResponseComment(frcaExpected));
+        assertEquals(EntitiesDb.ERROR_UPDATE_NON_EXISTENT + frcaExpected.toString(), ednee.getMessage());
 
         // set responseId back
         frcaExpected.feedbackResponseId = frId;
@@ -266,31 +240,22 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
         frcaExpected.commentGiver = "test-no-at-funny.com";
         frcaExpected.commentGiverType = FeedbackParticipantType.NONE;
 
-        try {
-            frcDb.updateFeedbackResponseComment(frcaExpected);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException ipe) {
-            assertEquals(StringHelper.toString(frcaExpected.getInvalidityInfo()), ipe.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> frcDb.updateFeedbackResponseComment(frcaExpected));
+        assertEquals(StringHelper.toString(frcaExpected.getInvalidityInfo()), ipe.getMessage());
     }
 
     private void testGetFeedbackResponseCommentsForSession() {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.getFeedbackResponseCommentsForSession(null, "");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseCommentsForSession(null, ""));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.getFeedbackResponseCommentsForSession("", null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.getFeedbackResponseCommentsForSession("", null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("typical success case");
 
@@ -337,26 +302,17 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.updateGiverEmailOfFeedbackResponseComments(null, giverEmail, updatedEmail);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frcDb.updateGiverEmailOfFeedbackResponseComments(null, giverEmail, updatedEmail));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.updateGiverEmailOfFeedbackResponseComments(courseId, null, updatedEmail);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.updateGiverEmailOfFeedbackResponseComments(courseId, null, updatedEmail));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            frcDb.updateGiverEmailOfFeedbackResponseComments(courseId, giverEmail, null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frcDb.updateGiverEmailOfFeedbackResponseComments(courseId, giverEmail, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testDeleteFeedbackResponseCommentsForResponse()
@@ -381,12 +337,8 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("null parameter");
 
-        try {
-            frcDb.deleteFeedbackResponseCommentsForResponse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> frcDb.deleteFeedbackResponseCommentsForResponse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void verifyListsContainSameResponseCommentAttributes(

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -129,15 +129,11 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("duplicate - with same id.");
 
-        try {
-            frDb.createEntity(fra);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(FeedbackResponsesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                                                      fra.getEntityTypeAsString())
-                                            + fra.getIdentificationString(),
-                                        e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class, () -> frDb.createEntity(fra));
+        AssertHelper.assertContains(
+                String.format(FeedbackResponsesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
+                        fra.getEntityTypeAsString()) + fra.getIdentificationString(),
+                eaee.getMessage());
 
         ______TS("delete - with id specified");
 
@@ -146,27 +142,19 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> frDb.createEntity(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("invalid params");
 
-        try {
-            fra.courseId = "invalid course id!";
-            frDb.createEntity(fra);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        fra.courseId = "invalid course id!";
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class, () -> frDb.createEntity(fra));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.COURSE_ID_ERROR_MESSAGE, "invalid course id!",
                         FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.COURSE_ID_MAX_LENGTH),
-                    e.getLocalizedMessage());
-        }
+                ipe.getLocalizedMessage());
 
     }
 
@@ -189,30 +177,21 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null fqId");
 
-        try {
-            frDb.getFeedbackResponse(null, "student1InCourse1@gmail.tmt", "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponse(null, "student1InCourse1@gmail.tmt", "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("null giverEmail");
 
-        try {
-            frDb.getFeedbackResponse(expected.feedbackQuestionId, null, "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponse(expected.feedbackQuestionId, null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("null receiverEmail");
 
-        try {
-            frDb.getFeedbackResponse(expected.feedbackQuestionId, "student1InCourse1@gmail.tmt", null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponse(expected.feedbackQuestionId, "student1InCourse1@gmail.tmt", null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("get by id");
 
@@ -238,12 +217,9 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForQuestion(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForQuestion(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -269,19 +245,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForQuestionInSection(null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForQuestionInSection(null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForQuestionInSection(questionId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForQuestionInSection(questionId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -302,19 +272,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForSession(null, courseId);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSession(null, courseId));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForSession(feedbackSessionName, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSession(feedbackSessionName, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback session");
 
@@ -341,19 +305,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForQuestion(null, "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestion(null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForQuestion(questionId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestion(questionId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -389,28 +347,19 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForQuestionInSection(
-                                                null, "student1InCourse1@gmail.tmt", "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestionInSection(
+                        null, "student1InCourse1@gmail.tmt", "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForQuestionInSection(questionId, null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestionInSection(questionId, null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForQuestionInSection(
-                                                questionId, "student1InCourse1@gmail.tmt", null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForQuestionInSection(
+                        questionId, "student1InCourse1@gmail.tmt", null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -438,19 +387,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForCourse(null, "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForCourse(null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForReceiverForCourse(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForReceiverForCourse(courseId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent courseId");
 
@@ -478,19 +421,12 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForQuestion(null, "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesFromGiverForQuestion(null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForQuestion(questionId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> frDb.getFeedbackResponsesFromGiverForQuestion(questionId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -526,28 +462,19 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForQuestionInSection(
-                                            null, "student1InCourse1@gmail.tmt", "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesFromGiverForQuestionInSection(
+                        null, "student1InCourse1@gmail.tmt", "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForQuestionInSection(questionId, null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesFromGiverForQuestionInSection(questionId, null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForQuestionInSection(
-                                            questionId, "student1InCourse1@gmail.tmt", null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesFromGiverForQuestionInSection(
+                        questionId, "student1InCourse1@gmail.tmt", null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -575,19 +502,12 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForCourse(null, "student1InCourse1@gmail.tmt");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesFromGiverForCourse(null, "student1InCourse1@gmail.tmt"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesFromGiverForCourse(courseId, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class, () -> frDb.getFeedbackResponsesFromGiverForCourse(courseId, null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback question");
 
@@ -615,19 +535,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForSessionWithinRange(null, courseId, 5);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionWithinRange(null, courseId, 5));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForSessionWithinRange(feedbackSessionName, null, 4);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionWithinRange(feedbackSessionName, null, 4));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback session");
 
@@ -655,19 +569,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForSessionInSection(null, courseId, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionInSection(null, courseId, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForSessionInSection(feedbackSessionName, null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionInSection(feedbackSessionName, null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback session");
 
@@ -695,19 +603,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForSessionFromSection(null, courseId, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionFromSection(null, courseId, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForSessionFromSection(feedbackSessionName, null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionFromSection(feedbackSessionName, null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback session");
 
@@ -740,19 +642,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.getFeedbackResponsesForSessionToSection(null, courseId, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionToSection(null, courseId, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
-        try {
-            frDb.getFeedbackResponsesForSessionToSection(feedbackSessionName, null, "Section 1");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> frDb.getFeedbackResponsesForSessionToSection(feedbackSessionName, null, "Section 1"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existent feedback session");
 
@@ -775,12 +671,8 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            frDb.updateFeedbackResponse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> frDb.updateFeedbackResponse(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("invalid feedback response attributes");
 
@@ -788,28 +680,22 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         invalidFra.setId(frDb.getFeedbackResponse(invalidFra.feedbackQuestionId,
                 invalidFra.giver, invalidFra.recipient).getId());
         invalidFra.courseId = "invalid course_";
-        try {
-            frDb.updateFeedbackResponse(invalidFra);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> frDb.updateFeedbackResponse(invalidFra));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.COURSE_ID_ERROR_MESSAGE, "invalid course_",
                         FieldValidator.COURSE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.COURSE_ID_MAX_LENGTH),
-                    e.getLocalizedMessage());
-        }
+                ipe.getLocalizedMessage());
 
         ______TS("feedback response does not exist");
 
         FeedbackResponseAttributes nonexistantFr = getResponseAttributes("response3ForQ2S1C1");
         nonexistantFr.setId("non-existent fr id");
-        try {
-            frDb.updateFeedbackResponse(nonexistantFr);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(FeedbackResponsesDb.ERROR_UPDATE_NON_EXISTENT, e.getLocalizedMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> frDb.updateFeedbackResponse(nonexistantFr));
+        AssertHelper.assertContains(FeedbackResponsesDb.ERROR_UPDATE_NON_EXISTENT, ednee.getLocalizedMessage());
 
         ______TS("standard success case");
 
@@ -817,14 +703,13 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         modifiedResponse = frDb.getFeedbackResponse(modifiedResponse.feedbackQuestionId,
                 modifiedResponse.giver, modifiedResponse.recipient);
-        FeedbackResponseDetails frd = modifiedResponse.getResponseDetails();
 
         Map<String, String[]> requestParameters = new HashMap<>();
         requestParameters.put("questiontype-1", new String[] { "TEXT" });
         requestParameters.put("responsetext-1-0", new String[] { "New answer text!" });
 
         String[] answer = {"New answer text!"};
-        frd = FeedbackResponseDetails.createResponseDetails(
+        FeedbackResponseDetails frd = FeedbackResponseDetails.createResponseDetails(
                     answer, FeedbackQuestionType.TEXT,
                     null, requestParameters, 1, 0);
         modifiedResponse.setResponseDetails(frd);

--- a/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
@@ -73,38 +73,25 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
         verifyPresentInDatastore(fsa);
 
         ______TS("duplicate");
-        try {
-            fsDb.createEntity(fsa);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(FeedbackSessionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                                                      fsa.getEntityTypeAsString())
-                                            + fsa.getIdentificationString(),
-                                        e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class, () -> fsDb.createEntity(fsa));
+        AssertHelper.assertContains(
+                String.format(FeedbackSessionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, fsa.getEntityTypeAsString())
+                        + fsa.getIdentificationString(),
+                eaee.getMessage());
 
         fsDb.deleteEntity(fsa);
         verifyAbsentInDatastore(fsa);
 
         ______TS("null params");
 
-        try {
-            fsDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fsDb.createEntity(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("invalid params");
 
-        try {
-            fsa.setStartTime(Instant.now());
-            fsDb.createEntity(fsa);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            // start time is now after end time
-            AssertHelper.assertContains("start time", e.getLocalizedMessage());
-        }
+        fsa.setStartTime(Instant.now());
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class, () -> fsDb.createEntity(fsa));
+        AssertHelper.assertContains("start time", ipe.getLocalizedMessage());
 
     }
 
@@ -150,21 +137,15 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         ______TS("null fsName");
 
-        try {
-            fsDb.getFeedbackSession("idOfTypicalCourse1", null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> fsDb.getFeedbackSession("idOfTypicalCourse1", null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("null courseId");
 
-        try {
-            fsDb.getFeedbackSession(null, "First feedback session");
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> fsDb.getFeedbackSession(null, "First feedback session"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
     }
 
@@ -189,12 +170,8 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fsDb.getFeedbackSessionsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fsDb.getFeedbackSessionsForCourse(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existant course");
 
@@ -222,12 +199,8 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         ______TS("null params");
 
-        try {
-            fsDb.getSoftDeletedFeedbackSessionsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fsDb.getSoftDeletedFeedbackSessionsForCourse(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
 
         ______TS("non-existant course");
 
@@ -341,12 +314,9 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
     public void testUpdateFeedbackSession() throws Exception {
 
         ______TS("null params");
-        try {
-            fsDb.updateFeedbackSession(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getLocalizedMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> fsDb.updateFeedbackSession(null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getLocalizedMessage());
+
         ______TS("invalid feedback sesion attributes");
         FeedbackSessionAttributes invalidFs = getNewFeedbackSession();
         fsDb.deleteEntity(invalidFs);
@@ -354,25 +324,20 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
         Instant afterEndTime = invalidFs.getEndTime().plus(Duration.ofDays(30));
         invalidFs.setStartTime(afterEndTime);
         invalidFs.setResultsVisibleFromTime(afterEndTime);
-        try {
-            fsDb.updateFeedbackSession(invalidFs);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(
-                    String.format(TIME_FRAME_ERROR_MESSAGE, SESSION_END_TIME_FIELD_NAME,
-                                  SESSION_START_TIME_FIELD_NAME),
-                    e.getLocalizedMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> fsDb.updateFeedbackSession(invalidFs));
+        assertEquals(
+                String.format(TIME_FRAME_ERROR_MESSAGE, SESSION_END_TIME_FIELD_NAME, SESSION_START_TIME_FIELD_NAME),
+                ipe.getLocalizedMessage());
+
         ______TS("feedback session does not exist");
         FeedbackSessionAttributes nonexistantFs = getNewFeedbackSession();
         nonexistantFs.setFeedbackSessionName("non existant fs");
         nonexistantFs.setCourseId("non.existant.course");
-        try {
-            fsDb.updateFeedbackSession(nonexistantFs);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(FeedbackSessionsDb.ERROR_UPDATE_NON_EXISTENT, e.getLocalizedMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> fsDb.updateFeedbackSession(nonexistantFs));
+        AssertHelper.assertContains(FeedbackSessionsDb.ERROR_UPDATE_NON_EXISTENT, ednee.getLocalizedMessage());
+
         ______TS("standard success case");
         FeedbackSessionAttributes modifiedSession = getNewFeedbackSession();
         fsDb.deleteEntity(modifiedSession);

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -74,53 +74,40 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: create a duplicate instructor");
 
-        try {
-            instructorsDb.createEntity(i);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(String.format(InstructorsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, "Instructor"),
-                                        e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> instructorsDb.createEntity(i));
+        AssertHelper.assertContains(String.format(InstructorsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, "Instructor"),
+                eaee.getMessage());
 
         ______TS("Failure: create an instructor with invalid parameters");
 
         i.googleId = "invalid id with spaces";
-        try {
-            instructorsDb.createEntity(i);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> instructorsDb.createEntity(i));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.GOOGLE_ID_ERROR_MESSAGE, i.googleId,
                         FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.GOOGLE_ID_MAX_LENGTH),
-                    e.getMessage());
-        }
+                ipe.getMessage());
 
         i.googleId = "valid.fresh.id";
         i.email = "invalid.email.tmt";
         i.role = "role invalid";
-        try {
-            instructorsDb.createEntity(i);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        ipe = assertThrows(InvalidParametersException.class, () -> instructorsDb.createEntity(i));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.EMAIL_ERROR_MESSAGE, i.email,
                         FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.EMAIL_MAX_LENGTH) + System.lineSeparator()
-                    + String.format(FieldValidator.ROLE_ERROR_MESSAGE, i.role),
-                    e.getMessage());
-        }
+                        + String.format(FieldValidator.ROLE_ERROR_MESSAGE, i.role),
+                ipe.getMessage());
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.createEntity(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -140,12 +127,10 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.getInstructorForEmail(null, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.getInstructorForEmail(null, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -165,12 +150,9 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.getInstructorForGoogleId(null, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.getInstructorForGoogleId(null, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -195,12 +177,10 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.getInstructorForRegistrationKey(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.getInstructorForRegistrationKey(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -233,12 +213,10 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.getInstructorsForGoogleId(null, false);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.getInstructorsForGoogleId(null, false));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -270,12 +248,8 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.getInstructorsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.getInstructorsForCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     @Test
@@ -312,22 +286,19 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         instructorToEdit.name = "";
         instructorToEdit.email = "aaa";
         instructorToEdit.role = "invalid role";
-        try {
-            instructorsDb.updateInstructorByGoogleId(instructorToEdit);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedEmptyStringErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> instructorsDb.updateInstructorByGoogleId(instructorToEdit));
+        AssertHelper.assertContains(
+                getPopulatedEmptyStringErrorMessage(
                         FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
                         FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH)
-                    + System.lineSeparator()
-                    + getPopulatedErrorMessage(
-                          FieldValidator.EMAIL_ERROR_MESSAGE, instructorToEdit.email,
-                          FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
-                          FieldValidator.EMAIL_MAX_LENGTH) + System.lineSeparator()
-                    + String.format(FieldValidator.ROLE_ERROR_MESSAGE, instructorToEdit.role),
-                    e.getMessage());
-        }
+                        + System.lineSeparator()
+                        + getPopulatedErrorMessage(
+                        FieldValidator.EMAIL_ERROR_MESSAGE, instructorToEdit.email,
+                        FieldValidator.EMAIL_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
+                        FieldValidator.EMAIL_MAX_LENGTH) + System.lineSeparator()
+                        + String.format(FieldValidator.ROLE_ERROR_MESSAGE, instructorToEdit.role),
+                ipe.getMessage());
 
         ______TS("Failure: non-existent entity");
 
@@ -335,23 +306,15 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         instructorToEdit.name = "New Name 2";
         instructorToEdit.email = "InstrDbT.new-email2@email.tmt";
         instructorToEdit.role = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER;
-        try {
-            instructorsDb.updateInstructorByGoogleId(instructorToEdit);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(
-                        EntitiesDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT,
-                        e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsDb.updateInstructorByGoogleId(instructorToEdit));
+        AssertHelper.assertContains(EntitiesDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT, ednee.getMessage());
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.updateInstructorByGoogleId(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.updateInstructorByGoogleId(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     @Test
@@ -389,22 +352,19 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         instructorToEdit.googleId = "invalid id";
         instructorToEdit.name = "";
         instructorToEdit.role = "invalid role";
-        try {
-            instructorsDb.updateInstructorByEmail(instructorToEdit);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> instructorsDb.updateInstructorByEmail(instructorToEdit));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         FieldValidator.GOOGLE_ID_ERROR_MESSAGE, instructorToEdit.googleId,
                         FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.REASON_INCORRECT_FORMAT,
                         FieldValidator.GOOGLE_ID_MAX_LENGTH) + System.lineSeparator()
-                    + getPopulatedEmptyStringErrorMessage(
-                          FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
-                          FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH)
-                    + System.lineSeparator()
-                    + String.format(FieldValidator.ROLE_ERROR_MESSAGE, instructorToEdit.role),
-                    e.getMessage());
-        }
+                        + getPopulatedEmptyStringErrorMessage(
+                        FieldValidator.SIZE_CAPPED_NON_EMPTY_STRING_ERROR_MESSAGE_EMPTY_STRING,
+                        FieldValidator.PERSON_NAME_FIELD_NAME, FieldValidator.PERSON_NAME_MAX_LENGTH)
+                        + System.lineSeparator()
+                        + String.format(FieldValidator.ROLE_ERROR_MESSAGE, instructorToEdit.role),
+                ipe.getMessage());
 
         ______TS("Failure: non-existent entity");
 
@@ -412,23 +372,18 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         instructorToEdit.name = "New Name 2";
         instructorToEdit.email = "newEmail@email.tmt";
         instructorToEdit.role = Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER;
-        try {
-            instructorsDb.updateInstructorByEmail(instructorToEdit);
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            AssertHelper.assertContains(
-                        EntitiesDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT,
-                        e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> instructorsDb.updateInstructorByEmail(instructorToEdit));
+        AssertHelper.assertContains(
+                EntitiesDb.ERROR_UPDATE_NON_EXISTENT_ACCOUNT,
+                ednee.getMessage());
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.updateInstructorByEmail(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.updateInstructorByEmail(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -448,12 +403,9 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.deleteInstructor(null, null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.deleteInstructor(null, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -473,12 +425,10 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.deleteInstructorsForGoogleId(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> instructorsDb.deleteInstructorsForGoogleId(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @Test
@@ -498,12 +448,9 @@ public class InstructorsDbTest extends BaseComponentTestCase {
 
         ______TS("Failure: null parameters");
 
-        try {
-            instructorsDb.deleteInstructorsForCourse(null);
-            signalFailureToDetectException();
-        } catch (AssertionError e) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.deleteInstructorsForCourse(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
     }
 
     @AfterClass

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -55,42 +55,33 @@ public class ProfilesDbTest extends BaseComponentTestCase {
     private void testUpdateProfileWithNullParameter()
             throws InvalidParametersException, EntityDoesNotExistException {
         ______TS("null parameter");
-        try {
-            profilesDb.updateStudentProfile(null);
-            signalFailureToDetectException(" - Assertion Error");
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> profilesDb.updateStudentProfile(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testUpdateProfileWithInvalidParameters()
             throws Exception {
         ______TS("invalid paramters case");
-        try {
-            profilesDb.updateStudentProfile(StudentProfileAttributes.builder("").build());
-            signalFailureToDetectException(" - InvalidParametersException");
-        } catch (InvalidParametersException ipe) {
-            assertEquals(getPopulatedEmptyStringErrorMessage(
-                             FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING,
-                             FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.GOOGLE_ID_MAX_LENGTH),
-                         ipe.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> profilesDb.updateStudentProfile(StudentProfileAttributes.builder("").build()));
+        assertEquals(
+                getPopulatedEmptyStringErrorMessage(
+                        FieldValidator.GOOGLE_ID_ERROR_MESSAGE_EMPTY_STRING,
+                        FieldValidator.GOOGLE_ID_FIELD_NAME, FieldValidator.GOOGLE_ID_MAX_LENGTH),
+                ipe.getMessage());
     }
 
     private void testUpdatingNonExistentProfile(AccountAttributes a)
             throws Exception {
         ______TS("non-existent account");
 
-        try {
-            a.studentProfile.googleId = "non-ExIsTenT";
-            profilesDb.updateStudentProfile(a.studentProfile);
-            signalFailureToDetectException(" - EntityDoesNotExistException");
-        } catch (EntityDoesNotExistException edne) {
-            AssertHelper.assertContains(
-                    EntitiesDb.ERROR_UPDATE_NON_EXISTENT_STUDENT_PROFILE + a.studentProfile.googleId,
-                    edne.getMessage());
-            a.studentProfile.googleId = a.googleId;
-        }
+        a.studentProfile.googleId = "non-ExIsTenT";
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> profilesDb.updateStudentProfile(a.studentProfile));
+        AssertHelper.assertContains(
+                EntitiesDb.ERROR_UPDATE_NON_EXISTENT_STUDENT_PROFILE + a.studentProfile.googleId,
+                ednee.getMessage());
+        a.studentProfile.googleId = a.googleId;
     }
 
     private void testUpdateProfileSuccessNoChangesToProfile(AccountAttributes a)
@@ -155,20 +146,14 @@ public class ProfilesDbTest extends BaseComponentTestCase {
             throws EntityDoesNotExistException {
         ______TS("null parameters");
         // googleId
-        try {
-            profilesDb.updateStudentProfilePicture(null, "anything");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> profilesDb.updateStudentProfilePicture(null, "anything"));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         // pictureKey
-        try {
-            profilesDb.updateStudentProfilePicture("anything", null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> profilesDb.updateStudentProfilePicture("anything", null));
+        AssertHelper.assertContains(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
     private void testUpdateProfilePictureWithEmptyParameters(AccountAttributes a)
@@ -176,32 +161,23 @@ public class ProfilesDbTest extends BaseComponentTestCase {
         ______TS("empty parameters");
 
         // googleId
-        try {
-            profilesDb.updateStudentProfilePicture("", "anything");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            AssertHelper.assertContains("GoogleId is empty", ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> profilesDb.updateStudentProfilePicture("", "anything"));
+        AssertHelper.assertContains("GoogleId is empty", ae.getMessage());
 
         // picture key
-        try {
-            profilesDb.updateStudentProfilePicture(a.googleId, "");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            AssertHelper.assertContains("PictureKey is empty", ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> profilesDb.updateStudentProfilePicture(a.googleId, ""));
+        AssertHelper.assertContains("PictureKey is empty", ae.getMessage());
     }
 
     private void testUpdateProfilePictureOnNonExistentProfile() {
         ______TS("non-existent profile");
 
-        try {
-            profilesDb.updateStudentProfilePicture("non-eXisTEnt", "random");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            AssertHelper.assertContains(EntitiesDb.ERROR_UPDATE_NON_EXISTENT_STUDENT_PROFILE + "non-eXisTEnt",
-                    edne.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> profilesDb.updateStudentProfilePicture("non-eXisTEnt", "random"));
+        AssertHelper.assertContains(EntitiesDb.ERROR_UPDATE_NON_EXISTENT_STUDENT_PROFILE + "non-eXisTEnt",
+                ednee.getMessage());
     }
 
     private void testUpdateProfilePictureSuccessInitiallyEmpty(

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -72,17 +72,13 @@ public class StudentsDbTest extends BaseComponentTestCase {
 
         ______TS("fail : invalid params");
         s.course = "invalid id space";
-        try {
-            studentsDb.createEntity(s);
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            AssertHelper.assertContains(
-                    getPopulatedErrorMessage(
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class, () -> studentsDb.createEntity(s));
+        AssertHelper.assertContains(
+                getPopulatedErrorMessage(
                         COURSE_ID_ERROR_MESSAGE, s.course,
                         FieldValidator.COURSE_ID_FIELD_NAME, REASON_INCORRECT_FORMAT,
                         FieldValidator.COURSE_ID_MAX_LENGTH),
-                    e.getMessage());
-        }
+                ipe.getMessage());
         verifyAbsentInDatastore(s);
 
         ______TS("success : valid params");
@@ -100,24 +96,16 @@ public class StudentsDbTest extends BaseComponentTestCase {
         assertNull(studentsDb.getStudentForGoogleId(s.course + "not existing", s.googleId + "not existing"));
 
         ______TS("fail : duplicate");
-        try {
-            studentsDb.createEntity(s);
-            signalFailureToDetectException();
-        } catch (EntityAlreadyExistsException e) {
-            AssertHelper.assertContains(
-                    String.format(
-                            StudentsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS,
-                            s.getEntityTypeAsString())
-                            + s.getIdentificationString(), e.getMessage());
-        }
+        EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,
+                () -> studentsDb.createEntity(s));
+        AssertHelper.assertContains(
+                String.format(StudentsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, s.getEntityTypeAsString())
+                        + s.getIdentificationString(),
+                eaee.getMessage());
 
         ______TS("null params check");
-        try {
-            studentsDb.createEntity(null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> studentsDb.createEntity(null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
     }
 
@@ -158,18 +146,11 @@ public class StudentsDbTest extends BaseComponentTestCase {
         assertTrue(studentsDb.getStudentsForTeam(s.team, s.course).get(0).isEnrollInfoSameAs(s));
 
         ______TS("null params case");
-        try {
-            studentsDb.getStudentForEmail(null, "valid@email.com");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
-        try {
-            studentsDb.getStudentForEmail("any-course-id", null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class, () -> studentsDb.getStudentForEmail(null, "valid@email.com"));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
+
+        ae = assertThrows(AssertionError.class, () -> studentsDb.getStudentForEmail("any-course-id", null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         studentsDb.deleteStudent(s.course, s.email);
         studentsDb.deleteStudent(s2.course, s2.email);
@@ -184,48 +165,35 @@ public class StudentsDbTest extends BaseComponentTestCase {
                                                      "new@email.com", "new.google.id", "lorem ipsum dolor si amet");
 
         ______TS("non-existent case");
-        try {
-            studentsDb.updateStudentWithoutSearchability("non-existent-course", "non@existent.email", "no-name",
-                                                         "non-existent-team", "non-existent-section", "non.existent.ID",
-                                                         "blah", "blah");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException e) {
-            assertEquals(StudentsDb.ERROR_UPDATE_NON_EXISTENT_STUDENT + "non-existent-course/non@existent.email",
-                         e.getMessage());
-        }
+        EntityDoesNotExistException ednee = assertThrows(EntityDoesNotExistException.class,
+                () -> studentsDb.updateStudentWithoutSearchability("non-existent-course", "non@existent.email", "no-name",
+                        "non-existent-team", "non-existent-section", "non.existent.ID",
+                        "blah", "blah"));
+        assertEquals(StudentsDb.ERROR_UPDATE_NON_EXISTENT_STUDENT + "non-existent-course/non@existent.email",
+                ednee.getMessage());
 
         // Only check first 2 params (course & email) which are used to identify the student entry.
         // The rest are actually allowed to be null.
         ______TS("null course case");
-        try {
-            studentsDb.updateStudentWithoutSearchability(null, s.email, "new-name", "new-team", "new-section",
-                                                         "new@email.com", "new.google.id", "lorem ipsum dolor si amet");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> studentsDb.updateStudentWithoutSearchability(null, s.email, "new-name", "new-team", "new-section",
+                        "new@email.com", "new.google.id", "lorem ipsum dolor si amet"));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("null email case");
-        try {
-            studentsDb.updateStudentWithoutSearchability(s.course, null, "new-name", "new-team", "new-section",
-                                                         "new@email.com", "new.google.id", "lorem ipsum dolor si amet");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> studentsDb.updateStudentWithoutSearchability(s.course, null, "new-name", "new-team", "new-section",
+                        "new@email.com", "new.google.id", "lorem ipsum dolor si amet"));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         ______TS("duplicate email case");
-        s = createNewStudent();
+        StudentAttributes duplicate = createNewStudent();
         // Create a second student with different email address
         StudentAttributes s2 = createNewStudent("valid2@email.com");
-        try {
-            studentsDb.updateStudentWithoutSearchability(s.course, s.email, "new-name", "new-team", "new-section",
-                                                         s2.email, "new.google.id", "lorem ipsum dolor si amet");
-            signalFailureToDetectException();
-        } catch (InvalidParametersException e) {
-            assertEquals(StudentsDb.ERROR_UPDATE_EMAIL_ALREADY_USED + s2.name + "/" + s2.email,
-                         e.getMessage());
-        }
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> studentsDb.updateStudentWithoutSearchability(duplicate.course, duplicate.email, "new-name",
+                        "new-team", "new-section", s2.email, "new.google.id", "lorem ipsum dolor si amet"));
+        assertEquals(StudentsDb.ERROR_UPDATE_EMAIL_ALREADY_USED + s2.name + "/" + s2.email, ipe.getMessage());
 
         ______TS("typical success case");
         String originalEmail = s.email;
@@ -267,19 +235,14 @@ public class StudentsDbTest extends BaseComponentTestCase {
         studentsDb.deleteStudentWithoutDocument(s.course, s.email);
 
         // Null params check:
-        try {
-            studentsDb.deleteStudentWithoutDocument(null, s.email);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        StudentAttributes[] finalStudent = new StudentAttributes[] { s };
+        AssertionError ae = assertThrows(AssertionError.class,
+                () -> studentsDb.deleteStudentWithoutDocument(null, finalStudent[0].email));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
-        try {
-            studentsDb.deleteStudentWithoutDocument(s.course, null);
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-        }
+        ae = assertThrows(AssertionError.class,
+                () -> studentsDb.deleteStudentWithoutDocument(finalStudent[0].course, null));
+        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
         studentsDb.deleteStudent(s.course, s.email);
 

--- a/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
+++ b/src/test/java/teammates/test/cases/util/FieldValidatorTest.java
@@ -30,13 +30,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String typicalFieldName = "my field";
         int typicalLength = 25;
 
-        try {
-            FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
-                    typicalLength, null);
-            signalFailureToDetectException("not expected to be null");
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () ->
+                FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName, typicalLength, null));
 
         int maxLength = 50;
         assertEquals("valid: typical value",
@@ -111,13 +106,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String typicalFieldName = "my field";
         int typicalLength = 25;
 
-        try {
-            FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName,
-                    typicalLength, null);
-            signalFailureToDetectException("not expected to be null");
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () ->
+                FieldValidatorExtension.getValidityInfoForSizeCappedNonEmptyString(typicalFieldName, typicalLength, null));
 
         int maxLength = 50;
         assertEquals("valid: typical value",
@@ -166,12 +156,8 @@ public class FieldValidatorTest extends BaseTestCase {
         String typicalFieldName = "name field";
         int typicalLength = 25;
 
-        try {
-            validator.getValidityInfoForAllowedName(typicalFieldName, typicalLength, null);
-            signalFailureToDetectException("not expected to be null");
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () ->
+                validator.getValidityInfoForAllowedName(typicalFieldName, typicalLength, null));
 
         ______TS("typical success case");
 
@@ -390,13 +376,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForRole_null_throwException() {
-        String errorMessageForNullRole = "Did not throw the expected AssertionError for null value";
-        try {
-            validator.getInvalidityInfoForRole(null);
-            signalFailureToDetectException(errorMessageForNullRole);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForRole(null));
     }
 
     @Test
@@ -423,25 +403,12 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForGoogleId_null_throwException() {
-        String errorMessageForNullGoogleId = "Did not throw the expected AssertionError for null value";
-        try {
-            validator.getInvalidityInfoForGoogleId(null);
-            signalFailureToDetectException(errorMessageForNullGoogleId);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForGoogleId(null));
     }
 
     @Test
     public void testGetInvalidityInfoForGoogleId_untrimmedGmailDomain_throwException() {
-        String errorMessageForUntrimmedEmailDomain = "Did not throw the expected AssertionError for Google ID "
-                                                     + "with untrimmed GMail domain (i.e., @gmail.com)";
-        try {
-            validator.getInvalidityInfoForGoogleId("abc@GMAIL.com");
-            signalFailureToDetectException(errorMessageForUntrimmedEmailDomain);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForGoogleId("abc@GMAIL.com"));
     }
 
     @Test
@@ -515,13 +482,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForEmail_null_throwException() {
-        String errorMessage = "Did not throw the expected AssertionError for null email";
-        try {
-            validator.getInvalidityInfoForEmail(null);
-            signalFailureToDetectException(errorMessage);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForEmail(null));
     }
 
     @Test
@@ -596,13 +557,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForEmailContent_null_throwException() {
-        String errorMessage = "Did not throw the expected AssertionError for null Email Content";
-        try {
-            validator.getInvalidityInfoForEmailContent(null);
-            signalFailureToDetectException(errorMessage);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForEmailContent(null));
     }
 
     @Test
@@ -622,13 +577,7 @@ public class FieldValidatorTest extends BaseTestCase {
 
     @Test
     public void testGetInvalidityInfoForCourseId_null_throwException() {
-        String errorMessage = "Did not throw the expected AssertionError for null Course ID";
-        try {
-            validator.getInvalidityInfoForCourseId(null);
-            signalFailureToDetectException(errorMessage);
-        } catch (AssertionError e) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> validator.getInvalidityInfoForCourseId(null));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -1,7 +1,5 @@
 package teammates.test.cases.util;
 
-import static org.junit.Assert.assertArrayEquals;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/teammates/test/cases/util/StringHelperTest.java
+++ b/src/test/java/teammates/test/cases/util/StringHelperTest.java
@@ -46,9 +46,9 @@ public class StringHelperTest extends BaseTestCase {
         assertTrue(StringHelper.isWhiteSpace(System.lineSeparator() + "   "));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testIsWhiteSpaceNull() {
-        StringHelper.isWhiteSpace(null);
+        assertThrows(NullPointerException.class, () -> StringHelper.isWhiteSpace(null));
     }
 
     @Test
@@ -210,12 +210,7 @@ public class StringHelperTest extends BaseTestCase {
 
         String[] invalidCiphertexts = {invalidHexString, ciphertextLength120, ciphertextLength136};
         for (String invalidCiphertext : invalidCiphertexts) {
-            try {
-                StringHelper.decrypt(invalidCiphertext);
-                signalFailureToDetectException();
-            } catch (InvalidParametersException e) {
-                ignoreExpectedException();
-            }
+            assertThrows(InvalidParametersException.class, () -> StringHelper.decrypt(invalidCiphertext));
         }
     }
 
@@ -424,10 +419,10 @@ public class StringHelperTest extends BaseTestCase {
         assertArrayEquals(expected, StringHelper.trim(input));
     }
 
-    @Test(expectedExceptions = NullPointerException.class)
+    @Test
     public void testTrimWithNullString() {
         String[] input = {"  apple tea", "banana  ", "   carrot cake      ", null};
-        StringHelper.trim(input);
+        assertThrows(NullPointerException.class, () -> StringHelper.trim(input));
     }
 
     @Test
@@ -456,9 +451,9 @@ public class StringHelperTest extends BaseTestCase {
         assertEquals("5||14||null", StringHelper.join("||", Arrays.asList(5, 14, null)));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testJoinWithNullElements() {
-        StringHelper.join(",", (List<Integer>) null);
+        assertThrows(IllegalArgumentException.class, () -> StringHelper.join(",", (List<Integer>) null));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/util/UrlTest.java
+++ b/src/test/java/teammates/test/cases/util/UrlTest.java
@@ -44,21 +44,11 @@ public class UrlTest extends BaseTestCase {
 
         ______TS("malformed URL: no protocol");
 
-        try {
-            url = new Url("www.google.com/page");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> new Url("www.google.com/page"));
 
         ______TS("malformed URL: unknown protocol");
 
-        try {
-            url = new Url("randomprotocol://www.google.com/page");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> new Url("randomprotocol://www.google.com/page"));
 
     }
 
@@ -115,12 +105,7 @@ public class UrlTest extends BaseTestCase {
 
         ______TS("malformed URL: not http(s)");
 
-        try {
-            url = new AppUrl("file:///C:/path/to/file.ext");
-            signalFailureToDetectException();
-        } catch (AssertionError ae) {
-            ignoreExpectedException();
-        }
+        assertThrows(AssertionError.class, () -> new AppUrl("file:///C:/path/to/file.ext"));
 
     }
 

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -1,7 +1,7 @@
 package teammates.test.driver;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -143,9 +143,8 @@ public final class AssertHelper {
     public static void assertLogIdContainsUserId(String actualMessage, String userIdentifier) {
         int endIndex = actualMessage.lastIndexOf(Const.ActivityLog.FIELD_SEPARATOR);
         String actualId = actualMessage.substring(endIndex + Const.ActivityLog.FIELD_SEPARATOR.length());
-        assertTrue("expected actual message's id to contain " + userIdentifier
-                   + " but was " + actualId,
-                   actualId.contains(userIdentifier));
+        assertTrue(actualId.contains(userIdentifier),
+                "expected actual message's id to contain " + userIdentifier + " but was " + actualId);
     }
 
     /**

--- a/src/test/java/teammates/test/driver/EmailChecker.java
+++ b/src/test/java/teammates/test/driver/EmailChecker.java
@@ -1,6 +1,6 @@
 package teammates.test.driver;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -1,7 +1,7 @@
 package teammates.test.driver;
 
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -1,6 +1,6 @@
 package teammates.test.driver;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/test/java/teammates/test/driver/TestProperties.java
+++ b/src/test/java/teammates/test/driver/TestProperties.java
@@ -1,7 +1,5 @@
 package teammates.test.driver;
 
-import static org.testng.AssertJUnit.fail;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -199,10 +197,10 @@ public final class TestProperties {
      */
     public static void verifyReadyForGodMode() {
         if (!isDevServer()) {
-            fail("GodMode regeneration works only in dev server.");
+            throw new RuntimeException("GodMode regeneration works only in dev server.");
         }
         if (isStudentMotdUrlEmpty()) {
-            fail("Student MOTD URL defined in app.student.motd.url in build.properties "
+            throw new RuntimeException("Student MOTD URL defined in app.student.motd.url in build.properties "
                     + "must not be empty. It is advised to use test-student-motd.html to test it.");
         }
     }

--- a/src/test/java/teammates/test/pageobjects/AdminAccountDetailsPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminAccountDetailsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.By;
 

--- a/src/test/java/teammates/test/pageobjects/AdminAccountManagementPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminAccountManagementPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/AdminEmailLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminEmailLogPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -3,11 +3,11 @@ package teammates.test.pageobjects;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;

--- a/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseDetailsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEnrollPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEnrollPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1,8 +1,8 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.ParseException;
 import java.time.LocalDate;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -1,9 +1,9 @@
 package teammates.test.pageobjects;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
@@ -1,8 +1,8 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
-import static org.testng.AssertJUnit.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.openqa.selenium.By;
 

--- a/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
+++ b/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -160,7 +160,7 @@
       <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="sun,com.google.appengine.repackaged,com.google.appengine.labs.repackaged"/>
+      <property name="illegalPkgs" value="sun,com.google.appengine.repackaged,com.google.appengine.labs.repackaged,org.junit.Assert,org.testng.Assert,org.testng.AssertJUnit"/>
     </module>
     <module name="NoLineWrap"/>
     <module name="SuppressionCommentFilter">

--- a/static-analysis/teammates-macker.xml
+++ b/static-analysis/teammates-macker.xml
@@ -295,6 +295,7 @@
                         <allow>
                             <from>
                                 <include class="${testCases}.datatransfer.**" />
+                                <include class="${testCases}.storage.**" />
                             </from>
                         </allow>
                     </deny>


### PR DESCRIPTION
Part of the original #8527.
<!-- Fixes #8527 -->

**Outline of Solution**

Used JUnit 5 Assertions API. Most of the current `assert*` usages are unaffected, but we now have a new (strong) member: `assertThrows`.

This construct:
```java
try {
    doSomethingThatWillThrowException();
    failAsThisShouldNotBeReachable();
} catch (SomeException e) {
    processException(e);
}

// or

@Test(expectedExceptions = SomeException.class)
public void testSomething() {
    doSomethingThatWillThrowException();
}
```

can be transformed to:

```java
SomeException e = assertThrows(SomeException.class, () -> doSomethingThatWillThrowException());
processException(e);
```

which is the best of both worlds.

Note that action tests are not migrated to this new technique because they will be affected by V7 migration anyway.