### PR TITLE
[#9491] Fix link from getting started page to instructor help page

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -5,7 +5,7 @@
   </p>
   <p>
     To get started using TEAMMATES, follow the following steps, or watch our <a href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1&rel=0" target="_blank"><i class="fas fa-film"></i> Video Tour</a>.<br>
-    For more help, browse the answers to some <a routerLink="../instructor">frequently asked questions</a>.
+    For more help, browse the answers to some <a routerLink="/{{instructorHelpPath}}">frequently asked questions</a>.
   </p>
   <ol>
     <li><a (click)="jumpTo('course-setup')" [routerLink]="">Set up a course</a></li>
@@ -31,15 +31,15 @@
         <p><b>EXAMPLE BOX</b></p>
       </li>
       <li>
-        <b><a routerLink="../instructor" fragment="course-add-students">Enroll students in the course</a></b><br>
+        <b><a routerLink="/{{instructorHelpPath}}" fragment="course-add-students">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
       </li>
       <li>
-        <b><a routerLink="../instructor" fragment="course-add-instructor">Add instructors to the course</a></b><br>
+        <b><a routerLink="/{{instructorHelpPath}}" fragment="course-add-instructor">Add instructors to the course</a></b><br>
         From the <b>Courses</b> page, click the <button class="btn btn-secondary btn-sm" type="button">Edit</button> button of the course you would like to add instructors to. You will be directed to the <b>Edit Course</b> page where you can add a new instructor to your course.
-        You can specify the <a routerLink="../instructor" fragment="course-instructor-access">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="../instructor" fragment="course-add-instructor">here</a>.
+        You can specify the <a routerLink="/{{instructorHelpPath}}" fragment="course-instructor-access">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="/{{instructorHelpPath}}" fragment="course-add-instructor">here</a>.
       </li>
     </ol>
   </div>
@@ -72,12 +72,12 @@
         </ul>
       </ul>
       <li>
-        <b><a routerLink="../instructor" fragment="session-questions">Add questions</a> to your session to suit your needs.</b><br>
+        <b><a routerLink="/{{instructorHelpPath}}" fragment="session-questions">Add questions</a> to your session to suit your needs.</b><br>
         For each question, you can set the following:
       </li>
       <ul>
         <li>
-          Question type: the style of question being asked. Choose from our 10 different <a routerLink="../instructor" fragment="questions">question types</a>.
+          Question type: the style of question being asked. Choose from our 10 different <a routerLink="/{{instructorHelpPath}}" fragment="questions">question types</a>.
         </li>
         <li>
           Question feedback path: the feedback giver and feedback recipient
@@ -88,7 +88,7 @@
       </ul>
       <li>
         <b>Preview your session</b><br>
-        After you have finished setting up your session, <a routerLink="../instructor" fragment="session-preview">preview the session</a> as a student or another instructor.
+        After you have finished setting up your session, <a routerLink="/{{instructorHelpPath}}" fragment="session-preview">preview the session</a> as a student or another instructor.
       </li>
     </ol>
   </div>
@@ -137,19 +137,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="../instructor" fragment="session-view-results">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
+        <a routerLink="/{{instructorHelpPath}}" fragment="session-view-results">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
       </li>
       <li>
         Moderate responses: edit inappropriate responses from respondents before publishing the responses.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="session-add-comments">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
+        <a routerLink="/{{instructorHelpPath}}" fragment="session-add-comments">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
       </li>
       <li>
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="session-cannot-submit">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+        <a routerLink="/{{instructorHelpPath}}" fragment="session-cannot-submit">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
     <p>
@@ -177,19 +177,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="../instructor" fragment="student-view-profile">View a student's profile</a> and <a routerLink="../instructor" fragment="student-view-responses">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
+        <a routerLink="/{{instructorHelpPath}}" fragment="student-view-profile">View a student's profile</a> and <a routerLink="/{{instructorHelpPath}}" fragment="student-view-responses">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="student-edit-details">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
+        <a routerLink="/{{instructorHelpPath}}" fragment="student-edit-details">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="student-email">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
+        <a routerLink="/{{instructorHelpPath}}" fragment="student-email">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
       </li>
       <li>
-        Search: <a routerLink="../instructor" fragment="student-search">search for students, teams or sections</a>, or <a routerLink="../instructor" fragment="session-search">search for questions, responses or comments</a>.
+        Search: <a routerLink="/{{instructorHelpPath}}" fragment="student-search">search for students, teams or sections</a>, or <a routerLink="/{{instructorHelpPath}}" fragment="session-search">search for questions, responses or comments</a>.
       </li>
       <li>
-        <a routerLink="../instructor" fragment="course-archive">Archive old courses</a>: archive old courses that you no longer need actively.
+        <a routerLink="/{{instructorHelpPath}}" fragment="course-archive">Archive old courses</a>: archive old courses that you no longer need actively.
       </li>
     </ul>
   </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.html
@@ -5,7 +5,7 @@
   </p>
   <p>
     To get started using TEAMMATES, follow the following steps, or watch our <a href="https://www.youtube.com/embed/mDtfmNmRwBM?autoplay=1&rel=0" target="_blank"><i class="fas fa-film"></i> Video Tour</a>.<br>
-    For more help, browse the answers to some <a routerLink="/{{instructorHelpPath}}">frequently asked questions</a>.
+    For more help, browse the answers to some <a [routerLink]="instructorHelpPath">frequently asked questions</a>.
   </p>
   <ol>
     <li><a (click)="jumpTo('course-setup')" [routerLink]="">Set up a course</a></li>
@@ -31,15 +31,15 @@
         <p><b>EXAMPLE BOX</b></p>
       </li>
       <li>
-        <b><a routerLink="/{{instructorHelpPath}}" fragment="course-add-students">Enroll students in the course</a></b><br>
+        <b><a [routerLink]="instructorHelpPath" fragment="course-add-students">Enroll students in the course</a></b><br>
         Go to the <b>Courses</b> page and click the <button class="btn btn-secondary btn-sm">Enroll</button> button of the corresponding course.<br>
         Students can be enrolled into teams (e.g. project groups) and sections (e.g. tutorial classes, lecture groups) to facilitate giving feedback in and among these smaller groups.<br>
         TEAMMATES will <b>not</b> automatically notify students that they have been enrolled. However, if you would like students to access TEAMMATES sooner (e.g. if you would like them to fill in their profile page in advance), click the <button class="btn btn-sm btn-secondary">View</button> button of the course in the <b>Courses</b> page. Then, click <button class="btn btn-sm btn-primary"><i class="far fa-envelope"></i> Remind Students to Join</button> button, which will send them instructions to access TEAMMATES immediately.
       </li>
       <li>
-        <b><a routerLink="/{{instructorHelpPath}}" fragment="course-add-instructor">Add instructors to the course</a></b><br>
+        <b><a [routerLink]="instructorHelpPath" fragment="course-add-instructor">Add instructors to the course</a></b><br>
         From the <b>Courses</b> page, click the <button class="btn btn-secondary btn-sm" type="button">Edit</button> button of the course you would like to add instructors to. You will be directed to the <b>Edit Course</b> page where you can add a new instructor to your course.
-        You can specify the <a routerLink="/{{instructorHelpPath}}" fragment="course-instructor-access">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a routerLink="/{{instructorHelpPath}}" fragment="course-add-instructor">here</a>.
+        You can specify the <a [routerLink]="instructorHelpPath" fragment="course-instructor-access">access level</a> of any instructor you add to a course. For more information about how to add an instructor to your course, click <a [routerLink]="instructorHelpPath" fragment="course-add-instructor">here</a>.
       </li>
     </ol>
   </div>
@@ -72,12 +72,12 @@
         </ul>
       </ul>
       <li>
-        <b><a routerLink="/{{instructorHelpPath}}" fragment="session-questions">Add questions</a> to your session to suit your needs.</b><br>
+        <b><a [routerLink]="instructorHelpPath" fragment="session-questions">Add questions</a> to your session to suit your needs.</b><br>
         For each question, you can set the following:
       </li>
       <ul>
         <li>
-          Question type: the style of question being asked. Choose from our 10 different <a routerLink="/{{instructorHelpPath}}" fragment="questions">question types</a>.
+          Question type: the style of question being asked. Choose from our 10 different <a [routerLink]="instructorHelpPath" fragment="questions">question types</a>.
         </li>
         <li>
           Question feedback path: the feedback giver and feedback recipient
@@ -88,7 +88,7 @@
       </ul>
       <li>
         <b>Preview your session</b><br>
-        After you have finished setting up your session, <a routerLink="/{{instructorHelpPath}}" fragment="session-preview">preview the session</a> as a student or another instructor.
+        After you have finished setting up your session, <a [routerLink]="instructorHelpPath" fragment="session-preview">preview the session</a> as a student or another instructor.
       </li>
     </ol>
   </div>
@@ -137,19 +137,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="session-view-results">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
+        <a [routerLink]="instructorHelpPath" fragment="session-view-results">View responses</a>: see what respondents have answered, even if the session is still ongoing. Go to the <b>Sessions</b> page and click the corresponding <button class="btn btn-secondary btn-sm">Results</button> button.
       </li>
       <li>
         Moderate responses: edit inappropriate responses from respondents before publishing the responses.
       </li>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="session-add-comments">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
+        <a [routerLink]="instructorHelpPath" fragment="session-add-comments">Add comments to responses</a>: reply to respondents' answers, or add your own notes on a response. You can make your comment visible to other instructors, the response giver, and/or the response giver's team.
       </li>
       <li>
         Remind students to submit responses: TEAMMATES automatically sends reminders to students; however, you can also manually send reminder emails to students at any time while a session is open. Click the <button class="btn btn-sm btn-secondary">Remind</button> button of the session from the <b>Home</b> or <b>Sessions</b> page.
       </li>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="session-cannot-submit">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
+        <a [routerLink]="instructorHelpPath" fragment="session-cannot-submit">Submit responses for students</a>: if a student has missed the closing time of the session, or is unable to submit the evaluation due to technical problems, you can submit the student's responses on his/her behalf.
       </li>
     </ul>
     <p>
@@ -177,19 +177,19 @@
     </p>
     <ul>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="student-view-profile">View a student's profile</a> and <a routerLink="/{{instructorHelpPath}}" fragment="student-view-responses">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
+        <a [routerLink]="instructorHelpPath" fragment="student-view-profile">View a student's profile</a> and <a [routerLink]="instructorHelpPath" fragment="student-view-responses">all past records of a student</a>: view the profile that any enrolled student has written for him/herself, and see in one place all submissions given/received by a student. Handy for examining how a student progressed through a course.
       </li>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="student-edit-details">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
+        <a [routerLink]="instructorHelpPath" fragment="student-edit-details">Edit a student's data</a>: change a student's registered name, section or team name, or email address. You can also note down comments on students, for example to inform other instructors of information about a student that they should take note of.
       </li>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="student-email">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
+        <a [routerLink]="instructorHelpPath" fragment="student-email">Email a group of students</a>: contact students regarding their feedback responses, or the course in general. Also handy for locating the email address of past students.
       </li>
       <li>
-        Search: <a routerLink="/{{instructorHelpPath}}" fragment="student-search">search for students, teams or sections</a>, or <a routerLink="/{{instructorHelpPath}}" fragment="session-search">search for questions, responses or comments</a>.
+        Search: <a [routerLink]="instructorHelpPath" fragment="student-search">search for students, teams or sections</a>, or <a [routerLink]="instructorHelpPath" fragment="session-search">search for questions, responses or comments</a>.
       </li>
       <li>
-        <a routerLink="/{{instructorHelpPath}}" fragment="course-archive">Archive old courses</a>: archive old courses that you no longer need actively.
+        <a [routerLink]="instructorHelpPath" fragment="course-archive">Archive old courses</a>: archive old courses that you no longer need actively.
       </li>
     </ul>
   </div>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-getting-started/instructor-help-getting-started.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../../../environments/environment';
 
 /**
@@ -10,10 +11,18 @@ import { environment } from '../../../../environments/environment';
   styleUrls: ['./instructor-help-getting-started.component.scss'],
 })
 export class InstructorHelpGettingStartedComponent implements OnInit {
-
   readonly supportEmail: string = environment.supportEmail;
+  instructorHelpPath: string = '';
 
-  constructor() { }
+  constructor(private route: ActivatedRoute) {
+    let r: ActivatedRoute = this.route;
+    while (r.firstChild) {
+      r = r.firstChild;
+    }
+    r.data.subscribe((resp: any) => {
+      this.instructorHelpPath = resp.instructorHelpPath;
+    });
+  }
 
   ngOnInit(): void {
   }

--- a/src/web/app/pages-instructor/instructor-pages.module.ts
+++ b/src/web/app/pages-instructor/instructor-pages.module.ts
@@ -174,6 +174,9 @@ const routes: Routes = [
   {
     path: 'getting-started',
     component: InstructorHelpGettingStartedComponent,
+    data: {
+      instructorHelpPath: 'web/instructor/help',
+    },
   },
   {
     path: '',

--- a/src/web/app/pages-instructor/instructor-pages.module.ts
+++ b/src/web/app/pages-instructor/instructor-pages.module.ts
@@ -175,7 +175,7 @@ const routes: Routes = [
     path: 'getting-started',
     component: InstructorHelpGettingStartedComponent,
     data: {
-      instructorHelpPath: 'web/instructor/help',
+      instructorHelpPath: '/web/instructor/help',
     },
   },
   {

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -69,7 +69,7 @@ const routes: Routes = [
         path: 'getting-started',
         component: InstructorHelpGettingStartedComponent,
         data: {
-          instructorHelpPath: 'web/front/help/instructor',
+          instructorHelpPath: '/web/front/help/instructor',
         },
       },
     ],
@@ -78,7 +78,7 @@ const routes: Routes = [
     path: 'getting-started',
     component: InstructorHelpGettingStartedComponent,
     data: {
-      instructorHelpPath: 'web/front/help/instructor',
+      instructorHelpPath: '/web/front/help/instructor',
     },
   },
   {

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -75,13 +75,6 @@ const routes: Routes = [
     ],
   },
   {
-    path: 'getting-started',
-    component: InstructorHelpGettingStartedComponent,
-    data: {
-      instructorHelpPath: '/web/front/help/instructor',
-    },
-  },
-  {
     path: '',
     pathMatch: 'full',
     redirectTo: 'home',

--- a/src/web/app/pages-static/static-pages.module.ts
+++ b/src/web/app/pages-static/static-pages.module.ts
@@ -68,12 +68,18 @@ const routes: Routes = [
       {
         path: 'getting-started',
         component: InstructorHelpGettingStartedComponent,
+        data: {
+          instructorHelpPath: 'web/front/help/instructor',
+        },
       },
     ],
   },
   {
     path: 'getting-started',
     component: InstructorHelpGettingStartedComponent,
+    data: {
+      instructorHelpPath: 'web/front/help/instructor',
+    },
   },
   {
     path: '',


### PR DESCRIPTION
Fixes #9491 

**Outline of Solution**
I passed the corresponding instructor help page path as a route data, fetched it in the getting started component, and used interpolation to use the right path.

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
