### PR TITLE
[#9390] Cannot create an instructor with an email that has a 2 letter domain

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/CreateAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateAccountAction.java
@@ -163,7 +163,7 @@ public class CreateAccountAction extends Action {
         String host = emailSplit[1];
 
         String head = StringHelper.replaceIllegalChars(username, FieldValidator.REGEX_COURSE_ID, '_');
-        String hostAbbreviation = host.substring(0, 3);
+        String hostAbbreviation = host.substring(0, Math.min(host.length(), 3));
 
         return head + "." + hostAbbreviation + "-demo";
     }


### PR DESCRIPTION
Fixes #9390 