### PR TITLE
[#9382] Migrate instructor getting started page

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -1,0 +1,3 @@
+<p>
+  instructor-help-getting-started works!
+</p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -8,12 +8,12 @@
     For more help, browse the answers to some <a routerLink="/web/front/help/instructor">frequently asked questions</a>.
   </p>
   <ol>
-    <li><a (click)="jumpTo('course-setup')" href>Set up a course</a></li>
-    <li><a (click)="jumpTo('session-setup')" href>Create a session</a></li>
-    <li><a (click)="jumpTo('session-invites')" href>Wait for your session to open</a></li>
-    <li><a (click)="jumpTo('session-results')" href>View and publish session results</a></li>
-    <li><a (click)="jumpTo('other-actions')" href>Learn about other actions you can perform</a></li>
-    <li><a (click)="jumpTo('contact-us')" href>Contact us</a></li>
+    <li><a (click)="jumpTo('course-setup')" [routerLink]="">Set up a course</a></li>
+    <li><a (click)="jumpTo('session-setup')" [routerLink]="">Create a session</a></li>
+    <li><a (click)="jumpTo('session-invites')" [routerLink]="">Wait for your session to open</a></li>
+    <li><a (click)="jumpTo('session-results')" [routerLink]="">View and publish session results</a></li>
+    <li><a (click)="jumpTo('other-actions')" [routerLink]="">Learn about other actions you can perform</a></li>
+    <li><a (click)="jumpTo('contact-us')" [routerLink]="">Contact us</a></li>
   </ol>
   <div class="separate-content-holder">
     <hr>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -1,4 +1,4 @@
-<h1 id="Top">Getting Started</h1>
+<h1 id="Top" class="color-orange">Getting Started</h1>
 <div id="contentHolder">
   <p>
     Welcome to TEAMMATES!

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -31,15 +31,15 @@
         <p><b>EXAMPLE BOX</b></p>
       </li>
       <li>
-        <b><a href="/web/front/help/instructor#course-add-students" target="_blank" rel="noopener noreferrer">Enroll students in the course</a></b><br>
+        <b><a routerLink="../instructor" fragment="course-add-students" target="_blank" rel="noopener noreferrer">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
       </li>
       <li>
-        <b><a href="/web/front/help/instructor#course-add-instructor" target="_blank" rel="noopener noreferrer">Add instructors to the course</a></b><br>
+        <b><a routerLink="../instructor" fragment="course-add-instructor" target="_blank" rel="noopener noreferrer">Add instructors to the course</a></b><br>
         From the <b>Courses</b> page, click the <button class="btn btn-secondary btn-sm" type="button">Edit</button> button of the course you would like to add instructors to. You will be directed to the <b>Edit Course</b> page where you can add a new instructor to your course.
-        You can specify the <a href="/web/front/help/instructor#course-instructor-access" target="_blank" rel="noopener noreferrer">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a href="/web/front/help/instructor#course-add-instructor" target="_blank" rel="noopener noreferrer">here</a>.
+        You can specify the <a routerLink="../instructor" fragment="course-instructor-access" target="_blank" rel="noopener noreferrer">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="../instructor" fragment="course-add-instructor" target="_blank" rel="noopener noreferrer">here</a>.
       </li>
     </ol>
   </div>
@@ -72,12 +72,12 @@
         </ul>
       </ul>
       <li>
-        <b><a href="/web/front/help/instructor#session-questions" target="_blank" rel="noopener noreferrer">Add questions</a> to your session to suit your needs.</b><br>
+        <b><a routerLink="../instructor" fragment="session-questions" target="_blank" rel="noopener noreferrer">Add questions</a> to your session to suit your needs.</b><br>
         For each question, you can set the following:
       </li>
       <ul>
         <li>
-          Question type: the style of question being asked. Choose from our 10 different <a href="/web/front/help/instructor#questions" target="_blank" rel="noopener noreferrer">question types</a>.
+          Question type: the style of question being asked. Choose from our 10 different <a routerLink="../instructor" fragment="questions" target="_blank" rel="noopener noreferrer">question types</a>.
         </li>
         <li>
           Question feedback path: the feedback giver and feedback recipient
@@ -88,7 +88,7 @@
       </ul>
       <li>
         <b>Preview your session</b><br>
-        After you have finished setting up your session, <a href="/web/front/help/instructor#session-preview" target="_blank" rel="noopener noreferrer">preview the session</a> as a student or another instructor.
+        After you have finished setting up your session, <a routerLink="../instructor" fragment="session-preview" target="_blank" rel="noopener noreferrer">preview the session</a> as a student or another instructor.
       </li>
     </ol>
   </div>
@@ -137,19 +137,19 @@
     </p>
     <ul>
       <li>
-        <a href="/web/front/help/instructor#session-view-results" target="_blank" rel="noopener noreferrer">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
+        <a routerLink="../instructor" fragment="session-view-results" target="_blank" rel="noopener noreferrer">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
       </li>
       <li>
         Moderate responses: edit inappropriate responses from respondents before publishing the responses.
       </li>
       <li>
-        <a href="/web/front/help/instructor#session-add-comments" target="_blank" rel="noopener noreferrer">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
+        <a routerLink="../instructor" fragment="session-add-comments" target="_blank" rel="noopener noreferrer">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
       </li>
       <li>
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
       </li>
       <li>
-        <a href="/web/front/help/instructor#session-cannot-submit" target="_blank" rel="noopener noreferrer">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+        <a routerLink="../instructor" fragment="session-cannot-submit" target="_blank" rel="noopener noreferrer">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
     <p>
@@ -177,19 +177,19 @@
     </p>
     <ul>
       <li>
-        <a href="/web/front/help/instructor#student-view-profile" target="_blank" rel="noopener noreferrer">View a student's profile</a> and <a href="/web/front/help/instructor#student-view-responses" target="_blank" rel="noopener noreferrer">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
+        <a routerLink="../instructor" fragment="student-view-profile" target="_blank" rel="noopener noreferrer">View a student's profile</a> and <a routerLink="../instructor" fragment="student-view-responses" target="_blank" rel="noopener noreferrer">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
       </li>
       <li>
-        <a href="/web/front/help/instructor#student-edit-details" target="_blank" rel="noopener noreferrer">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
+        <a routerLink="../instructor" fragment="student-edit-details" target="_blank" rel="noopener noreferrer">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
       </li>
       <li>
-        <a href="/web/front/help/instructor#student-email" target="_blank" rel="noopener noreferrer">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
+        <a routerLink="../instructor" fragment="student-email" target="_blank" rel="noopener noreferrer">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
       </li>
       <li>
-        Search: <a href="/web/front/help/instructor#student-search" target="_blank" rel="noopener noreferrer">search for students, teams or sections</a>, or <a href="/web/front/help/instructor#session-search" target="_blank" rel="noopener noreferrer">search for questions, responses or comments</a>.
+        Search: <a routerLink="../instructor" fragment="student-search" target="_blank" rel="noopener noreferrer">search for students, teams or sections</a>, or <a routerLink="../instructor" fragment="session-search" target="_blank" rel="noopener noreferrer">search for questions, responses or comments</a>.
       </li>
       <li>
-        <a href="/web/front/help/instructor#course-archive" target="_blank" rel="noopener noreferrer">Archive old courses</a>: archive old courses that you no longer need actively.
+        <a routerLink="../instructor" fragment="course-archive" target="_blank" rel="noopener noreferrer">Archive old courses</a>: archive old courses that you no longer need actively.
       </li>
     </ul>
   </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -1,4 +1,4 @@
-<h1 id="Top" class="color-orange">Getting Started</h1>
+<h1 id="top" class="color-orange">Getting Started</h1>
 <div id="contentHolder">
   <p>
     Welcome to TEAMMATES!
@@ -8,12 +8,12 @@
     For more help, browse the answers to some <a routerLink="/web/front/help/instructor">frequently asked questions</a>.
   </p>
   <ol>
-    <li><a href="#course-setup">Set up a course</a></li>
-    <li><a href="#session-setup">Create a session</a></li>
-    <li><a href="#session-invites">Wait for your session to open</a></li>
-    <li><a href="#session-results">View and publish session results</a></li>
-    <li><a href="#other-actions">Learn about other actions you can perform</a></li>
-    <li><a href="#contact-us">Contact us</a></li>
+    <li><a (click)="!!jumpTo('course-setup')" href>Set up a course</a></li>
+    <li><a (click)="!!jumpTo('session-setup')" href>Create a session</a></li>
+    <li><a (click)="!!jumpTo('session-invites')" href>Wait for your session to open</a></li>
+    <li><a (click)="!!jumpTo('session-results')" href>View and publish session results</a></li>
+    <li><a (click)="!!jumpTo('other-actions')" href>Learn about other actions you can perform</a></li>
+    <li><a (click)="!!jumpTo('contact-us')" href>Contact us</a></li>
   </ol>
   <div class="separate-content-holder">
     <hr>
@@ -44,7 +44,7 @@
     </ol>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -93,7 +93,7 @@
     </ol>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -125,7 +125,7 @@
     </p>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -165,7 +165,7 @@
     </ul>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -194,7 +194,7 @@
     </ul>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
   <div class="separate-content-holder">
     <hr>
@@ -208,6 +208,6 @@
     </p>
   </div>
   <p align="right">
-    <a href="#Top">Back to Top</a>
+    <button type="button" class="btn btn-info" (click)="jumpTo('top')">Back to Top <i class="fas fa-chevron-up"></i></button>
   </p>
 </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -31,15 +31,15 @@
         <p><b>EXAMPLE BOX</b></p>
       </li>
       <li>
-        <b><a routerLink="../instructor" fragment="course-add-students" target="_blank" rel="noopener noreferrer">Enroll students in the course</a></b><br>
+        <b><a routerLink="../instructor" fragment="course-add-students">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
       </li>
       <li>
-        <b><a routerLink="../instructor" fragment="course-add-instructor" target="_blank" rel="noopener noreferrer">Add instructors to the course</a></b><br>
+        <b><a routerLink="../instructor" fragment="course-add-instructor">Add instructors to the course</a></b><br>
         From the <b>Courses</b> page, click the <button class="btn btn-secondary btn-sm" type="button">Edit</button> button of the course you would like to add instructors to. You will be directed to the <b>Edit Course</b> page where you can add a new instructor to your course.
-        You can specify the <a routerLink="../instructor" fragment="course-instructor-access" target="_blank" rel="noopener noreferrer">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="../instructor" fragment="course-add-instructor" target="_blank" rel="noopener noreferrer">here</a>.
+        You can specify the <a routerLink="../instructor" fragment="course-instructor-access">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="../instructor" fragment="course-add-instructor">here</a>.
       </li>
     </ol>
   </div>
@@ -72,12 +72,12 @@
         </ul>
       </ul>
       <li>
-        <b><a routerLink="../instructor" fragment="session-questions" target="_blank" rel="noopener noreferrer">Add questions</a> to your session to suit your needs.</b><br>
+        <b><a routerLink="../instructor" fragment="session-questions">Add questions</a> to your session to suit your needs.</b><br>
         For each question, you can set the following:
       </li>
       <ul>
         <li>
-          Question type: the style of question being asked. Choose from our 10 different <a routerLink="../instructor" fragment="questions" target="_blank" rel="noopener noreferrer">question types</a>.
+          Question type: the style of question being asked. Choose from our 10 different <a routerLink="../instructor" fragment="questions">question types</a>.
         </li>
         <li>
           Question feedback path: the feedback giver and feedback recipient
@@ -88,7 +88,7 @@
       </ul>
       <li>
         <b>Preview your session</b><br>
-        After you have finished setting up your session, <a routerLink="../instructor" fragment="session-preview" target="_blank" rel="noopener noreferrer">preview the session</a> as a student or another instructor.
+        After you have finished setting up your session, <a routerLink="../instructor" fragment="session-preview">preview the session</a> as a student or another instructor.
       </li>
     </ol>
   </div>
@@ -137,19 +137,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="../instructor" fragment="session-view-results" target="_blank" rel="noopener noreferrer">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
+        <a routerLink="../instructor" fragment="session-view-results">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
       </li>
       <li>
         Moderate responses: edit inappropriate responses from respondents before publishing the responses.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="session-add-comments" target="_blank" rel="noopener noreferrer">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
+        <a routerLink="../instructor" fragment="session-add-comments">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
       </li>
       <li>
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="session-cannot-submit" target="_blank" rel="noopener noreferrer">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+        <a routerLink="../instructor" fragment="session-cannot-submit">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
     <p>
@@ -177,19 +177,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="../instructor" fragment="student-view-profile" target="_blank" rel="noopener noreferrer">View a student's profile</a> and <a routerLink="../instructor" fragment="student-view-responses" target="_blank" rel="noopener noreferrer">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
+        <a routerLink="../instructor" fragment="student-view-profile">View a student's profile</a> and <a routerLink="../instructor" fragment="student-view-responses">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="student-edit-details" target="_blank" rel="noopener noreferrer">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
+        <a routerLink="../instructor" fragment="student-edit-details">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="student-email" target="_blank" rel="noopener noreferrer">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
+        <a routerLink="../instructor" fragment="student-email">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
       </li>
       <li>
-        Search: <a routerLink="../instructor" fragment="student-search" target="_blank" rel="noopener noreferrer">search for students, teams or sections</a>, or <a routerLink="../instructor" fragment="session-search" target="_blank" rel="noopener noreferrer">search for questions, responses or comments</a>.
+        Search: <a routerLink="../instructor" fragment="student-search">search for students, teams or sections</a>, or <a routerLink="../instructor" fragment="session-search">search for questions, responses or comments</a>.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="course-archive" target="_blank" rel="noopener noreferrer">Archive old courses</a>: archive old courses that you no longer need actively.
+        <a routerLink="../instructor" fragment="course-archive">Archive old courses</a>: archive old courses that you no longer need actively.
       </li>
     </ul>
   </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -5,7 +5,7 @@
   </p>
   <p>
     To get started using TEAMMATES, follow the following steps, or watch our <a href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1&rel=0" target="_blank"><i class="fas fa-film"></i> Video Tour</a>.<br>
-    For more help, browse the answers to some <a routerLink="/web/front/help/instructor">frequently asked questions</a>.
+    For more help, browse the answers to some <a routerLink="../instructor">frequently asked questions</a>.
   </p>
   <ol>
     <li><a (click)="jumpTo('course-setup')" [routerLink]="">Set up a course</a></li>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -1,3 +1,213 @@
-<p>
-  instructor-help-getting-started works!
-</p>
+<h1 id="Top">Getting Started</h1>
+<div id="contentHolder">
+  <p>
+    Welcome to TEAMMATES!
+  </p>
+  <p>
+    To get started using TEAMMATES, follow the following steps, or watch our <a href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1&rel=0" target="_blank"><i class="fas fa-film"></i> Video Tour</a>.<br>
+    For more help, browse the answers to some <a routerLink="/web/front/help/instructor">frequently asked questions</a>.
+  </p>
+  <ol>
+    <li><a href="#course-setup">Set up a course</a></li>
+    <li><a href="#session-setup">Create a session</a></li>
+    <li><a href="#session-invites">Wait for your session to open</a></li>
+    <li><a href="#session-results">View and publish session results</a></li>
+    <li><a href="#other-actions">Learn about other actions you can perform</a></li>
+    <li><a href="#contact-us">Contact us</a></li>
+  </ol>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="course-setup">1. Set up a course</h2>
+  <div>
+    <p>
+      A course is how TEAMMATES organises feedback sessions. Each course contains instructors, students and sessions specific to the course.
+    </p>
+    <ol>
+      <li>
+        <b>Create a course</b><br>
+        From the <b>Home</b> page, click <button class="btn btn-primary btn-sm">Add New Course</button>.<br>
+        Fill out the following form. Hover your mouse over text to reveal tooltips which tell you what the element does.
+        <p><b>EXAMPLE BOX</b></p>
+      </li>
+      <li>
+        <b><a href="/web/front/help/instructor#course-add-students" target="_blank" rel="noopener noreferrer">Enroll students in the course</a></b><br>
+        Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
+        Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
+        TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
+      </li>
+      <li>
+        <b><a href="/web/front/help/instructor#course-add-instructor" target="_blank" rel="noopener noreferrer">Add instructors to the course</a></b><br>
+        From the <b>Courses</b> page, click the <button class="btn btn-secondary btn-sm" type="button">Edit</button> button of the course you would like to add instructors to. You will be directed to the <b>Edit Course</b> page where you can add a new instructor to your course.
+        You can specify the <a href="/web/front/help/instructor#course-instructor-access" target="_blank" rel="noopener noreferrer">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a href="/web/front/help/instructor#course-add-instructor" target="_blank" rel="noopener noreferrer">here</a>.
+      </li>
+    </ol>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="session-setup">2. Create a session</h2>
+  <div>
+    <p>
+      A feedback session is a course-specific feedback questionnaire. Design the questions you want answered in your feedback session, then wait for the session to open! Each feedback session will be open to responses between the opening and closing times you specify.
+    </p>
+    <ol>
+      <li>
+        <b>Create a session</b><br>
+        Go to the <b>Sessions</b> page and create a session. Choose between:
+      </li>
+      <ul>
+        <li>Session with my own questions</li>
+        <ul>
+          <li>Creates an empty feedback session</li>
+          <li>Allows you to craft custom questions that fit your needs</li>
+        </ul>
+        <li>Session using template: team peer evaluation</li>
+        <ul>
+          <li>Provides 5 standard questions for team peer evaluations</li>
+          <li> Allows you to modify/remove the given questions and add your own questions as required</li>
+        </ul>
+      </ul>
+      <li>
+        <b><a href="/web/front/help/instructor#session-questions" target="_blank" rel="noopener noreferrer">Add questions</a> to your session to suit your needs.</b><br>
+        For each question, you can set the following:
+      </li>
+      <ul>
+        <li>
+          Question type: the style of question being asked. Choose from our 10 different <a href="/web/front/help/instructor#questions" target="_blank" rel="noopener noreferrer">question types</a>.
+        </li>
+        <li>
+          Question feedback path: the feedback giver and feedback recipient
+        </li>
+        <li>
+          Response visibility options: who can see the answers, giver name and recipient of a response.
+        </li>
+      </ul>
+      <li>
+        <b>Preview your session</b><br>
+        After you have finished setting up your session, <a href="/web/front/help/instructor#session-preview" target="_blank" rel="noopener noreferrer">preview the session</a> as a student or another instructor.
+      </li>
+    </ol>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="session-invites">3. Wait for your session to open</h2>
+  <div>
+    <p>
+      After you have set up your session, you're all set! <b>You do not have to inform students when a session opens.</b>
+    </p>
+    <p>
+      TEAMMATES automatically sends emails to students and instructors according to the preferences you specify when you create a session. The default settings are:
+    </p>
+    <ul>
+      <li>
+        When a session opens, TEAMMATES will automatically email students instructions to access the session. A copy of that email will be sent to you.
+      </li>
+      <li>
+        24 hours before the closing time of a session, students will be sent a reminder to complete their responses.
+      </li>
+      <li>
+        When the results of a session are published, students will be sent instructions to access the results.
+      </li>
+    </ul>
+    <p>
+      You can manually send reminders to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
+    </p>
+    <p>
+      In addition, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course and click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
+    </p>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="session-results">4. View and publish session results</h2>
+  <div>
+    <p>
+      After a session has opened, you may:
+    </p>
+    <ul>
+      <li>
+        <a href="/web/front/help/instructor#session-view-results" target="_blank" rel="noopener noreferrer">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
+      </li>
+      <li>
+        Moderate responses: edit inappropriate responses from respondents before publishing the responses.
+      </li>
+      <li>
+        <a href="/web/front/help/instructor#session-add-comments" target="_blank" rel="noopener noreferrer">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
+      </li>
+      <li>
+        Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
+      </li>
+      <li>
+        <a href="/web/front/help/instructor#session-cannot-submit" target="_blank" rel="noopener noreferrer">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+      </li>
+    </ul>
+    <p>
+      After a session closes, you may:
+    </p>
+    <ul>
+      <li>
+        Publish results: make a session's results visible to students. Click the <button class="btn btn-sm btn-secondary dropdown-toggle">Results</button> dropdown on the <b>Sessions</b> page, then select <b>Publish Results</b>. Students will not be able to view the session's results until you publish them.
+      </li>
+      <li>
+        Download results of a session in spreadsheet format: first view the results of a session, then click <button class="btn btn-sm btn-primary">Download Results</button> to download the results of a session as a CSV file.
+      </li>
+    </ul>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="other-actions">5. Learn about other actions you can perform</h2>
+  <div>
+    <p>
+      Beyond allowing you to collect and disseminate feedback, TEAMMATES can be a useful repository of student and course information. You may use TEAMMATES to:
+    </p>
+    <ul>
+      <li>
+        <a href="/web/front/help/instructor#student-view-profile" target="_blank" rel="noopener noreferrer">View a student's profile</a> and <a href="/web/front/help/instructor#student-view-responses" target="_blank" rel="noopener noreferrer">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
+      </li>
+      <li>
+        <a href="/web/front/help/instructor#student-edit-details" target="_blank" rel="noopener noreferrer">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
+      </li>
+      <li>
+        <a href="/web/front/help/instructor#student-email" target="_blank" rel="noopener noreferrer">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
+      </li>
+      <li>
+        Search: <a href="/web/front/help/instructor#student-search" target="_blank" rel="noopener noreferrer">search for students, teams or sections</a>, or <a href="/web/front/help/instructor#session-search" target="_blank" rel="noopener noreferrer">search for questions, responses or comments</a>.
+      </li>
+      <li>
+        <a href="/web/front/help/instructor#course-archive" target="_blank" rel="noopener noreferrer">Archive old courses</a>: archive old courses that you no longer need actively.
+      </li>
+    </ul>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+  <div class="separate-content-holder">
+    <hr>
+  </div>
+  <h2 id="contact-us">6. Contact us</h2>
+  <div>
+    <p>
+      If you have doubts, comments, or questions about using TEAMMATES, just
+      <a href="mailto:{{supportEmail}}">email us</a>.
+      We respond within 24 hours.
+    </p>
+  </div>
+  <p align="right">
+    <a href="#Top">Back to Top</a>
+  </p>
+</div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -8,12 +8,12 @@
     For more help, browse the answers to some <a routerLink="/web/front/help/instructor">frequently asked questions</a>.
   </p>
   <ol>
-    <li><a (click)="!!jumpTo('course-setup')" href>Set up a course</a></li>
-    <li><a (click)="!!jumpTo('session-setup')" href>Create a session</a></li>
-    <li><a (click)="!!jumpTo('session-invites')" href>Wait for your session to open</a></li>
-    <li><a (click)="!!jumpTo('session-results')" href>View and publish session results</a></li>
-    <li><a (click)="!!jumpTo('other-actions')" href>Learn about other actions you can perform</a></li>
-    <li><a (click)="!!jumpTo('contact-us')" href>Contact us</a></li>
+    <li><a (click)="jumpTo('course-setup')" href>Set up a course</a></li>
+    <li><a (click)="jumpTo('session-setup')" href>Create a session</a></li>
+    <li><a (click)="jumpTo('session-invites')" href>Wait for your session to open</a></li>
+    <li><a (click)="jumpTo('session-results')" href>View and publish session results</a></li>
+    <li><a (click)="jumpTo('other-actions')" href>Learn about other actions you can perform</a></li>
+    <li><a (click)="jumpTo('contact-us')" href>Contact us</a></li>
   </ol>
   <div class="separate-content-holder">
     <hr>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.scss
@@ -1,0 +1,5 @@
+.separate-content-holder {
+  height: 5em;
+  padding-top: 1em;
+  width: 100%;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorHelpGettingStartedComponent } from './instructor-help-getting-started.component';
 
 describe('InstructorHelpGettingStartedComponent', () => {
@@ -9,6 +10,9 @@ describe('InstructorHelpGettingStartedComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorHelpGettingStartedComponent],
+      imports: [
+        RouterTestingModule,
+      ],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
@@ -8,7 +8,7 @@ describe('InstructorHelpGettingStartedComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ InstructorHelpGettingStartedComponent ]
+      declarations: [InstructorHelpGettingStartedComponent],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InstructorHelpGettingStartedComponent } from './instructor-help-getting-started.component';
+
+describe('InstructorHelpGettingStartedComponent', () => {
+  let component: InstructorHelpGettingStartedComponent;
+  let fixture: ComponentFixture<InstructorHelpGettingStartedComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ InstructorHelpGettingStartedComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InstructorHelpGettingStartedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'tm-instructor-help-getting-started',
+  templateUrl: './instructor-help-getting-started.component.html',
+  styleUrls: ['./instructor-help-getting-started.component.scss']
+})
+export class InstructorHelpGettingStartedComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { environment } from "../../../../environments/environment";
 
 @Component({
   selector: 'tm-instructor-help-getting-started',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./instructor-help-getting-started.component.scss']
 })
 export class InstructorHelpGettingStartedComponent implements OnInit {
+
+  readonly supportEmail: string = environment.supportEmail;
 
   constructor() { }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -18,4 +18,16 @@ export class InstructorHelpGettingStartedComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  /**
+   * To scroll to a specific HTML id
+   */
+  jumpTo(target: string): void {
+    const destination: Element | null = document.getElementById(target);
+    if (destination !== null) {
+      destination.scrollIntoView();
+      // to prevent the navbar from covering the text
+      window.scrollTo(0, window.pageYOffset - 50);
+    }
+  }
+
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { environment } from "../../../../environments/environment";
+import { environment } from '../../../../environments/environment';
 
+/**
+ * Getting Started Section for Instructors
+ */
 @Component({
   selector: 'tm-instructor-help-getting-started',
   templateUrl: './instructor-help-getting-started.component.html',
-  styleUrls: ['./instructor-help-getting-started.component.scss']
+  styleUrls: ['./instructor-help-getting-started.component.scss'],
 })
 export class InstructorHelpGettingStartedComponent implements OnInit {
 
@@ -12,7 +15,7 @@ export class InstructorHelpGettingStartedComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -21,13 +21,14 @@ export class InstructorHelpGettingStartedComponent implements OnInit {
   /**
    * To scroll to a specific HTML id
    */
-  jumpTo(target: string): void {
+  jumpTo(target: string): boolean {
     const destination: Element | null = document.getElementById(target);
     if (destination !== null) {
       destination.scrollIntoView();
       // to prevent the navbar from covering the text
       window.scrollTo(0, window.pageYOffset - 50);
     }
+    return false;
   }
 
 }

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -23,7 +23,7 @@ export class InstructorHelpGettingStartedComponent implements OnInit {
    */
   jumpTo(target: string): boolean {
     const destination: Element | null = document.getElementById(target);
-    if (destination !== null) {
+    if (destination) {
       destination.scrollIntoView();
       // to prevent the navbar from covering the text
       window.scrollTo(0, window.pageYOffset - 50);

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -3,7 +3,7 @@
   <div>
     <p>
       Have questions about how to use TEAMMATES? This page answers some frequently asked questions.
-      <br> If you are new to TEAMMATES, our <a routerLink="../getting-started">Getting Started</a> guide will introduce you to the basic functions of TEAMMATES.
+      <br> If you are new to TEAMMATES, our <a routerLink="/web/front/getting-started">Getting Started</a> guide will introduce you to the basic functions of TEAMMATES.
       <br> If you have any remaining questions, don't hesitate to <a href="mailto:{{ supportEmail }}">email us</a>. We respond within 24 hours.
     </p>
     <div id="topics" style="display: block;">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.component.html
@@ -3,7 +3,7 @@
   <div>
     <p>
       Have questions about how to use TEAMMATES? This page answers some frequently asked questions.
-      <br> If you are new to TEAMMATES, our <a routerLink="/web/front/getting-started">Getting Started</a> guide will introduce you to the basic functions of TEAMMATES.
+      <br> If you are new to TEAMMATES, our <a routerLink="../getting-started">Getting Started</a> guide will introduce you to the basic functions of TEAMMATES.
       <br> If you have any remaining questions, don't hesitate to <a href="mailto:{{ supportEmail }}">email us</a>. We respond within 24 hours.
     </p>
     <div id="topics" style="display: block;">

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -10,14 +10,14 @@ import {
   InstructorHelpCoursesSectionComponent,
 } from './instructor-help-courses-section/instructor-help-courses-section.component';
 import {
+  InstructorHelpGettingStartedComponent,
+} from './instructor-help-getting-started/instructor-help-getting-started.component';
+import {
   InstructorHelpQuestionsSectionComponent,
 } from './instructor-help-questions-section/instructor-help-questions-section.component';
 import {
   InstructorHelpSessionsSectionComponent,
 } from './instructor-help-sessions-section/instructor-help-sessions-section.component';
-import {
-  InstructorHelpGettingStartedComponent,
-} from './instructor-help-getting-started/instructor-help-getting-started.component';
 import {
   InstructorHelpStudentsSectionComponent,
 } from './instructor-help-students-section/instructor-help-students-section.component';

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -16,9 +16,11 @@ import {
   InstructorHelpSessionsSectionComponent,
 } from './instructor-help-sessions-section/instructor-help-sessions-section.component';
 import {
+  InstructorHelpGettingStartedComponent,
+} from './instructor-help-getting-started/instructor-help-getting-started.component';
+import {
   InstructorHelpStudentsSectionComponent,
 } from './instructor-help-students-section/instructor-help-students-section.component';
-import { InstructorHelpGettingStartedComponent } from './instructor-help-getting-started/instructor-help-getting-started.component';
 
 /**
  * Module for instructor help page.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -18,6 +18,7 @@ import {
 import {
   InstructorHelpStudentsSectionComponent,
 } from './instructor-help-students-section/instructor-help-students-section.component';
+import { InstructorHelpGettingStartedComponent } from './instructor-help-getting-started/instructor-help-getting-started.component';
 
 /**
  * Module for instructor help page.
@@ -35,6 +36,7 @@ import {
     InstructorHelpSessionsSectionComponent,
     InstructorHelpQuestionsSectionComponent,
     InstructorHelpCoursesSectionComponent,
+    InstructorHelpGettingStartedComponent,
   ],
   exports: [
     InstructorHelpPageComponent,

--- a/src/web/app/pages-instructor/instructor-pages.module.ts
+++ b/src/web/app/pages-instructor/instructor-pages.module.ts
@@ -52,6 +52,9 @@ import { StudentListComponent } from './student-list/student-list.component';
 import { StudentProfileComponent } from './student-profile/student-profile.component';
 
 import { StatusMessageModule } from '../components/status-message/status-message.module';
+import {
+  InstructorHelpGettingStartedComponent,
+} from '../pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component';
 import { InstructorHomePageModule } from './instructor-home-page/instructor-home-page.module';
 
 const routes: Routes = [
@@ -153,6 +156,10 @@ const routes: Routes = [
   {
     path: 'help',
     component: InstructorHelpPageComponent,
+  },
+  {
+    path: 'getting-started',
+    component: InstructorHelpGettingStartedComponent,
   },
   {
     path: '',

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -3,10 +3,10 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 import { PageNotFoundModule } from '../page-not-found/page-not-found.module';
-import { InstructorHelpPageComponent } from '../pages-help/instructor-help-page/instructor-help-page.component';
 import {
-  InstructorHelpGettingStartedComponent
+  InstructorHelpGettingStartedComponent,
 } from '../pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component';
+import { InstructorHelpPageComponent } from '../pages-help/instructor-help-page/instructor-help-page.component';
 import { InstructorHelpPageModule } from '../pages-help/instructor-help-page/instructor-help-page.module';
 import { StudentHelpPageComponent } from '../pages-help/student-help-page/student-help-page.component';
 import { StudentHelpPageModule } from '../pages-help/student-help-page/student-help-page.module';

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -58,6 +58,10 @@ const routes: Routes = [
         path: 'instructor',
         component: InstructorHelpPageComponent,
       },
+      {
+        path: 'getting-started',
+        component: InstructorHelpGettingStartedComponent,
+      },
     ],
   },
   {

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -4,6 +4,9 @@ import { RouterModule, Routes } from '@angular/router';
 import { PageNotFoundComponent } from '../page-not-found/page-not-found.component';
 import { PageNotFoundModule } from '../page-not-found/page-not-found.module';
 import { InstructorHelpPageComponent } from '../pages-help/instructor-help-page/instructor-help-page.component';
+import {
+  InstructorHelpGettingStartedComponent
+} from '../pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component';
 import { InstructorHelpPageModule } from '../pages-help/instructor-help-page/instructor-help-page.module';
 import { StudentHelpPageComponent } from '../pages-help/student-help-page/student-help-page.component';
 import { StudentHelpPageModule } from '../pages-help/student-help-page/student-help-page.module';
@@ -56,6 +59,10 @@ const routes: Routes = [
         component: InstructorHelpPageComponent,
       },
     ],
+  },
+  {
+    path: 'getting-started',
+    component: InstructorHelpGettingStartedComponent,
   },
   {
     path: '',


### PR DESCRIPTION
Part of #9382 

**Outline of Solution**
Current look in v7
![image](https://user-images.githubusercontent.com/35655790/52160926-c592fc00-26f8-11e9-9cb3-9e7d78c7f94b.png)

The route for this page is `/web/front/getting-started`

PS: In the html file for the list of links at the beginning, I used `<a (click)="jumpTo(...)" href>` to maintain the link styling (blue color, underline and cursor) and for accessibility reasons.
Taken from [here](https://github.com/ng-bootstrap/ng-bootstrap/issues/142#issuecomment-231587330)

Things left to be done:
- [ ] Fix links to the instructor help page
