### PR TITLE
[#9420] Consolidate nationalities RESTFul API

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/GetNationalitiesAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetNationalitiesAction.java
@@ -1,9 +1,7 @@
 package teammates.ui.webapi.action;
 
-import java.util.List;
-
 import teammates.common.util.NationalityHelper;
-import teammates.ui.webapi.output.ApiOutput;
+import teammates.ui.webapi.output.NationalitiesData;
 
 /**
  * Action: Get a list of valid nationalities.
@@ -21,22 +19,7 @@ public class GetNationalitiesAction extends Action {
 
     @Override
     public ActionResult execute() {
-        NationalityData nationalities = new NationalityData(NationalityHelper.getNationalities());
+        NationalitiesData nationalities = new NationalitiesData(NationalityHelper.getNationalities());
         return new JsonResult(nationalities);
-    }
-
-    /**
-     * Output format for {@link GetNationalitiesAction}.
-     */
-    public static class NationalityData extends ApiOutput {
-        private List<String> nationalities;
-
-        public NationalityData(List<String> nationalities) {
-            this.nationalities = nationalities;
-        }
-
-        public List<String> getNationalities() {
-            return nationalities;
-        }
     }
 }

--- a/src/main/java/teammates/ui/webapi/output/NationalitiesData.java
+++ b/src/main/java/teammates/ui/webapi/output/NationalitiesData.java
@@ -1,0 +1,18 @@
+package teammates.ui.webapi.output;
+
+import java.util.List;
+
+/**
+ * The API output format of a list of nationalities (as strings).
+ */
+public class NationalitiesData extends ApiOutput {
+    private List<String> nationalities;
+
+    public NationalitiesData(List<String> nationalities) {
+        this.nationalities = nationalities;
+    }
+
+    public List<String> getNationalities() {
+        return this.nationalities;
+    }
+}

--- a/src/test/java/teammates/test/cases/webapi/GetNationalitiesActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetNationalitiesActionTest.java
@@ -6,8 +6,8 @@ import org.testng.annotations.Test;
 import teammates.common.util.Const;
 import teammates.common.util.NationalityHelper;
 import teammates.ui.webapi.action.GetNationalitiesAction;
-import teammates.ui.webapi.action.GetNationalitiesAction.NationalityData;
 import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.NationalitiesData;
 
 /**
  * SUT: {@link GetNationalitiesAction}.
@@ -27,15 +27,13 @@ public class GetNationalitiesActionTest extends BaseActionTest<GetNationalitiesA
     @Override
     @Test
     protected void testExecute() throws Exception {
-
         ______TS("List of nationalities fetched matches the list stored in the server");
-
         GetNationalitiesAction action = getAction();
         JsonResult result = getJsonResult(action);
+
+        NationalitiesData output = (NationalitiesData) result.getOutput();
+
         assertEquals(HttpStatus.SC_OK, result.getStatusCode());
-
-        NationalityData output = (NationalityData) result.getOutput();
-
         assertEquals(NationalityHelper.getNationalities().toString(), output.getNationalities().toString());
     }
 

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.ts
@@ -6,7 +6,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { environment } from '../../../environments/environment';
 
 import { AuthService } from '../../../services/auth.service';
-import { AuthInfo, MessageOutput } from '../../../types/api-output';
+import { AuthInfo, MessageOutput, Nationalities } from '../../../types/api-output';
 
 import { FormControl, FormGroup } from '@angular/forms';
 
@@ -27,10 +27,6 @@ interface StudentDetails {
   studentProfile: StudentProfile;
   name: string;
   requestId: string;
-}
-
-interface NationalityData {
-  nationalities: string[];
 }
 
 /**
@@ -83,7 +79,7 @@ export class StudentProfilePageComponent implements OnInit {
    * Fetches the list of nationalities needed for the drop down box.
    */
   initNationalities(): void {
-    this.httpRequestService.get('/nationalities').subscribe((response: NationalityData) => {
+    this.httpRequestService.get('/nationalities').subscribe((response: Nationalities) => {
       this.nationalities = response.nationalities;
     });
   }


### PR DESCRIPTION
Part of #9420 

Return a `NationalitiesData` DTO for the `GET /nationalities` endpoint.

Remaining changes are to fix action tests and frontend to use this new
response DTO.

Expected works:
* [x] Make use of the auto-sync feature for API request & response.
* ~~Parameters are used to identify the resource to modify, use request body to pass data~~ (not applicable)
* ~~POST/PUT should return the updated entity if any~~ (not applicable)
* [x] Change frontend API request only if necessary, we will do the consolidation on top of the existing APIs. It would a bit messy to change the frontend simultaneously (as there are a lot of RPC calls in the old endpoints).
* [x] Provide full action level tests for new Action introduced. Refer to `Related Old Endpoints` to find relevant tests so you can just copy/paste. (no old tests to migrate)
