### PR TITLE
[#9198] Student: submit response to distribute-points question: all responses are rejected

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -758,63 +758,11 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
 
         int numOptions = distributeToRecipients ? numOfResponseSpecific : constSumOptions.size();
         int totalPoints = pointsPerOption ? points * numOptions : points;
-        int sum = 0;
-        for (FeedbackResponseAttributes response : responses) {
-            FeedbackConstantSumResponseDetails frd = (FeedbackConstantSumResponseDetails) response.getResponseDetails();
 
-            //Check that all response points are >= 0
-            for (Integer i : frd.getAnswerList()) {
-                if (i < 0) {
-                    errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_NEGATIVE);
-                    return errors;
-                }
-            }
-
-            //Check that points sum up properly
-            if (distributeToRecipients) {
-                sum += frd.getAnswerList().get(0);
-            } else {
-                sum = 0;
-                for (Integer i : frd.getAnswerList()) {
-                    sum += i;
-                }
-                if (sum != totalPoints || frd.getAnswerList().size() != constSumOptions.size()) {
-                    errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_MISMATCH);
-                    return errors;
-                }
-            }
-
-            //Check that points are given unevenly for all/at least some options as per the question settings
-            Set<Integer> answerSet = new HashSet<>();
-            if (distributePointsFor.equals(
-                    FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY.getDisplayedOption())) {
-                boolean hasDifferentPoints = false;
-                for (int i : frd.getAnswerList()) {
-                    if (!answerSet.isEmpty() && !answerSet.contains(i)) {
-                        hasDifferentPoints = true;
-                        break;
-                    }
-                    answerSet.add(i);
-                }
-
-                if (!hasDifferentPoints) {
-                    errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_SOME_UNIQUE);
-                    return errors;
-                }
-            } else if (forceUnevenDistribution || distributePointsFor.equals(
-                    FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY.getDisplayedOption())) {
-                for (int i : frd.getAnswerList()) {
-                    if (answerSet.contains(i)) {
-                        errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_UNIQUE);
-                        return errors;
-                    }
-                    answerSet.add(i);
-                }
-            }
-        }
-        if (distributeToRecipients && sum != totalPoints) {
-            errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_MISMATCH + sum + "/" + totalPoints);
-            return errors;
+        if (distributeToRecipients) {
+            errors = getErrorsForConstSumRecipients(responses, totalPoints);
+        } else {
+            errors = getErrorsForConstSumOptions(responses, totalPoints);
         }
 
         return errors;
@@ -855,4 +803,83 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         return points;
     }
 
+    private List<String> getErrorsForConstSumOptions(List<FeedbackResponseAttributes> responses, int totalPoints) {
+        List<String> errors = new ArrayList<>();
+
+        for (FeedbackResponseAttributes response : responses) {
+            FeedbackConstantSumResponseDetails frd = (FeedbackConstantSumResponseDetails) response.getResponseDetails();
+            List<Integer> givenPoints = frd.getAnswerList();
+
+            errors = getErrors(givenPoints, totalPoints);
+
+            //Return an error if any response is erroneous
+            if (!errors.isEmpty()) {
+                return errors;
+            }
+        }
+        return errors;
+    }
+
+    private List<String> getErrorsForConstSumRecipients(List<FeedbackResponseAttributes> responses, int totalPoints) {
+        List<Integer> givenPoints = new ArrayList<>();
+
+        for (FeedbackResponseAttributes response : responses) {
+            FeedbackConstantSumResponseDetails frd = (FeedbackConstantSumResponseDetails) response.getResponseDetails();
+
+            int givenPoint = frd.getAnswerList().get(0);
+            givenPoints.add(givenPoint);
+        }
+
+        return getErrors(givenPoints, totalPoints);
+    }
+
+    private List<String> getErrors(List<Integer> givenPoints, int totalPoints) {
+        List<String> errors = new ArrayList<>();
+
+        //Check that all points are >= 0
+        int sum = 0;
+        for (int i : givenPoints) {
+            if (i < 0) {
+                errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_NEGATIVE);
+                return errors;
+            }
+
+            sum += i;
+        }
+
+        //Check that points sum up properly
+        if (sum != totalPoints) {
+            errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_MISMATCH);
+            return errors;
+        }
+
+        //Check that points are given unevenly for all/at least some options as per the question settings
+        Set<Integer> answerSet = new HashSet<>();
+        if (distributePointsFor.equals(
+                FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY.getDisplayedOption())) {
+            boolean hasDifferentPoints = false;
+            for (int i : givenPoints) {
+                if (!answerSet.isEmpty() && !answerSet.contains(i)) {
+                    hasDifferentPoints = true;
+                    break;
+                }
+                answerSet.add(i);
+            }
+
+            if (!hasDifferentPoints) {
+                errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_SOME_UNIQUE);
+                return errors;
+            }
+        } else if (forceUnevenDistribution || distributePointsFor.equals(
+                FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY.getDisplayedOption())) {
+            for (int i : givenPoints) {
+                if (answerSet.contains(i)) {
+                    errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_UNIQUE);
+                    return errors;
+                }
+                answerSet.add(i);
+            }
+        }
+        return errors;
+    }
 }

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -855,7 +855,7 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
 
         //Check that points are given unevenly for all/at least some options as per the question settings
         Set<Integer> answerSet = new HashSet<>();
-        if (distributePointsFor.equals(
+        if (givenPoints.size() > 1 && distributePointsFor.equals(
                 FeedbackConstantSumDistributePointsType.DISTRIBUTE_SOME_UNEVENLY.getDisplayedOption())) {
             boolean hasDifferentPoints = false;
             for (int i : givenPoints) {
@@ -870,8 +870,8 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
                 errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_SOME_UNIQUE);
                 return errors;
             }
-        } else if (forceUnevenDistribution || distributePointsFor.equals(
-                FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY.getDisplayedOption())) {
+        } else if (givenPoints.size() > 1 && (forceUnevenDistribution || distributePointsFor.equals(
+                FeedbackConstantSumDistributePointsType.DISTRIBUTE_ALL_UNEVENLY.getDisplayedOption()))) {
             for (int i : givenPoints) {
                 if (answerSet.contains(i)) {
                     errors.add(Const.FeedbackQuestion.CONST_SUM_ERROR_UNIQUE);

--- a/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -104,6 +104,11 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.selectRecipient(2, 2, "Extra guy");
         submitPage.fillResponseRichTextEditor(2, 2, "Response to extra guy.");
         submitPage.fillResponseTextBox(13, 0, "1");
+        submitPage.fillResponseTextBox(18, 0, "100");
+        submitPage.fillResponseTextBox(18, 1, "100");
+        submitPage.fillResponseTextBox(18, 2, "100");
+        submitPage.fillResponseTextBox(19, 0, 0, "70");
+        submitPage.fillResponseTextBox(19, 0, 1, "30");
 
         // Test partial response for question
         submitPage.fillResponseRichTextEditor(4, 1, "Feedback to Instructor 3");
@@ -112,9 +117,6 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.selectRecipient(8, 0, "Teammates Test2");
         submitPage.toggleMsqOption(8, 0, "UI");
         submitPage.toggleMsqOption(8, 0, "Design");
-
-        submitPage.fillResponseTextBox(17, 0, 0, "90");
-        submitPage.fillResponseTextBox(17, 0, 1, "10");
 
         // Just check that some of the responses persisted.
         FeedbackQuestionAttributes fq =
@@ -127,10 +129,10 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
                 BackDoor.getFeedbackQuestion("IFSubmitUiT.CS2104", "First Session", 10);
         FeedbackQuestionAttributes fqNumscale =
                 BackDoor.getFeedbackQuestion("IFSubmitUiT.CS2104", "First Session", 15);
-        FeedbackQuestionAttributes fqConstSum =
-                BackDoor.getFeedbackQuestion("IFSubmitUiT.CS2104", "First Session", 19);
-        FeedbackQuestionAttributes fqConstSum2 =
+        FeedbackQuestionAttributes fqConstSumRecipient =
                 BackDoor.getFeedbackQuestion("IFSubmitUiT.CS2104", "First Session", 20);
+        FeedbackQuestionAttributes fqConstSumOption =
+                BackDoor.getFeedbackQuestion("IFSubmitUiT.CS2104", "First Session", 21);
 
         assertNull(BackDoor.getFeedbackResponse(
                                fq.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.alice.b@gmail.tmt"));
@@ -143,13 +145,15 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertNull(BackDoor.getFeedbackResponse(
                                fqNumscale.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
         assertNull(BackDoor.getFeedbackResponse(
-                               fqConstSum.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
+                               fqConstSumRecipient.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
+        assertNull(BackDoor.getFeedbackResponse(
+                               fqConstSumOption.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
 
         submitPage.submitWithoutConfirmationEmail();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
                 Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "3, 5, 7, 9, 10, 11, 12, 14, "
-                        + "15, 16, 18, 19, 20, 21, 22, 23, 24.");
+                        + "15, 16, 17, 20, 21, 22, 23.");
 
         assertNotNull(BackDoor.getFeedbackResponse(
                                    fq.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.alice.b@gmail.tmt"));
@@ -162,7 +166,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertNotNull(BackDoor.getFeedbackResponse(
                                    fqNumscale.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
         assertNotNull(BackDoor.getFeedbackResponse(
-                                   fqConstSum.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
+                                   fqConstSumOption.getId(), "IFSubmitUiT.instr@gmail.tmt", "IFSubmitUiT.instr@gmail.tmt"));
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
         submitPage.verifyHtmlMainContent("/instructorFeedbackSubmitPagePartiallyFilled.html");
@@ -219,52 +223,24 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.toggleMsqOption(16, 0, "Teammates Test");
         submitPage.toggleMsqOption(16, 0, "Teammates Test3");
 
-        submitPage.fillResponseTextBox(17, 0, 0, "70");
-        submitPage.fillResponseTextBox(17, 0, 1, "30");
-
-        submitPage.fillResponseTextBox(18, 0, 0, "90");
-        submitPage.fillResponseTextBox(18, 1, 0, "110");
-        submitPage.fillResponseTextBox(18, 2, 0, "100");
-
-        submitPage.fillResponseTextBox(19, 0, 0, "85");
-        submitPage.fillResponseTextBox(19, 1, 0, "110");
-        submitPage.fillResponseTextBox(19, 2, 0, "105");
-
-        submitPage.fillResponseTextBox(20, 0, 0, "35");
-        submitPage.fillResponseTextBox(20, 0, 1, "40");
-        submitPage.fillResponseTextBox(20, 0, 2, "25");
-        submitPage.fillResponseTextBox(20, 1, 0, "10");
-        submitPage.fillResponseTextBox(20, 1, 1, "50");
-        submitPage.fillResponseTextBox(20, 1, 2, "40");
-        submitPage.fillResponseTextBox(20, 2, 0, "15");
-        submitPage.fillResponseTextBox(20, 2, 1, "35");
-        submitPage.fillResponseTextBox(20, 2, 2, "50");
-
-        submitPage.fillResponseTextBox(22, 0, 0, "35");
-        submitPage.fillResponseTextBox(22, 0, 1, "40");
-        submitPage.fillResponseTextBox(22, 0, 2, "25");
-        submitPage.fillResponseTextBox(22, 1, 0, "10");
-        submitPage.fillResponseTextBox(22, 1, 1, "50");
-        submitPage.fillResponseTextBox(22, 1, 2, "40");
-        submitPage.fillResponseTextBox(22, 2, 0, "15");
-        submitPage.fillResponseTextBox(22, 2, 1, "35");
-        submitPage.fillResponseTextBox(22, 2, 2, "50");
-
         // Just check the edited responses, and two new response.
         assertNull(BackDoor.getFeedbackResponse(fq.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 2"));
-        assertNull(BackDoor.getFeedbackResponse(fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 1</td></div>'\""));
-        assertNull(BackDoor.getFeedbackResponse(fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 2"));
-        assertNull(BackDoor.getFeedbackResponse(fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 3"));
+        assertNull(BackDoor.getFeedbackResponse(fqConstSumOption.getId(),
+                "IFSubmitUiT.instr@gmail.tmt", "Team 1</td></div>'\""));
+        assertNull(BackDoor.getFeedbackResponse(fqConstSumOption.getId(),
+                "IFSubmitUiT.instr@gmail.tmt", "Team 2"));
+        assertNull(BackDoor.getFeedbackResponse(fqConstSumOption.getId(),
+                "IFSubmitUiT.instr@gmail.tmt", "Team 3"));
 
         // checks that "" can be submitted and other choices reset when "" is clicked
-        submitPage.toggleMsqOption(23, 0, "Team 3");
-        submitPage.toggleMsqOption(23, 0, "");
+        submitPage.toggleMsqOption(17, 0, "Team 3");
+        submitPage.toggleMsqOption(17, 0, "");
 
         assertFalse(submitPage.isConfirmationEmailBoxTicked());
         submitPage.submitWithoutConfirmationEmail();
 
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
-                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "21, 24.");
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "20, 21, 22, 23.");
         assertEquals("<p>" + editedResponse + "</p>",
                     BackDoor.getFeedbackResponse(
                                  fq.getId(), "IFSubmitUiT.instr@gmail.tmt",
@@ -296,26 +272,27 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
 
         FeedbackConstantSumResponseDetails frConstSum =
                 (FeedbackConstantSumResponseDetails) BackDoor.getFeedbackResponse(
-                         fqConstSum.getId(), "IFSubmitUiT.instr@gmail.tmt",
+                         fqConstSumOption.getId(), "IFSubmitUiT.instr@gmail.tmt",
                          "IFSubmitUiT.instr@gmail.tmt").getResponseDetails();
 
         assertEquals("70, 30", frConstSum.getAnswerString());
 
         FeedbackConstantSumResponseDetails frConstSum0 =
                 (FeedbackConstantSumResponseDetails) BackDoor.getFeedbackResponse(
-                         fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 1</td></div>'\"").getResponseDetails();
+                         fqConstSumRecipient.getId(), "IFSubmitUiT.instr@gmail.tmt",
+                        "Team 1</td></div>'\"").getResponseDetails();
 
-        assertEquals("90", frConstSum0.getAnswerString());
+        assertEquals("100", frConstSum0.getAnswerString());
 
         FeedbackConstantSumResponseDetails frConstSum1 =
                 (FeedbackConstantSumResponseDetails) BackDoor.getFeedbackResponse(
-                         fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 2").getResponseDetails();
+                         fqConstSumRecipient.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 2").getResponseDetails();
 
-        assertEquals("110", frConstSum1.getAnswerString());
+        assertEquals("100", frConstSum1.getAnswerString());
 
         FeedbackConstantSumResponseDetails frConstSum2 =
                 (FeedbackConstantSumResponseDetails) BackDoor.getFeedbackResponse(
-                         fqConstSum2.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 3").getResponseDetails();
+                         fqConstSumRecipient.getId(), "IFSubmitUiT.instr@gmail.tmt", "Team 3").getResponseDetails();
 
         assertEquals("100", frConstSum2.getAnswerString());
 
@@ -332,7 +309,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
                 Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, "
-                        + "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24.");
+                        + "11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23.");
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
         submitPage.waitForPageToLoad();
@@ -358,7 +335,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
                 Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS
-                        + "1, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24.");
+                        + "1, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23.");
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
         submitPage.waitForPageToLoad();
@@ -381,7 +358,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
                 Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS
-                        + "1, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24.");
+                        + "1, 2, 3, 4, 5, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23.");
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
         submitPage.waitForPageToLoad();
@@ -566,90 +543,138 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
 
         // Test instructions displayed for filling the form
-        qnNumber = 17;
-        assertEquals("Total points distributed should add up to 100.",
-                     submitPage.getConstSumInstruction(qnNumber));
-
         qnNumber = 18;
         assertEquals("Total points distributed should add up to 400.",
                      submitPage.getConstSumInstruction(qnNumber));
 
         qnNumber = 19;
+        assertEquals("Total points distributed should add up to 100.",
+                     submitPage.getConstSumInstruction(qnNumber));
+
+        qnNumber = 20;
         assertEquals("Total points distributed should add up to 400.\n"
                      + "Every recipient should be allocated different number of points.",
                      submitPage.getConstSumInstruction(qnNumber));
 
-        qnNumber = 20;
+        qnNumber = 21;
         assertEquals("Total points distributed should add up to 100.\n"
                     + "Every option should be allocated different number of points.",
                     submitPage.getConstSumInstruction(qnNumber));
 
-        qnNumber = 21;
+        qnNumber = 22;
         assertEquals("Total points distributed should add up to 400.\n"
                     + "At least one recipient should be allocated different number of points.",
                     submitPage.getConstSumInstruction(qnNumber));
 
-        qnNumber = 22;
+        qnNumber = 23;
         assertEquals("Total points distributed should add up to 100.\n"
                     + "At least one option should be allocated different number of points.",
                     submitPage.getConstSumInstruction(qnNumber));
 
-        qnNumber = 24;
-        assertEquals("Total points distributed should add up to 100.\n"
-                    + "At least one option should be allocated different number of points.",
-                    submitPage.getConstSumInstruction(qnNumber));
+        // Test messages for const sum (to recipient) qn without restriction
+        qnNumber = 18;
 
-        // Test messages displayed for different user input
-        qnNumber = 17;
-        assertEquals("All points distributed!", submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "80");
-        assertEquals("Actual total is 110! Remove the extra 10 points allocated.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
-        assertEquals("Actual total is 30! Distribute the remaining 70 points.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "");
+        assertEquals("",
+                submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "110");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "110");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "110");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "110");
+        assertEquals("Actual total is 440! Remove the extra 40 points allocated.",
+                submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "0");
+        assertEquals("Actual total is 330! Distribute the remaining 70 points.",
+                submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(
+                "Please fix the error(s) for distribution question(s) 18."
+                        + " To skip a distribution question, leave the boxes blank.");
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "100");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "100");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "100");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "100");
+        assertEquals("All points distributed!", submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9, 20, 21, 22, 23.");
+
+        // Test messages for const sum (to option) qn without restriction
+        submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
+        qnNumber = 19;
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
         submitPage.fillResponseTextBox(qnNumber, 0, 1, "");
         assertEquals("",
+                submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "80");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "30");
+        assertEquals("Actual total is 110! Remove the extra 10 points allocated.",
                      submitPage.getConstSumMessage(qnNumber, 0));
 
-        // Test error message when submitting
-        submitPage.fillResponseTextBox(qnNumber, 0, 1, "10");
-        assertEquals("Actual total is 10! Distribute the remaining 90 points.",
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
+        assertEquals("Actual total is 30! Distribute the remaining 70 points.",
                      submitPage.getConstSumMessage(qnNumber, 0));
 
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(
-                "Please fix the error(s) for distribution question(s) 17, 18, 19."
+                "Please fix the error(s) for distribution question(s) 19."
                         + " To skip a distribution question, leave the boxes blank.");
 
-        // Test error message for const sum (to recipient) qn with uneven distribution
-        qnNumber = 19;
-        assertEquals("Actual total is 300! Distribute the remaining 100 points.\n"
-                     + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 3));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "105");
-        assertEquals("Actual total is 320! Distribute the remaining 80 points.\n"
-                     + "Multiple recipients are given same points! eg. 105.",
-                     submitPage.getConstSumMessage(qnNumber, 3));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "106");
-        assertEquals("Actual total is 321! Distribute the remaining 79 points.\n"
-                     + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 3));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "400");
-        submitPage.fillResponseTextBox(qnNumber, 1, 0, "400");
-        assertEquals("Actual total is 905! Remove the extra 505 points allocated.\n"
-                     + "Multiple recipients are given same points! eg. 400.",
-                     submitPage.getConstSumMessage(qnNumber, 3));
-        submitPage.fillResponseTextBox(qnNumber, 1, 0, "154");
-        assertEquals("Actual total is 659! Remove the extra 259 points allocated.\n"
-                     + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 3));
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "70");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "30");
+        assertEquals("All points distributed!", submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9, 20, 21, 22, 23.");
+
+        // Test messages for const sum (to recipient) qn with uneven distribution
+        submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
+        qnNumber = 20;
 
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
         submitPage.fillResponseTextBox(qnNumber, 1, 0, "");
         submitPage.fillResponseTextBox(qnNumber, 2, 0, "");
         submitPage.fillResponseTextBox(qnNumber, 3, 0, "");
         assertEquals("", submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "80");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "120");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "100");
+        assertEquals("Actual total is 300! Distribute the remaining 100 points.\n"
+                     + "All allocated points are different!",
+                     submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "100");
+        assertEquals("Actual total is 320! Distribute the remaining 80 points.\n"
+                     + "Multiple recipients are given same points! eg. 100.",
+                     submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "110");
+        assertEquals("Actual total is 330! Distribute the remaining 70 points.\n"
+                     + "All allocated points are different!",
+                     submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "400");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "400");
+        assertEquals("Actual total is 900! Remove the extra 500 points allocated.\n"
+                     + "Multiple recipients are given same points! eg. 400.",
+                     submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "410");
+        assertEquals("Actual total is 910! Remove the extra 510 points allocated.\n"
+                     + "All allocated points are different!",
+                     submitPage.getConstSumMessage(qnNumber, 3));
 
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "50");
         submitPage.fillResponseTextBox(qnNumber, 1, 0, "50");
@@ -661,45 +686,88 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
 
         submitPage.submitWithoutConfirmationEmail();
         submitPage.waitForTextsForAllStatusMessagesToUserEquals(
-                "Please fix the error(s) for distribution question(s) 17, 18, 19."
+                "Please fix the error(s) for distribution question(s) 20."
                         + " To skip a distribution question, leave the boxes blank.");
 
-        // Test error message for const sum (to options) qn with uneven distribution
-        qnNumber = 20;
-        assertEquals("All points distributed!\n"
-                     + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 0));
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "50");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "90");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "160");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "100");
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9, 21, 22, 23.");
+
+        // Test messages for const sum (to options) qn with uneven distribution
+        submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
+        qnNumber = 21;
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "");
+        assertEquals("", submitPage.getConstSumMessage(qnNumber, 0));
+
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "25");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "40");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "25");
         assertEquals("Actual total is 90! Distribute the remaining 10 points.\n"
                      + "Multiple options are given same points! eg. 25.",
                      submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "26");
-        assertEquals("Actual total is 91! Distribute the remaining 9 points.\n"
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "30");
+        assertEquals("Actual total is 95! Distribute the remaining 5 points.\n"
                      + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "50");
-        assertEquals("Actual total is 115! Remove the extra 15 points allocated.\n"
-                     + "All allocated points are different!",
-                     submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 1, "50");
-        assertEquals("Actual total is 125! Remove the extra 25 points allocated.\n"
-                     + "Multiple options are given same points! eg. 50.",
                      submitPage.getConstSumMessage(qnNumber, 0));
 
-        // Test error message for const sum (to recipients) qn with uneven distribution for at least some recipients
-        qnNumber = 21;
-        submitPage.fillResponseTextBox(21, 0, 0, "95");
-        submitPage.fillResponseTextBox(21, 1, 0, "95");
-        submitPage.fillResponseTextBox(21, 2, 0, "95");
-        submitPage.fillResponseTextBox(21, 3, 0, "96");
-        assertEquals("Actual total is 381! Distribute the remaining 19 points.\n"
-                     + "At least one recipient has been allocated different number of points.",
-                     submitPage.getConstSumMessage(qnNumber, 3));
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "40");
+        assertEquals("Actual total is 110! Remove the extra 10 points allocated.\n"
+                        + "Multiple options are given same points! eg. 40.",
+                submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "60");
+        assertEquals("Actual total is 130! Remove the extra 30 points allocated.\n"
+                     + "All allocated points are different!",
+                     submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(
+                "Please fix the error(s) for distribution question(s) 21."
+                        + " To skip a distribution question, leave the boxes blank.");
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "10");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "30");
+        assertEquals("All points distributed!\n"
+                        + "All allocated points are different!",
+                submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9, 22, 23.");
+
+        // Test messages for const sum (to recipients) qn with uneven distribution for at least some recipients
+        submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
+        qnNumber = 22;
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "");
+        assertEquals("", submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "95");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "95");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "95");
         submitPage.fillResponseTextBox(qnNumber, 3, 0, "95");
         assertEquals("Actual total is 380! Distribute the remaining 20 points.\n"
-                     + "All recipients are given 95 points. "
-                     + "Please allocate different points to at least one recipient.",
+                        + "All recipients are given 95 points. "
+                        + "Please allocate different points to at least one recipient.",
+                submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "100");
+        assertEquals("Actual total is 385! Distribute the remaining 15 points.\n"
+                     + "At least one recipient has been allocated different number of points.",
                      submitPage.getConstSumMessage(qnNumber, 3));
+
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "105");
         submitPage.fillResponseTextBox(qnNumber, 1, 0, "105");
         submitPage.fillResponseTextBox(qnNumber, 2, 0, "105");
@@ -708,6 +776,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
                      + "All recipients are given 105 points. "
                      + "Please allocate different points to at least one recipient.",
                      submitPage.getConstSumMessage(qnNumber, 3));
+
         submitPage.fillResponseTextBox(qnNumber, 3, 0, "110");
         assertEquals("Actual total is 425! Remove the extra 25 points allocated.\n"
                      + "At least one recipient has been allocated different number of points.",
@@ -722,52 +791,71 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
                      + "Please allocate different points to at least one recipient.",
                      submitPage.getConstSumMessage(qnNumber, 3));
 
-        // Test error message for const sum (to options) qn with uneven distribution for at least some  options
-        qnNumber = 22;
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(
+                "Please fix the error(s) for distribution question(s) 22."
+                        + " To skip a distribution question, leave the boxes blank.");
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "110");
+        submitPage.fillResponseTextBox(qnNumber, 1, 0, "120");
+        submitPage.fillResponseTextBox(qnNumber, 2, 0, "130");
+        submitPage.fillResponseTextBox(qnNumber, 3, 0, "40");
         assertEquals("All points distributed!\n"
-                     + "At least one option has been allocated different number of points.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
+                        + "At least one recipient has been allocated different number of points.",
+                submitPage.getConstSumMessage(qnNumber, 3));
+
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9, 23.");
+
+        // Test messages for const sum (to options) qn with uneven distribution for at least some options
+        submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
+        qnNumber = 23;
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "");
+        assertEquals("", submitPage.getConstSumMessage(qnNumber, 0));
+
         submitPage.fillResponseTextBox(qnNumber, 0, 0, "25");
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "25");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "25");
+        assertEquals("Actual total is 75! Distribute the remaining 25 points.\n"
+                        + "All options are given 25 points. "
+                        + "Please allocate different points to at least one option.",
+                submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "40");
         assertEquals("Actual total is 90! Distribute the remaining 10 points.\n"
                      + "At least one option has been allocated different number of points.",
                      submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 1, "25");
-        assertEquals("Actual total is 75! Distribute the remaining 25 points.\n"
-                     + "All options are given 25 points. "
-                     + "Please allocate different points to at least one option.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 0, "60");
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "40");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "40");
+        assertEquals("Actual total is 120! Remove the extra 20 points allocated.\n"
+                        + "All options are given 40 points. "
+                        + "Please allocate different points to at least one option.",
+                submitPage.getConstSumMessage(qnNumber, 0));
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 0, "30");
         assertEquals("Actual total is 110! Remove the extra 10 points allocated.\n"
                      + "At least one option has been allocated different number of points.",
                      submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(qnNumber, 0, 1, "60");
-        submitPage.fillResponseTextBox(qnNumber, 0, 2, "60");
-        assertEquals("Actual total is 180! Remove the extra 80 points allocated.\n"
-                     + "All options are given 60 points. "
-                     + "Please allocate different points to at least one option.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
 
-        qnNumber = 24;
-        submitPage.fillResponseTextBox(24, 0, 0, "33");
-        submitPage.fillResponseTextBox(24, 0, 1, "33");
-        submitPage.fillResponseTextBox(24, 0, 2, "33");
-        assertEquals("Actual total is 99! Distribute the remaining 1 points.\n"
-                     + "All options are given 33 points. "
-                     + "Please allocate different points to at least one option.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(24, 0, 0, "31");
-        assertEquals("Actual total is 97! Distribute the remaining 3 points.\n"
-                     + "At least one option has been allocated different number of points.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
-        submitPage.fillResponseTextBox(24, 0, 2, "36");
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(
+                "Please fix the error(s) for distribution question(s) 23."
+                        + " To skip a distribution question, leave the boxes blank.");
+
+        submitPage.fillResponseTextBox(qnNumber, 0, 1, "20");
+        submitPage.fillResponseTextBox(qnNumber, 0, 2, "50");
         assertEquals("All points distributed!\n"
-                     + "At least one option has been allocated different number of points.",
-                     submitPage.getConstSumMessage(qnNumber, 0));
+                        + "At least one option has been allocated different number of points.",
+                submitPage.getConstSumMessage(qnNumber, 0));
 
-        // For other const sum question, just test one message.
-        qnNumber = 18;
-        assertEquals("Actual total is 300! Distribute the remaining 100 points.",
-                     submitPage.getConstSumMessage(qnNumber, 3));
+        submitPage.submitWithoutConfirmationEmail();
+        submitPage.waitForTextsForAllStatusMessagesToUserEquals(Const.StatusMessages.FEEDBACK_RESPONSES_SAVED,
+                Const.StatusMessages.FEEDBACK_UNANSWERED_QUESTIONS + "9.");
     }
 
     private void testContribSubmitAction() {

--- a/src/test/resources/data/InstructorFeedbackSubmitPageUiTest.json
+++ b/src/test/resources/data/InstructorFeedbackSubmitPageUiTest.json
@@ -725,9 +725,9 @@
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":false,\"distributePointsFor\":\"None\",\"pointsPerOption\":false,\"questionText\":\"How important are the following factors to you? Give points accordingly.\",\"numOfConstSumOptions\":2,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Grades\",\"Fun\"]}",
+      "questionMetaData": "{\"msqChoices\":[],\"questionText\":\"Which teams would you like to be an instructor of again?\",\"questionType\":\"MSQ\",\"generateOptionsFor\":\"TEAMS\",\"numOfMsqChoices\":0,\"otherEnabled\":false}",
       "questionNumber": 19,
-      "questionType": "CONSTSUM",
+      "questionType": "MSQ",
       "giverType": "INSTRUCTORS",
       "recipientType": "SELF",
       "numberOfEntitiesToGiveFeedbackTo": 1,
@@ -767,8 +767,29 @@
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"questionText\":\"Rate the contribution of your team members and yourself.\"}",
+      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":false,\"distributePointsFor\":\"None\",\"pointsPerOption\":false,\"questionText\":\"How important are the following factors to you? Give points accordingly.\",\"numOfConstSumOptions\":2,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Grades\",\"Fun\"]}",
       "questionNumber": 21,
+      "questionType": "CONSTSUM",
+      "giverType": "INSTRUCTORS",
+      "recipientType": "SELF",
+      "numberOfEntitiesToGiveFeedbackTo": 1,
+      "showResponsesTo": [
+        "RECEIVER",
+        "INSTRUCTORS"
+      ],
+      "showGiverNameTo": [
+        "INSTRUCTORS"
+      ],
+      "showRecipientNameTo": [
+        "INSTRUCTORS"
+      ]
+    },
+    "qn22InSession1": {
+      "feedbackSessionName": "First Session",
+      "courseId": "IFSubmitUiT.CS2104",
+      "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
+      "questionMetaData": "{\"questionText\":\"Rate the contribution of your team members and yourself.\"}",
+      "questionNumber": 22,
       "questionType": "CONTRIB",
       "giverType": "STUDENTS",
       "recipientType": "OWN_TEAM_MEMBERS_INCLUDING_SELF",
@@ -783,32 +804,11 @@
         "INSTRUCTORS"
       ]
     },
-    "qn22InSession1": {
-      "feedbackSessionName": "First Session",
-      "courseId": "IFSubmitUiT.CS2104",
-      "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":true,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"All options\",\"pointsPerOption\":true,\"questionText\":\"Split points among the teams, based on how much effort you think the teams have put into the project\",\"numOfConstSumOptions\":0,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[]}",
-      "questionNumber": 22,
-      "questionType": "CONSTSUM",
-      "giverType": "INSTRUCTORS",
-      "recipientType": "TEAMS",
-      "numberOfEntitiesToGiveFeedbackTo": -100,
-      "showResponsesTo": [
-        "RECEIVER",
-        "INSTRUCTORS"
-      ],
-      "showGiverNameTo": [
-        "INSTRUCTORS"
-      ],
-      "showRecipientNameTo": [
-        "INSTRUCTORS"
-      ]
-    },
     "qn23InSession1": {
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"All options\",\"pointsPerOption\":false,\"questionText\":\"How much more time should the teams spend on the following, regarding their product? Give points accordingly.\",\"numOfConstSumOptions\":3,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Design\",\"Usability\",\"Algo\"]}",
+      "questionMetaData": "{\"distributeToRecipients\":true,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"All options\",\"pointsPerOption\":true,\"questionText\":\"Split points among the teams, based on how much effort you think the teams have put into the project\",\"numOfConstSumOptions\":0,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[]}",
       "questionNumber": 23,
       "questionType": "CONSTSUM",
       "giverType": "INSTRUCTORS",
@@ -829,7 +829,7 @@
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":true,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"At least some options\",\"pointsPerOption\":true,\"questionText\":\"Split points among the teams, based on how much effort you think the teams have put into the project\",\"numOfConstSumOptions\":0,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[]}",
+      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"All options\",\"pointsPerOption\":false,\"questionText\":\"How much more time should the teams spend on the following, regarding their product? Give points accordingly.\",\"numOfConstSumOptions\":3,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Design\",\"Usability\",\"Algo\"]}",
       "questionNumber": 24,
       "questionType": "CONSTSUM",
       "giverType": "INSTRUCTORS",
@@ -850,7 +850,7 @@
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"At least some options\",\"pointsPerOption\":false,\"questionText\":\"How much more time should the teams spend on the following, regarding their product? Give points accordingly.\",\"numOfConstSumOptions\":3,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Design\",\"Usability\",\"Algo\"]}",
+      "questionMetaData": "{\"distributeToRecipients\":true,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"At least some options\",\"pointsPerOption\":true,\"questionText\":\"Split points among the teams, based on how much effort you think the teams have put into the project\",\"numOfConstSumOptions\":0,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[]}",
       "questionNumber": 25,
       "questionType": "CONSTSUM",
       "giverType": "INSTRUCTORS",
@@ -871,32 +871,11 @@
       "feedbackSessionName": "First Session",
       "courseId": "IFSubmitUiT.CS2104",
       "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"msqChoices\":[],\"questionText\":\"Which teams would you like to be an instructor of again?\",\"questionType\":\"MSQ\",\"generateOptionsFor\":\"TEAMS\",\"numOfMsqChoices\":0,\"otherEnabled\":false}",
+      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"At least some options\",\"pointsPerOption\":false,\"questionText\":\"How much more time should the teams spend on the following, regarding their product? Give points accordingly.\",\"numOfConstSumOptions\":3,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Design\",\"Usability\",\"Algo\"]}",
       "questionNumber": 26,
-      "questionType": "MSQ",
-      "giverType": "INSTRUCTORS",
-      "recipientType": "SELF",
-      "numberOfEntitiesToGiveFeedbackTo": 1,
-      "showResponsesTo": [
-        "RECEIVER",
-        "INSTRUCTORS"
-      ],
-      "showGiverNameTo": [
-        "INSTRUCTORS"
-      ],
-      "showRecipientNameTo": [
-        "INSTRUCTORS"
-      ]
-    },
-    "qn27InSession1": {
-      "feedbackSessionName": "First Session",
-      "courseId": "IFSubmitUiT.CS2104",
-      "creatorEmail": "IFSubmitUiT.instr@gmail.tmt",
-      "questionMetaData": "{\"distributeToRecipients\":false,\"forceUnevenDistribution\":true,\"distributePointsFor\":\"At least some options\",\"pointsPerOption\":false,\"questionText\":\"How much more time should be spent on the following? Give points accordingly.\",\"numOfConstSumOptions\":3,\"questionType\":\"CONSTSUM\",\"points\":100,\"constSumOptions\":[\"Design\",\"Usability\",\"Algo\"]}",
-      "questionNumber": 27,
       "questionType": "CONSTSUM",
       "giverType": "INSTRUCTORS",
-      "recipientType": "SELF",
+      "recipientType": "TEAMS",
       "numberOfEntitiesToGiveFeedbackTo": -100,
       "showResponsesTo": [
         "RECEIVER",

--- a/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
@@ -2467,7 +2467,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-17" type="hidden" value="CONSTSUM">
+    <input name="questiontype-17" type="hidden" value="MSQ">
     <input name="questionid-17" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2476,7 +2476,7 @@
           Question 17:
           <br>
           <span class="text-preserve-space">
-            How important are the following factors to you? Give points accordingly.
+            Which teams would you like to be an instructor of again?
           </span>
         </div>
         <div class="panel-body">
@@ -2492,16 +2492,6 @@
             </li>
           </ul>
           <div class="constraints-17">
-            <p class="text-color-blue align-left text-bold">
-              Note:
-            </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-17">
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Total points distributed should add up to 100.
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
           <br>
           <div class="evalueeForm-17 form-group margin-0" style="padding-left: 75px">
@@ -2520,42 +2510,63 @@
               </label>
               (Student):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-17">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Grades
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-0" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="70">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Fun
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-1" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="30">
-                </div>
-              </div>
+            <div class="col-sm-12">
+              <p class="text-muted" hidden="">
+                You need to choose at least -1 options.
+              </p>
+              <p class="text-muted" hidden="">
+                You cannot choose more than -1 options.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 1</td></div>'&quot;">
+                          Team 1&lt;/td&gt;&lt;/div&gt;'"
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 2">
+                          Team 2
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 3">
+                          Team 3
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input checked="" name="responsetext-17-0" type="checkbox" value="">
+                          <i>
+                            None of the above
+                          </i>
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <input disabled="" name="msqMaxSelectableChoices-17" type="hidden" value="-1">
+              <input disabled="" name="msqMinSelectableChoices-17" type="hidden" value="-1">
             </div>
-            <input id="constSumToRecipients-17" type="hidden" value="false">
-            <input id="constSumPointsPerOption-17" type="hidden" value="false">
-            <input id="constSumNumOption-17" type="hidden" value="2">
-            <input id="constSumPoints-17" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-17" type="hidden" value="false">
-            <input id="constSumDistributePointsOptions-17" type="hidden" value="None">
             <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
-          </div>
-          <div id="constSumInputAlert-17-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-17-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
         </div>
       </div>
@@ -2634,7 +2645,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="90">
+                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2679,7 +2690,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="110">
+                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2754,14 +2765,14 @@
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
     <input name="questionid-19" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-19" type="hidden" value="3">
+    <input name="questionresponsetotal-19" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 19:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How important are the following factors to you? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2770,7 +2781,7 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              The receiving teams can see your response, but not the name of the recipient, or your name.
+              You can see your own feedback in the results page later on.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
@@ -2783,165 +2794,60 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-19">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
-              <br>
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Every recipient should be allocated different number of points.
+              Total points distributed should add up to 100.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
-          <div class="evalueeLabel-19 form-inline mobile-align-left">
-            <label for="input" style="text-indent: 24px">
-              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
-                Evaluee/Recipient
-              </span>
-            </label>
-          </div>
-          <br>
           <br>
           <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
                 <select class="participantSelect middlealign form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
                   <option value="">
                   </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
+                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
+                    Myself
                   </option>
                 </select>
                 <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  Myself
                 </span>
               </label>
-              (Team):
+              (Student):
             </div>
             <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Grades
                 </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="85">
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="70">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Fun
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-1" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="30">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
+            <input id="constSumToRecipients-19" type="hidden" value="false">
+            <input id="constSumPointsPerOption-19" type="hidden" value="false">
+            <input id="constSumNumOption-19" type="hidden" value="2">
             <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+            <input id="constSumUnevenDistribution-19" type="hidden" value="false">
+            <input id="constSumDistributePointsOptions-19" type="hidden" value="None">
+            <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
           </div>
-          <div id="constSumInputAlert-19-0" style="display:none">
+          <div id="constSumInputAlert-19-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-19-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-19-1" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option selected="" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-1-0" min="0" name="responsetext-19-1" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="110">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
-          </div>
-          <div id="constSumInputAlert-19-1" style="display:none">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-1">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-19-2" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option selected="" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-2-0" min="0" name="responsetext-19-2" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="105">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
-          </div>
-          <div id="constSumInputAlert-19-2" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-2">
               <span class="text-color-green">
                 <span class="glyphicon glyphicon-ok padding-right-10px">
                 </span>
                 All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
               </span>
               <br>
             </p>
@@ -2961,7 +2867,7 @@
           Question 20:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -2983,11 +2889,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-20">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Every option should be allocated different number of points.
+              Every recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3004,10 +2910,10 @@
           <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-0" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-0" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
+                  <option value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
                   <option style="display: none;" value="Team 2">
@@ -3023,54 +2929,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-1" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="40">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-2" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="25">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
           </div>
-          <div id="constSumInputAlert-20-0" style="">
+          <div id="constSumInputAlert-20-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3078,13 +2954,13 @@
           <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-1" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
-                  <option selected="" value="Team 2">
+                  <option value="Team 2">
                     Team 2
                   </option>
                   <option style="display: none;" value="Team 3">
@@ -3097,54 +2973,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="10">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-1" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="50">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-2" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="40">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
           </div>
-          <div id="constSumInputAlert-20-1" style="">
+          <div id="constSumInputAlert-20-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-1">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3152,8 +2998,8 @@
           <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-2" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
@@ -3161,7 +3007,7 @@
                   <option style="display: none;" value="Team 2">
                     Team 2
                   </option>
-                  <option selected="" value="Team 3">
+                  <option value="Team 3">
                     Team 3
                   </option>
                 </select>
@@ -3171,54 +3017,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="15">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-1" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-2" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="50">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
           </div>
           <div id="constSumInputAlert-20-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-2">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3236,7 +3052,7 @@
           Question 21:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3258,11 +3074,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-21">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
+              Total points distributed should add up to 100.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one recipient should be allocated different number of points.
+              Every option should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3298,23 +3114,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-0-0" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-1" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-2" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-0" style="display:none">
+          <div id="constSumInputAlert-21-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3342,23 +3175,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-1-0" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-1" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-2" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-1" style="display:none">
+          <div id="constSumInputAlert-21-1" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3386,21 +3236,38 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-2-0" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-1" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-2" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
           <div id="constSumInputAlert-21-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-2">
@@ -3421,7 +3288,7 @@
           Question 22:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -3443,11 +3310,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-22">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one option should be allocated different number of points.
+              At least one recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3464,10 +3331,10 @@
           <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-0" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-0" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
+                  <option value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
                   <option style="display: none;" value="Team 2">
@@ -3483,54 +3350,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-1" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="40">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-2" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="25">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
           </div>
-          <div id="constSumInputAlert-22-0" style="">
+          <div id="constSumInputAlert-22-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3538,13 +3375,13 @@
           <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-1" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
-                  <option selected="" value="Team 2">
+                  <option value="Team 2">
                     Team 2
                   </option>
                   <option style="display: none;" value="Team 3">
@@ -3557,54 +3394,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="10">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-1" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="50">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-2" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="40">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
           </div>
-          <div id="constSumInputAlert-22-1" style="">
+          <div id="constSumInputAlert-22-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-1">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3612,8 +3419,8 @@
           <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-2" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
@@ -3621,7 +3428,7 @@
                   <option style="display: none;" value="Team 2">
                     Team 2
                   </option>
-                  <option selected="" value="Team 3">
+                  <option value="Team 3">
                     Team 3
                   </option>
                 </select>
@@ -3631,54 +3438,24 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="15">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-1" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-2" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="50">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
           </div>
           <div id="constSumInputAlert-22-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-2">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -3687,16 +3464,16 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-23" type="hidden" value="MSQ">
+    <input name="questiontype-23" type="hidden" value="CONSTSUM">
     <input name="questionid-23" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-23" type="hidden" value="1">
+    <input name="questionresponsetotal-23" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 23:
           <br>
           <span class="text-preserve-space">
-            Which teams would you like to be an instructor of again?
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3705,123 +3482,17 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              You can see your own feedback in the results page later on.
+              The receiving teams can see your response, but not the name of the recipient, or your name.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
             </li>
           </ul>
           <div class="constraints-23">
-          </div>
-          <br>
-          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
-                  </option>
-                </select>
-                <span>
-                  Myself
-                </span>
-              </label>
-              (Student):
-            </div>
-            <div class="col-sm-12">
-              <p class="text-muted" hidden="">
-                You need to choose at least -1 options.
-              </p>
-              <p class="text-muted" hidden="">
-                You cannot choose more than -1 options.
-              </p>
-              <table>
-                <tbody>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 1</td></div>'&quot;">
-                          Team 1&lt;/td&gt;&lt;/div&gt;'"
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 2">
-                          Team 2
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 3">
-                          Team 3
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input checked="" name="responsetext-23-0" type="checkbox" value="">
-                          <i>
-                            None of the above
-                          </i>
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <input disabled="" name="msqMaxSelectableChoices-23" type="hidden" value="-1">
-              <input disabled="" name="msqMinSelectableChoices-23" type="hidden" value="-1">
-            </div>
-            <input name="responseid-23-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
-          </div>
-        </div>
-      </div>
-    </div>
-    <br>
-    <br>
-    <input name="questiontype-24" type="hidden" value="CONSTSUM">
-    <input name="questionid-24" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-24" type="hidden" value="1">
-    <div class="form-horizontal">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          Question 24:
-          <br>
-          <span class="text-preserve-space">
-            How much more time should be spent on the following? Give points accordingly.
-          </span>
-        </div>
-        <div class="panel-body">
-          <p class="text-muted">
-            Only the following persons can see your responses:
-          </p>
-          <ul class="text-muted">
-            <li class="unordered">
-              You can see your own feedback in the results page later on.
-            </li>
-            <li class="unordered">
-              Instructors in this course can see your response, the name of the recipient, and your name.
-            </li>
-          </ul>
-          <div class="constraints-24">
             <p class="text-color-blue align-left text-bold">
               Note:
             </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-24">
+            <p class="text-color-blue padding-left-35px" id="constSumInstruction-23">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
               Total points distributed should add up to 100.
@@ -3833,30 +3504,44 @@
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
+          <div class="evalueeLabel-23 form-inline mobile-align-left">
+            <label for="input" style="text-indent: 24px">
+              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
+                Evaluee/Recipient
+              </span>
+            </label>
+          </div>
           <br>
-          <div class="evalueeForm-24 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-24-0" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
                   </option>
                 </select>
                 <span>
-                  Myself
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
                 </span>
               </label>
-              (Student):
+              (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-24">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
               <div class="margin-top-7px margin-bottom-15px flex">
                 <label class="const-sum-options-label">
                   Design
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-0" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-0" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3864,7 +3549,7 @@
                   Usability
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-1" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-1" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3872,19 +3557,141 @@
                   Algo
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-2" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-2" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-24" type="hidden" value="false">
-            <input id="constSumPointsPerOption-24" type="hidden" value="false">
-            <input id="constSumNumOption-24" type="hidden" value="3">
-            <input id="constSumPoints-24" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-24" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-24" type="hidden" value="At least some options">
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-24-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-24-0">
+          <div id="constSumInputAlert-23-0" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-0" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-1" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-2" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-1" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-0" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-1" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-2" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-2" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-2">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
@@ -2457,7 +2457,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-17" type="hidden" value="CONSTSUM">
+    <input name="questiontype-17" type="hidden" value="MSQ">
     <input name="questionid-17" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2466,7 +2466,7 @@
           Question 17:
           <br>
           <span class="text-preserve-space">
-            How important are the following factors to you? Give points accordingly.
+            Which teams would you like to be an instructor of again?
           </span>
         </div>
         <div class="panel-body">
@@ -2482,16 +2482,6 @@
             </li>
           </ul>
           <div class="constraints-17">
-            <p class="text-color-blue align-left text-bold">
-              Note:
-            </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-17">
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Total points distributed should add up to 100.
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
           <br>
           <div class="evalueeForm-17 form-group margin-0" style="padding-left: 75px">
@@ -2510,42 +2500,73 @@
               </label>
               (Student):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-17">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Grades
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-0" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="70">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Fun
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-1" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="30">
-                </div>
-              </div>
+            <div class="col-sm-12">
+              <p class="text-muted" hidden="">
+                You need to choose at least -1 options.
+              </p>
+              <p class="text-muted" hidden="">
+                You cannot choose more than -1 options.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="New Team">
+                          New Team
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 1</td></div>'&quot;">
+                          Team 1&lt;/td&gt;&lt;/div&gt;'"
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 2">
+                          Team 2
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 3">
+                          Team 3
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input checked="" name="responsetext-17-0" type="checkbox" value="">
+                          <i>
+                            None of the above
+                          </i>
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <input disabled="" name="msqMaxSelectableChoices-17" type="hidden" value="-1">
+              <input disabled="" name="msqMinSelectableChoices-17" type="hidden" value="-1">
             </div>
-            <input id="constSumToRecipients-17" type="hidden" value="false">
-            <input id="constSumPointsPerOption-17" type="hidden" value="false">
-            <input id="constSumNumOption-17" type="hidden" value="2">
-            <input id="constSumPoints-17" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-17" type="hidden" value="false">
-            <input id="constSumDistributePointsOptions-17" type="hidden" value="None">
             <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
-          </div>
-          <div id="constSumInputAlert-17-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-17-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
         </div>
       </div>
@@ -2627,7 +2648,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="90">
+                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2675,7 +2696,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="110">
+                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2800,14 +2821,14 @@
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
     <input name="questionid-19" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-19" type="hidden" value="4">
+    <input name="questionresponsetotal-19" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 19:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How important are the following factors to you? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2816,7 +2837,7 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              The receiving teams can see your response, but not the name of the recipient, or your name.
+              You can see your own feedback in the results page later on.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
@@ -2829,221 +2850,60 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-19">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 400.
-              <br>
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Every recipient should be allocated different number of points.
+              Total points distributed should add up to 100.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
-          <div class="evalueeLabel-19 form-inline mobile-align-left">
-            <label for="input" style="text-indent: 24px">
-              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
-                Evaluee/Recipient
-              </span>
-            </label>
-          </div>
-          <br>
           <br>
           <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
                 <select class="participantSelect middlealign form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
                   <option value="">
                   </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
+                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
+                    Myself
                   </option>
                 </select>
                 <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  Myself
                 </span>
               </label>
-              (Team):
+              (Student):
             </div>
             <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Grades
                 </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="85">
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="70">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Fun
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-1" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="30">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
+            <input id="constSumToRecipients-19" type="hidden" value="false">
+            <input id="constSumPointsPerOption-19" type="hidden" value="false">
+            <input id="constSumNumOption-19" type="hidden" value="2">
             <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
+            <input id="constSumUnevenDistribution-19" type="hidden" value="false">
+            <input id="constSumDistributePointsOptions-19" type="hidden" value="None">
+            <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
           </div>
-          <div id="constSumInputAlert-19-0" style="display:none">
+          <div id="constSumInputAlert-19-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-19-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-19-1" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option selected="" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-1-0" min="0" name="responsetext-19-1" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="110">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
-          </div>
-          <div id="constSumInputAlert-19-1" style="display:none">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-1">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-19-2" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option selected="" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-2-0" min="0" name="responsetext-19-2" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="105">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-            <input name="responseid-19-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
-          </div>
-          <div id="constSumInputAlert-19-2" style="display:none">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-2">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-3" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  New Team
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-3-0" min="0" name="responsetext-19-3" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-          </div>
-          <div id="constSumInputAlert-19-3" style="">
-            <p class="padding-left-35px text-color-red" id="constSumMessage-19-3">
-              <span class="text-color-red">
-                <span class="glyphicon glyphicon-remove padding-right-10px">
-                </span>
-                Actual total is 300! Distribute the remaining 100 points.
-              </span>
-              <br>
               <span class="text-color-green">
                 <span class="glyphicon glyphicon-ok padding-right-10px">
                 </span>
-                All allocated points are different!
+                All points distributed!
               </span>
               <br>
             </p>
@@ -3063,7 +2923,7 @@
           Question 20:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -3085,11 +2945,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-20">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 400.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Every option should be allocated different number of points.
+              Every recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3106,238 +2966,7 @@
           <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-0" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-1" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="40">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-2" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="25">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
-            <input id="constSumPoints-20" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
-          </div>
-          <div id="constSumInputAlert-20-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-20-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-1" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option selected="" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="10">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-1" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="50">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-2" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="40">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
-            <input id="constSumPoints-20" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
-          </div>
-          <div id="constSumInputAlert-20-1" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-20-1">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-20-2" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option selected="" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="15">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-1" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-2" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="50">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
-            <input id="constSumPoints-20" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
-            <input name="responseid-20-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
-          </div>
-          <div id="constSumInputAlert-20-2" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-20-2">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All allocated points are different!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-3" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
                   <option value="New Team">
@@ -3359,35 +2988,159 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-3-0" min="0" name="responsetext-20-3" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-3-1" min="0" name="responsetext-20-3" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-3-2" min="0" name="responsetext-20-3" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
+            <input id="constSumPoints-20" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
+          </div>
+          <div id="constSumInputAlert-20-0" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-20-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
+            <input id="constSumPoints-20" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
+          </div>
+          <div id="constSumInputAlert-20-1" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-20-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
+            <input id="constSumPoints-20" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-20" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
+          </div>
+          <div id="constSumInputAlert-20-2" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-20-2">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-20 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-20-3" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-20-3-0" min="0" name="responsetext-20-3" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
@@ -3411,7 +3164,7 @@
           Question 21:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3433,11 +3186,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-21">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 400.
+              Total points distributed should add up to 100.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one recipient should be allocated different number of points.
+              Every option should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3476,23 +3229,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-0-0" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-1" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-2" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-0" style="display:none">
+          <div id="constSumInputAlert-21-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3523,23 +3293,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-1-0" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-1" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-2" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-1" style="display:none">
+          <div id="constSumInputAlert-21-1" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3570,23 +3357,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-2-0" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-1" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-2" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-2" style="display:none">
+          <div id="constSumInputAlert-21-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-2">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3617,21 +3421,38 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-3-0" min="0" name="responsetext-21-3" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-3-1" min="0" name="responsetext-21-3" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-3-2" min="0" name="responsetext-21-3" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
           <div id="constSumInputAlert-21-3" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-3">
@@ -3652,7 +3473,7 @@
           Question 22:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -3674,11 +3495,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-22">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 400.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one option should be allocated different number of points.
+              At least one recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3695,238 +3516,7 @@
           <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-0" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option selected="" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-1" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="40">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-2" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="25">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
-            <input id="constSumPoints-22" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
-          </div>
-          <div id="constSumInputAlert-22-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-22-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-1" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option selected="" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="10">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-1" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="50">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-2" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="40">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
-            <input id="constSumPoints-22" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
-          </div>
-          <div id="constSumInputAlert-22-1" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-22-1">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-22-2" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option style="display: none;" value="New Team">
-                    New Team
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option selected="" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="15">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-1" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="35">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-2" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="50">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
-            <input id="constSumPoints-22" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
-            <input name="responseid-22-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
-          </div>
-          <div id="constSumInputAlert-22-2" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-22-2">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                At least one option has been allocated different number of points.
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-3" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
                   <option value="New Team">
@@ -3948,35 +3538,159 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-3-0" min="0" name="responsetext-22-3" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-3-1" min="0" name="responsetext-22-3" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-3-2" min="0" name="responsetext-22-3" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
+            <input id="constSumPoints-22" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-22-0" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-22-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
+            <input id="constSumPoints-22" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-22-1" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-22-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
+            <input id="constSumPoints-22" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-22" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-22-2" style="display:none">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-22-2">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-22 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-22-3" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label" style="display:none">
+                </label>
+                <div class="">
+                  <input class="form-control pointsBox" id="responsetext-22-3-0" min="0" name="responsetext-22-3" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
@@ -3991,16 +3705,16 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-23" type="hidden" value="MSQ">
+    <input name="questiontype-23" type="hidden" value="CONSTSUM">
     <input name="questionid-23" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-23" type="hidden" value="1">
+    <input name="questionresponsetotal-23" type="hidden" value="4">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 23:
           <br>
           <span class="text-preserve-space">
-            Which teams would you like to be an instructor of again?
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -4009,133 +3723,17 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              You can see your own feedback in the results page later on.
+              The receiving teams can see your response, but not the name of the recipient, or your name.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
             </li>
           </ul>
           <div class="constraints-23">
-          </div>
-          <br>
-          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
-              <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
-                  <option value="">
-                  </option>
-                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
-                  </option>
-                </select>
-                <span>
-                  Myself
-                </span>
-              </label>
-              (Student):
-            </div>
-            <div class="col-sm-12">
-              <p class="text-muted" hidden="">
-                You need to choose at least -1 options.
-              </p>
-              <p class="text-muted" hidden="">
-                You cannot choose more than -1 options.
-              </p>
-              <table>
-                <tbody>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="New Team">
-                          New Team
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 1</td></div>'&quot;">
-                          Team 1&lt;/td&gt;&lt;/div&gt;'"
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 2">
-                          Team 2
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 3">
-                          Team 3
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input checked="" name="responsetext-23-0" type="checkbox" value="">
-                          <i>
-                            None of the above
-                          </i>
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <input disabled="" name="msqMaxSelectableChoices-23" type="hidden" value="-1">
-              <input disabled="" name="msqMinSelectableChoices-23" type="hidden" value="-1">
-            </div>
-            <input name="responseid-23-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
-          </div>
-        </div>
-      </div>
-    </div>
-    <br>
-    <br>
-    <input name="questiontype-24" type="hidden" value="CONSTSUM">
-    <input name="questionid-24" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-24" type="hidden" value="1">
-    <div class="form-horizontal">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          Question 24:
-          <br>
-          <span class="text-preserve-space">
-            How much more time should be spent on the following? Give points accordingly.
-          </span>
-        </div>
-        <div class="panel-body">
-          <p class="text-muted">
-            Only the following persons can see your responses:
-          </p>
-          <ul class="text-muted">
-            <li class="unordered">
-              You can see your own feedback in the results page later on.
-            </li>
-            <li class="unordered">
-              Instructors in this course can see your response, the name of the recipient, and your name.
-            </li>
-          </ul>
-          <div class="constraints-24">
             <p class="text-color-blue align-left text-bold">
               Note:
             </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-24">
+            <p class="text-color-blue padding-left-35px" id="constSumInstruction-23">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
               Total points distributed should add up to 100.
@@ -4147,30 +3745,47 @@
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
+          <div class="evalueeLabel-23 form-inline mobile-align-left">
+            <label for="input" style="text-indent: 24px">
+              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
+                Evaluee/Recipient
+              </span>
+            </label>
+          </div>
           <br>
-          <div class="evalueeForm-24 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-24-0" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
+                  <option value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
                   </option>
                 </select>
                 <span>
-                  Myself
+                  New Team
                 </span>
               </label>
-              (Student):
+              (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-24">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
               <div class="margin-top-7px margin-bottom-15px flex">
                 <label class="const-sum-options-label">
                   Design
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-0" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-0" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -4178,7 +3793,7 @@
                   Usability
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-1" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-1" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -4186,19 +3801,211 @@
                   Algo
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-2" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-2" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-24" type="hidden" value="false">
-            <input id="constSumPointsPerOption-24" type="hidden" value="false">
-            <input id="constSumNumOption-24" type="hidden" value="3">
-            <input id="constSumPoints-24" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-24" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-24" type="hidden" value="At least some options">
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-24-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-24-0">
+          <div id="constSumInputAlert-23-0" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-0" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-1" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-2" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-1" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-0" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-1" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-2" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-2" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-2">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-3" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="New Team">
+                    New Team
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-3-0" min="0" name="responsetext-23-3" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-3-1" min="0" name="responsetext-23-3" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-3-2" min="0" name="responsetext-23-3" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-3" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-3">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpen.html
@@ -2440,7 +2440,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-17" type="hidden" value="CONSTSUM">
+    <input name="questiontype-17" type="hidden" value="MSQ">
     <input name="questionid-17" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2449,7 +2449,7 @@
           Question 17:
           <br>
           <span class="text-preserve-space">
-            How important are the following factors to you? Give points accordingly.
+            Which teams would you like to be an instructor of again?
           </span>
         </div>
         <div class="panel-body">
@@ -2465,16 +2465,6 @@
             </li>
           </ul>
           <div class="constraints-17">
-            <p class="text-color-blue align-left text-bold">
-              Note:
-            </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-17">
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Total points distributed should add up to 100.
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
           <br>
           <div class="evalueeForm-17 form-group margin-0" style="padding-left: 75px">
@@ -2493,35 +2483,62 @@
               </label>
               (Student):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-17">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Grades
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-0" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Fun
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-1" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="">
-                </div>
-              </div>
+            <div class="col-sm-12">
+              <p class="text-muted" hidden="">
+                You need to choose at least -1 options.
+              </p>
+              <p class="text-muted" hidden="">
+                You cannot choose more than -1 options.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 1</td></div>'&quot;">
+                          Team 1&lt;/td&gt;&lt;/div&gt;'"
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 2">
+                          Team 2
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 3">
+                          Team 3
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="">
+                          <i>
+                            None of the above
+                          </i>
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <input disabled="" name="msqMaxSelectableChoices-17" type="hidden" value="-1">
+              <input disabled="" name="msqMinSelectableChoices-17" type="hidden" value="-1">
             </div>
-            <input id="constSumToRecipients-17" type="hidden" value="false">
-            <input id="constSumPointsPerOption-17" type="hidden" value="false">
-            <input id="constSumNumOption-17" type="hidden" value="2">
-            <input id="constSumPoints-17" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-17" type="hidden" value="false">
-            <input id="constSumDistributePointsOptions-17" type="hidden" value="None">
-          </div>
-          <div id="constSumInputAlert-17-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-17-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
         </div>
       </div>
@@ -2711,14 +2728,14 @@
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
     <input name="questionid-19" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-19" type="hidden" value="3">
+    <input name="questionresponsetotal-19" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 19:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How important are the following factors to you? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2727,7 +2744,7 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              The receiving teams can see your response, but not the name of the recipient, or your name.
+              You can see your own feedback in the results page later on.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
@@ -2740,152 +2757,55 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-19">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
-              <br>
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Every recipient should be allocated different number of points.
+              Total points distributed should add up to 100.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
-          <div class="evalueeLabel-19 form-inline mobile-align-left">
-            <label for="input" style="text-indent: 24px">
-              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
-                Evaluee/Recipient
-              </span>
-            </label>
-          </div>
-          <br>
           <br>
           <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
                 <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
+                  <option value="IFSubmitUiT.instr@gmail.tmt">
+                    Myself
                   </option>
                 </select>
                 <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  Myself
                 </span>
               </label>
-              (Team):
+              (Student):
             </div>
             <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Grades
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Fun
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-1" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
+            <input id="constSumToRecipients-19" type="hidden" value="false">
+            <input id="constSumPointsPerOption-19" type="hidden" value="false">
+            <input id="constSumNumOption-19" type="hidden" value="2">
             <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
+            <input id="constSumUnevenDistribution-19" type="hidden" value="false">
+            <input id="constSumDistributePointsOptions-19" type="hidden" value="None">
           </div>
-          <div id="constSumInputAlert-19-0" style="display:none">
+          <div id="constSumInputAlert-19-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-19-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-1" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-1-0" min="0" name="responsetext-19-1" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-          </div>
-          <div id="constSumInputAlert-19-1" style="display:none">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-1">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-2" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-2-0" min="0" name="responsetext-19-2" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-          </div>
-          <div id="constSumInputAlert-19-2" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-2">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -2903,7 +2823,7 @@
           Question 20:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -2925,11 +2845,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-20">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Every option should be allocated different number of points.
+              Every recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -2965,40 +2885,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-1" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-2" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-20-0" style="">
+          <div id="constSumInputAlert-20-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3026,40 +2929,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-1" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-2" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-20-1" style="">
+          <div id="constSumInputAlert-20-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3087,35 +2973,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-1" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-2" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
@@ -3139,7 +3008,7 @@
           Question 21:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3161,11 +3030,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-21">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
+              Total points distributed should add up to 100.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one recipient should be allocated different number of points.
+              Every option should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3201,23 +3070,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-0-0" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-1" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-2" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-0" style="display:none">
+          <div id="constSumInputAlert-21-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3245,23 +3131,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-1-0" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-1" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-2" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-1" style="display:none">
+          <div id="constSumInputAlert-21-1" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3289,21 +3192,38 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-2-0" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-1" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-2" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
           <div id="constSumInputAlert-21-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-2">
@@ -3324,7 +3244,7 @@
           Question 22:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -3346,11 +3266,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-22">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one option should be allocated different number of points.
+              At least one recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3386,40 +3306,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-1" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-2" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-22-0" style="">
+          <div id="constSumInputAlert-22-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3447,40 +3350,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-1" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-2" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-22-1" style="">
+          <div id="constSumInputAlert-22-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3508,35 +3394,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-1" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-2" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
@@ -3551,16 +3420,16 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-23" type="hidden" value="MSQ">
+    <input name="questiontype-23" type="hidden" value="CONSTSUM">
     <input name="questionid-23" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-23" type="hidden" value="1">
+    <input name="questionresponsetotal-23" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 23:
           <br>
           <span class="text-preserve-space">
-            Which teams would you like to be an instructor of again?
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3569,122 +3438,17 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              You can see your own feedback in the results page later on.
+              The receiving teams can see your response, but not the name of the recipient, or your name.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
             </li>
           </ul>
           <div class="constraints-23">
-          </div>
-          <br>
-          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
-                  </option>
-                </select>
-                <span>
-                  Myself
-                </span>
-              </label>
-              (Student):
-            </div>
-            <div class="col-sm-12">
-              <p class="text-muted" hidden="">
-                You need to choose at least -1 options.
-              </p>
-              <p class="text-muted" hidden="">
-                You cannot choose more than -1 options.
-              </p>
-              <table>
-                <tbody>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 1</td></div>'&quot;">
-                          Team 1&lt;/td&gt;&lt;/div&gt;'"
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 2">
-                          Team 2
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 3">
-                          Team 3
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="">
-                          <i>
-                            None of the above
-                          </i>
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <input disabled="" name="msqMaxSelectableChoices-23" type="hidden" value="-1">
-              <input disabled="" name="msqMinSelectableChoices-23" type="hidden" value="-1">
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <br>
-    <br>
-    <input name="questiontype-24" type="hidden" value="CONSTSUM">
-    <input name="questionid-24" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-24" type="hidden" value="1">
-    <div class="form-horizontal">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          Question 24:
-          <br>
-          <span class="text-preserve-space">
-            How much more time should be spent on the following? Give points accordingly.
-          </span>
-        </div>
-        <div class="panel-body">
-          <p class="text-muted">
-            Only the following persons can see your responses:
-          </p>
-          <ul class="text-muted">
-            <li class="unordered">
-              You can see your own feedback in the results page later on.
-            </li>
-            <li class="unordered">
-              Instructors in this course can see your response, the name of the recipient, and your name.
-            </li>
-          </ul>
-          <div class="constraints-24">
             <p class="text-color-blue align-left text-bold">
               Note:
             </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-24">
+            <p class="text-color-blue padding-left-35px" id="constSumInstruction-23">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
               Total points distributed should add up to 100.
@@ -3696,30 +3460,44 @@
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
+          <div class="evalueeLabel-23 form-inline mobile-align-left">
+            <label for="input" style="text-indent: 24px">
+              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
+                Evaluee/Recipient
+              </span>
+            </label>
+          </div>
           <br>
-          <div class="evalueeForm-24 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-24-0" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
                   </option>
                 </select>
                 <span>
-                  Myself
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
                 </span>
               </label>
-              (Student):
+              (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-24">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
               <div class="margin-top-7px margin-bottom-15px flex">
                 <label class="const-sum-options-label">
                   Design
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-0" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-0" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3727,7 +3505,7 @@
                   Usability
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-1" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-1" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3735,19 +3513,141 @@
                   Algo
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-2" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-2" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-24" type="hidden" value="false">
-            <input id="constSumPointsPerOption-24" type="hidden" value="false">
-            <input id="constSumNumOption-24" type="hidden" value="3">
-            <input id="constSumPoints-24" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-24" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-24" type="hidden" value="At least some options">
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-24-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-24-0">
+          <div id="constSumInputAlert-23-0" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-0" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-1" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-2" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-1" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-0" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-1" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-2" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-2" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-2">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageOpenWithHelperView.html
@@ -2413,7 +2413,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-17" type="hidden" value="CONSTSUM">
+    <input name="questiontype-17" type="hidden" value="MSQ">
     <input name="questionid-17" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2422,7 +2422,7 @@
           Question 17:
           <br>
           <span class="text-preserve-space">
-            How important are the following factors to you? Give points accordingly.
+            Which teams would you like to be an instructor of again?
           </span>
         </div>
         <div class="panel-body">
@@ -2438,16 +2438,6 @@
             </li>
           </ul>
           <div class="constraints-17">
-            <p class="text-color-blue align-left text-bold">
-              Note:
-            </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-17">
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Total points distributed should add up to 100.
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
           <br>
           <div class="evalueeForm-17 form-group margin-0" style="padding-left: 75px">
@@ -2466,35 +2456,62 @@
               </label>
               (Student):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-17">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Grades
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-0" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Fun
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-1" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="">
-                </div>
-              </div>
+            <div class="col-sm-12">
+              <p class="text-muted" hidden="">
+                You need to choose at least -1 options.
+              </p>
+              <p class="text-muted" hidden="">
+                You cannot choose more than -1 options.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 1</td></div>'&quot;">
+                          Team 1&lt;/td&gt;&lt;/div&gt;'"
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 2">
+                          Team 2
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 3">
+                          Team 3
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="">
+                          <i>
+                            None of the above
+                          </i>
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <input disabled="" name="msqMaxSelectableChoices-17" type="hidden" value="-1">
+              <input disabled="" name="msqMinSelectableChoices-17" type="hidden" value="-1">
             </div>
-            <input id="constSumToRecipients-17" type="hidden" value="false">
-            <input id="constSumPointsPerOption-17" type="hidden" value="false">
-            <input id="constSumNumOption-17" type="hidden" value="2">
-            <input id="constSumPoints-17" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-17" type="hidden" value="false">
-            <input id="constSumDistributePointsOptions-17" type="hidden" value="None">
-          </div>
-          <div id="constSumInputAlert-17-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-17-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
         </div>
       </div>
@@ -2597,7 +2614,7 @@
           Question 19:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How important are the following factors to you? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2606,7 +2623,7 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              The receiving team can see your response, but not the name of the recipient, or your name.
+              You can see your own feedback in the results page later on.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
@@ -2621,53 +2638,50 @@
               </span>
               Total points distributed should add up to 100.
               <br>
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Every recipient should be allocated different number of points.
-              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
-          <div class="evalueeLabel-19 form-inline mobile-align-left">
-            <label for="input" style="text-indent: 24px">
-              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
-                Evaluee/Recipient
-              </span>
-            </label>
-          </div>
-          <br>
           <br>
           <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
                 <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="Team 2">
-                    Team 2
+                  <option value="IFSubmitUiT.instr2@gmail.tmt">
+                    Myself
                   </option>
                 </select>
                 <span>
-                  Team 2
+                  Myself
                 </span>
               </label>
-              (Team):
+              (Student):
             </div>
             <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Grades
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Fun
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-1" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
+            <input id="constSumToRecipients-19" type="hidden" value="false">
+            <input id="constSumPointsPerOption-19" type="hidden" value="false">
+            <input id="constSumNumOption-19" type="hidden" value="2">
             <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
+            <input id="constSumUnevenDistribution-19" type="hidden" value="false">
+            <input id="constSumDistributePointsOptions-19" type="hidden" value="None">
           </div>
           <div id="constSumInputAlert-19-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-19-0">
@@ -2688,7 +2702,7 @@
           Question 20:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -2714,7 +2728,7 @@
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Every option should be allocated different number of points.
+              Every recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -2744,35 +2758,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-1" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-2" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
@@ -2796,7 +2793,7 @@
           Question 21:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2822,7 +2819,7 @@
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one recipient should be allocated different number of points.
+              Every option should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -2852,21 +2849,38 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-0-0" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-1" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-2" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
           <div id="constSumInputAlert-21-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-0">
@@ -2887,7 +2901,7 @@
           Question 22:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -2913,7 +2927,7 @@
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one option should be allocated different number of points.
+              At least one recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -2943,35 +2957,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-1" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-2" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
@@ -2986,7 +2983,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-23" type="hidden" value="MSQ">
+    <input name="questiontype-23" type="hidden" value="CONSTSUM">
     <input name="questionid-23" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-23" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2995,7 +2992,7 @@
           Question 23:
           <br>
           <span class="text-preserve-space">
-            Which teams would you like to be an instructor of again?
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3004,122 +3001,17 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              You can see your own feedback in the results page later on.
+              The receiving team can see your response, but not the name of the recipient, or your name.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
             </li>
           </ul>
           <div class="constraints-23">
-          </div>
-          <br>
-          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option value="IFSubmitUiT.instr2@gmail.tmt">
-                    Myself
-                  </option>
-                </select>
-                <span>
-                  Myself
-                </span>
-              </label>
-              (Student):
-            </div>
-            <div class="col-sm-12">
-              <p class="text-muted" hidden="">
-                You need to choose at least -1 options.
-              </p>
-              <p class="text-muted" hidden="">
-                You cannot choose more than -1 options.
-              </p>
-              <table>
-                <tbody>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 1</td></div>'&quot;">
-                          Team 1&lt;/td&gt;&lt;/div&gt;'"
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 2">
-                          Team 2
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 3">
-                          Team 3
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="">
-                          <i>
-                            None of the above
-                          </i>
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <input disabled="" name="msqMaxSelectableChoices-23" type="hidden" value="-1">
-              <input disabled="" name="msqMinSelectableChoices-23" type="hidden" value="-1">
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <br>
-    <br>
-    <input name="questiontype-24" type="hidden" value="CONSTSUM">
-    <input name="questionid-24" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-24" type="hidden" value="1">
-    <div class="form-horizontal">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          Question 24:
-          <br>
-          <span class="text-preserve-space">
-            How much more time should be spent on the following? Give points accordingly.
-          </span>
-        </div>
-        <div class="panel-body">
-          <p class="text-muted">
-            Only the following persons can see your responses:
-          </p>
-          <ul class="text-muted">
-            <li class="unordered">
-              You can see your own feedback in the results page later on.
-            </li>
-            <li class="unordered">
-              Instructors in this course can see your response, the name of the recipient, and your name.
-            </li>
-          </ul>
-          <div class="constraints-24">
             <p class="text-color-blue align-left text-bold">
               Note:
             </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-24">
+            <p class="text-color-blue padding-left-35px" id="constSumInstruction-23">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
               Total points distributed should add up to 100.
@@ -3131,30 +3023,38 @@
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
+          <div class="evalueeLabel-23 form-inline mobile-align-left">
+            <label for="input" style="text-indent: 24px">
+              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
+                Evaluee/Recipient
+              </span>
+            </label>
+          </div>
           <br>
-          <div class="evalueeForm-24 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-24-0" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="IFSubmitUiT.instr2@gmail.tmt">
-                    Myself
+                  <option value="Team 2">
+                    Team 2
                   </option>
                 </select>
                 <span>
-                  Myself
+                  Team 2
                 </span>
               </label>
-              (Student):
+              (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-24">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
               <div class="margin-top-7px margin-bottom-15px flex">
                 <label class="const-sum-options-label">
                   Design
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-0" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-0" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3162,7 +3062,7 @@
                   Usability
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-1" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-1" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3170,19 +3070,19 @@
                   Algo
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-2" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-2" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-24" type="hidden" value="false">
-            <input id="constSumPointsPerOption-24" type="hidden" value="false">
-            <input id="constSumNumOption-24" type="hidden" value="3">
-            <input id="constSumPoints-24" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-24" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-24" type="hidden" value="At least some options">
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-24-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-24-0">
+          <div id="constSumInputAlert-23-0" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
@@ -2448,7 +2448,7 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-17" type="hidden" value="CONSTSUM">
+    <input name="questiontype-17" type="hidden" value="MSQ">
     <input name="questionid-17" type="hidden" value="${question.id}">
     <input name="questionresponsetotal-17" type="hidden" value="1">
     <div class="form-horizontal">
@@ -2457,7 +2457,7 @@
           Question 17:
           <br>
           <span class="text-preserve-space">
-            How important are the following factors to you? Give points accordingly.
+            Which teams would you like to be an instructor of again?
           </span>
         </div>
         <div class="panel-body">
@@ -2473,25 +2473,15 @@
             </li>
           </ul>
           <div class="constraints-17">
-            <p class="text-color-blue align-left text-bold">
-              Note:
-            </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-17">
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Total points distributed should add up to 100.
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
           <br>
           <div class="evalueeForm-17 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
-                <select class="participantSelect middlealign form-control" name="responserecipient-17-0" style="display:none;max-width:125px">
-                  <option value="">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-17-0" style="display:none;max-width:125px">
+                  <option selected="" value="">
                   </option>
-                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
+                  <option value="IFSubmitUiT.instr@gmail.tmt">
                     Myself
                   </option>
                 </select>
@@ -2501,42 +2491,62 @@
               </label>
               (Student):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-17">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Grades
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-0" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="90">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Fun
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-17-0-1" min="0" name="responsetext-17-0" onchange="updateConstSumQnMessages('17')" step="1" type="number" value="10">
-                </div>
-              </div>
+            <div class="col-sm-12">
+              <p class="text-muted" hidden="">
+                You need to choose at least -1 options.
+              </p>
+              <p class="text-muted" hidden="">
+                You cannot choose more than -1 options.
+              </p>
+              <table>
+                <tbody>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 1</td></div>'&quot;">
+                          Team 1&lt;/td&gt;&lt;/div&gt;'"
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 2">
+                          Team 2
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="Team 3">
+                          Team 3
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div class="checkbox">
+                        <label class="bold-label">
+                          <input name="responsetext-17-0" type="checkbox" value="">
+                          <i>
+                            None of the above
+                          </i>
+                        </label>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+              <input disabled="" name="msqMaxSelectableChoices-17" type="hidden" value="-1">
+              <input disabled="" name="msqMinSelectableChoices-17" type="hidden" value="-1">
             </div>
-            <input id="constSumToRecipients-17" type="hidden" value="false">
-            <input id="constSumPointsPerOption-17" type="hidden" value="false">
-            <input id="constSumNumOption-17" type="hidden" value="2">
-            <input id="constSumPoints-17" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-17" type="hidden" value="false">
-            <input id="constSumDistributePointsOptions-17" type="hidden" value="None">
-            <input name="responseid-17-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
-          </div>
-          <div id="constSumInputAlert-17-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-17-0">
-              <span class="text-color-green">
-                <span class="glyphicon glyphicon-ok padding-right-10px">
-                </span>
-                All points distributed!
-              </span>
-              <br>
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
           </div>
         </div>
       </div>
@@ -2591,10 +2601,10 @@
           <div class="evalueeForm-18 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-18-0" style="display:none;max-width:125px">
-                  <option selected="" value="">
+                <select class="participantSelect middlealign form-control" name="responserecipient-18-0" style="display:none;max-width:125px">
+                  <option value="">
                   </option>
-                  <option value="Team 1</td></div>'&quot;">
+                  <option selected="" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
                   <option style="display: none;" value="Team 2">
@@ -2615,7 +2625,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-18-0-0" min="0" name="responsetext-18-0" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2625,6 +2635,7 @@
             <input id="constSumPoints-18" type="hidden" value="100">
             <input id="constSumUnevenDistribution-18" type="hidden" value="false">
             <input id="constSumDistributePointsOptions-18" type="hidden" value="None">
+            <input name="responseid-18-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 1</td></div>'&quot;">
           </div>
           <div id="constSumInputAlert-18-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-18-0">
@@ -2635,13 +2646,13 @@
           <div class="evalueeForm-18 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-18-1" style="display:none;max-width:125px">
-                  <option selected="" value="">
+                <select class="participantSelect middlealign form-control" name="responserecipient-18-1" style="display:none;max-width:125px">
+                  <option value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
                   </option>
-                  <option value="Team 2">
+                  <option selected="" value="Team 2">
                     Team 2
                   </option>
                   <option style="display: none;" value="Team 3">
@@ -2659,7 +2670,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-18-1-0" min="0" name="responsetext-18-1" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2669,6 +2680,7 @@
             <input id="constSumPoints-18" type="hidden" value="100">
             <input id="constSumUnevenDistribution-18" type="hidden" value="false">
             <input id="constSumDistributePointsOptions-18" type="hidden" value="None">
+            <input name="responseid-18-1" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 2">
           </div>
           <div id="constSumInputAlert-18-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-18-1">
@@ -2679,8 +2691,8 @@
           <div class="evalueeForm-18 form-group margin-0" style="padding-left: 75px">
             <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-18-2" style="display:none;max-width:125px">
-                  <option selected="" value="">
+                <select class="participantSelect middlealign form-control" name="responserecipient-18-2" style="display:none;max-width:125px">
+                  <option value="">
                   </option>
                   <option style="display: none;" value="Team 1</td></div>'&quot;">
                     Team 1&lt;/td&gt;&lt;/div&gt;'"
@@ -2688,7 +2700,7 @@
                   <option style="display: none;" value="Team 2">
                     Team 2
                   </option>
-                  <option value="Team 3">
+                  <option selected="" value="Team 3">
                     Team 3
                   </option>
                 </select>
@@ -2703,7 +2715,7 @@
                 <label class="const-sum-options-label" style="display:none">
                 </label>
                 <div class="">
-                  <input class="form-control pointsBox" id="responsetext-18-2-0" min="0" name="responsetext-18-2" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-18-2-0" min="0" name="responsetext-18-2" onchange="updateConstSumQnMessages('18')" step="1" type="number" value="100">
                 </div>
               </div>
             </div>
@@ -2713,9 +2725,16 @@
             <input id="constSumPoints-18" type="hidden" value="100">
             <input id="constSumUnevenDistribution-18" type="hidden" value="false">
             <input id="constSumDistributePointsOptions-18" type="hidden" value="None">
+            <input name="responseid-18-2" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%Team 3">
           </div>
           <div id="constSumInputAlert-18-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-18-2">
+              <span class="text-color-green">
+                <span class="glyphicon glyphicon-ok padding-right-10px">
+                </span>
+                All points distributed!
+              </span>
+              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -2726,14 +2745,14 @@
     <br>
     <input name="questiontype-19" type="hidden" value="CONSTSUM">
     <input name="questionid-19" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-19" type="hidden" value="3">
+    <input name="questionresponsetotal-19" type="hidden" value="1">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 19:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How important are the following factors to you? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -2742,7 +2761,7 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              The receiving teams can see your response, but not the name of the recipient, or your name.
+              You can see your own feedback in the results page later on.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
@@ -2755,152 +2774,62 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-19">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
-              <br>
-              <span class="glyphicon glyphicon-info-sign padding-right-10px">
-              </span>
-              Every recipient should be allocated different number of points.
+              Total points distributed should add up to 100.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
-          <div class="evalueeLabel-19 form-inline mobile-align-left">
-            <label for="input" style="text-indent: 24px">
-              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
-                Evaluee/Recipient
-              </span>
-            </label>
-          </div>
-          <br>
           <br>
           <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
-                  <option selected="" value="">
+                <select class="participantSelect middlealign form-control" name="responserecipient-19-0" style="display:none;max-width:125px">
+                  <option value="">
                   </option>
-                  <option value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
+                  <option selected="" value="IFSubmitUiT.instr@gmail.tmt">
+                    Myself
                   </option>
                 </select>
                 <span>
-                  Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  Myself
                 </span>
               </label>
-              (Team):
+              (Student):
             </div>
             <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Grades
                 </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-0" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="70">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Fun
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-19-0-1" min="0" name="responsetext-19-0" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="30">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
+            <input id="constSumToRecipients-19" type="hidden" value="false">
+            <input id="constSumPointsPerOption-19" type="hidden" value="false">
+            <input id="constSumNumOption-19" type="hidden" value="2">
             <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
+            <input id="constSumUnevenDistribution-19" type="hidden" value="false">
+            <input id="constSumDistributePointsOptions-19" type="hidden" value="None">
+            <input name="responseid-19-0" type="hidden" value="${question.id}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt">
           </div>
-          <div id="constSumInputAlert-19-0" style="display:none">
+          <div id="constSumInputAlert-19-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-19-0">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-1" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option value="Team 2">
-                    Team 2
-                  </option>
-                  <option style="display: none;" value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 2
+              <span class="text-color-green">
+                <span class="glyphicon glyphicon-ok padding-right-10px">
                 </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-1-0" min="0" name="responsetext-19-1" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-          </div>
-          <div id="constSumInputAlert-19-1" style="display:none">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-1">
-            </p>
-            <hr class="margin-top-0 border-top-dark-gray">
-          </div>
-          <br>
-          <div class="evalueeForm-19 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-19-2" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option style="display: none;" value="Team 1</td></div>'&quot;">
-                    Team 1&lt;/td&gt;&lt;/div&gt;'"
-                  </option>
-                  <option style="display: none;" value="Team 2">
-                    Team 2
-                  </option>
-                  <option value="Team 3">
-                    Team 3
-                  </option>
-                </select>
-                <span>
-                  Team 3
-                </span>
-              </label>
-              (Team):
-            </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-19">
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
-                </label>
-                <div class="">
-                  <input class="form-control pointsBox" id="responsetext-19-2-0" min="0" name="responsetext-19-2" onchange="updateConstSumQnMessages('19')" step="1" type="number" value="">
-                </div>
-              </div>
-            </div>
-            <input id="constSumToRecipients-19" type="hidden" value="true">
-            <input id="constSumPointsPerOption-19" type="hidden" value="true">
-            <input id="constSumNumOption-19" type="hidden" value="0">
-            <input id="constSumPoints-19" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-19" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-19" type="hidden" value="All options">
-          </div>
-          <div id="constSumInputAlert-19-2" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-19-2">
+                All points distributed!
+              </span>
+              <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
@@ -2918,7 +2847,7 @@
           Question 20:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -2940,11 +2869,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-20">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Every option should be allocated different number of points.
+              Every recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -2980,40 +2909,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-0-0" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-1" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-0-2" min="0" name="responsetext-20-0" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-20-0" style="">
+          <div id="constSumInputAlert-20-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3041,40 +2953,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-1-0" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-1" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-1-2" min="0" name="responsetext-20-1" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-20-1" style="">
+          <div id="constSumInputAlert-20-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-20-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3102,35 +2997,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-20">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-20">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-20-2-0" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-1" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-20-2-2" min="0" name="responsetext-20-2" onchange="updateConstSumQnMessages('20')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-20" type="hidden" value="false">
-            <input id="constSumPointsPerOption-20" type="hidden" value="false">
-            <input id="constSumNumOption-20" type="hidden" value="3">
+            <input id="constSumToRecipients-20" type="hidden" value="true">
+            <input id="constSumPointsPerOption-20" type="hidden" value="true">
+            <input id="constSumNumOption-20" type="hidden" value="0">
             <input id="constSumPoints-20" type="hidden" value="100">
             <input id="constSumUnevenDistribution-20" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-20" type="hidden" value="All options">
@@ -3154,7 +3032,7 @@
           Question 21:
           <br>
           <span class="text-preserve-space">
-            Split points among the teams, based on how much effort you think the teams have put into the project
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3176,11 +3054,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-21">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 300.
+              Total points distributed should add up to 100.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one recipient should be allocated different number of points.
+              Every option should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3216,23 +3094,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-0-0" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-1" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-0-2" min="0" name="responsetext-21-0" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-0" style="display:none">
+          <div id="constSumInputAlert-21-0" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3260,23 +3155,40 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-1-0" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-1" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-1-2" min="0" name="responsetext-21-1" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
-          <div id="constSumInputAlert-21-1" style="display:none">
+          <div id="constSumInputAlert-21-1" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3304,21 +3216,38 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-21">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-21">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label" style="display:none">
+                <label class="const-sum-options-label">
+                  Design
                 </label>
-                <div class="">
+                <div class="margin-left-auto">
                   <input class="form-control pointsBox" id="responsetext-21-2-0" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
                 </div>
               </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-1" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-21-2-2" min="0" name="responsetext-21-2" onchange="updateConstSumQnMessages('21')" step="1" type="number" value="">
+                </div>
+              </div>
             </div>
-            <input id="constSumToRecipients-21" type="hidden" value="true">
-            <input id="constSumPointsPerOption-21" type="hidden" value="true">
-            <input id="constSumNumOption-21" type="hidden" value="0">
+            <input id="constSumToRecipients-21" type="hidden" value="false">
+            <input id="constSumPointsPerOption-21" type="hidden" value="false">
+            <input id="constSumNumOption-21" type="hidden" value="3">
             <input id="constSumPoints-21" type="hidden" value="100">
             <input id="constSumUnevenDistribution-21" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-21" type="hidden" value="At least some options">
+            <input id="constSumDistributePointsOptions-21" type="hidden" value="All options">
           </div>
           <div id="constSumInputAlert-21-2" style="">
             <p class="text-color-green padding-left-35px" id="constSumMessage-21-2">
@@ -3339,7 +3268,7 @@
           Question 22:
           <br>
           <span class="text-preserve-space">
-            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
+            Split points among the teams, based on how much effort you think the teams have put into the project
           </span>
         </div>
         <div class="panel-body">
@@ -3361,11 +3290,11 @@
             <p class="text-color-blue padding-left-35px" id="constSumInstruction-22">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              Total points distributed should add up to 100.
+              Total points distributed should add up to 300.
               <br>
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
-              At least one option should be allocated different number of points.
+              At least one recipient should be allocated different number of points.
               <br>
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3401,40 +3330,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-0-0" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-1" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-0-2" min="0" name="responsetext-22-0" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-22-0" style="">
+          <div id="constSumInputAlert-22-0" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-0">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3462,40 +3374,23 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-1-0" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-1" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-1-2" min="0" name="responsetext-22-1" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-22-1" style="">
+          <div id="constSumInputAlert-22-1" style="display:none">
             <p class="text-color-green padding-left-35px" id="constSumMessage-22-1">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
@@ -3523,35 +3418,18 @@
               </label>
               (Team):
             </div>
-            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-22">
+            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-22">
               <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Design
+                <label class="const-sum-options-label" style="display:none">
                 </label>
-                <div class="margin-left-auto">
+                <div class="">
                   <input class="form-control pointsBox" id="responsetext-22-2-0" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
                 </div>
               </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Usability
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-1" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
-              <div class="margin-top-7px margin-bottom-15px flex">
-                <label class="const-sum-options-label">
-                  Algo
-                </label>
-                <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-22-2-2" min="0" name="responsetext-22-2" onchange="updateConstSumQnMessages('22')" step="1" type="number" value="">
-                </div>
-              </div>
             </div>
-            <input id="constSumToRecipients-22" type="hidden" value="false">
-            <input id="constSumPointsPerOption-22" type="hidden" value="false">
-            <input id="constSumNumOption-22" type="hidden" value="3">
+            <input id="constSumToRecipients-22" type="hidden" value="true">
+            <input id="constSumPointsPerOption-22" type="hidden" value="true">
+            <input id="constSumNumOption-22" type="hidden" value="0">
             <input id="constSumPoints-22" type="hidden" value="100">
             <input id="constSumUnevenDistribution-22" type="hidden" value="true">
             <input id="constSumDistributePointsOptions-22" type="hidden" value="At least some options">
@@ -3566,16 +3444,16 @@
     </div>
     <br>
     <br>
-    <input name="questiontype-23" type="hidden" value="MSQ">
+    <input name="questiontype-23" type="hidden" value="CONSTSUM">
     <input name="questionid-23" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-23" type="hidden" value="1">
+    <input name="questionresponsetotal-23" type="hidden" value="3">
     <div class="form-horizontal">
       <div class="panel panel-primary">
         <div class="panel-heading">
           Question 23:
           <br>
           <span class="text-preserve-space">
-            Which teams would you like to be an instructor of again?
+            How much more time should the teams spend on the following, regarding their product? Give points accordingly.
           </span>
         </div>
         <div class="panel-body">
@@ -3584,122 +3462,17 @@
           </p>
           <ul class="text-muted">
             <li class="unordered">
-              You can see your own feedback in the results page later on.
+              The receiving teams can see your response, but not the name of the recipient, or your name.
             </li>
             <li class="unordered">
               Instructors in this course can see your response, the name of the recipient, and your name.
             </li>
           </ul>
           <div class="constraints-23">
-          </div>
-          <br>
-          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
-              <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
-                  <option selected="" value="">
-                  </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
-                  </option>
-                </select>
-                <span>
-                  Myself
-                </span>
-              </label>
-              (Student):
-            </div>
-            <div class="col-sm-12">
-              <p class="text-muted" hidden="">
-                You need to choose at least -1 options.
-              </p>
-              <p class="text-muted" hidden="">
-                You cannot choose more than -1 options.
-              </p>
-              <table>
-                <tbody>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 1</td></div>'&quot;">
-                          Team 1&lt;/td&gt;&lt;/div&gt;'"
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 2">
-                          Team 2
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="Team 3">
-                          Team 3
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div class="checkbox">
-                        <label class="bold-label">
-                          <input name="responsetext-23-0" type="checkbox" value="">
-                          <i>
-                            None of the above
-                          </i>
-                        </label>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-              <input disabled="" name="msqMaxSelectableChoices-23" type="hidden" value="-1">
-              <input disabled="" name="msqMinSelectableChoices-23" type="hidden" value="-1">
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <br>
-    <br>
-    <input name="questiontype-24" type="hidden" value="CONSTSUM">
-    <input name="questionid-24" type="hidden" value="${question.id}">
-    <input name="questionresponsetotal-24" type="hidden" value="1">
-    <div class="form-horizontal">
-      <div class="panel panel-primary">
-        <div class="panel-heading">
-          Question 24:
-          <br>
-          <span class="text-preserve-space">
-            How much more time should be spent on the following? Give points accordingly.
-          </span>
-        </div>
-        <div class="panel-body">
-          <p class="text-muted">
-            Only the following persons can see your responses:
-          </p>
-          <ul class="text-muted">
-            <li class="unordered">
-              You can see your own feedback in the results page later on.
-            </li>
-            <li class="unordered">
-              Instructors in this course can see your response, the name of the recipient, and your name.
-            </li>
-          </ul>
-          <div class="constraints-24">
             <p class="text-color-blue align-left text-bold">
               Note:
             </p>
-            <p class="text-color-blue padding-left-35px" id="constSumInstruction-24">
+            <p class="text-color-blue padding-left-35px" id="constSumInstruction-23">
               <span class="glyphicon glyphicon-info-sign padding-right-10px">
               </span>
               Total points distributed should add up to 100.
@@ -3711,30 +3484,44 @@
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>
+          <div class="evalueeLabel-23 form-inline mobile-align-left">
+            <label for="input" style="text-indent: 24px">
+              <span class="tool-tip-decorate" data-original-title="The party being evaluated or given feedback to" data-placement="top" data-toggle="tooltip" title="">
+                Evaluee/Recipient
+              </span>
+            </label>
+          </div>
           <br>
-          <div class="evalueeForm-24 form-group margin-0" style="padding-left: 75px">
-            <div class="col-sm-12 form-inline mobile-align-left" style="display:none">
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
               <label>
-                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-24-0" style="display:none;max-width:125px">
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-0" style="display:none;max-width:125px">
                   <option selected="" value="">
                   </option>
-                  <option value="IFSubmitUiT.instr@gmail.tmt">
-                    Myself
+                  <option value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
                   </option>
                 </select>
                 <span>
-                  Myself
+                  Team 1&lt;/td&gt;&lt;/div&gt;'"
                 </span>
               </label>
-              (Student):
+              (Team):
             </div>
-            <div class="col-sm-6 width-auto" id="constSumSubmissionFormOptionFragment-24">
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
               <div class="margin-top-7px margin-bottom-15px flex">
                 <label class="const-sum-options-label">
                   Design
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-0" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-0" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3742,7 +3529,7 @@
                   Usability
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-1" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-1" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
               <div class="margin-top-7px margin-bottom-15px flex">
@@ -3750,19 +3537,141 @@
                   Algo
                 </label>
                 <div class="margin-left-auto">
-                  <input class="form-control pointsBox" id="responsetext-24-0-2" min="0" name="responsetext-24-0" onchange="updateConstSumQnMessages('24')" step="1" type="number" value="">
+                  <input class="form-control pointsBox" id="responsetext-23-0-2" min="0" name="responsetext-23-0" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
                 </div>
               </div>
             </div>
-            <input id="constSumToRecipients-24" type="hidden" value="false">
-            <input id="constSumPointsPerOption-24" type="hidden" value="false">
-            <input id="constSumNumOption-24" type="hidden" value="3">
-            <input id="constSumPoints-24" type="hidden" value="100">
-            <input id="constSumUnevenDistribution-24" type="hidden" value="true">
-            <input id="constSumDistributePointsOptions-24" type="hidden" value="At least some options">
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
           </div>
-          <div id="constSumInputAlert-24-0" style="">
-            <p class="text-color-green padding-left-35px" id="constSumMessage-24-0">
+          <div id="constSumInputAlert-23-0" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-0">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-1" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option value="Team 2">
+                    Team 2
+                  </option>
+                  <option style="display: none;" value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 2
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-0" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-1" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-1-2" min="0" name="responsetext-23-1" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-1" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-1">
+            </p>
+            <hr class="margin-top-0 border-top-dark-gray">
+          </div>
+          <br>
+          <div class="evalueeForm-23 form-group margin-0" style="padding-left: 75px">
+            <div class="col-sm-12 form-inline mobile-align-left" style="text-align:left">
+              <label>
+                <select class="participantSelect middlealign newResponse form-control" name="responserecipient-23-2" style="display:none;max-width:125px">
+                  <option selected="" value="">
+                  </option>
+                  <option style="display: none;" value="Team 1</td></div>'&quot;">
+                    Team 1&lt;/td&gt;&lt;/div&gt;'"
+                  </option>
+                  <option style="display: none;" value="Team 2">
+                    Team 2
+                  </option>
+                  <option value="Team 3">
+                    Team 3
+                  </option>
+                </select>
+                <span>
+                  Team 3
+                </span>
+              </label>
+              (Team):
+            </div>
+            <div class="col-sm-6 width-auto padding-left-55px margin-top-15px" id="constSumSubmissionFormOptionFragment-23">
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Design
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-0" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Usability
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-1" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+              <div class="margin-top-7px margin-bottom-15px flex">
+                <label class="const-sum-options-label">
+                  Algo
+                </label>
+                <div class="margin-left-auto">
+                  <input class="form-control pointsBox" id="responsetext-23-2-2" min="0" name="responsetext-23-2" onchange="updateConstSumQnMessages('23')" step="1" type="number" value="">
+                </div>
+              </div>
+            </div>
+            <input id="constSumToRecipients-23" type="hidden" value="false">
+            <input id="constSumPointsPerOption-23" type="hidden" value="false">
+            <input id="constSumNumOption-23" type="hidden" value="3">
+            <input id="constSumPoints-23" type="hidden" value="100">
+            <input id="constSumUnevenDistribution-23" type="hidden" value="true">
+            <input id="constSumDistributePointsOptions-23" type="hidden" value="At least some options">
+          </div>
+          <div id="constSumInputAlert-23-2" style="">
+            <p class="text-color-green padding-left-35px" id="constSumMessage-23-2">
             </p>
             <hr class="margin-top-0 border-top-dark-gray">
           </div>


### PR DESCRIPTION
Fixes #9198 

**Outline of Solution**
The issue arose because constant sum (recipient) questions require responses for different recipients to be related, but constant sum (option) questions treat different recipients differently.

To resolve the issue, I have made the checks for constant sum (recipient) questions and constant sum (option) questions more distinct. For questions that force an uneven distribution (all uneven or at least some), if the question only have a single response, checks for the distribution are skipped.

I have also tidied up the tests in `InstructorFeedbackSubmitPageUiTest.java`, and made sure the tests are more comprehensive. The tests now include the following cases and check both unsuccessful and successful submissions:
Q18: recipient, does not force uneven
Q19: options, does not force uneven
Q20: recipient, force uneven, all different
Q21: options, force uneven, all different
Q22: recipient, force uneven, at least some different
Q23: options, force uneven, at least some different

Two notes:

1. Admittedly, it would be better to write action tests instead of just UI tests to test the submission. However, there is no such test for any question type yet, so a new issue may be raised for this.
2. It may be worth separating the tests in `InstructorFeedbackSubmitPageUiTest.java` into isolated java files (for example, `InstructorFeedbackSubmitConstSumUiTest.java`) when we want to test each individual question type. There are already files like `FeedbackConstSumRecipientQuestionUiTest.java`, but these files test what happens when the instructor edits a particular question type and not the responses to the question types.