### PR TITLE
[#9382] Refactor chained boolean values into function

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-section.component.ts
@@ -101,4 +101,12 @@ export class InstructorHelpSectionComponent implements OnInit, OnChanges, AfterV
       }
     }
   }
+
+  /**
+   * Checks if any question in the subsection is to be displayed after the search
+   */
+  displaySubsection(questionsToDisplay: Boolean[], firstPoint: number, lastPoint: number): boolean {
+    return questionsToDisplay.length === 0 || questionsToDisplay.slice(firstPoint, lastPoint)
+        .reduce((x: any, y: any) => x || y, false);
+  }
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.html
@@ -1,7 +1,7 @@
 <div>
   <h2 class="color-blue" *ngIf="showQuestion.length === 0 || showQuestion.includes(true)">Students</h2>
   <!-- Section -->
-  <h3 *ngIf="showQuestion.length === 0 || showQuestion[0] || showQuestion[1] || showQuestion[2]">Student Records</h3>
+  <h3 *ngIf="displaySubsection(showQuestion, 0, 3)">Student Records</h3>
   <!-- Question -->
   <div class="instr-help-qn0" *ngIf="showQuestion.length === 0 || showQuestion[0]" #question>
     <p>
@@ -112,7 +112,7 @@
     </div>
   </div>
   <!-- Section -->
-  <h3 *ngIf="showQuestion.length === 0 || showQuestion[3] || showQuestion[4]">Finding Students</h3>
+  <h3 *ngIf="displaySubsection(showQuestion, 3, 5)">Finding Students</h3>
   <!--Question -->
   <div class="instr-help-qn3" *ngIf="showQuestion.length === 0 || showQuestion[3]" #question>
     <p>
@@ -183,7 +183,7 @@
     </div>
   </div>
   <!-- Section -->
-  <h3 *ngIf="showQuestion.length === 0 || showQuestion[5] || showQuestion[6]">Student Accounts</h3>
+  <h3 *ngIf="displaySubsection(showQuestion, 5, 7)">Student Accounts</h3>
   <!--Question-->
   <div class="instr-help-qn5" *ngIf="showQuestion.length === 0 || showQuestion[5]" #question>
     <p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -23,7 +23,7 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
    * Returns a boolean value if any question in the subsection is to be displayed after the search
    */
   displaySubsection(array: boolean[], firstPoint: number, lastPoint: number): boolean {
-    return array.length === 0 || this.showQuestion
+    return array.length === 0 || this.array
         .slice(firstPoint, lastPoint)
         .reduce((x: boolean, y: boolean) => x || y, false);
   }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -22,7 +22,7 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
   /**
    * Returns a boolean value if any question in the subsection is to be displayed after the search
    */
-  displaySubsection(array: boolean, firstPoint: number, lastPoint: number): boolean {
+  displaySubsection(array: boolean[], firstPoint: number, lastPoint: number): boolean {
     return array.length === 0 || this.showQuestion
         .slice(firstPoint, lastPoint)
         .reduce((x: boolean, y: boolean) => x || y, false);

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -19,6 +19,15 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
     super();
   }
 
+  /**
+   * Returns a boolean value if any question in the subsection is to be displayed after the search
+   */
+  displaySubsection(array: any, firstPoint: number, lastPoint: number): boolean {
+    return array.length === 0 || this.showQuestion
+        .slice(firstPoint, lastPoint)
+        .reduce((x: boolean, y: boolean) => x || y, false);
+  }
+
   ngOnInit(): void {
 
   }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -22,9 +22,9 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
   /**
    * Returns a boolean value if any question in the subsection is to be displayed after the search
    */
-  displaySubsection(array: boolean[], firstPoint: number, lastPoint: number): boolean {
+  displaySubsection(array: Boolean[], firstPoint: number, lastPoint: number): boolean {
     return array.length === 0 || array.slice(firstPoint, lastPoint)
-        .reduce((x: boolean, y: boolean) => x || y, false);
+        .reduce((x: any, y: any) => x || y, false);
   }
 
   ngOnInit(): void {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -19,16 +19,16 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
     super();
   }
 
-  /**
-   * Returns a boolean value if any question in the subsection is to be displayed after the search
-   */
-  displaySubsection(array: Boolean[], firstPoint: number, lastPoint: number): boolean {
-    return array.length === 0 || array.slice(firstPoint, lastPoint)
-        .reduce((x: any, y: any) => x || y, false);
-  }
-
   ngOnInit(): void {
 
+  }
+
+  /**
+   * Checks if any question in the subsection is to be displayed after the search
+   */
+  displaySubsection(questionsToDisplay: Boolean[], firstPoint: number, lastPoint: number): boolean {
+    return questionsToDisplay.length === 0 || questionsToDisplay.slice(firstPoint, lastPoint)
+        .reduce((x: any, y: any) => x || y, false);
   }
 
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -22,7 +22,7 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
   /**
    * Returns a boolean value if any question in the subsection is to be displayed after the search
    */
-  displaySubsection(array: any, firstPoint: number, lastPoint: number): boolean {
+  displaySubsection(array: boolean, firstPoint: number, lastPoint: number): boolean {
     return array.length === 0 || this.showQuestion
         .slice(firstPoint, lastPoint)
         .reduce((x: boolean, y: boolean) => x || y, false);

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -23,8 +23,7 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
    * Returns a boolean value if any question in the subsection is to be displayed after the search
    */
   displaySubsection(array: boolean[], firstPoint: number, lastPoint: number): boolean {
-    return array.length === 0 || this.array
-        .slice(firstPoint, lastPoint)
+    return array.length === 0 || array.slice(firstPoint, lastPoint)
         .reduce((x: boolean, y: boolean) => x || y, false);
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-students-section/instructor-help-students-section.component.ts
@@ -22,13 +22,4 @@ export class InstructorHelpStudentsSectionComponent extends InstructorHelpSectio
   ngOnInit(): void {
 
   }
-
-  /**
-   * Checks if any question in the subsection is to be displayed after the search
-   */
-  displaySubsection(questionsToDisplay: Boolean[], firstPoint: number, lastPoint: number): boolean {
-    return questionsToDisplay.length === 0 || questionsToDisplay.slice(firstPoint, lastPoint)
-        .reduce((x: any, y: any) => x || y, false);
-  }
-
 }


### PR DESCRIPTION
Part of #9382 

Done to avoid chaining of multiple boolean conditions using the Or operator. A single function is used to compute the value instead, and can be used for other sections where the number of conditions would be too many to feasibly chain.