### PR TITLE
[#9215] Add validation to 'Recommended length for response' input number

### DIFF
--- a/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
+++ b/src/main/webapp/dev/js/main/instructorFeedbackEdit.js
@@ -1342,6 +1342,19 @@ function setTooltipTriggerOnFeedbackPathMenuOptions() {
     });
 }
 
+/**
+ *Adds onchange event handler on
+ *instructor feedback edit questions
+ */
+function validateRecommendedLength() {
+    let length = '0';
+    const re = /[0-9]+/;
+    if (re.test($('.recommendedlength').val())) {
+        length = $('.recommendedlength').val();
+    }
+    $('.recommendedlength').val(length);
+}
+
 $(document).ready(() => {
     prepareInstructorPages();
 
@@ -1365,6 +1378,10 @@ $(document).ready(() => {
     $(document).on('change', '.participantSelect', (e) => {
         matchVisibilityOptionToFeedbackPath(e.currentTarget);
         getVisibilityMessage(e.currentTarget);
+    });
+
+    $(document).on('change', '.recommendedlength', () => {
+        validateRecommendedLength();
     });
 
     $(document).on('click', '.btn-duplicate-qn', (e) => {

--- a/src/main/webapp/partials/instructorHelpQuestions.jsp
+++ b/src/main/webapp/partials/instructorHelpQuestions.jsp
@@ -96,7 +96,7 @@
                               Recommended length
                             </span>
                             for the response:
-                            <input disabled="" type="number" class="form-control" name="recommendedlength" value="">
+                            <input disabled="" type="number" class="form-control recommendedlength" name="recommendedlength" value="">
                             words
                           </div>
                         </div>
@@ -4064,7 +4064,7 @@
                                 In the calculation, we do not allow (1) to affect (2). We use (2) to calculate the average perceived contribution for each student. A more detailed version of this calculation can be found
                                 <a href="/technicalInformation.jsp#calculatePointsContribution" target="_blank">here</a>.
                               </p>
-                              <p>
+                           js   <p>
                                 The results and statistics are presented in the example below. Here is a summary of the terms used:
                               </p>
                               <ul>


### PR DESCRIPTION
Fixes #9215  

When the onchange event listener on the input is triggered it will validate with a regex to check if the value is a positive number, if it is not it will establish it as 0.
