### PR TITLE
[#9250]Remove keepUpdateTimestamp in CourseStudent 

### DIFF
--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -323,7 +323,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
         }
 
         // Set true to prevent changes to last update timestamp
-        courseStudent.keepUpdateTimestamp = keepUpdateTimestamp;
         saveEntity(courseStudent, attributes);
     }
 

--- a/src/main/java/teammates/storage/entity/CourseStudent.java
+++ b/src/main/java/teammates/storage/entity/CourseStudent.java
@@ -24,14 +24,6 @@ import teammates.common.util.StringHelper;
 public class CourseStudent extends BaseEntity {
 
     /**
-     * Setting this to true prevents changes to the lastUpdate time stamp.
-     * Set to true when using scripts to update entities when you want to
-     * preserve the lastUpdate time stamp.
-     **/
-    @Ignore
-    public transient boolean keepUpdateTimestamp;
-
-    /**
      * ID of the student.
      *
      * @see #makeId()
@@ -119,9 +111,7 @@ public class CourseStudent extends BaseEntity {
     }
 
     public void setLastUpdate(Instant updatedAt) {
-        if (!keepUpdateTimestamp) {
             this.updatedAt = updatedAt;
-        }
     }
 
     public String getUniqueId() {


### PR DESCRIPTION
[#9250] Remove keepUpdateTimestamp in CourseStudent
Fixes #9250 
Removed the variable keepUpdateTimestamp in CourseStudent #9250 and the condition of the setLastUpdate method. Line 326 of the StudentsDb class was also deleted because the variable keepUpdateTimestamp does not exist in the CourseStudent class.                     


