### PR TITLE
[#9461] Focus state of nav bar item results in bad readability

### DIFF
--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -41,7 +41,8 @@ footer a {
 .dropdown-item {
   color: rgba(255, 255, 255, .5);
 
-  &:hover {
+  &:hover,
+  &:focus {
     background-color: inherit;
     color: rgba(255, 255, 255, .75);
   }


### PR DESCRIPTION
Fixes #9461

**Outline of Solution**

Made the behaviour of the `focus` state of the nav bar dropdown items consistent with the other nav bar items (it retains the properties of the `hover` state).

![20190220_13h09_23](https://user-images.githubusercontent.com/29021586/53067827-f3f24300-3510-11e9-9807-d180165840f5.gif)
