### PR TITLE
[#9250] Removed keepUpdateTimestamp in CourseStudent

### DIFF
--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -225,7 +225,7 @@ public final class StudentsLogic {
         }
 
         studentsDb.updateStudent(student.course, originalEmail, student.name, student.team, student.section,
-                                 student.email, student.googleId, student.comments, hasDocument, false);
+                                 student.email, student.googleId, student.comments, hasDocument);
 
         // cascade email change, if any
         if (!originalEmail.equals(student.email)) {
@@ -250,7 +250,7 @@ public final class StudentsLogic {
         }
         studentsDb.updateStudent(originalStudent.course, originalEmail, originalStudent.name,
                                  originalStudent.team, originalStudent.section, originalStudent.email,
-                                 originalStudent.googleId, originalStudent.comments, hasDocument, false);
+                                 originalStudent.googleId, originalStudent.comments, hasDocument);
     }
 
     public CourseEnrollmentResult enrollStudents(String enrollLines, String courseId)

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -233,19 +233,7 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
     /**
      * Update student's record without searchability
      * This function is only used for testing, its purpose is to not create document if not necessary.
-     * @param keepUpdateTimestamp Set true to prevent changes to updatedAt. Use when updating entities with scripts.
      */
-    public void updateStudentWithoutSearchability(String courseId, String email,
-            String newName,
-            String newTeamName, String newSectionName, String newEmail,
-            String newGoogleId,
-            String newComments,
-            boolean keepUpdateTimestamp) throws InvalidParametersException,
-            EntityDoesNotExistException {
-        updateStudent(courseId, email, newName, newTeamName, newSectionName,
-                                        newEmail, newGoogleId, newComments, false, keepUpdateTimestamp);
-    }
-
     public void updateStudentWithoutSearchability(String courseId, String email,
             String newName,
             String newTeamName, String newSectionName, String newEmail,
@@ -253,12 +241,12 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
             String newComments) throws InvalidParametersException,
             EntityDoesNotExistException {
         updateStudent(courseId, email, newName, newTeamName, newSectionName,
-                newEmail, newGoogleId, newComments, false, false);
+                                        newEmail, newGoogleId, newComments, false);
     }
 
     public void updateStudent(String courseId, String email, String newName,
             String newTeamName, String newSectionName, String newEmail, String newGoogleId,
-            String newComments, boolean hasDocument, boolean keepUpdateTimestamp)
+            String newComments, boolean hasDocument)
             throws InvalidParametersException, EntityDoesNotExistException {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, email);
@@ -275,10 +263,10 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
                 CourseStudent newCourseStudent = new CourseStudent(newEmail, newName, newGoogleId, newComments,
                                                                    courseId, newTeamName, newSectionName);
                 recreateStudentWithNewEmail(newCourseStudent, lastName, courseStudent, hasDocument,
-                                            keepUpdateTimestamp, courseId, email);
+                                            courseId, email);
             } else {
                 updateStudentDetails(newName, newTeamName, newSectionName, newGoogleId,
-                                     newComments, hasDocument, keepUpdateTimestamp, courseStudent, lastName);
+                                     newComments, hasDocument, courseStudent, lastName);
             }
         }
     }
@@ -286,13 +274,10 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
     @SuppressWarnings("PMD.PreserveStackTrace")
     private void recreateStudentWithNewEmail(
             CourseStudent newCourseStudent, String lastName, CourseStudent courseStudent,
-            boolean hasDocument, boolean keepUpdateTimestamp, String courseId, String email)
+            boolean hasDocument, String courseId, String email)
             throws InvalidParametersException {
         newCourseStudent.setLastName(lastName);
         newCourseStudent.setCreatedAt(courseStudent.getCreatedAt());
-        if (keepUpdateTimestamp) {
-            newCourseStudent.setLastUpdate(courseStudent.getUpdatedAt());
-        }
 
         StudentAttributes newCourseStudentAttributes = makeAttributes(newCourseStudent);
         try {
@@ -308,7 +293,7 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
 
     private void updateStudentDetails(String newName, String newTeamName, String newSectionName,
             String newGoogleId, String newComments, boolean hasDocument,
-            boolean keepUpdateTimestamp, CourseStudent courseStudent, String lastName) {
+            CourseStudent courseStudent, String lastName) {
         courseStudent.setName(newName);
         courseStudent.setLastName(lastName);
         courseStudent.setComments(newComments);
@@ -322,8 +307,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
             putDocument(attributes);
         }
 
-        // Set true to prevent changes to last update timestamp
-        courseStudent.keepUpdateTimestamp = keepUpdateTimestamp;
         saveEntity(courseStudent, attributes);
     }
 

--- a/src/main/java/teammates/storage/entity/CourseStudent.java
+++ b/src/main/java/teammates/storage/entity/CourseStudent.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 import com.google.gson.annotations.SerializedName;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
-import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.OnSave;
 import com.googlecode.objectify.annotation.Translate;

--- a/src/main/java/teammates/storage/entity/CourseStudent.java
+++ b/src/main/java/teammates/storage/entity/CourseStudent.java
@@ -22,15 +22,6 @@ import teammates.common.util.StringHelper;
 @Entity
 @Index
 public class CourseStudent extends BaseEntity {
-
-    /**
-     * Setting this to true prevents changes to the lastUpdate time stamp.
-     * Set to true when using scripts to update entities when you want to
-     * preserve the lastUpdate time stamp.
-     **/
-    @Ignore
-    public transient boolean keepUpdateTimestamp;
-
     /**
      * ID of the student.
      *
@@ -119,9 +110,7 @@ public class CourseStudent extends BaseEntity {
     }
 
     public void setLastUpdate(Instant updatedAt) {
-        if (!keepUpdateTimestamp) {
-            this.updatedAt = updatedAt;
-        }
+        this.updatedAt = updatedAt;
     }
 
     public String getUniqueId() {

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -46,16 +46,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
         // Assert lastUpdate has changed, and is now.
         assertFalse(student.getUpdatedAt().equals(updatedStudent.getUpdatedAt()));
         AssertHelper.assertInstantIsNow(updatedStudent.getUpdatedAt());
-
-        ______TS("success : keep lastUpdated");
-
-        s.name = "new-name-2";
-        studentsDb.updateStudentWithoutSearchability(s.course, s.email, s.name, s.team,
-                                                     s.section, s.email, s.googleId, s.comments, true);
-        StudentAttributes updatedStudent2 = studentsDb.getStudentForGoogleId(s.course, s.googleId);
-
-        // Assert lastUpdate has NOT changed.
-        assertEquals(updatedStudent.getUpdatedAt(), updatedStudent2.getUpdatedAt());
     }
 
     @Test


### PR DESCRIPTION
Fixes #9250 

**Outline of Solution**
Removed keepUpdateTimestamp from CourseStudent.java along with the parts that showed up within the StudentsDb.java file and StudentsLogic.java.  I also removed the corresponding test.