### PR TITLE
[#9420] Consolidate time-related RESTFul APIs

### DIFF
--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -7,13 +7,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneRulesProvider;
-import java.util.List;
 
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Const.SystemParams;

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -25,48 +25,6 @@ public final class TimeHelper {
 
     private static final Logger log = Logger.getLogger();
 
-    /**
-     * Represents the ambiguity status for a {@link LocalDateTime} at a given time {@code zone},
-     * brought about by Daylight Saving Time (DST).
-     */
-    public enum LocalDateTimeAmbiguityStatus {
-        /**
-         * The local date time can be unambiguously resolved to a single instant.
-         * It has only one valid interpretation.
-         */
-        UNAMBIGUOUS,
-
-        /**
-         * The local date time falls within the gap period when clocks spring forward at the start of DST.
-         * Strictly speaking, it is non-existent, and needs to be readjusted to be valid.
-         */
-        GAP,
-
-        /**
-         * The local date time falls within the overlap period when clocks fall back at the end of DST.
-         * It has more than one valid interpretation.
-         */
-        OVERLAP;
-
-        /**
-         * Gets the ambiguity status for a {@link LocalDateTime} at a given time {@code zone}.
-         */
-        public static LocalDateTimeAmbiguityStatus of(LocalDateTime localDateTime, ZoneId zone) {
-            if (localDateTime == null || zone == null) {
-                return null;
-            }
-
-            List<ZoneOffset> offsets = zone.getRules().getValidOffsets(localDateTime);
-            if (offsets.size() == 1) {
-                return UNAMBIGUOUS;
-            }
-            if (offsets.isEmpty()) {
-                return GAP;
-            }
-            return OVERLAP;
-        }
-    }
-
     private TimeHelper() {
         // utility class
     }

--- a/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
@@ -11,7 +11,7 @@ import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
-import teammates.ui.webapi.output.ApiOutput;
+import teammates.ui.webapi.output.LocalDateTimeInfoData;
 
 /**
  * Resolve local date time under certain timezone to an UNIX timestamp.
@@ -47,18 +47,18 @@ public class GetLocalDateTimeInfoAction extends Action {
             throw new InvalidHttpParameterException(e.getMessage(), e);
         }
 
-        LocalDateTimeInfo localDateTimeInfo = null;
+        LocalDateTimeInfoData ldtInfo = null;
         switch(TimeHelper.LocalDateTimeAmbiguityStatus.of(localDateTime, zoneId)) {
         case UNAMBIGUOUS:
-            localDateTimeInfo = LocalDateTimeInfo.unambiguous(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
+            ldtInfo = LocalDateTimeInfoData.unambiguous(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
             break;
         case GAP:
-            localDateTimeInfo = LocalDateTimeInfo.gap(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
+            ldtInfo = LocalDateTimeInfoData.gap(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
             break;
         case OVERLAP:
             Instant earlierInterpretation = localDateTime.atZone(zoneId).withEarlierOffsetAtOverlap().toInstant();
             Instant laterInterpretation = localDateTime.atZone(zoneId).withLaterOffsetAtOverlap().toInstant();
-            localDateTimeInfo = LocalDateTimeInfo.overlap(localDateTime.atZone(zoneId).toInstant().toEpochMilli(),
+            ldtInfo = LocalDateTimeInfoData.overlap(localDateTime.atZone(zoneId).toInstant().toEpochMilli(),
                     earlierInterpretation.toEpochMilli(), laterInterpretation.toEpochMilli());
             break;
         default:
@@ -66,74 +66,6 @@ public class GetLocalDateTimeInfoAction extends Action {
             break;
         }
 
-        return new JsonResult(localDateTimeInfo);
-    }
-
-    /**
-     * Output format for {@link GetLocalDateTimeInfoAction}.
-     */
-    public static class LocalDateTimeInfo extends ApiOutput {
-
-        private long resolvedTimestamp;
-        private TimeHelper.LocalDateTimeAmbiguityStatus resolvedStatus;
-
-        private Long earlierInterpretationTimestamp;
-        private Long laterInterpretationTimestamp;
-
-        /**
-         * Constructs {@link LocalDateTimeInfo} with UNAMBIGUOUS status.
-         */
-        public static LocalDateTimeInfo unambiguous(long resolvedTimestamp) {
-            LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
-
-            localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS;
-            localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
-
-            return localDateTimeInfo;
-        }
-
-        /**
-         * Constructs {@link LocalDateTimeInfo} with GAP status.
-         */
-        public static LocalDateTimeInfo gap(long resolvedTimestamp) {
-            LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
-
-            localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.GAP;
-            localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
-
-            return localDateTimeInfo;
-        }
-
-        /**
-         * Constructs {@link LocalDateTimeInfo} with OVERLAP status.
-         */
-        public static LocalDateTimeInfo overlap(long resolvedTimestamp,
-                                                long earlierInterpretationTimestamp, long laterInterpretationTimestamp) {
-            LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
-
-            localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP;
-            localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
-
-            localDateTimeInfo.earlierInterpretationTimestamp = earlierInterpretationTimestamp;
-            localDateTimeInfo.laterInterpretationTimestamp = laterInterpretationTimestamp;
-
-            return localDateTimeInfo;
-        }
-
-        public long getResolvedTimestamp() {
-            return resolvedTimestamp;
-        }
-
-        public TimeHelper.LocalDateTimeAmbiguityStatus getResolvedStatus() {
-            return resolvedStatus;
-        }
-
-        public Long getEarlierInterpretationTimestamp() {
-            return earlierInterpretationTimestamp;
-        }
-
-        public Long getLaterInterpretationTimestamp() {
-            return laterInterpretationTimestamp;
-        }
+        return new JsonResult(ldtInfo);
     }
 }

--- a/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
@@ -11,7 +11,7 @@ import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
-import teammates.ui.webapi.output.LocalDateTimeInfoData;
+import teammates.ui.webapi.output.LocalDateTimeInfo;
 
 /**
  * Resolve local date time under certain timezone to an UNIX timestamp.
@@ -47,18 +47,18 @@ public class GetLocalDateTimeInfoAction extends Action {
             throw new InvalidHttpParameterException(e.getMessage(), e);
         }
 
-        LocalDateTimeInfoData ldtInfo = null;
+        LocalDateTimeInfo ldtInfo = null;
         switch(TimeHelper.LocalDateTimeAmbiguityStatus.of(localDateTime, zoneId)) {
         case UNAMBIGUOUS:
-            ldtInfo = LocalDateTimeInfoData.unambiguous(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
+            ldtInfo = LocalDateTimeInfo.unambiguous(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
             break;
         case GAP:
-            ldtInfo = LocalDateTimeInfoData.gap(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
+            ldtInfo = LocalDateTimeInfo.gap(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
             break;
         case OVERLAP:
             Instant earlierInterpretation = localDateTime.atZone(zoneId).withEarlierOffsetAtOverlap().toInstant();
             Instant laterInterpretation = localDateTime.atZone(zoneId).withLaterOffsetAtOverlap().toInstant();
-            ldtInfo = LocalDateTimeInfoData.overlap(localDateTime.atZone(zoneId).toInstant().toEpochMilli(),
+            ldtInfo = LocalDateTimeInfo.overlap(localDateTime.atZone(zoneId).toInstant().toEpochMilli(),
                     earlierInterpretation.toEpochMilli(), laterInterpretation.toEpochMilli());
             break;
         default:

--- a/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetLocalDateTimeInfoAction.java
@@ -10,7 +10,6 @@ import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 import teammates.ui.webapi.output.LocalDateTimeInfo;
 
 /**
@@ -48,7 +47,7 @@ public class GetLocalDateTimeInfoAction extends Action {
         }
 
         LocalDateTimeInfo ldtInfo = null;
-        switch(TimeHelper.LocalDateTimeAmbiguityStatus.of(localDateTime, zoneId)) {
+        switch(LocalDateTimeInfo.LocalDateTimeAmbiguityStatus.of(localDateTime, zoneId)) {
         case UNAMBIGUOUS:
             ldtInfo = LocalDateTimeInfo.unambiguous(localDateTime.atZone(zoneId).toInstant().toEpochMilli());
             break;

--- a/src/main/java/teammates/ui/webapi/action/GetTimeZonesAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetTimeZonesAction.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import teammates.common.exception.UnauthorizedAccessException;
-import teammates.ui.webapi.output.ApiOutput;
+import teammates.ui.webapi.output.TimeZonesData;
 
 /**
  * Action: get supported time zones.
@@ -37,31 +37,7 @@ public class GetTimeZonesAction extends Action {
                 tzOffsets.put(tz, offset);
             }
         }
-        TimezoneData output = new TimezoneData(tzVersion, tzOffsets);
+        TimeZonesData output = new TimeZonesData(tzVersion, tzOffsets);
         return new JsonResult(output);
     }
-
-    /**
-     * Output format for {@link GetTimeZonesAction}.
-     */
-    public static class TimezoneData extends ApiOutput {
-
-        private final String version;
-        private final Map<String, Integer> offsets;
-
-        public TimezoneData(String version, Map<String, Integer> offsets) {
-            this.version = version;
-            this.offsets = offsets;
-        }
-
-        public String getVersion() {
-            return version;
-        }
-
-        public Map<String, Integer> getOffsets() {
-            return offsets;
-        }
-
-    }
-
 }

--- a/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
+++ b/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
@@ -1,13 +1,16 @@
 package teammates.ui.webapi.output;
 
-import teammates.common.util.TimeHelper;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
 
 /**
  * The API output format of a {@code LocalDateTimeInfo} to hold information for resolving DST overlaps/gaps.
  */
 public class LocalDateTimeInfo extends ApiOutput {
     private long resolvedTimestamp;
-    private TimeHelper.LocalDateTimeAmbiguityStatus resolvedStatus;
+    private LocalDateTimeAmbiguityStatus resolvedStatus;
 
     private Long earlierInterpretationTimestamp;
     private Long laterInterpretationTimestamp;
@@ -18,7 +21,7 @@ public class LocalDateTimeInfo extends ApiOutput {
     public static LocalDateTimeInfo unambiguous(long resolvedTimestamp) {
         LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
-        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS;
+        localDateTimeInfo.resolvedStatus = LocalDateTimeAmbiguityStatus.UNAMBIGUOUS;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
 
         return localDateTimeInfo;
@@ -30,7 +33,7 @@ public class LocalDateTimeInfo extends ApiOutput {
     public static LocalDateTimeInfo gap(long resolvedTimestamp) {
         LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
-        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.GAP;
+        localDateTimeInfo.resolvedStatus = LocalDateTimeAmbiguityStatus.GAP;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
 
         return localDateTimeInfo;
@@ -43,7 +46,7 @@ public class LocalDateTimeInfo extends ApiOutput {
                                             long earlierInterpretationTimestamp, long laterInterpretationTimestamp) {
         LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
-        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP;
+        localDateTimeInfo.resolvedStatus = LocalDateTimeAmbiguityStatus.OVERLAP;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
 
         localDateTimeInfo.earlierInterpretationTimestamp = earlierInterpretationTimestamp;
@@ -56,7 +59,7 @@ public class LocalDateTimeInfo extends ApiOutput {
         return resolvedTimestamp;
     }
 
-    public TimeHelper.LocalDateTimeAmbiguityStatus getResolvedStatus() {
+    public LocalDateTimeAmbiguityStatus getResolvedStatus() {
         return resolvedStatus;
     }
 
@@ -66,5 +69,47 @@ public class LocalDateTimeInfo extends ApiOutput {
 
     public Long getLaterInterpretationTimestamp() {
         return laterInterpretationTimestamp;
+    }
+
+    /**
+     * Represents the ambiguity status for a {@link LocalDateTime} at a given time {@code zone},
+     * brought about by Daylight Saving Time (DST).
+     */
+    public enum LocalDateTimeAmbiguityStatus {
+        /**
+         * The local date time can be unambiguously resolved to a single instant.
+         * It has only one valid interpretation.
+         */
+        UNAMBIGUOUS,
+
+        /**
+         * The local date time falls within the gap period when clocks spring forward at the start of DST.
+         * Strictly speaking, it is non-existent, and needs to be readjusted to be valid.
+         */
+        GAP,
+
+        /**
+         * The local date time falls within the overlap period when clocks fall back at the end of DST.
+         * It has more than one valid interpretation.
+         */
+        OVERLAP;
+
+        /**
+         * Gets the ambiguity status for a {@link LocalDateTime} at a given time {@code zone}.
+         */
+        public static LocalDateTimeAmbiguityStatus of(LocalDateTime localDateTime, ZoneId zone) {
+            if (localDateTime == null || zone == null) {
+                return null;
+            }
+
+            List<ZoneOffset> offsets = zone.getRules().getValidOffsets(localDateTime);
+            if (offsets.size() == 1) {
+                return UNAMBIGUOUS;
+            }
+            if (offsets.isEmpty()) {
+                return GAP;
+            }
+            return OVERLAP;
+        }
     }
 }

--- a/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
+++ b/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
@@ -1,5 +1,6 @@
 package teammates.ui.webapi.output;
 
+import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -11,8 +12,9 @@ import java.util.List;
 public class LocalDateTimeInfo extends ApiOutput {
     private long resolvedTimestamp;
     private LocalDateTimeAmbiguityStatus resolvedStatus;
-
+    @Nullable
     private Long earlierInterpretationTimestamp;
+    @Nullable
     private Long laterInterpretationTimestamp;
 
     /**

--- a/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
+++ b/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
@@ -1,10 +1,11 @@
 package teammates.ui.webapi.output;
 
-import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 /**
  * The API output format of a {@code LocalDateTimeInfo} to hold information for resolving DST overlaps/gaps.

--- a/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
+++ b/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfo.java
@@ -5,7 +5,7 @@ import teammates.common.util.TimeHelper;
 /**
  * The API output format of a {@code LocalDateTimeInfo} to hold information for resolving DST overlaps/gaps.
  */
-public class LocalDateTimeInfoData extends ApiOutput {
+public class LocalDateTimeInfo extends ApiOutput {
     private long resolvedTimestamp;
     private TimeHelper.LocalDateTimeAmbiguityStatus resolvedStatus;
 
@@ -13,10 +13,10 @@ public class LocalDateTimeInfoData extends ApiOutput {
     private Long laterInterpretationTimestamp;
 
     /**
-     * Constructs {@link LocalDateTimeInfoData} with UNAMBIGUOUS status.
+     * Constructs {@link LocalDateTimeInfo} with UNAMBIGUOUS status.
      */
-    public static LocalDateTimeInfoData unambiguous(long resolvedTimestamp) {
-        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+    public static LocalDateTimeInfo unambiguous(long resolvedTimestamp) {
+        LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
         localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
@@ -25,10 +25,10 @@ public class LocalDateTimeInfoData extends ApiOutput {
     }
 
     /**
-     * Constructs {@link LocalDateTimeInfoData} with GAP status.
+     * Constructs {@link LocalDateTimeInfo} with GAP status.
      */
-    public static LocalDateTimeInfoData gap(long resolvedTimestamp) {
-        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+    public static LocalDateTimeInfo gap(long resolvedTimestamp) {
+        LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
         localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.GAP;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
@@ -37,11 +37,11 @@ public class LocalDateTimeInfoData extends ApiOutput {
     }
 
     /**
-     * Constructs {@link LocalDateTimeInfoData} with OVERLAP status.
+     * Constructs {@link LocalDateTimeInfo} with OVERLAP status.
      */
-    public static LocalDateTimeInfoData overlap(long resolvedTimestamp,
-                                                long earlierInterpretationTimestamp, long laterInterpretationTimestamp) {
-        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+    public static LocalDateTimeInfo overlap(long resolvedTimestamp,
+                                            long earlierInterpretationTimestamp, long laterInterpretationTimestamp) {
+        LocalDateTimeInfo localDateTimeInfo = new LocalDateTimeInfo();
 
         localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP;
         localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;

--- a/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfoData.java
+++ b/src/main/java/teammates/ui/webapi/output/LocalDateTimeInfoData.java
@@ -1,0 +1,70 @@
+package teammates.ui.webapi.output;
+
+import teammates.common.util.TimeHelper;
+
+/**
+ * The API output format of a {@code LocalDateTimeInfo} to hold information for resolving DST overlaps/gaps.
+ */
+public class LocalDateTimeInfoData extends ApiOutput {
+    private long resolvedTimestamp;
+    private TimeHelper.LocalDateTimeAmbiguityStatus resolvedStatus;
+
+    private Long earlierInterpretationTimestamp;
+    private Long laterInterpretationTimestamp;
+
+    /**
+     * Constructs {@link LocalDateTimeInfoData} with UNAMBIGUOUS status.
+     */
+    public static LocalDateTimeInfoData unambiguous(long resolvedTimestamp) {
+        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+
+        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS;
+        localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
+
+        return localDateTimeInfo;
+    }
+
+    /**
+     * Constructs {@link LocalDateTimeInfoData} with GAP status.
+     */
+    public static LocalDateTimeInfoData gap(long resolvedTimestamp) {
+        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+
+        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.GAP;
+        localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
+
+        return localDateTimeInfo;
+    }
+
+    /**
+     * Constructs {@link LocalDateTimeInfoData} with OVERLAP status.
+     */
+    public static LocalDateTimeInfoData overlap(long resolvedTimestamp,
+                                                long earlierInterpretationTimestamp, long laterInterpretationTimestamp) {
+        LocalDateTimeInfoData localDateTimeInfo = new LocalDateTimeInfoData();
+
+        localDateTimeInfo.resolvedStatus = TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP;
+        localDateTimeInfo.resolvedTimestamp = resolvedTimestamp;
+
+        localDateTimeInfo.earlierInterpretationTimestamp = earlierInterpretationTimestamp;
+        localDateTimeInfo.laterInterpretationTimestamp = laterInterpretationTimestamp;
+
+        return localDateTimeInfo;
+    }
+
+    public long getResolvedTimestamp() {
+        return resolvedTimestamp;
+    }
+
+    public TimeHelper.LocalDateTimeAmbiguityStatus getResolvedStatus() {
+        return resolvedStatus;
+    }
+
+    public Long getEarlierInterpretationTimestamp() {
+        return earlierInterpretationTimestamp;
+    }
+
+    public Long getLaterInterpretationTimestamp() {
+        return laterInterpretationTimestamp;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/output/TimeZonesData.java
+++ b/src/main/java/teammates/ui/webapi/output/TimeZonesData.java
@@ -1,0 +1,24 @@
+package teammates.ui.webapi.output;
+
+import java.util.Map;
+
+/**
+ * The API output format for available timezones and their offsets-in-seconds.
+ */
+public class TimeZonesData extends ApiOutput {
+    private String version;
+    private Map<String, Integer> offsets; // timezone name => offset from UTC in seconds
+
+    public TimeZonesData(String version, Map<String, Integer> offsets) {
+        this.version = version;
+        this.offsets = offsets;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Map<String, Integer> getOffsets() {
+        return offsets;
+    }
+}

--- a/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
@@ -7,6 +7,7 @@ import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.ui.webapi.action.GetLocalDateTimeInfoAction;
 import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.LocalDateTimeInfoData;
 
 /**
  * SUT: {@link GetLocalDateTimeInfoAction}.
@@ -51,8 +52,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         GetLocalDateTimeInfoAction a = getAction(params);
         JsonResult r = getJsonResult(a);
-        GetLocalDateTimeInfoAction.LocalDateTimeInfo localDateTimeInfo =
-                (GetLocalDateTimeInfoAction.LocalDateTimeInfo) r.getOutput();
+        LocalDateTimeInfoData localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS, localDateTimeInfo.getResolvedStatus());
         assertEquals(1543669200000L, localDateTimeInfo.getResolvedTimestamp());
@@ -71,7 +71,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         a = getAction(params);
         r = getJsonResult(a);
-        localDateTimeInfo = (GetLocalDateTimeInfoAction.LocalDateTimeInfo) r.getOutput();
+        localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.GAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1332639000000L, localDateTimeInfo.getResolvedTimestamp());
@@ -90,7 +90,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         a = getAction(params);
         r = getJsonResult(a);
-        localDateTimeInfo = (GetLocalDateTimeInfoAction.LocalDateTimeInfo) r.getOutput();
+        localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1351384200000L, localDateTimeInfo.getResolvedTimestamp());

--- a/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
@@ -4,7 +4,6 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 import teammates.ui.webapi.action.GetLocalDateTimeInfoAction;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.LocalDateTimeInfo;
@@ -54,7 +53,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
         JsonResult r = getJsonResult(a);
         LocalDateTimeInfo localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
-        assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS, localDateTimeInfo.getResolvedStatus());
+        assertEquals(LocalDateTimeInfo.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS, localDateTimeInfo.getResolvedStatus());
         assertEquals(1543669200000L, localDateTimeInfo.getResolvedTimestamp());
         assertNull(localDateTimeInfo.getEarlierInterpretationTimestamp());
         assertNull(localDateTimeInfo.getLaterInterpretationTimestamp());
@@ -73,7 +72,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
         r = getJsonResult(a);
         localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
-        assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.GAP, localDateTimeInfo.getResolvedStatus());
+        assertEquals(LocalDateTimeInfo.LocalDateTimeAmbiguityStatus.GAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1332639000000L, localDateTimeInfo.getResolvedTimestamp());
         assertNull(localDateTimeInfo.getEarlierInterpretationTimestamp());
         assertNull(localDateTimeInfo.getLaterInterpretationTimestamp());
@@ -92,7 +91,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
         r = getJsonResult(a);
         localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
-        assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP, localDateTimeInfo.getResolvedStatus());
+        assertEquals(LocalDateTimeInfo.LocalDateTimeAmbiguityStatus.OVERLAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1351384200000L, localDateTimeInfo.getResolvedTimestamp());
         assertEquals(1351384200000L, localDateTimeInfo.getEarlierInterpretationTimestamp().longValue());
         assertEquals(1351387800000L, localDateTimeInfo.getLaterInterpretationTimestamp().longValue());

--- a/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetLocalDateTimeInfoActionTest.java
@@ -7,7 +7,7 @@ import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 import teammates.ui.webapi.action.GetLocalDateTimeInfoAction;
 import teammates.ui.webapi.action.JsonResult;
-import teammates.ui.webapi.output.LocalDateTimeInfoData;
+import teammates.ui.webapi.output.LocalDateTimeInfo;
 
 /**
  * SUT: {@link GetLocalDateTimeInfoAction}.
@@ -52,7 +52,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         GetLocalDateTimeInfoAction a = getAction(params);
         JsonResult r = getJsonResult(a);
-        LocalDateTimeInfoData localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
+        LocalDateTimeInfo localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.UNAMBIGUOUS, localDateTimeInfo.getResolvedStatus());
         assertEquals(1543669200000L, localDateTimeInfo.getResolvedTimestamp());
@@ -71,7 +71,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         a = getAction(params);
         r = getJsonResult(a);
-        localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
+        localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.GAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1332639000000L, localDateTimeInfo.getResolvedTimestamp());
@@ -90,7 +90,7 @@ public class GetLocalDateTimeInfoActionTest extends BaseActionTest<GetLocalDateT
 
         a = getAction(params);
         r = getJsonResult(a);
-        localDateTimeInfo = (LocalDateTimeInfoData) r.getOutput();
+        localDateTimeInfo = (LocalDateTimeInfo) r.getOutput();
 
         assertEquals(TimeHelper.LocalDateTimeAmbiguityStatus.OVERLAP, localDateTimeInfo.getResolvedStatus());
         assertEquals(1351384200000L, localDateTimeInfo.getResolvedTimestamp());

--- a/src/test/java/teammates/test/cases/webapi/GetTimeZonesActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetTimeZonesActionTest.java
@@ -1,14 +1,12 @@
 package teammates.test.cases.webapi;
 
-import java.util.Map;
-
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
 import teammates.ui.webapi.action.GetTimeZonesAction;
-import teammates.ui.webapi.action.GetTimeZonesAction.TimezoneData;
 import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.TimeZonesData;
 
 /**
  * SUT: {@link GetTimeZonesAction}.
@@ -28,25 +26,27 @@ public class GetTimeZonesActionTest extends BaseActionTest<GetTimeZonesAction> {
     @Override
     @Test
     protected void testExecute() throws Exception {
-
         ______TS("Normal case");
 
         GetTimeZonesAction a = getAction();
         JsonResult r = getJsonResult(a);
 
-        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
 
+        TimeZonesData output = (TimeZonesData) r.getOutput();
+
+        assertEquals(HttpStatus.SC_OK, r.getStatusCode());
         // This test does not check the timezone database used is the latest
         // Only check that the version number is returned, and some sample values for timezone offset
-
-        TimezoneData output = (TimezoneData) r.getOutput();
-        Map<String, Integer> offsets = output.getOffsets();
         assertNotNull(output.getVersion());
-        assertEquals(8 * 60 * 60, offsets.get("Asia/Singapore").intValue());
-        assertEquals(-5 * 60 * 60, offsets.get("America/New_York").intValue());
-        assertEquals(11 * 60 * 60, offsets.get("Australia/Sydney").intValue());
-        assertEquals(0, offsets.get("Europe/London").intValue());
 
+        /* TODO the asserts below are brittle as the expected values are not guaranteed to be correct
+         * e.g. New York observes DST, so the offset is not always UTC-05:00 the entire year.
+         * e.g. timezones can change, like Caracas modifying their timezone. This affects the offset as well.
+         */
+        assertEquals(8 * 60 * 60, output.getOffsets().get("Asia/Singapore").intValue());
+        assertEquals(-5 * 60 * 60, output.getOffsets().get("America/New_York").intValue());
+        assertEquals(11 * 60 * 60, output.getOffsets().get("Australia/Sydney").intValue());
+        assertEquals(0, output.getOffsets().get("Europe/London").intValue());
     }
 
     @Override
@@ -54,5 +54,4 @@ public class GetTimeZonesActionTest extends BaseActionTest<GetTimeZonesAction> {
     protected void testAccessControl() throws Exception {
         verifyOnlyAdminCanAccess();
     }
-
 }

--- a/src/web/app/pages-admin/admin-timezone-page/admin-timezone-page.component.ts
+++ b/src/web/app/pages-admin/admin-timezone-page/admin-timezone-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpRequestService } from '../../../services/http-request.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import { TimeZones } from "../../../types/api-output";
+import { TimeZones } from '../../../types/api-output';
 
 /**
  * Timezone listing page for admin use.

--- a/src/web/app/pages-admin/admin-timezone-page/admin-timezone-page.component.ts
+++ b/src/web/app/pages-admin/admin-timezone-page/admin-timezone-page.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpRequestService } from '../../../services/http-request.service';
 import { TimezoneService } from '../../../services/timezone.service';
-
-interface TimezoneData {
-  version: string;
-  offsets: { [key: string]: number };
-}
+import { TimeZones } from "../../../types/api-output";
 
 /**
  * Timezone listing page for admin use.
@@ -27,7 +23,7 @@ export class AdminTimezonePageComponent implements OnInit {
   ngOnInit(): void {
     this.momentTzVersion = this.timezoneService.getTzVersion();
     this.momentTimezones = this.timezoneService.getTzOffsets();
-    this.httpRequestService.get('/timezone').subscribe((res: TimezoneData) => {
+    this.httpRequestService.get('/timezone').subscribe((res: TimeZones) => {
       this.javaTzVersion = res.version;
       this.javaTimezones = res.offsets;
     });

--- a/src/web/services/timezone.service.ts
+++ b/src/web/services/timezone.service.ts
@@ -5,6 +5,8 @@ import { map } from 'rxjs/operators';
 import { default as timezone } from '../data/timezone.json';
 import { HttpRequestService } from './http-request.service';
 
+import { LocalDateTimeAmbiguityStatus, LocalDateTimeInfo } from '../types/api-output';
+
 /**
  * The date time format used in date time resolution.
  */
@@ -16,41 +18,6 @@ export const LOCAL_DATE_TIME_FORMAT: string = 'YYYY-MM-DD HH:mm';
 export interface TimeResolvingResult {
   timestamp: number;
   message: string;
-}
-
-/**
- * Represents the resolution of local data time.
- */
-interface LocalDateTimeInfo {
-  resolvedTimestamp: number;
-  resolvedStatus: LocalDateTimeAmbiguityStatus;
-
-  earlierInterpretationTimestamp?: number;
-  laterInterpretationTimestamp?: number;
-}
-
-/**
- * Represents the ambiguity status for a local date time at a given time Zone,
- * brought about by Daylight Saving Time (DST).
- */
-enum LocalDateTimeAmbiguityStatus {
-  /**
-   * The local date time can be unambiguously resolved to a single timestamp.
-   * It has only one valid interpretation.
-   */
-  UNAMBIGUOUS = 'UNAMBIGUOUS',
-
-  /**
-   * The local date time falls within the gap period when clocks spring forward at the start of DST.
-   * Strictly speaking, it is non-existent, and needs to be readjusted to be valid.
-   */
-  GAP = 'GAP',
-
-  /**
-   * The local date time falls within the overlap period when clocks fall back at the end of DST.
-   * It has more than one valid interpretation.
-   */
-  OVERLAP = 'OVERLAP',
 }
 
 /**


### PR DESCRIPTION
Part of #9420

Implement response DTOs for the following endpoints:
- `GET /timezones` => `TimeZonesData`
- `GET /localdatetime` => `LocalDateTimeInfoData` (yes, I know. Unfortunately the `Data` suffix is stripped when the types are generated for ts, so I think it's easier to just name the class this way.)