### PR TITLE
[#9219] Fix NPE in feedbackResponseAdjustment when changing student data

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -622,6 +622,10 @@ public final class FeedbackResponsesLogic {
             FeedbackResponseAttributes response) throws InvalidParametersException, EntityDoesNotExistException {
 
         FeedbackResponse feedbackResponse = frDb.getFeedbackResponseEntityOptimized(response);
+        if (feedbackResponse == null) {
+            throw new EntityDoesNotExistException("Trying to update a feedback response that does not exist.");
+        }
+
         boolean isGiverSameForResponseAndEnrollment = feedbackResponse.getGiverEmail()
                 .equals(enrollment.email);
         boolean isReceiverSameForResponseAndEnrollment = feedbackResponse.getRecipientEmail()


### PR DESCRIPTION
Fixes #9219 

**PR Checklist**

<!-- Remove this portion after you have made the checks. -->

Ensure that you have:
- [x] Read and understood our PR guideline: https://github.com/TEAMMATES/teammates/blob/master/docs/process.md#step-4-submit-a-pr
  - [x] Added the issue number to the "Fixes" keyword above
  - [x] Titled the PR as specified in the abovementioned document
- [x] Made your changes on a branch other than `master` and `release`
- [x] Gone through all the changes in this PR and ensured that:
  - [x] They addressed one (and only one) issue
  - [x] No unintended changes were made
- [x] Run and passed static analysis: `./gradlew lint` and `npm run lint`
- [x] Added/updated tests, if changes in functionality were involved
- [x] Added/updated documentation to public APIs (classes, methods, variables), if applicable

**Outline of Solution**

I looked into the logic, `frDb.getFeedbackResponseEntityOptimized(response)` has been called and has not been checked if the returning value is null. However it is still used later on assuming it is not null. 

Although logically it is not possible that the response does not exist(because the response is retrieved from DB just before), This entire action is not enclosed in any transaction. Thus it might be the case that some deletion happens in the middle, and causing the NPE problem here. 
