### PR TITLE
[#9255] Migrate Instructor Course Details Page to Angular 7

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -965,6 +965,8 @@ public final class Const {
         public static final String JOIN = "/join";
         public static final String TIMEZONE = "/timezone";
 
+        public static final String INSTRUCTOR_COURSE_DETAILS = "/courses/details";
+
         public static final String COURSE_STUDENT_DETAILS = "/courses/students/details";
         public static final String STUDENT_PROFILE_PICTURE = "/students/profilePic";
     }
@@ -988,7 +990,6 @@ public final class Const {
         public static final String INSTRUCTOR_COURSE_SOFT_DELETED_COURSE_DELETE = "/page/instructorCourseDeleteCourse";
         public static final String INSTRUCTOR_COURSE_SOFT_DELETED_COURSE_DELETE_ALL =
                 "/page/instructorCourseDeleteAllCourses";
-        public static final String INSTRUCTOR_COURSE_DETAILS_PAGE = "/page/instructorCourseDetailsPage";
         public static final String INSTRUCTOR_COURSE_EDIT_PAGE = "/page/instructorCourseEditPage";
         public static final String INSTRUCTOR_COURSE_EDIT_SAVE = "/page/instructorCourseEditSave";
         public static final String INSTRUCTOR_COURSE_STUDENT_DETAILS_PAGE = "/page/instructorCourseStudentDetailsPage";

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -494,7 +494,7 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null.
      */
-    public CourseDetailsBundle getCourseDetails(String courseId) throws EntityDoesNotExistException {
+    public CourseDetailsBundle getCourseDetails(String courseId) {
         Assumption.assertNotNull(courseId);
         return coursesLogic.getCourseSummary(courseId);
     }
@@ -1043,7 +1043,7 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null. <br>
      */
-    public String getCourseStudentListAsCsv(String courseId, String googleId) throws EntityDoesNotExistException {
+    public String getCourseStudentListAsCsv(String courseId, String googleId) {
 
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(googleId);

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -23,6 +23,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Assumption;
@@ -136,9 +137,10 @@ public final class CoursesLogic {
     /**
      * Used to trigger an {@link EntityDoesNotExistException} if the course is not present.
      */
-    public void verifyCourseIsPresent(String courseId) throws EntityDoesNotExistException {
+    public void verifyCourseIsPresent(String courseId) {
         if (!isCoursePresent(courseId)) {
-            throw new EntityDoesNotExistException("Course does not exist: " + courseId);
+            throw new EntityNotFoundException(
+                    new EntityDoesNotExistException("Course does not exist: " + courseId));
         }
     }
 
@@ -417,11 +419,12 @@ public final class CoursesLogic {
     /**
      * Returns the {@link CourseDetailsBundle} course details for a course using courseId.
      */
-    public CourseDetailsBundle getCourseSummary(String courseId) throws EntityDoesNotExistException {
+    public CourseDetailsBundle getCourseSummary(String courseId) {
         CourseAttributes cd = coursesDb.getCourse(courseId);
 
         if (cd == null) {
-            throw new EntityDoesNotExistException("The course does not exist: " + courseId);
+            throw new EntityNotFoundException(
+                new EntityDoesNotExistException("The course does not exist: " + courseId));
         }
 
         return getCourseSummary(cd);
@@ -567,8 +570,7 @@ public final class CoursesLogic {
      * @return Map with courseId as key, and CourseDetailsBundle as value.
      *         Does not include details within the course, such as feedback sessions.
      */
-    public Map<String, CourseDetailsBundle> getCourseSummariesForInstructor(String googleId, boolean omitArchived)
-            throws EntityDoesNotExistException {
+    public Map<String, CourseDetailsBundle> getCourseSummariesForInstructor(String googleId, boolean omitArchived) {
 
         instructorsLogic.verifyInstructorExists(googleId);
 
@@ -746,7 +748,7 @@ public final class CoursesLogic {
     /**
      * Returns a CSV for the details (name, email, status) of all students belonging to a given course.
      */
-    public String getCourseStudentListAsCsv(String courseId, String googleId) throws EntityDoesNotExistException {
+    public String getCourseStudentListAsCsv(String courseId, String googleId) {
 
         Map<String, CourseDetailsBundle> courses = getCourseSummariesForInstructor(googleId, false);
         CourseDetailsBundle course = courses.get(courseId);
@@ -786,7 +788,7 @@ public final class CoursesLogic {
         return export.toString();
     }
 
-    public boolean hasIndicatedSections(String courseId) throws EntityDoesNotExistException {
+    public boolean hasIndicatedSections(String courseId) {
         verifyCourseIsPresent(courseId);
 
         List<StudentAttributes> studentList = studentsLogic.getStudentsForCourse(courseId);

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -7,6 +7,7 @@ import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.FieldValidator;
@@ -156,12 +157,11 @@ public final class InstructorsLogic {
                || instructorList.size() == 1 && coursesLogic.isSampleCourse(instructorList.get(0).courseId);
     }
 
-    public void verifyInstructorExists(String instructorId)
-            throws EntityDoesNotExistException {
+    public void verifyInstructorExists(String instructorId) {
 
         if (!accountsLogic.isAccountAnInstructor(instructorId)) {
-            throw new EntityDoesNotExistException("Instructor does not exist :"
-                    + instructorId);
+            throw new EntityNotFoundException(
+                    new EntityDoesNotExistException("Instructor does not exist :" + instructorId));
         }
     }
 

--- a/src/main/java/teammates/ui/controller/ActionFactory.java
+++ b/src/main/java/teammates/ui/controller/ActionFactory.java
@@ -32,7 +32,6 @@ public class ActionFactory {
         map(INSTRUCTOR_COURSE_SOFT_DELETED_COURSE_RESTORE_ALL, InstructorCourseRestoreAllSoftDeletedCoursesAction.class);
         map(INSTRUCTOR_COURSE_SOFT_DELETED_COURSE_DELETE, InstructorCourseDeleteSoftDeletedCourseAction.class);
         map(INSTRUCTOR_COURSE_SOFT_DELETED_COURSE_DELETE_ALL, InstructorCourseDeleteAllSoftDeletedCoursesAction.class);
-        map(INSTRUCTOR_COURSE_DETAILS_PAGE, InstructorCourseDetailsPageAction.class);
         map(INSTRUCTOR_COURSE_REMIND, InstructorCourseRemindAction.class);
         map(INSTRUCTOR_COURSE_EDIT_PAGE, InstructorCourseEditPageAction.class);
         map(INSTRUCTOR_COURSE_EDIT_SAVE, InstructorCourseEditSaveAction.class);

--- a/src/main/java/teammates/ui/controller/StudentHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentHomePageAction.java
@@ -10,6 +10,7 @@ import teammates.common.datatransfer.FeedbackSessionDetailsBundle;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.StatusMessage;
@@ -111,7 +112,7 @@ public class StudentHomePageAction extends Action {
             addPlaceholderFeedbackSessions(course, sessionSubmissionStatusMap);
             FeedbackSessionDetailsBundle.sortFeedbackSessionsByCreationTime(course.feedbackSessions);
 
-        } catch (EntityDoesNotExistException e) {
+        } catch (EntityNotFoundException e) {
             showEventualConsistencyMessage(courseId);
             statusToAdmin = Const.ACTION_RESULT_FAILURE + " :" + e.getMessage();
         }

--- a/src/main/java/teammates/ui/newcontroller/ActionFactory.java
+++ b/src/main/java/teammates/ui/newcontroller/ActionFactory.java
@@ -48,6 +48,8 @@ public class ActionFactory {
         map(ResourceURIs.JOIN, PUT, JoinCourseAction.class);
         map(ResourceURIs.COURSE_STUDENT_DETAILS, GET, GetCourseStudentDetailsAction.class);
         map(ResourceURIs.STUDENT_PROFILE_PICTURE, GET, GetStudentProfilePictureAction.class);
+
+        map(ResourceURIs.INSTRUCTOR_COURSE_DETAILS, GET, GetInstructorCourseDetailsAction.class);
     }
 
     private static void map(String uri, String method, Class<? extends Action> actionClass) {

--- a/src/main/java/teammates/ui/newcontroller/GetInstructorCourseDetailsAction.java
+++ b/src/main/java/teammates/ui/newcontroller/GetInstructorCourseDetailsAction.java
@@ -1,0 +1,148 @@
+package teammates.ui.newcontroller;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+
+import teammates.common.datatransfer.CourseDetailsBundle;
+import teammates.common.datatransfer.SectionDetailsBundle;
+import teammates.common.datatransfer.TeamDetailsBundle;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.common.util.Url;
+import teammates.ui.template.StudentListSectionData;
+
+/**
+ * Action: gets details of a course in instructor.
+ */
+public class GetInstructorCourseDetailsAction extends Action {
+
+    @Override
+    protected AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    public void checkSpecificAccessControl() {
+        if (!userInfo.isInstructor) {
+            throw new UnauthorizedAccessException("Instructor privilege is required to access this resource.");
+        }
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+
+        CourseDetailsBundle courseDetails = logic.getCourseDetails(courseId);
+        if (courseDetails == null) {
+            throw new EntityNotFoundException(
+                    new EntityDoesNotExistException("No course with given instructor is found."));
+        }
+        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+        gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId));
+    }
+
+    @Override
+    public ActionResult execute() {
+
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+
+        CourseDetailsBundle courseDetails = logic.getCourseDetails(courseId);
+        if (courseDetails == null) {
+            return new JsonResult("No course with given instructor is found.", HttpStatus.SC_NOT_FOUND);
+        }
+
+        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+        gateKeeper.verifyAccessible(instructor, logic.getCourse(courseId));
+
+        List<InstructorAttributes> instructors = logic.getInstructorsForCourse(courseId);
+
+        List<StudentListSectionData> sections = new ArrayList<>();
+        for (SectionDetailsBundle section : courseDetails.sections) {
+            Map<String, String> emailPhotoUrlMapping = new HashMap<>();
+            for (TeamDetailsBundle teamDetails : section.teams) {
+                for (StudentAttributes student : teamDetails.students) {
+                    String studentPhotoUrl = student.getPublicProfilePictureUrl();
+                    studentPhotoUrl = Url.addParamToUrl(studentPhotoUrl, Const.ParamsNames.USER_ID, userInfo.id);
+                    emailPhotoUrlMapping.put(student.email, studentPhotoUrl);
+                }
+            }
+            boolean isAllowedToViewStudentInSection = instructor.isAllowedForPrivilege(section.name,
+                    Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_STUDENT_IN_SECTIONS);
+            boolean isAllowedToModifyStudent = instructor.isAllowedForPrivilege(section.name,
+                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT);
+            sections.add(new StudentListSectionData(section, isAllowedToViewStudentInSection,
+                    isAllowedToModifyStudent, emailPhotoUrlMapping, userInfo.getId(), "",
+                    Const.PageNames.INSTRUCTOR_COURSE_DETAILS_PAGE));
+        }
+
+        CourseInfo output = new CourseInfo(instructor, courseDetails, instructors, sections);
+
+        boolean isHtmlTableNeeded = getRequestParamAsBoolean(Const.ParamsNames.CSV_TO_HTML_TABLE_NEEDED);
+        if (isHtmlTableNeeded) {
+            String courseStudentListAsCsv = logic.getCourseStudentListAsCsv(courseId, userInfo.getId());
+            output.setStudentListHtmlTableAsString(StringHelper.csvToHtmlTable(courseStudentListAsCsv));
+        }
+
+        return new JsonResult(output);
+    }
+
+    /**
+     * Output format for {@link GetInstructorCourseDetailsAction}.
+     */
+    public static class CourseInfo extends ActionResult.ActionOutput {
+        private final CourseDetailsBundle courseDetails;
+        private final InstructorAttributes currentInstructor;
+        private final List<InstructorAttributes> instructors;
+        private final List<StudentListSectionData> sections;
+        private final boolean hasSection;
+        private String studentListHtmlTableAsString;
+
+        public CourseInfo(InstructorAttributes currentInstructor, CourseDetailsBundle courseDetails,
+                          List<InstructorAttributes> instructors, List<StudentListSectionData> sections) {
+            this.currentInstructor = currentInstructor;
+            this.courseDetails = courseDetails;
+            this.instructors = instructors;
+            this.sections = sections;
+
+            if (sections.size() == 1) {
+                StudentListSectionData section = sections.get(0);
+                this.hasSection = !"None".equals(section.getSectionName());
+            } else {
+                this.hasSection = true;
+            }
+        }
+
+        public void setStudentListHtmlTableAsString(String studentListHtmlTableAsString) {
+            this.studentListHtmlTableAsString = studentListHtmlTableAsString;
+        }
+
+        public CourseDetailsBundle getCourseDetails() {
+            return courseDetails;
+        }
+
+        public InstructorAttributes getCurrentInstructor() {
+            return currentInstructor;
+        }
+
+        public List<InstructorAttributes> getInstructors() {
+            return instructors;
+        }
+
+        public List<StudentListSectionData> getSections() {
+            return sections;
+        }
+
+        public boolean isHasSection() {
+            return hasSection;
+        }
+
+        public String getStudentListHtmlTableAsString() {
+            return studentListHtmlTableAsString;
+        }
+    }
+}

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -1,5 +1,61 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { environment } from '../../../environments/environment';
+import { HttpRequestService } from '../../../services/http-request.service';
+import { StatusMessageService } from '../../../services/status-message.service';
+import { ErrorMessageOutput } from '../../message-output';
+
+interface StudentListStudentData {
+  studentName: string;
+  studentEmail: string;
+  studentStatus: string;
+  photoUrl: string;
+}
+
+interface StudentListTeamData {
+  teamName: string;
+  students: StudentListStudentData[];
+}
+
+interface StudentListSectionData {
+  sectionName: string;
+  teams: StudentListTeamData[];
+}
+
+interface CourseAttributes {
+  id: string;
+  name: string;
+}
+
+interface CourseStats {
+  sectionsTotal: string;
+  teamsTotal: string;
+  studentsTotal: string;
+}
+
+interface CourseDetailsBundle {
+  course: CourseAttributes;
+  stats: CourseStats;
+}
+
+interface InstructorAttributes {
+  googleId: string;
+  name: string;
+  email: string;
+  displayedName: string;
+  isArchived: boolean;
+  isDisplayedToStudents: boolean;
+}
+
+interface CourseInfo {
+  courseDetails: CourseDetailsBundle;
+  currentInstructor: InstructorAttributes;
+  instructors: InstructorAttributes[];
+  studentListHtmlTableAsString: string;
+  sections: StudentListSectionData[];
+  hasSection: boolean;
+}
 
 /**
  * Instructor course details page.
@@ -12,6 +68,12 @@ import { ActivatedRoute } from '@angular/router';
 export class InstructorCourseDetailsPageComponent implements OnInit {
 
   user: string = '';
+  courseDetails? : CourseDetailsBundle;
+  currentInstructor? : InstructorAttributes;
+  instructors? : InstructorAttributes[];
+  sections? : StudentListSectionData[];
+
+  private backendUrl: string = environment.backendUrl;
 
   constructor(private route: ActivatedRoute) { }
 

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.ts
@@ -75,11 +75,31 @@ export class InstructorCourseDetailsPageComponent implements OnInit {
 
   private backendUrl: string = environment.backendUrl;
 
-  constructor(private route: ActivatedRoute) { }
+  constructor(private route: ActivatedRoute, private httpRequestService: HttpRequestService,
+              private statusMessageService: StatusMessageService, private ngbModal: NgbModal) { }
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
       this.user = queryParams.user;
+      this.loadCourseDetails(queryParams.courseid);
+    });
+  }
+  /**
+   * Loads the course's details based on the given course ID and email.
+   */
+  loadCourseDetails(courseid: string): void {
+    const paramMap: { [key: string]: string } = { courseid };
+    this.httpRequestService.get('/courses/details', paramMap).subscribe((resp: CourseInfo) => {
+      this.courseDetails = resp.courseDetails;
+      this.currentInstructor = resp.currentInstructor;
+      this.instructors = resp.instructors;
+      this.sections = resp.sections;
+
+      if (!this.courseDetails) {
+        this.statusMessageService.showErrorMessage('Error retrieving course details');
+      }
+    }, (resp: ErrorMessageOutput) => {
+      this.statusMessageService.showErrorMessage(resp.error.message);
     });
   }
 


### PR DESCRIPTION
Part of #9255

PR is still in progress.

Aim to migrated `InstructorCourseDetailsPageAction` to `GetInstructorCourseDetailsAction`. The new endpoint is at `/webapi/instructor/courses/details` and requires 1 GET parameters, courseid.

To be completed:
- [x] Logic migration for controller, ActionURIs, ViewURIs
- [ ] `*.jsp`, `*.tag`, `*.js` to be migrated to Angular counterparts (`*.html`, `*.scss`, `*.ts`) (in progress)
- [ ] Testing of api Endpoints
- [ ] Delete migrated files