### PR TITLE
[#9079] Use Travis build stages to make lint/test independent from each other

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - ./gradlew jacocoReport
         - npm run coverage
         - bash <(curl -s https://codecov.io/bash)
-    - name: "E2E Tests"
+    - name: "E2E Tests - Firefox"
       addons:
         firefox: "63.0"
       before_script:
@@ -71,6 +71,32 @@ jobs:
         - cd $TRAVIS_BUILD_DIR
         - gcloud -q components install app-engine-java
       script:
+        - ./gradlew createConfigs testClasses
+        - npm run build -- --progress=false
+        - ./gradlew appengineStart
+        - ./gradlew e2eTests
+    - name: "E2E Tests - Chrome"
+      addons:
+        apt:
+          sources:
+            - google-chrome
+          packages:
+            - google-chrome-stable
+      before_script:
+        - export DISPLAY=:99.0
+        - sh -e /etc/init.d/xvfb start
+        - sleep 3
+        - export PATH=$HOME/google-cloud-sdk/bin:$PATH
+        - cd $HOME
+        - curl -fsS -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
+        - curl -fsSL -o chromedriver.zip https://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip
+        - tar -xzf google-cloud-sdk.tar.gz
+        - unzip chromedriver.zip
+        - ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false
+        - cd $TRAVIS_BUILD_DIR
+        - gcloud -q components install app-engine-java
+      script:
+        - mv src/e2e/resources/test.travis-chrome.properties src/e2e/resources/test.travis.properties
         - ./gradlew createConfigs testClasses
         - npm run build -- --progress=false
         - ./gradlew appengineStart

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,6 @@ branches:
 notifications:
   email: false
 
-sudo: required
-dist: trusty
-
-addons:
-  firefox: "63.0"
-
 before_install:
   - |
       git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md)|(\.txt)|(\.png)|(\.jpg)|(\.gif)|^(LICENSE)|^(docs)|^(\.templates)'
@@ -26,38 +20,58 @@ before_install:
         echo "Only doc files or IDE configurations were updated in PR, not running the CI."
         exit
       fi
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
-    --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1440x900x16"
   - nvm install 10
 
-before_script:
-  - export DISPLAY=:99.0
-  - tar -xjf /tmp/firefox-63.0.tar.bz2 --directory $TRAVIS_BUILD_DIR/
-  - export PATH=$TRAVIS_BUILD_DIR/firefox:./node_modules/.bin:$HOME/google-cloud-sdk/bin:$PATH
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -rf $HOME/.gradle/caches/*/fileHashes/
+  - rm -rf $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -rf node_modules/.cache/uglifyjs-webpack-plugin/
 
-  - cd $HOME
-  - curl -fsS -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
-  - curl -fsSL -o geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
-  - tar -xzf google-cloud-sdk.tar.gz
-  - tar -xzf geckodriver.tar.gz
-  - ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false
-  - cd $TRAVIS_BUILD_DIR
-  - gcloud -q components install app-engine-java
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - node_modules
 
-  - ./gradlew createConfigs testClasses
-  - ./gradlew downloadStaticAnalysisTools
-  - ./gradlew lint --continue
-  - npm install
-  - npm run lint
-  - npm run build -- --progress=false
-
-install: true
-script:
-  - ./gradlew componentTests
-  - npm run coverage
-  - ./gradlew appengineStart
-  - ./gradlew e2eTests
-
-after_success:
-  - ./gradlew jacocoReport
-  - bash <(curl -s https://codecov.io/bash)
+jobs:
+  include:
+    - stage: "Prepare Dependencies"
+      name: "Prepare Dependencies"
+      script:
+        - ./gradlew downloadDependencies downloadTestDependencies downloadLinters
+        - npm install
+        - npm update
+    - stage: "Lint/Test"
+      name: "Lint"
+      script:
+        - ./gradlew createConfigs testClasses
+        - ./gradlew lint --continue
+        - npm run lint
+    - name: "Component Tests"
+      script:
+        - ./gradlew createConfigs componentTests
+        - ./gradlew jacocoReport
+        - npm run coverage
+        - bash <(curl -s https://codecov.io/bash)
+    - name: "E2E Tests"
+      addons:
+        firefox: "63.0"
+      before_script:
+        - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid \
+          --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1440x900x16"
+        - export DISPLAY=:99.0
+        - export PATH=$HOME/google-cloud-sdk/bin:$PATH
+        - cd $HOME
+        - curl -fsS -o google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz
+        - curl -fsSL -o geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
+        - tar -xzf google-cloud-sdk.tar.gz
+        - tar -xzf geckodriver.tar.gz
+        - ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false
+        - cd $TRAVIS_BUILD_DIR
+        - gcloud -q components install app-engine-java
+      script:
+        - ./gradlew createConfigs testClasses
+        - npm run build -- --progress=false
+        - ./gradlew appengineStart
+        - ./gradlew e2eTests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,24 +25,10 @@ skip_commits:
     - .templates/**/*
 
 build_script:
-  - set PATH=C:\google-cloud-sdk\bin;%PATH%
-
-  - curl -fsS -o C:\google-cloud-sdk.zip https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.zip
-  - cd C:\
-  - 7z x google-cloud-sdk.zip
-  - google-cloud-sdk/install.bat --usage-reporting false --path-update false --command-completion false
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - gcloud -q components install app-engine-java
-
   - gradlew.bat createConfigs testClasses
-  - gradlew.bat downloadStaticAnalysisTools
+  - gradlew.bat downloadLinters
   - gradlew.bat lint --continue
+  - gradlew.bat componentTests
   - npm install
   - npm run lint
-  - npm run build -- --progress=false
-
-test_script:
-  - gradlew.bat componentTests
   - npm run coverage
-  - gradlew.bat appengineStart
-  - gradlew.bat e2eTests

--- a/build.gradle
+++ b/build.gradle
@@ -320,6 +320,24 @@ task setupIntellijStaticAnalysis {
     finalizedBy syncIntelliJCheckStyleVersion
 }
 
+task downloadDependencies {
+    doFirst {
+        configurations.compile.resolve()
+    }
+}
+
+task downloadTestDependencies {
+    doFirst {
+        configurations.testCompile.resolve()
+    }
+}
+
+task downloadLinters {
+    doFirst {
+        configurations.staticAnalysis.resolve()
+    }
+}
+
 // RUN SERVER TASKS
 
 compileJava.options.encoding = "UTF-8"
@@ -409,14 +427,6 @@ task printSpotbugsTestViolations {
     }
     doFirst {
         print new File("${buildDir}/reports/spotbugs/test.emacs").getText("UTF-8")
-    }
-}
-
-task downloadStaticAnalysisTools {
-    description "Downloads all static analysis tools."
-    group "Static analysis"
-    doFirst {
-        configurations.staticAnalysis.resolve()
     }
 }
 

--- a/src/e2e/resources/test.travis-chrome.properties
+++ b/src/e2e/resources/test.travis-chrome.properties
@@ -1,11 +1,11 @@
 #-----------------------------------------------------------------------------
-# This file contains specific configuration values for testing on AppVeyor.
+# This file contains specific configuration values for testing on Travis.
 #-----------------------------------------------------------------------------
 
 test.app.url=http\://localhost\:8080
 test.csrf.key=samplekey
 test.backdoor.key=samplekey
 test.selenium.browser=chrome
-test.chromedriver.path=C:\\Tools\\WebDriver\\chromedriver.exe
+test.chromedriver.path=/home/travis/chromedriver
 test.timeout=15
 test.persistence.timeout=16


### PR DESCRIPTION
(still) Part of #9079

Benefits:
- Build time reduced from (currently) ~11 mins to ~8.5 mins
- If linting fails, testing will still proceed but the build will still be marked as fail, but this time without wasting time because the linting stage is done in parallel.

Note that this is only possible in V7 because the component tests and E2E tests are independent. In V6, it can be done, but the benefit (in terms of time saving) is very limited.