### PR TITLE
[#9494] Consolidate Instructor Privilege RESTFul API

### DIFF
--- a/src/main/java/teammates/common/datatransfer/InstructorPrivilegesBundle.java
+++ b/src/main/java/teammates/common/datatransfer/InstructorPrivilegesBundle.java
@@ -1,0 +1,106 @@
+package teammates.common.datatransfer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import teammates.common.util.Assumption;
+
+/**
+ * Represents detailed privilege of an instructor.
+ * <br> Contains:
+ * <br> * course, section, session level privileges of the instructor.
+ *
+ */
+public class InstructorPrivilegesBundle {
+
+    private Map<String, Boolean> courseLevel;
+    private Map<String, Map<String, Boolean>> sectionLevel;
+    private Map<String, Map<String, Map<String, Boolean>>> sessionLevel;
+
+    public InstructorPrivilegesBundle() {
+        this.courseLevel = new LinkedHashMap<>();
+        this.sectionLevel = new LinkedHashMap<>();
+        this.sessionLevel = new LinkedHashMap<>();
+    }
+
+    private void setCourseLevelPrivileges(Map<String, Boolean> courseLevel) {
+        this.courseLevel = courseLevel;
+    }
+
+    private void setSectionLevelPrivileges(Map<String, Map<String, Boolean>> sectionLevel) {
+        this.sectionLevel = sectionLevel;
+    }
+
+    private void setSessionLevelPrivileges(Map<String, Map<String, Map<String, Boolean>>> sessionLevel) {
+        this.sessionLevel = sessionLevel;
+    }
+
+    public void setPrivileges(InstructorPrivileges privileges) {
+        setCourseLevelPrivileges(privileges.getCourseLevelPrivileges());
+        setSessionLevelPrivileges(privileges.getSessionLevelPrivileges());
+        setSectionLevelPrivileges(privileges.getSectionLevelPrivileges());
+    }
+
+    public void updatePrivilegeInCourseLevel(String privilegeName, boolean isAllowed) {
+        if (!InstructorPrivileges.isPrivilegeNameValid(privilegeName)) {
+            return;
+        }
+        this.courseLevel.put(privilegeName, isAllowed);
+    }
+
+    public void updatePrivilegeInSectionLevel(String sectionName, String privilegeName, boolean isAllowed) {
+        if (!InstructorPrivileges.isPrivilegeNameValidForSectionLevel(privilegeName)) {
+            return;
+        }
+        this.sectionLevel.computeIfAbsent(sectionName, key -> new LinkedHashMap<>())
+                .put(privilegeName, isAllowed);
+    }
+
+    public void updatePrivilegeInSessionLevel(String sectionName, String sessionName,
+                                               String privilegeName, boolean isAllowed) {
+        if (!InstructorPrivileges.isPrivilegeNameValidForSessionLevel(privilegeName)) {
+            return;
+        }
+        this.sessionLevel.computeIfAbsent(sectionName, key -> new LinkedHashMap<>());
+        this.sessionLevel.get(sectionName).computeIfAbsent(sessionName, key -> new LinkedHashMap<>())
+                .put(privilegeName, isAllowed);
+    }
+
+    public static InstructorPrivilegesBundle toInstructorPrivilegeBundle(InstructorPrivileges privileges) {
+        InstructorPrivilegesBundle privilegesBundle = new InstructorPrivilegesBundle();
+        privilegesBundle.setCourseLevelPrivileges(privileges.getCourseLevelPrivileges());
+        privilegesBundle.setSectionLevelPrivileges(privileges.getSectionLevelPrivileges());
+        privilegesBundle.setSessionLevelPrivileges(privileges.getSessionLevelPrivileges());
+        return privilegesBundle;
+    }
+
+    public boolean isAllowedInCourseLevel(String privilegeName) {
+
+        Assumption.assertTrue(InstructorPrivileges.isPrivilegeNameValid(privilegeName));
+
+        return this.courseLevel.getOrDefault(privilegeName, false);
+    }
+
+    public boolean isAllowedInSectionLevel(String sectionName, String privilegeName) {
+
+        Assumption.assertTrue(InstructorPrivileges.isPrivilegeNameValid(privilegeName));
+
+        if (!this.sectionLevel.containsKey(sectionName)) {
+            return isAllowedInCourseLevel(privilegeName);
+        }
+
+        return this.sectionLevel.get(sectionName).getOrDefault(privilegeName, false);
+    }
+
+    public Map<String, Boolean> getCourseLevelPrivileges() {
+        return courseLevel;
+    }
+
+    public Map<String, Map<String, Boolean>> getSectionLevelPrivileges() {
+        return sectionLevel;
+    }
+
+    public Map<String, Map<String, Map<String, Boolean>>> getSessionLevelPrivileges() {
+        return sessionLevel;
+    }
+}

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -585,6 +585,8 @@ public final class Const {
         public static final String STUDENTS_ENROLLMENT_INFO = "enrollstudents";
 
         public static final String INSTRUCTOR_IS_DISPLAYED_TO_STUDENT = "instructorisdisplayed";
+        public static final String INSTRUCTOR_PRIVILEGES_IS_ALL_NEEDED = "instructorprivilegesisallneeded";
+        public static final String INSTRUCTOR_IS_PRIVILEGE_MAP_NEEDED = "instructorisprivilegemapneeded";
         public static final String INSTRUCTOR_DISPLAY_NAME = "instructordisplayname";
         public static final String INSTRUCTOR_ROLE_NAME = "instructorrole";
         public static final String INSTRUCTOR_SECTION = "section";

--- a/src/main/java/teammates/ui/webapi/action/GetInstructorPrivilegeAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetInstructorPrivilegeAction.java
@@ -1,14 +1,39 @@
 package teammates.ui.webapi.action;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
-import teammates.ui.webapi.output.ApiOutput;
+import teammates.ui.webapi.output.InstructorPrivilegeData;
 
 /**
  * Get the instructor privilege.
  */
 public class GetInstructorPrivilegeAction extends Action {
+
+    static final Map<String, InstructorPrivileges> INSTRUCTOR_PRIVILEGES = new HashMap<>();
+
+    static {
+        InstructorPrivileges coOwnerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+        InstructorPrivileges managerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER);
+        InstructorPrivileges observerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
+        InstructorPrivileges tutorPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR);
+        InstructorPrivileges customPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+
+        INSTRUCTOR_PRIVILEGES.put("coowner", coOwnerPrivileges);
+        INSTRUCTOR_PRIVILEGES.put("manager", managerPrivileges);
+        INSTRUCTOR_PRIVILEGES.put("observer", observerPrivileges);
+        INSTRUCTOR_PRIVILEGES.put("tutor", tutorPrivileges);
+        INSTRUCTOR_PRIVILEGES.put("custom", customPrivileges);
+    }
 
     @Override
     protected AuthType getMinAuthLevel() {
@@ -27,48 +52,54 @@ public class GetInstructorPrivilegeAction extends Action {
     @Override
     public ActionResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        String sectionName = getRequestParamValue(Const.ParamsNames.SECTION_NAME);
         String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
-        InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+        String isAllPrivilegesNeeded = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_PRIVILEGES_IS_ALL_NEEDED);
+        String isMapNeeded = getRequestParamValue(Const.ParamsNames.INSTRUCTOR_IS_PRIVILEGE_MAP_NEEDED);
+        boolean isAllInstructorPrivilegesNeeded = isAllPrivilegesNeeded != null
+                && Boolean.parseBoolean(isAllPrivilegesNeeded);
+        boolean isPrivilegeMapNeeded = isMapNeeded != null && Boolean.parseBoolean(isMapNeeded);
 
-        InstructorPrivilegeResponse response = new InstructorPrivilegeResponse();
-        response.setCanModifyCourse(
-                instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE));
-        response.setCanModifySession(
-                instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION));
-        response.setCanModifyStudent(
-                instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT));
-        response.setCanSubmitSessionInSections(
-                instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS)
-                        || instructor.isAllowedForPrivilegeAnySection(
+        InstructorPrivilegeData response = new InstructorPrivilegeData();
+
+        if (isPrivilegeMapNeeded) {
+            response.setInstructorPrivilegesMap(INSTRUCTOR_PRIVILEGES);
+        } else {
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+
+            if (isAllInstructorPrivilegesNeeded) {
+                response.setPrivilegesBundle(instructor.privileges);
+            } else if (sectionName == null) {
+                response.setPrivilegesCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE,
+                        instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE));
+
+                response.setPrivilegesCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION,
+                        instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION));
+
+                response.setPrivilegesCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT,
+                        instructor.isAllowedForPrivilege(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT));
+
+                response.setPrivilegesCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS,
+                        instructor.isAllowedForPrivilege(
+                                Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS));
+
+                response.setPrivilegesSectionLevel(feedbackSessionName,
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS,
+                        instructor.isAllowedForPrivilegeAnySection(
                                 feedbackSessionName, Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS));
-
+            } else {
+                boolean isAllowedToViewStudentInSection = instructor.isAllowedForPrivilege(sectionName,
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_STUDENT_IN_SECTIONS);
+                // modify student is a privilege in course level.
+                boolean isAllowedToModifyStudent = instructor.isAllowedForPrivilege(
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT);
+                response.setPrivilegesSectionLevel(sectionName,
+                        Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_STUDENT_IN_SECTIONS,
+                        isAllowedToViewStudentInSection);
+                response.setPrivilegesCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT,
+                        isAllowedToModifyStudent);
+            }
+        }
         return new JsonResult(response);
     }
-
-    /**
-     * The output format of {@link GetInstructorPrivilegeAction}.
-     */
-    public static class InstructorPrivilegeResponse extends ApiOutput {
-        private boolean canModifyCourse;
-        private boolean canModifySession;
-        private boolean canModifyStudent;
-        private boolean canSubmitSessionInSections;
-
-        public void setCanModifyCourse(boolean canModifyCourse) {
-            this.canModifyCourse = canModifyCourse;
-        }
-
-        public void setCanModifySession(boolean canModifySession) {
-            this.canModifySession = canModifySession;
-        }
-
-        public void setCanModifyStudent(boolean canModifyStudent) {
-            this.canModifyStudent = canModifyStudent;
-        }
-
-        public void setCanSubmitSessionInSections(boolean canSubmitSessionInSections) {
-            this.canSubmitSessionInSections = canSubmitSessionInSections;
-        }
-    }
-
 }

--- a/src/main/java/teammates/ui/webapi/output/InstructorPrivilegeData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorPrivilegeData.java
@@ -1,0 +1,66 @@
+package teammates.ui.webapi.output;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesBundle;
+
+/**
+ * The output format of instructor privileges.
+ */
+public class InstructorPrivilegeData extends ApiOutput {
+    private InstructorPrivilegesBundle privilegesBundle;
+
+    private Map<String, InstructorPrivilegesBundle> instructorPrivilegesMap;
+
+    public InstructorPrivilegeData() {
+        privilegesBundle = new InstructorPrivilegesBundle();
+    }
+
+    public InstructorPrivilegesBundle getPrivileges() {
+        return privilegesBundle;
+    }
+
+    public Map<String, InstructorPrivilegesBundle> getInstructorPrivilegesMap() {
+        return instructorPrivilegesMap;
+    }
+
+    /**
+     * Set course level instructor privilege.
+     */
+    public void setPrivilegesCourseLevel(String privilegeName, boolean isAllowed) {
+        privilegesBundle.updatePrivilegeInCourseLevel(privilegeName, isAllowed);
+    }
+
+    /**
+     * Set section level instructor privilege.
+     */
+    public void setPrivilegesSectionLevel(String sectionName, String privilegeName, boolean isAllowed) {
+        privilegesBundle.updatePrivilegeInSectionLevel(sectionName, privilegeName, isAllowed);
+    }
+
+    /**
+     * Set session level instructor privilege.
+     */
+    public void setPrivilegesSessionLevel(String sectionName, String sessionName, String privilegeName, boolean isAllowed) {
+        privilegesBundle.updatePrivilegeInSessionLevel(sectionName, sessionName, privilegeName, isAllowed);
+    }
+
+    /**
+     * Set instructor privilege map.
+     */
+    public void setInstructorPrivilegesMap(Map<String, InstructorPrivileges> map) {
+        instructorPrivilegesMap = new LinkedHashMap<>();
+        map.forEach((k, v) -> {
+            instructorPrivilegesMap.putIfAbsent(k, InstructorPrivilegesBundle.toInstructorPrivilegeBundle(v));
+        });
+    }
+
+    /**
+     * build instructor privileges data bundle.
+     */
+    public void setPrivilegesBundle(InstructorPrivileges privileges) {
+        this.privilegesBundle.setPrivileges(privileges);
+    }
+}

--- a/src/test/java/teammates/test/cases/webapi/GetInstructorPrivilegeActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetInstructorPrivilegeActionTest.java
@@ -1,14 +1,25 @@
 package teammates.test.cases.webapi;
 
+import java.util.Map;
+
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.DataBundle;
+import teammates.common.datatransfer.InstructorPrivileges;
+import teammates.common.datatransfer.InstructorPrivilegesBundle;
+import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.ui.webapi.action.GetInstructorPrivilegeAction;
+import teammates.ui.webapi.output.InstructorPrivilegeData;
 
 /**
  * SUT: {@link GetInstructorPrivilegeAction}.
  */
 public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstructorPrivilegeAction> {
+
+    private DataBundle dataBundle = getTypicalDataBundle();
 
     @Override
     protected String getActionUri() {
@@ -20,16 +31,175 @@ public class GetInstructorPrivilegeActionTest extends BaseActionTest<GetInstruct
         return GET;
     }
 
+    @Override
+    protected void prepareTestData() {
+        InstructorAttributes instructor1ofCourse1 = dataBundle.instructors.get("instructor1OfCourse1");
+        String section1 = dataBundle.students.get("student1InCourse1").getSection();
+        String session1 = dataBundle.feedbackSessions.get("session1InCourse1").getFeedbackSessionName();
+        InstructorPrivileges privileges = instructor1ofCourse1.privileges;
+        // update section privilege for testing purpose.
+
+        // section level privilege
+        privileges.updatePrivilege(section1,
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_STUDENT_IN_SECTIONS, true);
+
+        // session level privilege
+        privileges.updatePrivilege(section1, session1,
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_SESSION_IN_SECTIONS, true);
+        instructor1ofCourse1.privileges = privileges;
+
+        dataBundle.instructors.put("instructor1OfCourse1", instructor1ofCourse1);
+        removeAndRestoreDataBundle(dataBundle);
+    }
+
+    private void verifyIsSamePrivilegeSet(InstructorPrivilegesBundle bundle, InstructorPrivileges privileges) {
+        assertTrue(bundle.getCourseLevelPrivileges().equals(privileges.getCourseLevelPrivileges()));
+        assertTrue(bundle.getSectionLevelPrivileges().equals(privileges.getSectionLevelPrivileges()));
+        assertTrue(bundle.getSessionLevelPrivileges().equals(privileges.getSessionLevelPrivileges()));
+    }
+
     @Test
     @Override
     protected void testExecute() throws Exception {
-        // TODO
+        InstructorAttributes instructor1ofCourse1 = dataBundle.instructors.get("instructor1OfCourse1");
+        FeedbackSessionAttributes session1ofCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        StudentAttributes student1InCourse1 = dataBundle.students.get("student1InCourse1");
+        loginAsInstructor(instructor1ofCourse1.getGoogleId());
+
+        InstructorPrivileges coOwnerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER);
+        InstructorPrivileges managerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_MANAGER);
+        InstructorPrivileges observerPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_OBSERVER);
+        InstructorPrivileges tutorPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_TUTOR);
+        InstructorPrivileges customPrivileges = new InstructorPrivileges(
+                Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_CUSTOM);
+
+        ______TS("Request to retrieve complete instructor privileges for the instructor");
+
+        String[] courseIdParam = {
+                Const.ParamsNames.INSTRUCTOR_PRIVILEGES_IS_ALL_NEEDED, "true",
+                Const.ParamsNames.COURSE_ID, instructor1ofCourse1.getCourseId(),
+        };
+
+        GetInstructorPrivilegeAction a = getAction(courseIdParam);
+        InstructorPrivilegeData output = (InstructorPrivilegeData) getJsonResult(a).getOutput();
+
+        InstructorPrivilegesBundle privileges = output.getPrivileges();
+
+        Map<String, Boolean> courseLevelPrivileges = privileges.getCourseLevelPrivileges();
+        Map<String, Map<String, Boolean>> sectionLevelPrivileges = privileges.getSectionLevelPrivileges();
+        Map<String, Map<String, Map<String, Boolean>>> sessionLevelPrivileges = privileges.getSessionLevelPrivileges();
+
+        assertEquals(instructor1ofCourse1.privileges.getCourseLevelPrivileges().size(), courseLevelPrivileges.size());
+        instructor1ofCourse1.privileges.getCourseLevelPrivileges()
+                .forEach((k, v) -> assertEquals(v, courseLevelPrivileges.get(k)));
+
+        assertEquals(instructor1ofCourse1.privileges.getSectionLevelPrivileges().size(), sectionLevelPrivileges.size());
+        instructor1ofCourse1.privileges.getSectionLevelPrivileges()
+                .forEach((section, sectionP) -> {
+                    assertEquals(sectionP.size(), sectionLevelPrivileges.get(section).size());
+                    sectionP.forEach((k, v) -> assertEquals(v, sectionLevelPrivileges.get(section).get(k))); });
+
+        assertEquals(instructor1ofCourse1.privileges.getSessionLevelPrivileges().size(), sessionLevelPrivileges.size());
+        instructor1ofCourse1.privileges.getSessionLevelPrivileges()
+                .forEach((session, sessionP) -> {
+                    assertEquals(sessionP.size(), sessionLevelPrivileges.get(session).size());
+                    sessionP.forEach((section, sectionP) -> {
+                        assertEquals(sectionP.size(), sessionLevelPrivileges.get(session).get(section).size());
+                        sectionP.forEach((k, v) ->
+                                assertEquals(v, sessionLevelPrivileges.get(session).get(section).get(k)));
+                    });
+                });
+
+        assertNull(output.getInstructorPrivilegesMap());
+
+        ______TS("Request to retrieve instructor roles privileges map.");
+
+        String[] mapParams = {
+                Const.ParamsNames.COURSE_ID, instructor1ofCourse1.getCourseId(),
+                Const.ParamsNames.INSTRUCTOR_IS_PRIVILEGE_MAP_NEEDED, "true",
+        };
+
+        a = getAction(mapParams);
+        output = (InstructorPrivilegeData) getJsonResult(a).getOutput();
+
+        privileges = output.getPrivileges();
+        assertEquals(0, privileges.getSessionLevelPrivileges().size());
+        assertEquals(0, privileges.getSectionLevelPrivileges().size());
+        assertEquals(0, privileges.getCourseLevelPrivileges().size());
+
+        Map<String, InstructorPrivilegesBundle> privilegesMap = output.getInstructorPrivilegesMap();
+        verifyIsSamePrivilegeSet(privilegesMap.get("coowner"), coOwnerPrivileges);
+        verifyIsSamePrivilegeSet(privilegesMap.get("manager"), managerPrivileges);
+        verifyIsSamePrivilegeSet(privilegesMap.get("observer"), observerPrivileges);
+        verifyIsSamePrivilegeSet(privilegesMap.get("tutor"), tutorPrivileges);
+        verifyIsSamePrivilegeSet(privilegesMap.get("custom"), customPrivileges);
+
+        ______TS("Request with course id and section name, selected privileges of "
+                + "the instructor for the section will be returned.");
+
+        String[] sectionParams = {
+                Const.ParamsNames.COURSE_ID, instructor1ofCourse1.getCourseId(),
+                Const.ParamsNames.SECTION_NAME, student1InCourse1.getSection(),
+        };
+
+        a = getAction(sectionParams);
+        output = (InstructorPrivilegeData) getJsonResult(a).getOutput();
+
+        privileges = output.getPrivileges();
+        assertTrue(privileges.isAllowedInSectionLevel(student1InCourse1.getSection(),
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_VIEW_STUDENT_IN_SECTIONS));
+        assertTrue(privileges.isAllowedInCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT));
+
+        assertEquals(1, privileges.getCourseLevelPrivileges().size());
+        assertEquals(1, privileges.getSectionLevelPrivileges().size());
+        assertEquals(1, privileges.getSectionLevelPrivileges().get(student1InCourse1.getSection()).size());
+        assertEquals(0, privileges.getSessionLevelPrivileges().size());
+
+        ______TS("Request with course id, selected privileges will be returned");
+
+        String[] invalidSectionNameParams = {
+                Const.ParamsNames.COURSE_ID, instructor1ofCourse1.getCourseId(),
+                Const.ParamsNames.FEEDBACK_SESSION_NAME, session1ofCourse1.getFeedbackSessionName(),
+        };
+
+        a = getAction(invalidSectionNameParams);
+        output = (InstructorPrivilegeData) getJsonResult(a).getOutput();
+
+        privileges = output.getPrivileges();
+
+        assertEquals(4, privileges.getCourseLevelPrivileges().size());
+        assertEquals(1, privileges.getSectionLevelPrivileges().size());
+        assertEquals(1, privileges.getSectionLevelPrivileges()
+                .get(session1ofCourse1.getFeedbackSessionName()).size());
+        assertEquals(0, privileges.getSessionLevelPrivileges().size());
+
+        assertTrue(privileges.isAllowedInCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_COURSE));
+        assertTrue(privileges.isAllowedInCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION));
+        assertTrue(privileges.isAllowedInCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_STUDENT));
+        assertTrue(privileges.isAllowedInCourseLevel(Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS));
+        assertFalse(privileges.isAllowedInSectionLevel(session1ofCourse1.getFeedbackSessionName(),
+                Const.ParamsNames.INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS));
     }
 
     @Test
     @Override
     protected void testAccessControl() throws Exception {
-        // TODO
+        InstructorAttributes instructor1ofCourse1 = dataBundle.instructors.get("instructor1OfCourse1");
+
+        String[] submissionParams = {
+                Const.ParamsNames.COURSE_ID, instructor1ofCourse1.getCourseId(),
+        };
+
+        verifyInaccessibleWithoutLogin(submissionParams);
+        verifyInaccessibleForUnregisteredUsers(submissionParams);
+        verifyInaccessibleForStudents(submissionParams);
+        verifyInaccessibleForAdmin(submissionParams);
+        verifyAccessibleForInstructorsOfTheSameCourse(submissionParams);
+
     }
 
 }


### PR DESCRIPTION
Part of #9494 


**Outline of Solution**
Redesigned response DTO for instructor privilege. According to request parameters, selected privileges will be returned. 

There are in total 3 cases to cover all the related old endpoints.
(1). Course id and `INSTRUCTOR_IS_PRIVILEGE_MAP_NEEDED` set to `true`, a map containing privileges for different instructor roles will be returned. related old endpoint: `GetCourseEditDetailsAction`


(2). Course id and `INSTRUCTOR_PRIVILEGES_IS_ALL_NEEDED` has been set to `true`. In this case complete privileges of the instructor will be returned. related old endpoint: `GetInstructorCoursesAction`


(3). Course id (feedback session name is optional here). In this case selected privileges will be returned. related old endpoints: `GetInstructorPrivilegeAction`.


(4). Course id , section name. In this case two special privileges will be returned. related old endpoints: `GetInstructorCourseDetailsAction`

This solution's new response DTO is more general to fit into different requirements. Some front end changes will be required.
