### PR TITLE
[#9494] Consolidate GET /student RESTFul API

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1095,10 +1095,6 @@ public final class Const {
         public static final String TABLE_SORT = "/test/tableSort.jsp";
     }
 
-    public static class ErrorMessages {
-        public static final String UNAUTHORIZED_ACCESS = "You are not allowed to view this resource!";
-    }
-
     /* These are status messages that may be shown to the user */
     @Deprecated
     public static class StatusMessages {

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1095,6 +1095,10 @@ public final class Const {
         public static final String TABLE_SORT = "/test/tableSort.jsp";
     }
 
+    public static class ErrorMessages {
+        public static final String UNAUTHORIZED_ACCESS = "You are not allowed to view this resource!";
+    }
+
     /* These are status messages that may be shown to the user */
     @Deprecated
     public static class StatusMessages {

--- a/src/test/java/teammates/test/cases/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetStudentActionTest.java
@@ -29,7 +29,8 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         return GET;
     }
 
-    private void assertStudentDataMatches(StudentData studentData, StudentAttributes student, boolean isInstructor) {
+    private void assertStudentDataMatches(StudentData studentData, StudentAttributes student,
+                                          boolean isRequestFromInstructor) {
         assertEquals(student.getEmail(), studentData.getEmail());
         assertEquals(student.getCourse(), studentData.getCourseId());
         assertEquals(student.getName(), studentData.getName());
@@ -44,7 +45,7 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         assertEquals(student.getTeam(), studentData.getTeamName());
         assertEquals(student.getSection(), studentData.getSectionName());
 
-        if (isInstructor) {
+        if (isRequestFromInstructor) {
             assertEquals(student.getComments(), studentData.getComments());
 
             if (student.isRegistered()) {

--- a/src/test/java/teammates/test/cases/webapi/GetStudentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetStudentActionTest.java
@@ -1,9 +1,18 @@
 package teammates.test.cases.webapi;
 
+import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
+import teammates.common.util.StringHelper;
+import teammates.logic.core.StudentsLogic;
 import teammates.ui.webapi.action.GetStudentAction;
+import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.JoinState;
+import teammates.ui.webapi.output.MessageOutput;
+import teammates.ui.webapi.output.StudentData;
 
 /**
  * SUT: {@link GetStudentAction}.
@@ -20,16 +29,178 @@ public class GetStudentActionTest extends BaseActionTest<GetStudentAction> {
         return GET;
     }
 
+    private void assertStudentDataMatches(StudentData studentData, StudentAttributes student, boolean isInstructor) {
+        assertEquals(student.getEmail(), studentData.getEmail());
+        assertEquals(student.getCourse(), studentData.getCourseId());
+        assertEquals(student.getName(), studentData.getName());
+
+        if (student.getLastName() == null) {
+            String[] name = student.name.split(" ");
+            assertEquals(name[name.length - 1], studentData.getLastName());
+        } else {
+            assertEquals(student.getLastName(), studentData.getLastName());
+        }
+
+        assertEquals(student.getTeam(), studentData.getTeamName());
+        assertEquals(student.getSection(), studentData.getSectionName());
+
+        if (isInstructor) {
+            assertEquals(student.getComments(), studentData.getComments());
+
+            if (student.isRegistered()) {
+                assertTrue(studentData.getJoinState().equals(JoinState.JOINED));
+            } else {
+                assertTrue(studentData.getJoinState().equals(JoinState.NOT_JOINED));
+            }
+        } else {
+            assertNull(studentData.getComments());
+            assertNull(studentData.getJoinState());
+        }
+    }
+
     @Test
     @Override
     protected void testExecute() throws Exception {
-        // TODO
+
+        ______TS("Failure Case: No Course ID in params");
+
+        verifyHttpParameterFailure();
+
+        ______TS("Failure Case: Unregistered Student with no RegKey");
+
+        gaeSimulation.logoutUser();
+
+        StudentAttributes unregStudent =
+                StudentsLogic.inst().getStudentForEmail("idOfTypicalCourse1", "student1InCourse1@gmail.tmt");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, unregStudent.getCourse(),
+        };
+
+        GetStudentAction action = getAction(submissionParams);
+        JsonResult result = getJsonResult(action);
+        MessageOutput message = (MessageOutput) result.getOutput();
+
+        assertEquals(HttpStatus.SC_NOT_FOUND, result.getStatusCode());
+        assertEquals("No student found", message.getMessage());
+
+        ______TS("Success Case: Unregistered Student");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, unregStudent.getCourse(),
+                Const.ParamsNames.REGKEY, StringHelper.encrypt(unregStudent.key),
+        };
+
+        action = getAction(submissionParams);
+        result = getJsonResult(action);
+        StudentData outputData = (StudentData) result.getOutput();
+
+        assertEquals(HttpStatus.SC_OK, result.getStatusCode());
+        assertStudentDataMatches(outputData, unregStudent, false);
+
+        StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+        gaeSimulation.logoutUser();
+        loginAsStudent(student1InCourse1.googleId);
+
+        ______TS("Failure Case: Student - Logged In with no params");
+
+        verifyHttpParameterFailure();
+
+        ______TS("Success Case: Student - Logged In");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student1InCourse1.getCourse(),
+        };
+
+        action = getAction(submissionParams);
+        result = getJsonResult(action);
+        outputData = (StudentData) result.getOutput();
+
+        assertEquals(HttpStatus.SC_OK, result.getStatusCode());
+        assertStudentDataMatches(outputData, student1InCourse1, false);
+
+        InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+        gaeSimulation.logoutUser();
+        loginAsInstructor(instructor1OfCourse1.getGoogleId());
+
+        ______TS("Failure Case: Instructor - Incomplete Params");
+
+        verifyHttpParameterFailure();
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, unregStudent.getCourse(),
+        };
+
+        verifyHttpParameterFailure(submissionParams);
+
+        submissionParams = new String[] {
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getCourse(),
+        };
+
+        verifyHttpParameterFailure(submissionParams);
+
+        ______TS("Success Case: Instructor");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student1InCourse1.getCourse(),
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getEmail(),
+        };
+
+        action = getAction(submissionParams);
+        result = getJsonResult(action);
+        outputData = (StudentData) result.getOutput();
+
+        assertEquals(HttpStatus.SC_OK, result.getStatusCode());
+        assertStudentDataMatches(outputData, student1InCourse1, true);
     }
 
     @Test
     @Override
     protected void testAccessControl() throws Exception {
-        // TODO
-    }
 
+        StudentAttributes student1InCourse1 = typicalBundle.students.get("student1InCourse1");
+        StudentAttributes student2InCourse2 = typicalBundle.students.get("student2InCourse2");
+
+        ______TS("Student - must be in the course");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student1InCourse1.getCourse(),
+        };
+
+        verifyAccessibleForStudentsOfTheSameCourse(submissionParams);
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student2InCourse2.getCourse(),
+        };
+
+        verifyInaccessibleForStudents(submissionParams);
+
+        ______TS("Instructor - must be in same course as student");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, student1InCourse1.getCourse(),
+                Const.ParamsNames.STUDENT_EMAIL, student1InCourse1.getEmail(),
+        };
+
+        verifyAccessibleForInstructorsOfTheSameCourse(submissionParams);
+        verifyInaccessibleForInstructorsOfOtherCourses(submissionParams);
+
+        ______TS("Unregistered Student - can access with key");
+
+        StudentAttributes unregStudent =
+                StudentsLogic.inst().getStudentForEmail("idOfTypicalCourse1", "student1InCourse1@gmail.tmt");
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, unregStudent.getCourse(),
+        };
+
+        verifyInaccessibleForUnregisteredUsers(submissionParams);
+
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, unregStudent.getCourse(),
+                Const.ParamsNames.REGKEY, StringHelper.encrypt(unregStudent.key),
+        };
+
+        verifyAccessibleForUnregisteredUsers(submissionParams);
+    }
 }

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -148,7 +148,7 @@ export class SessionSubmissionPageComponent implements OnInit {
       case Intent.STUDENT_SUBMISSION:
         const paramMap: { [key: string]: string } = {
           courseid: this.courseId,
-          regKey: this.regKey,
+          key: this.regKey,
           studentemail: this.moderatedPerson || this.previewAsPerson,
         };
 

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -128,7 +128,7 @@ export class SessionSubmissionPageComponent implements OnInit {
       this.courseId = queryParams.courseid;
       this.feedbackSessionName = queryParams.fsname;
       this.regKey = queryParams.key ? queryParams.key : '';
-      this.moderatedPerson = queryParams.moderatedperson ? queryParams.moderatedperson : '';
+      // this.moderatedPerson = queryParams.moderatedperson ? queryParams.moderatedperson : '';
       this.previewAsPerson = queryParams.previewas ? queryParams.previewas : '';
 
       if (this.previewAsPerson) {
@@ -146,16 +146,16 @@ export class SessionSubmissionPageComponent implements OnInit {
   loadPersonName(): void {
     switch (this.intent) {
       case Intent.STUDENT_SUBMISSION:
-        this.httpRequestService.get('/student', {
+        const paramMap: { [key: string]: string } = {
           courseid: this.courseId,
-          fsname: this.feedbackSessionName,
-          intent: this.intent,
-          key: this.regKey,
-          moderatedperson: this.moderatedPerson,
-          previewas: this.previewAsPerson,
-        }).subscribe((student: Student) => {
-          this.personName = student.name;
-        });
+          regKey: this.regKey,
+          studentemail: this.moderatedPerson || this.previewAsPerson,
+        };
+
+        this.httpRequestService.get('/student', paramMap)
+            .subscribe((student: Student) => {
+              this.personName = student.name;
+            });
         break;
       case Intent.INSTRUCTOR_SUBMISSION:
         this.httpRequestService.get('/instructor', {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -128,7 +128,7 @@ export class SessionSubmissionPageComponent implements OnInit {
       this.courseId = queryParams.courseid;
       this.feedbackSessionName = queryParams.fsname;
       this.regKey = queryParams.key ? queryParams.key : '';
-      // this.moderatedPerson = queryParams.moderatedperson ? queryParams.moderatedperson : '';
+      this.moderatedPerson = queryParams.moderatedperson ? queryParams.moderatedperson : '';
       this.previewAsPerson = queryParams.previewas ? queryParams.previewas : '';
 
       if (this.previewAsPerson) {


### PR DESCRIPTION
Part of #9494

Note: This PR has a dependancy on #9500 (re-uses the `StudentData` and `JoinState`)

**Outline of Solution**
This PR refactors the GET /student API call such that it can be reused for a number of actions, namely:
1. Student Feedback Submission 
2. Retrieve Student Records
3. Get Student Course Details
4. Get Student Edit Details

The PR cleans up the action and has only one required param - the course ID. The other params needed depend on who is using the API.

- **Unregistered Student**
Needs a `RegKey` that is used for verification. Can only view his own details

- **Logged in Student**
The `UserInfo` is sufficient to check accessibility. Can only view his own details.

- **Logged in Instructor**
Needs a `studentemail` param (the student whose details you need) The instructor's ID is used for verfication (instructor must have privilege to view the student)
 


Tests have been added for the specific cases above. The API returns a `StudentData` object similar to #9500 (some fields will be `null` for non-instructors)

