### PR TITLE
[#8527] Migrate back to JUnit 4's Assert API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ dependencies {
                     "com.google.appengine:appengine-remote-api:${appengineVersion}",
                     "com.google.appengine:appengine-testing:${appengineVersion}",
                     "org.httpunit:httpunit:1.7.2",
-                    "org.junit.jupiter:junit-jupiter-api:5.3.1",
                     "org.seleniumhq.selenium:selenium-java:2.53.1",
                     testng,
                     "org.kohsuke:wordnet-random-name:1.3",

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -3,6 +3,7 @@ package teammates.test.cases;
 import java.io.IOException;
 import java.lang.reflect.Method;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.function.Executable;
 import org.testng.annotations.AfterClass;
@@ -131,27 +132,27 @@ public class BaseTestCase {
     }
 
     protected static void assertEquals(int expected, int actual) {
-        Assertions.assertEquals(expected, actual);
+        Assert.assertEquals(expected, actual);
     }
 
     protected static void assertEquals(String message, int expected, int actual) {
-        Assertions.assertEquals(expected, actual, message);
+        Assert.assertEquals(message, expected, actual);
     }
 
     protected static void assertEquals(long expected, long actual) {
-        Assertions.assertEquals(expected, actual);
+        Assert.assertEquals(expected, actual);
     }
 
     protected static void assertEquals(double expected, double actual, double delta) {
-        Assertions.assertEquals(expected, actual, delta);
+        Assert.assertEquals(expected, actual, delta);
     }
 
     protected static void assertEquals(Object expected, Object actual) {
-        Assertions.assertEquals(expected, actual);
+        Assert.assertEquals(expected, actual);
     }
 
     protected static void assertEquals(String message, Object expected, Object actual) {
-        Assertions.assertEquals(expected, actual, message);
+        Assert.assertEquals(message, expected, actual);
     }
 
     protected static void assertNotEquals(Object unexpected, Object actual) {

--- a/src/test/java/teammates/test/cases/BaseTestCase.java
+++ b/src/test/java/teammates/test/cases/BaseTestCase.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.function.Executable;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -116,19 +114,19 @@ public class BaseTestCase {
      */
 
     protected static void assertTrue(boolean condition) {
-        Assertions.assertTrue(condition);
+        Assert.assertTrue(condition);
     }
 
     protected static void assertTrue(String message, boolean condition) {
-        Assertions.assertTrue(condition, message);
+        Assert.assertTrue(message, condition);
     }
 
     protected static void assertFalse(boolean condition) {
-        Assertions.assertFalse(condition);
+        Assert.assertFalse(condition);
     }
 
     protected static void assertFalse(String message, boolean condition) {
-        Assertions.assertFalse(condition, message);
+        Assert.assertFalse(message, condition);
     }
 
     protected static void assertEquals(int expected, int actual) {
@@ -155,40 +153,83 @@ public class BaseTestCase {
         Assert.assertEquals(message, expected, actual);
     }
 
-    protected static void assertNotEquals(Object unexpected, Object actual) {
-        Assertions.assertNotEquals(unexpected, actual);
+    protected static void assertNotEquals(Object first, Object second) {
+        Assert.assertNotEquals(first, second);
     }
 
     protected static void assertNotSame(Object unexpected, Object actual) {
-        Assertions.assertNotSame(unexpected, actual);
+        Assert.assertNotSame(unexpected, actual);
     }
 
-    protected static void assertNull(Object actual) {
-        Assertions.assertNull(actual);
+    protected static void assertNull(Object object) {
+        Assert.assertNull(object);
     }
 
-    protected static void assertNull(String message, Object actual) {
-        Assertions.assertNull(actual, message);
+    protected static void assertNull(String message, Object object) {
+        Assert.assertNull(message, object);
     }
 
-    protected static void assertNotNull(Object actual) {
-        Assertions.assertNotNull(actual);
+    protected static void assertNotNull(Object object) {
+        Assert.assertNotNull(object);
     }
 
-    protected static void assertNotNull(String message, Object actual) {
-        Assertions.assertNotNull(actual, message);
+    protected static void assertNotNull(String message, Object object) {
+        Assert.assertNotNull(message, object);
     }
 
     protected static void fail(String message) {
-        Assertions.fail(message);
+        Assert.fail(message);
     }
 
-    protected static void assertArrayEquals(Object[] expected, Object[] actual) {
-        Assertions.assertArrayEquals(expected, actual);
+    protected static void assertArrayEquals(Object[] expecteds, Object[] actuals) {
+        Assert.assertArrayEquals(expecteds, actuals);
     }
 
+    // This method is adapted from JUnit 5's assertThrows.
+    // Once we upgrade to JUnit 5, their built-in method shall be used instead.
+    @SuppressWarnings({
+            "unchecked",
+            "PMD.AvoidCatchingThrowable", // As per reference method's specification
+    })
     protected static <T extends Throwable> T assertThrows(Class<T> expectedType, Executable executable) {
-        return Assertions.assertThrows(expectedType, executable);
+        try {
+            executable.execute();
+        } catch (Throwable actualException) {
+            if (expectedType.isInstance(actualException)) {
+                return (T) actualException;
+            } else {
+                String message = String.format("Expected %s to be thrown, but %s was instead thrown.",
+                        getCanonicalName(expectedType), getCanonicalName(actualException.getClass()));
+                throw new AssertionError(message, actualException);
+            }
+        }
+
+        String message = String.format("Expected %s to be thrown, but nothing was thrown.", getCanonicalName(expectedType));
+        throw new AssertionError(message);
+    }
+
+    private static String getCanonicalName(Class<?> clazz) {
+        String canonicalName = clazz.getCanonicalName();
+        return canonicalName == null ? clazz.getName() : canonicalName;
+    }
+
+    /**
+     * {@code Executable} is a functional interface that can be used to
+     * implement any generic block of code that potentially throws a
+     * {@link Throwable}.
+     *
+     * <p>The {@code Executable} interface is similar to {@link Runnable},
+     * except that an {@code Executable} can throw any kind of exception.
+     */
+    // This interface is adapted from JUnit 5's Executable interface.
+    // Once we upgrade to JUnit 5, this interface shall no longer be necessary.
+    public interface Executable {
+
+        /**
+         * Executes a block of code, potentially throwing a {@link Throwable}.
+         */
+        void execute() throws Throwable;
+
     }
 
 }

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -1,7 +1,7 @@
 package teammates.test.driver;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -143,8 +143,8 @@ public final class AssertHelper {
     public static void assertLogIdContainsUserId(String actualMessage, String userIdentifier) {
         int endIndex = actualMessage.lastIndexOf(Const.ActivityLog.FIELD_SEPARATOR);
         String actualId = actualMessage.substring(endIndex + Const.ActivityLog.FIELD_SEPARATOR.length());
-        assertTrue(actualId.contains(userIdentifier),
-                "expected actual message's id to contain " + userIdentifier + " but was " + actualId);
+        assertTrue("expected actual message's id to contain " + userIdentifier + " but was " + actualId,
+                actualId.contains(userIdentifier));
     }
 
     /**

--- a/src/test/java/teammates/test/driver/AssertHelper.java
+++ b/src/test/java/teammates/test/driver/AssertHelper.java
@@ -1,6 +1,6 @@
 package teammates.test.driver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;

--- a/src/test/java/teammates/test/driver/EmailChecker.java
+++ b/src/test/java/teammates/test/driver/EmailChecker.java
@@ -1,6 +1,6 @@
 package teammates.test.driver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 

--- a/src/test/java/teammates/test/driver/GaeSimulation.java
+++ b/src/test/java/teammates/test/driver/GaeSimulation.java
@@ -1,7 +1,7 @@
 package teammates.test.driver;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -1,6 +1,6 @@
 package teammates.test.driver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/test/java/teammates/test/pageobjects/AdminAccountDetailsPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminAccountDetailsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.By;
 

--- a/src/test/java/teammates/test/pageobjects/AdminAccountManagementPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminAccountManagementPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/AdminEmailLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminEmailLogPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -4,10 +4,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -3,7 +3,7 @@ package teammates.test.pageobjects;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.By;

--- a/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
+++ b/src/test/java/teammates/test/pageobjects/FeedbackSubmitPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;

--- a/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseDetailsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseDetailsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEditPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseEnrollPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseEnrollPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsEditPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCourseStudentDetailsViewPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCoursesPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1,8 +1,8 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.text.ParseException;
 import java.time.LocalDate;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -2,8 +2,8 @@ package teammates.test.pageobjects;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackSessionsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.fail;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;

--- a/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorStudentRecordsPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
@@ -1,8 +1,8 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.openqa.selenium.By;
 

--- a/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
+++ b/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
@@ -1,6 +1,6 @@
 package teammates.test.pageobjects;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.openqa.selenium.WebElement;

--- a/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
+++ b/src/test/java/teammates/test/pageobjects/UserErrorReportPage.java
@@ -1,7 +1,7 @@
 package teammates.test.pageobjects;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/static-analysis/teammates-checkstyle.xml
+++ b/static-analysis/teammates-checkstyle.xml
@@ -160,7 +160,7 @@
       <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
     <module name="IllegalImport">
-      <property name="illegalPkgs" value="sun,com.google.appengine.repackaged,com.google.appengine.labs.repackaged,org.junit.Assert,org.testng.Assert,org.testng.AssertJUnit"/>
+      <property name="illegalPkgs" value="sun,com.google.appengine.repackaged,com.google.appengine.labs.repackaged,org.testng.Assert,org.testng.AssertJUnit"/>
     </module>
     <module name="NoLineWrap"/>
     <module name="SuppressionCommentFilter">


### PR DESCRIPTION
Part of #8527. Partially reverts #9155. <!-- Fixes #8527 -->

**Outline of Solution**

@xpdavid this PR has two commits:
- First commit changed all `assertEquals` to `org.junit`'s implementation. This restored the IntelliJ and Eclipse built-in comparison functions as we know it.
- Second commit changed all other `assert*` to `org.junit`'s implementation, hard-coded `assertThrows` (it's actually a really simple function), and removed dependency to JUnit 5.

Only the first commit is necessary to resolve the issue discussed, but I feel the second commit makes the code base more consistent. If we're going to migrate to JUnit 5, one can simply revert this PR (regardless of whether the second commit is included) to benefit from the new Assertions API. Let me know if the second commit should be included.