### PR TITLE
[#9119] FeedbackResponseCommentsLogicTest: Fix verification for test

### DIFF
--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -85,20 +85,24 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         verifyPresentInDatastore(frComment);
 
         ______TS("typical successful case: frComment already exists");
+
+        FeedbackResponseCommentAttributes actualComment =
+                frcLogic.getFeedbackResponseComment(
+                        frComment.feedbackResponseId, frComment.commentGiver, frComment.createdAt);
+
+        frComment.commentText = "New Text";
         frcLogic.createFeedbackResponseComment(frComment);
-        List<FeedbackResponseCommentAttributes> actualFrComments =
-                frcLogic.getFeedbackResponseCommentForSession(frComment.courseId, frComment.feedbackSessionName);
 
-        FeedbackResponseCommentAttributes actualFrComment = null;
-        for (FeedbackResponseCommentAttributes comment : actualFrComments) {
-            if (comment.commentText.equals(frComment.commentText)) {
-                actualFrComment = comment;
-                break;
-            }
-        }
+        // check that it uses existing ID from database
+        assertEquals(actualComment.getId(), frComment.getId());
 
-        assertNotNull(actualFrComment);
+        // re-fetch the comment from database
+        actualComment = frcLogic.getFeedbackResponseComment(frComment.getId());
 
+        // check whether the comment text has been updated
+        assertEquals(frComment.commentText, actualComment.commentText);
+
+        
         //delete afterwards
         frcLogic.deleteFeedbackResponseCommentById(frComment.getId());
         assertNull(frcLogic.getFeedbackResponseComment(frComment.getId()));

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -84,7 +84,8 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         frcLogic.createFeedbackResponseComment(frComment);
         verifyPresentInDatastore(frComment);
 
-        ______TS("typical successful case: frComment already exists");
+        ______TS("successful case: add duplicate frComment - comment will reuse ID of existing comment and update "
+                + "itself");
 
         FeedbackResponseCommentAttributes actualComment =
                 frcLogic.getFeedbackResponseComment(
@@ -93,7 +94,7 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         frComment.commentText = "New Text";
         frcLogic.createFeedbackResponseComment(frComment);
 
-        // check that it uses existing ID from database
+        // verify that ID of duplicate comment has been set by method (uses existing ID of original comment)
         assertEquals(actualComment.getId(), frComment.getId());
 
         // re-fetch the comment from database

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -102,7 +102,6 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
         // check whether the comment text has been updated
         assertEquals(frComment.commentText, actualComment.commentText);
 
-        
         //delete afterwards
         frcLogic.deleteFeedbackResponseCommentById(frComment.getId());
         assertNull(frcLogic.getFeedbackResponseComment(frComment.getId()));


### PR DESCRIPTION
Fixes #9119

The initial testing code did not verify the case where a duplicate comment is added.

When a duplicate comment is added,  the expected behaviour is:
1. Check database and retrieve the ID of the existing comment
2. Set ID of the existing comment to the duplicate comment
3. Update this comment if needed

As such, in the test, I do a verification of whether the ID has been set correctly. I also change the `commentText` and check if the update works.