### PR TITLE
[#9382] Migrate session results skeleton back-end

### DIFF
--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackConstantSumQuestionDetails.java
@@ -497,6 +497,14 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackContributionQuestionDetails.java
@@ -323,6 +323,14 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMcqQuestionDetails.java
@@ -558,6 +558,14 @@ public class FeedbackMcqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -693,6 +693,14 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackNumericalScaleQuestionDetails.java
@@ -448,6 +448,14 @@ public class FeedbackNumericalScaleQuestionDetails extends FeedbackQuestionDetai
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackQuestionDetails.java
@@ -39,25 +39,35 @@ public abstract class FeedbackQuestionDetails {
 
     public abstract String getQuestionTypeDisplayName();
 
+    @Deprecated
     public abstract String getQuestionWithExistingResponseSubmissionFormHtml(
             boolean sessionIsOpen, int qnIdx, int responseIdx, String courseId,
             int totalNumRecipients, FeedbackResponseDetails existingResponseDetails, StudentAttributes student);
 
+    @Deprecated
     public abstract String getQuestionWithoutExistingResponseSubmissionFormHtml(
                                 boolean sessionIsOpen, int qnIdx, int responseIdx, String courseId,
                                 int totalNumRecipients, StudentAttributes student);
 
+    @Deprecated
     public abstract String getQuestionSpecificEditFormHtml(int questionNumber);
 
+    @Deprecated
     public abstract String getNewQuestionSpecificEditFormHtml();
 
+    @Deprecated
     public abstract String getQuestionAdditionalInfoHtml(int questionNumber, String additionalInfoId);
 
+    @Deprecated
     public abstract String getQuestionResultStatisticsHtml(List<FeedbackResponseAttributes> responses,
                                                            FeedbackQuestionAttributes question,
                                                            String studentEmail,
                                                            FeedbackSessionResultsBundle bundle,
                                                            String view);
+
+    public abstract String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent);
 
     public abstract String getQuestionResultStatisticsCsv(List<FeedbackResponseAttributes> responses,
                                                           FeedbackQuestionAttributes question,
@@ -141,6 +151,7 @@ public abstract class FeedbackQuestionDetails {
      * Returns a HTML option for selecting question type.
      * Used in instructorFeedbackEdit.jsp for selecting the question type for a new question.
      */
+    @Deprecated
     public abstract String getQuestionTypeChoiceOption();
 
     /**
@@ -201,6 +212,7 @@ public abstract class FeedbackQuestionDetails {
     // The following function handle the display of rows between possible givers
     // and recipients who did not respond to a question in feedback sessions
 
+    @Deprecated
     public String getNoResponseTextInHtml(String giverEmail, String recipientEmail,
                                           FeedbackSessionResultsBundle bundle,
                                           FeedbackQuestionAttributes question) {

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankOptionsQuestionDetails.java
@@ -337,6 +337,14 @@ public class FeedbackRankOptionsQuestionDetails extends FeedbackRankQuestionDeta
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
                         List<FeedbackResponseAttributes> responses,
                         FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRankRecipientsQuestionDetails.java
@@ -373,6 +373,14 @@ public class FeedbackRankRecipientsQuestionDetails extends FeedbackRankQuestionD
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
                         List<FeedbackResponseAttributes> responses,
                         FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackResponseDetails.java
@@ -37,8 +37,10 @@ public abstract class FeedbackResponseDetails {
 
     public abstract String getAnswerString();
 
+    @Deprecated
     public abstract String getAnswerHtmlInstructorView(FeedbackQuestionDetails questionDetails);
 
+    @Deprecated
     public String getAnswerHtmlStudentView(FeedbackQuestionDetails questionDetails) {
         return getAnswerHtmlInstructorView(questionDetails);
     }
@@ -81,6 +83,7 @@ public abstract class FeedbackResponseDetails {
      * <p>default action is to call getAnswerHtml(FeedbackQuestionDetails questionDetails).
      * override in child class if necessary.
      */
+    @Deprecated
     public String getAnswerHtml(FeedbackResponseAttributes response, FeedbackQuestionAttributes question,
                                 FeedbackSessionResultsBundle feedbackSessionResultsBundle) {
         return getAnswerHtmlInstructorView(question.getQuestionDetails());

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackRubricQuestionDetails.java
@@ -807,6 +807,14 @@ public class FeedbackRubricQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackTextQuestionDetails.java
@@ -158,6 +158,14 @@ public class FeedbackTextQuestionDetails extends FeedbackQuestionDetails {
     }
 
     @Override
+    public String getQuestionResultStatisticsJson(
+            List<FeedbackResponseAttributes> responses, FeedbackQuestionAttributes question,
+            String userEmail, FeedbackSessionResultsBundle bundle, boolean isStudent) {
+        // TODO
+        return "";
+    }
+
+    @Override
     public String getQuestionResultStatisticsCsv(
             List<FeedbackResponseAttributes> responses,
             FeedbackQuestionAttributes question,

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -934,6 +934,7 @@ public final class Const {
         public static final String INSTRUCTORS = "/instructors";
         public static final String INSTRUCTOR = "/instructor";
         public static final String INSTRUCTOR_PRIVILEGE = "/instructor/privilege";
+        public static final String RESULT = "/result";
         public static final String STUDENTS = "/students";
         public static final String STUDENT = "/student";
         public static final String SESSIONS_ADMIN = "/sessions/admin";

--- a/src/main/java/teammates/ui/webapi/action/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/action/ActionFactory.java
@@ -48,6 +48,7 @@ public class ActionFactory {
         map(ResourceURIs.INSTRUCTORS, DELETE, DeleteInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR, GET, GetInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR_PRIVILEGE, GET, GetInstructorPrivilegeAction.class);
+        map(ResourceURIs.RESULT, GET, GetSessionResultsAction.class);
         map(ResourceURIs.STUDENTS, DELETE, DeleteStudentAction.class);
         map(ResourceURIs.STUDENT, GET, GetStudentAction.class);
         map(ResourceURIs.SESSIONS_ADMIN, GET, GetOngoingSessionsAction.class);

--- a/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
@@ -1,0 +1,69 @@
+package teammates.ui.webapi.action;
+
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.exception.UnauthorizedAccessException;
+import teammates.common.util.Const;
+
+/**
+ * Gets feedback session results including statistics where necessary.
+ */
+public class GetSessionResultsAction extends Action {
+
+    @Override
+    protected AuthType getMinAuthLevel() {
+        return AuthType.PUBLIC;
+    }
+
+    @Override
+    public void checkSpecificAccessControl() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+
+        FeedbackSessionAttributes fs = logic.getFeedbackSession(feedbackSessionName, courseId);
+
+        if (fs == null) {
+            throw new EntityNotFoundException(new EntityDoesNotExistException("Feedback session is not found"));
+        }
+
+        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
+        switch (intent) {
+        case INSTRUCTOR_RESULT:
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+            gateKeeper.verifyAccessible(instructor, fs);
+            break;
+        case STUDENT_RESULT:
+            StudentAttributes student = getStudent(courseId);
+
+            gateKeeper.verifyAccessible(student, fs);
+
+            if (!fs.isPublished()) {
+                throw new UnauthorizedAccessException("This feedback session is not yet published.");
+            }
+            break;
+        case INSTRUCTOR_SUBMISSION:
+        case STUDENT_SUBMISSION:
+            throw new InvalidHttpParameterException("Invalid intent for this action");
+        default:
+            throw new InvalidHttpParameterException("Unknown intent " + intent);
+        }
+    }
+
+    private StudentAttributes getStudent(String courseId) {
+        if (userInfo == null) {
+            String regkey = getNonNullRequestParamValue(Const.ParamsNames.REGKEY);
+            return logic.getStudentForRegistrationKey(regkey);
+        }
+        return logic.getStudentForGoogleId(courseId, userInfo.id);
+    }
+
+    @Override
+    public ActionResult execute() {
+        return null;
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetSessionResultsAction.java
@@ -1,5 +1,7 @@
 package teammates.ui.webapi.action;
 
+import teammates.common.datatransfer.FeedbackSessionResultsBundle;
+import teammates.common.datatransfer.SectionDetail;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -8,6 +10,7 @@ import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
+import teammates.ui.webapi.output.SessionResultsData;
 
 /**
  * Gets feedback session results including statistics where necessary.
@@ -63,7 +66,69 @@ public class GetSessionResultsAction extends Action {
 
     @Override
     public ActionResult execute() {
-        return null;
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
+
+        // Allow additional filter by question ID (equivalent to question number) and section name
+        String questionId = getRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
+        String selectedSection = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESULTS_GROUPBYSECTION);
+
+        FeedbackSessionResultsBundle bundle;
+        Intent intent = Intent.valueOf(getNonNullRequestParamValue(Const.ParamsNames.INTENT));
+        switch (intent) {
+        case INSTRUCTOR_RESULT:
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.id);
+
+            try {
+                // TODO optimize the logic layer to get rid of functions that are no longer necessary
+                if (questionId == null) {
+                    if (selectedSection == null) {
+                        bundle = logic.getFeedbackSessionResultsForInstructorWithinRangeFromView(
+                                feedbackSessionName, courseId, instructor.email,
+                                1, Const.FeedbackSessionResults.QUESTION_SORT_TYPE);
+                    } else {
+                        bundle = logic.getFeedbackSessionResultsForInstructorInSection(
+                                feedbackSessionName, courseId, instructor.email, selectedSection,
+                                SectionDetail.EITHER);
+                    }
+                } else {
+                    if (selectedSection == null) {
+                        bundle = logic.getFeedbackSessionResultsForInstructorFromQuestion(feedbackSessionName, courseId,
+                                instructor.email, questionId);
+                    } else {
+                        bundle = logic.getFeedbackSessionResultsForInstructorFromQuestionInSection(
+                                feedbackSessionName, courseId,
+                                instructor.email, questionId, selectedSection, SectionDetail.EITHER);
+                    }
+                }
+            } catch (EntityDoesNotExistException e) {
+                throw new EntityNotFoundException(e);
+            }
+
+            return new JsonResult(new SessionResultsData(bundle, instructor));
+        case STUDENT_RESULT:
+            // Question number and section name filters are not applied here
+            StudentAttributes student = getStudent(courseId);
+
+            try {
+                bundle = logic.getFeedbackSessionResultsForStudent(feedbackSessionName, courseId, student.email);
+            } catch (EntityDoesNotExistException e) {
+                throw new EntityNotFoundException(e);
+            }
+
+            if (bundle.isStudentHasSomethingNewToSee(student)) {
+                // TODO do something
+            } else {
+                // TODO do something else
+            }
+
+            return new JsonResult(new SessionResultsData(bundle, student));
+        case INSTRUCTOR_SUBMISSION:
+        case STUDENT_SUBMISSION:
+            throw new InvalidHttpParameterException("Invalid intent for this action");
+        default:
+            throw new InvalidHttpParameterException("Unknown intent " + intent);
+        }
     }
 
 }

--- a/src/main/java/teammates/ui/webapi/action/Intent.java
+++ b/src/main/java/teammates/ui/webapi/action/Intent.java
@@ -19,4 +19,15 @@ public enum Intent {
      * To submit the feedback session as students.
      */
     STUDENT_SUBMISSION,
+
+    /**
+     * To view the feedback session result as instructors.
+     */
+    INSTRUCTOR_RESULT,
+
+    /**
+     * To view the feedback session result as students.
+     */
+    STUDENT_RESULT,
+
 }

--- a/src/main/java/teammates/ui/webapi/action/SaveFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SaveFeedbackResponseAction.java
@@ -60,6 +60,9 @@ public class SaveFeedbackResponseAction extends BasicFeedbackSubmissionAction {
             recipientsOfTheQuestion =
                     logic.getRecipientsOfQuestionForInstructor(feedbackQuestion, instructorAttributes.getEmail());
             break;
+        case INSTRUCTOR_RESULT:
+        case STUDENT_RESULT:
+            throw new InvalidHttpParameterException("Invalid intent for this action");
         default:
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }

--- a/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
+++ b/src/main/java/teammates/ui/webapi/output/SessionResultsData.java
@@ -1,0 +1,259 @@
+package teammates.ui.webapi.output;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.FeedbackSessionResultsBundle;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
+import teammates.common.util.Const;
+
+/**
+ * API output format for session results, including statistics.
+ */
+public class SessionResultsData extends ApiOutput {
+
+    private static final String REGEX_ANONYMOUS_PARTICIPANT_HASH = "[0-9]{1,10}";
+
+    private final List<QuestionOutput> questions = new ArrayList<>();
+
+    public SessionResultsData(FeedbackSessionResultsBundle bundle, InstructorAttributes instructor) {
+        Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponses =
+                bundle.getQuestionResponseMapSortedByRecipient();
+
+        questionsWithResponses.forEach((question, responses) -> {
+            FeedbackQuestionDetails questionDetails = question.getQuestionDetails();
+            QuestionOutput qnOutput = new QuestionOutput(question.questionNumber, question.questionType,
+                    questionDetails.getQuestionText(),
+                    questionDetails.getQuestionResultStatisticsJson(responses, question, instructor.email, bundle, false));
+
+            List<ResponseOutput> allResponses = buildResponses(responses, bundle);
+            for (ResponseOutput respOutput : allResponses) {
+                qnOutput.allResponses.add(respOutput);
+            }
+
+            questions.add(qnOutput);
+        });
+    }
+
+    public SessionResultsData(FeedbackSessionResultsBundle bundle, StudentAttributes student) {
+        Map<FeedbackQuestionAttributes, List<FeedbackResponseAttributes>> questionsWithResponses =
+                bundle.getQuestionResponseMapSortedByRecipient();
+
+        questionsWithResponses.forEach((question, responses) -> {
+            FeedbackQuestionDetails questionDetails = question.getQuestionDetails();
+            QuestionOutput qnOutput = new QuestionOutput(question.questionNumber, question.questionType,
+                    questionDetails.getQuestionText(),
+                    questionDetails.getQuestionResultStatisticsJson(responses, question, student.email, bundle, true));
+
+            if (questionDetails.isIndividualResponsesShownToStudents()) {
+                List<ResponseOutput> allResponses = buildResponses(question, responses, bundle, student);
+                for (ResponseOutput respOutput : allResponses) {
+                    if ("You".equals(respOutput.giver)) {
+                        qnOutput.responsesFromSelf.add(respOutput);
+                    } else if ("You".equals(respOutput.recipient)) {
+                        qnOutput.responsesToSelf.add(respOutput);
+                    } else {
+                        qnOutput.otherResponses.add(respOutput);
+                    }
+                }
+            }
+
+            questions.add(qnOutput);
+        });
+    }
+
+    public List<QuestionOutput> getQuestions() {
+        return questions;
+    }
+
+    private static String removeAnonymousHash(String identifier) {
+        return identifier.replaceAll(Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT + " (student|instructor|team) "
+                + REGEX_ANONYMOUS_PARTICIPANT_HASH, Const.DISPLAYED_NAME_FOR_ANONYMOUS_PARTICIPANT + " $1");
+    }
+
+    private List<ResponseOutput> buildResponses(
+            FeedbackQuestionAttributes question, List<FeedbackResponseAttributes> responses,
+            FeedbackSessionResultsBundle bundle, StudentAttributes student) {
+        Map<String, List<FeedbackResponseAttributes>> responsesMap = new HashMap<>();
+
+        for (FeedbackResponseAttributes response : responses) {
+            responsesMap.computeIfAbsent(response.recipient, k -> new ArrayList<>()).add(response);
+        }
+
+        List<ResponseOutput> output = new ArrayList<>();
+
+        responsesMap.forEach((recipient, responsesForRecipient) -> {
+            boolean isUserRecipient = student.email.equals(recipient);
+            boolean isUserTeamRecipient = question.recipientType == FeedbackParticipantType.TEAMS
+                    && student.team.equals(recipient);
+            String recipientName;
+            if (isUserRecipient) {
+                recipientName = "You";
+            } else if (isUserTeamRecipient) {
+                recipientName = String.format("Your Team (%s)", bundle.getNameForEmail(recipient));
+            } else {
+                recipientName = bundle.getNameForEmail(recipient);
+            }
+            recipientName = removeAnonymousHash(recipientName);
+
+            for (FeedbackResponseAttributes response : responsesForRecipient) {
+                String giverName = bundle.getGiverNameForResponse(response);
+                String displayedGiverName;
+
+                boolean isUserGiver = student.email.equals(response.giver);
+                boolean isUserPartOfGiverTeam = student.team.equals(giverName);
+                if (question.giverType == FeedbackParticipantType.TEAMS && isUserPartOfGiverTeam) {
+                    displayedGiverName = "Your Team (" + giverName + ")";
+                } else if (isUserGiver) {
+                    displayedGiverName = "You";
+                } else {
+                    displayedGiverName = removeAnonymousHash(giverName);
+                }
+
+                if (isUserGiver && !isUserRecipient) {
+                    // If the giver is the user, show the real name of the recipient
+                    // since the giver would know which recipient he/she gave the response to
+                    recipientName = bundle.getNameForEmail(response.recipient);
+                }
+
+                // TODO fetch feedback response comments
+
+                output.add(new ResponseOutput(recipientName, response.recipientSection,
+                        displayedGiverName, response.giverSection, response.responseDetails));
+            }
+
+        });
+        return output;
+    }
+
+    private List<ResponseOutput> buildResponses(
+            List<FeedbackResponseAttributes> responses, FeedbackSessionResultsBundle bundle) {
+        Map<String, List<FeedbackResponseAttributes>> responsesMap = new HashMap<>();
+
+        for (FeedbackResponseAttributes response : responses) {
+            responsesMap.computeIfAbsent(response.recipient, k -> new ArrayList<>()).add(response);
+        }
+
+        List<ResponseOutput> output = new ArrayList<>();
+
+        responsesMap.forEach((recipient, responsesForRecipient) -> {
+            String recipientName = removeAnonymousHash(bundle.getNameForEmail(recipient));
+
+            for (FeedbackResponseAttributes response : responsesForRecipient) {
+                String giverName = removeAnonymousHash(bundle.getGiverNameForResponse(response));
+
+                // TODO fetch feedback response comments
+
+                output.add(new ResponseOutput(recipientName, response.recipientSection,
+                        giverName, response.giverSection, response.responseDetails));
+            }
+
+        });
+        return output;
+    }
+
+    private static class QuestionOutput {
+
+        private final String questionText;
+        private final FeedbackQuestionType questionType;
+        private final int questionNumber;
+        private final String questionStatistics;
+
+        // For instructor view
+        private List<ResponseOutput> allResponses = new ArrayList<>();
+
+        // For student view
+        private List<ResponseOutput> responsesToSelf = new ArrayList<>();
+        private List<ResponseOutput> responsesFromSelf = new ArrayList<>();
+        private List<ResponseOutput> otherResponses = new ArrayList<>();
+
+        QuestionOutput(int questionNumber, FeedbackQuestionType questionType, String questionText,
+                String questionStatistics) {
+            this.questionNumber = questionNumber;
+            this.questionType = questionType;
+            this.questionText = questionText;
+            this.questionStatistics = questionStatistics;
+        }
+
+        public String getQuestionText() {
+            return questionText;
+        }
+
+        public FeedbackQuestionType getQuestionType() {
+            return questionType;
+        }
+
+        public int getQuestionNumber() {
+            return questionNumber;
+        }
+
+        public String getQuestionStatistics() {
+            return questionStatistics;
+        }
+
+        public List<ResponseOutput> getAllResponses() {
+            return allResponses;
+        }
+
+        public List<ResponseOutput> getResponsesFromSelf() {
+            return responsesFromSelf;
+        }
+
+        public List<ResponseOutput> getResponsesToSelf() {
+            return responsesToSelf;
+        }
+
+        public List<ResponseOutput> getOtherResponses() {
+            return otherResponses;
+        }
+
+    }
+
+    private static class ResponseOutput {
+
+        private final String giver;
+        private final String giverSection;
+        private final String recipient;
+        private final String recipientSection;
+        private final String responseMetadata;
+
+        ResponseOutput(String giver, String giverSection, String recipient,
+                String recipientSection, FeedbackResponseDetails responseDetails) {
+            this.giver = giver;
+            this.giverSection = giverSection;
+            this.recipient = recipient;
+            this.recipientSection = recipientSection;
+            this.responseMetadata = responseDetails.getJsonString();
+        }
+
+        public String getGiver() {
+            return giver;
+        }
+
+        public String getGiverSection() {
+            return giverSection;
+        }
+
+        public String getRecipient() {
+            return recipient;
+        }
+
+        public String getRecipientSection() {
+            return recipientSection;
+        }
+
+        public String getResponseMetadata() {
+            return responseMetadata;
+        }
+    }
+
+}


### PR DESCRIPTION
Part of #9382 (this is the most difficult API to migrate, by far)

The API is still in conceptual stage. It is designed with usages for student/instructor session result page in mind, but whether or not it actually works can only be known when the pages are actually migrated.

Endpoint: `/result`
Params:
- `courseId`, self-explanatory
- `feedbackSessionName`, self-explanatory
- `intent`, either `STUDENT_RESULT` or `INSTRUCTOR_RESULT` (cannot be abused as there will be access control check)
- `questionId` to filter by question ID (which is equivalent to question number)
- `sectionName` to filter by section

Presence of either `questionId` or `sectionName` or both will limit the API response to just the specified `questionId` and/or `sectionName`.