### PR TITLE
[#9382] Fix logic bug when there are no existing students in course

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -247,6 +247,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    * Toggles the view of 'Existing Students' spreadsheet interface
    */
   toggleExistingStudentsPanel(): void {
+    // Has to be done before the API call is made so that HOT is available for data population
     this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed;
     this.loading = true;
     const existingStudentsHOTInstance: Handsontable =
@@ -269,11 +270,12 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
           } else {
             // Shows a message if there are no existing students. Panel would not be expanded.
             this.isExistingStudentsPresent = false;
+            this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed; // Collapse the panel again
           }
         }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorMessage(resp.error.message);
       this.isAjaxSuccess = false;
-      this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed; // collapse the panel again
+      this.isExistingStudentsPanelCollapsed = !this.isExistingStudentsPanelCollapsed; // Collapse the panel again
     });
     this.loading = false;
   }


### PR DESCRIPTION
Part of #9382 

This user flow wasn't thoroughly tested as there are no easy ways to add new courses during the time when this page was migrated. 

This PR fixes the issue where the `Existing students` panel stays expanded even when there are no existing students in the course.