### PR TITLE
[#9103] Searching: Same session name in different courses will produce malformed results

### DIFF
--- a/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
+++ b/src/main/java/teammates/storage/search/FeedbackResponseCommentSearchDocument.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.google.appengine.api.search.Document;
 import com.google.appengine.api.search.Field;
@@ -244,11 +245,13 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
             if (question == null) {
                 continue;
             }
-            // construct session name to question map
-            bundle.questions.putIfAbsent(question.feedbackSessionName, new ArrayList<>());
+            // construct course id and session name to question map
+            initializeCourseIdAndSessionNameToQuestionMapping(bundle, question.getCourseId(),
+                    question.feedbackSessionName);
+            String uniqueSessionIdentifier = question.getCourseId() + "%" + question.getFeedbackSessionName();
             if (!isAdded.contains(question.getId())) {
                 isAdded.add(question.getId());
-                bundle.questions.get(question.feedbackSessionName).add(question);
+                bundle.questions.get(uniqueSessionIdentifier).add(question);
             }
 
             // get related session from results
@@ -375,7 +378,8 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
     private static FeedbackQuestionAttributes getFeedbackQuestion(
             Map<String, List<FeedbackQuestionAttributes>> questions, FeedbackResponseAttributes response) {
         FeedbackQuestionAttributes question = null;
-        for (FeedbackQuestionAttributes qn : questions.get(response.feedbackSessionName)) {
+        String uniqueSessionIdentifier = response.courseId + "%" + response.feedbackSessionName;
+        for (FeedbackQuestionAttributes qn : questions.get(uniqueSessionIdentifier)) {
             if (qn.getId().equals(response.feedbackQuestionId)) {
                 question = qn;
                 break;
@@ -524,5 +528,26 @@ public class FeedbackResponseCommentSearchDocument extends SearchDocument {
 
         frCommentSearchResults.questions.forEach((fsName, questionList) -> questionList.removeIf(fq ->
                 frCommentSearchResults.responses.get(fq.getId()).isEmpty()));
+    }
+
+    /**
+     * Initializes the course id and session name to question mapping.
+     *
+     * <p>Shifts existing questions (if any) for the session from the current mapping to the new mapping.</p>
+     */
+    private static void initializeCourseIdAndSessionNameToQuestionMapping(
+            FeedbackResponseCommentSearchResultBundle bundle, String courseId, String sessionName) {
+        String uniqueSessionIdentifier = courseId + "%" + sessionName;
+        if (bundle.questions.get(uniqueSessionIdentifier) == null) {
+            List<FeedbackQuestionAttributes> questionsInSession = new ArrayList<>();
+            List<FeedbackQuestionAttributes> existingQuestions = bundle.questions.get(sessionName);
+            if (existingQuestions != null && !existingQuestions.isEmpty()) {
+                questionsInSession = existingQuestions.stream()
+                        .filter(question -> question.getCourseId().equals(courseId))
+                        .collect(Collectors.toList());
+                existingQuestions.removeAll(questionsInSession);
+            }
+            bundle.questions.put(uniqueSessionIdentifier, questionsInSession);
+        }
     }
 }

--- a/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
+++ b/src/main/java/teammates/ui/pagedata/InstructorSearchPageData.java
@@ -117,21 +117,23 @@ public class InstructorSearchPageData extends PageData {
 
         List<FeedbackSessionRow> rows = new ArrayList<>();
 
-        for (String fsName : frcSearchResultBundle.questions.keySet()) {
-            String courseId = frcSearchResultBundle.sessions.get(fsName).getCourseId();
+        for (String fsIdentifier : frcSearchResultBundle.questions.keySet()) {
+            String[] identifier = fsIdentifier.split("%");
+            String fsName = identifier[0];
+            String courseId = identifier[1];
 
             rows.add(new FeedbackSessionRow(fsName, courseId, createQuestionTables(
-                                                                fsName, frcSearchResultBundle)));
+                                                                fsIdentifier, frcSearchResultBundle)));
         }
         return rows;
     }
 
     private List<QuestionTable> createQuestionTables(
-                                    String fsName,
+                                    String fsIdentifier,
                                     FeedbackResponseCommentSearchResultBundle frcSearchResultBundle) {
 
         List<QuestionTable> questionTables = new ArrayList<>();
-        List<FeedbackQuestionAttributes> questionList = frcSearchResultBundle.questions.get(fsName);
+        List<FeedbackQuestionAttributes> questionList = frcSearchResultBundle.questions.get(fsIdentifier);
 
         for (FeedbackQuestionAttributes question : questionList) {
             int questionNumber = question.questionNumber;

--- a/src/test/java/teammates/test/cases/BaseComponentTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseComponentTestCase.java
@@ -142,6 +142,8 @@ public class BaseComponentTestCase extends BaseTestCaseWithDatastoreAccess {
         int[] i = new int[] { 0 };
         actual.comments.forEach((key, comments) -> comments.forEach(comment -> {
             assertEquals(sortedComments[i[0]].commentText, comment.commentText);
+            assertEquals(sortedComments[i[0]].courseId, comment.courseId);
+            assertEquals(sortedComments[i[0]].feedbackSessionName, comment.feedbackSessionName);
             i[0]++;
         }));
     }

--- a/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
@@ -27,6 +27,10 @@ public class FeedbackResponseCommentSearchTest extends BaseSearchTest {
                 .get("comment1FromT1C1ToR1Q2S1C1");
         FeedbackResponseCommentAttributes frc1I3Q1S2C2 = dataBundle.feedbackResponseComments
                 .get("comment1FromT1C1ToR1Q1S2C2");
+        FeedbackResponseCommentAttributes frc1I1Q1S3C1 = dataBundle.feedbackResponseComments
+                .get("comment1FromT1C1ToR1Q1S3C1");
+        FeedbackResponseCommentAttributes frc1I1Q1S3C2 = dataBundle.feedbackResponseComments
+                .get("comment1FromT1C1ToR1Q1S3C2");
 
         ArrayList<InstructorAttributes> instructors = new ArrayList<InstructorAttributes>();
 
@@ -75,6 +79,11 @@ public class FeedbackResponseCommentSearchTest extends BaseSearchTest {
 
         bundle = commentsDb.search("\"student2 In Course1\"", instructors);
         verifySearchResults(bundle, frc1I1Q2S1C1);
+
+        ______TS("success: search for comments in different sessions with the same session name");
+
+        bundle = commentsDb.search("\"special\"", instructors);
+        verifySearchResults(bundle, frc1I1Q1S3C1, frc1I1Q1S3C2);
 
         ______TS("success: search for comments; confirms deleted comments are not included in results");
         FeedbackResponseCommentAttributes commentToDelete = commentsDb.getFeedbackResponseComment(frc1I3Q1S2C2.courseId,

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -424,7 +424,7 @@
       "googleId": "idOfInstructor3",
       "courseId": "idOfTypicalCourse1",
       "name": "Instructor3 Course1",
-      "email": "instructor3@course1.tmt",
+      "email": "instructor3@course.tmt",
       "isArchived": false,
       "role": "Co-owner",
       "isDisplayedToStudents": true,
@@ -448,7 +448,7 @@
       "googleId": "idOfInstructor3",
       "courseId": "idOfTypicalCourse2",
       "name": "Instructor3 Course2",
-      "email": "instructor3@course2.tmt",
+      "email": "instructor3@course.tmt",
       "isArchived": false,
       "role": "Co-owner",
       "isDisplayedToStudents": true,
@@ -765,6 +765,26 @@
       "isClosingEmailEnabled": true,
       "isPublishedEmailEnabled": true
     },
+    "session3InCourse1": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instr3@course1n2.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "createdTime": "2013-03-20T23:59:00Z",
+      "startTime": "2013-06-01T21:59:00Z",
+      "endTime": "2026-04-28T21:59:00Z",
+      "sessionVisibleFromTime": "2013-03-20T21:59:00Z",
+      "resultsVisibleFromTime": "2026-04-29T21:59:00Z",
+      "timeZone": "Africa/Johannesburg",
+      "gracePeriod": 5,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
     "gracePeriodSession": {
       "feedbackSessionName": "Grace Period Session",
       "courseId": "idOfTypicalCourse1",
@@ -889,6 +909,26 @@
       "feedbackSessionName": "Not answerable feedback session",
       "courseId": "idOfTypicalCourse2",
       "creatorEmail": "instructor1@course2.tmt",
+      "instructions": "Please please fill in the following questions.",
+      "createdTime": "2012-03-20T23:59:00Z",
+      "startTime": "2012-04-01T15:59:00Z",
+      "endTime": "2027-04-30T15:59:00Z",
+      "sessionVisibleFromTime": "1970-11-27T00:00:00Z",
+      "resultsVisibleFromTime": "1970-01-01T00:00:00Z",
+      "timeZone": "Asia/Singapore",
+      "gracePeriod": 0,
+      "sentOpenEmail": true,
+      "sentClosingEmail": false,
+      "sentClosedEmail": false,
+      "sentPublishedEmail": false,
+      "isOpeningEmailEnabled": true,
+      "isClosingEmailEnabled": true,
+      "isPublishedEmailEnabled": true
+    },
+    "session3InCourse2": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse2",
+      "creatorEmail": "instr3@course1n2.tmt",
       "instructions": "Please please fill in the following questions.",
       "createdTime": "2012-03-20T23:59:00Z",
       "startTime": "2012-04-01T15:59:00Z",
@@ -1229,6 +1269,26 @@
         "RECEIVER"
       ]
     },
+    "qn1InSession3InCourse1": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "creatorEmail": "instr3@course1n2.tmt",
+      "questionMetaData": "What is the best selling point of your product?",
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    },
     "qn1InSession4InCourse1": {
       "feedbackSessionName": "non visible session",
       "courseId": "idOfTypicalCourse1",
@@ -1318,6 +1378,26 @@
       "showResponsesTo": [],
       "showGiverNameTo": [],
       "showRecipientNameTo": []
+    },
+    "qn1InSession3InCourse2": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse2",
+      "creatorEmail": "instr3@course1n2.tmt",
+      "questionMetaData": "What is the best selling point of your product?",
+      "questionNumber": 1,
+      "questionType": "TEXT",
+      "giverType": "STUDENTS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
     },
     "qn1InSession1InTestingSanitizationCourse": {
       "feedbackSessionName": "Normal feedback session name",
@@ -1418,6 +1498,17 @@
       "giverSection": "Section 1",
       "recipientSection": "Section 2"
     },
+    "response1ForQ1S3C1": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse1",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student1InCourse1@gmail.tmt",
+      "recipient": "student1InCourse1@gmail.tmt",
+      "responseMetaData": "Student 1 feedback.",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
+    },
     "response1GracePeriodFeedback": {
       "feedbackSessionName": "Grace Period Session",
       "courseId": "idOfTypicalCourse1",
@@ -1494,6 +1585,17 @@
       "responseMetaData": "Response from instr1InC2 to student1InC2.",
       "giverSection": "None",
       "recipientSection": "None"
+    },
+    "response1ForQ1S3C2": {
+      "feedbackSessionName": "Third feedback session",
+      "courseId": "idOfTypicalCourse2",
+      "feedbackQuestionId": "1",
+      "feedbackQuestionType": "TEXT",
+      "giver": "student1InCourse2@gmail.tmt",
+      "recipient": "student1InCourse2@gmail.tmt",
+      "responseMetaData": "Student 1 feedback.",
+      "giverSection": "Section 1",
+      "recipientSection": "Section 1"
     },
     "response1ForNVSQ1": {
       "feedbackSessionName": "session without student questions",
@@ -1573,6 +1675,42 @@
       "isCommentFromFeedbackParticipant": false,
       "createdAt": "2027-01-01T23:59:00Z",
       "commentText": "Instructor 3 comment to instr1C2 response to student1C2"
+    },
+    "comment1FromT1C1ToR1Q1S3C1": {
+      "courseId": "idOfTypicalCourse1",
+      "feedbackSessionName": "Third feedback session",
+      "feedbackQuestionId": "1",
+      "commentGiver": "instr3@course1n2.tmt",
+      "giverSection": "None",
+      "receiverSection": "None",
+      "commentGiverType": "INSTRUCTORS",
+      "feedbackResponseId": "1%student1InCourse1@gmail.tmt%student1InCourse1@gmail.tmt",
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "createdAt": "2026-03-01T23:59:00Z",
+      "commentText": "Instructor 3 special comment to student 1 feedback",
+      "lastEditorEmail": "instr3@course1n2.tmt",
+      "lastEditedAt": "2012-04-02T23:59:00Z"
+    },
+    "comment1FromT1C1ToR1Q1S3C2": {
+      "courseId": "idOfTypicalCourse2",
+      "feedbackSessionName": "Third feedback session",
+      "feedbackQuestionId": "1",
+      "commentGiver": "instr3@course1n2.tmt",
+      "giverSection": "None",
+      "receiverSection": "None",
+      "commentGiverType": "INSTRUCTORS",
+      "feedbackResponseId": "1%student1InCourse2@gmail.tmt%student1InCourse2@gmail.tmt",
+      "showCommentTo": [],
+      "showGiverNameTo": [],
+      "isVisibilityFollowingFeedbackQuestion": false,
+      "isCommentFromFeedbackParticipant": false,
+      "createdAt": "2026-03-01T23:59:00Z",
+      "commentText": "Instructor 3 special comment to student 1 feedback",
+      "lastEditorEmail": "instr3@course1n2.tmt",
+      "lastEditedAt": "2012-04-02T23:59:00Z"
     }
   },
   "profiles": {}


### PR DESCRIPTION
Fixes #9103 

**Outline of solution**

I have updated the mapping from session name to question mapping to course id + "%" + session name to question mapping. The reason for choosing "%" as a delimiter is because this symbol is not allowed in course and session names ("|" is another choice). Additionally, I have added code to migrate questions in the old mapping to the new mapping when an old session is accessed.

Unfortunately, testing this is a bigger issue. I cannot really find an appropriate place to write the tests for this bug, but I will keep looking in the next few days. In the meantime, I have added one to `FeedbackResponseCommentSearchTest.java`. Do suggest if you know where is more appropriate.