### PR TITLE
[#9494] Consolidate GET /instructors RESTFul API

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/action/ActionFactory.java
@@ -45,6 +45,7 @@ public class ActionFactory {
         map(ResourceURIs.COURSE, DELETE, DeleteCourseAction.class);
         map(ResourceURIs.COURSE, PUT, ArchiveCourseAction.class);
         map(ResourceURIs.COURSES, GET, GetCoursesAction.class);
+        map(ResourceURIs.INSTRUCTORS, GET, GetInstructorsAction.class);
         map(ResourceURIs.INSTRUCTORS, DELETE, DeleteInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR, GET, GetInstructorAction.class);
         map(ResourceURIs.INSTRUCTOR_PRIVILEGE, GET, GetInstructorPrivilegeAction.class);

--- a/src/main/java/teammates/ui/webapi/action/GetInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/GetInstructorsAction.java
@@ -1,0 +1,80 @@
+package teammates.ui.webapi.action;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.util.Const;
+import teammates.ui.webapi.output.InstructorsData;
+
+/**
+ * Get a list of instructors of a course.
+ */
+public class GetInstructorsAction extends Action {
+
+    @Override
+    protected AuthType getMinAuthLevel() {
+        return AuthType.LOGGED_IN;
+    }
+
+    @Override
+    public void checkSpecificAccessControl() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        CourseAttributes course = logic.getCourse(courseId);
+        if (course == null) {
+            throw new EntityNotFoundException(new EntityDoesNotExistException("course not found"));
+        }
+
+        String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
+        if (intentStr == null) {
+            // get partial details of instructors with information hiding
+            // student should belong to the course
+            StudentAttributes student = logic.getStudentForGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(student, course);
+        } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+            // get all instructors of a course without information hiding
+            // this need instructor privileges
+            InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, userInfo.getId());
+            gateKeeper.verifyAccessible(instructor, course);
+        } else {
+            throw new InvalidHttpParameterException("unknown intent");
+        }
+
+    }
+
+    @Override
+    public ActionResult execute() {
+        String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
+        List<InstructorAttributes> instructorsOfCourse = logic.getInstructorsForCourse(courseId);
+
+        InstructorsData data;
+
+        String intentStr = getRequestParamValue(Const.ParamsNames.INTENT);
+        if (intentStr == null) {
+            instructorsOfCourse =
+                    instructorsOfCourse.stream()
+                            .filter(InstructorAttributes::isDisplayedToStudents)
+                            .collect(Collectors.toList());
+            data = new InstructorsData(instructorsOfCourse);
+
+            // hide information
+            data.getInstructors().forEach(i -> {
+                i.setJoinState(null);
+                i.setIsDisplayedToStudents(null);
+            });
+        } else if (intentStr.equals(Intent.FULL_DETAIL.toString())) {
+            // get all instructors of a course without information hiding
+            data = new InstructorsData(instructorsOfCourse);
+        } else {
+            throw new InvalidHttpParameterException("unknown intent");
+        }
+
+        return new JsonResult(data);
+    }
+
+}

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -1,0 +1,60 @@
+package teammates.ui.webapi.output;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+
+/**
+ * The API output format of an instructor.
+ */
+public class InstructorData extends ApiOutput {
+    private final String courseId;
+    private final String email;
+
+    private Boolean isDisplayedToStudents;
+    private final String displayedToStudentsAs;
+    private final String name;
+
+    private JoinState joinState;
+
+    public InstructorData(InstructorAttributes instructorAttributes) {
+        this.courseId = instructorAttributes.getCourseId();
+        this.email = instructorAttributes.getEmail();
+
+        this.isDisplayedToStudents = instructorAttributes.isDisplayedToStudents();
+        this.displayedToStudentsAs = instructorAttributes.getDisplayedName();
+        this.name = instructorAttributes.getName();
+
+        this.joinState = instructorAttributes.isRegistered() ? JoinState.JOINED : JoinState.NOT_JOINED;
+    }
+
+    public String getCourseId() {
+        return courseId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Boolean getIsDisplayedToStudents() {
+        return isDisplayedToStudents;
+    }
+
+    public void setIsDisplayedToStudents(Boolean displayedToStudents) {
+        isDisplayedToStudents = displayedToStudents;
+    }
+
+    public String getDisplayedToStudentsAs() {
+        return displayedToStudentsAs;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public JoinState getJoinState() {
+        return joinState;
+    }
+
+    public void setJoinState(JoinState joinState) {
+        this.joinState = joinState;
+    }
+}

--- a/src/main/java/teammates/ui/webapi/output/InstructorsData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorsData.java
@@ -1,0 +1,22 @@
+package teammates.ui.webapi.output;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+
+/**
+ * The API output format of a list of instructors.
+ */
+public class InstructorsData extends ApiOutput {
+
+    private final List<InstructorData> instructors;
+
+    public InstructorsData(List<InstructorAttributes> instructorAttributesList) {
+        this.instructors = instructorAttributesList.stream().map(InstructorData::new).collect(Collectors.toList());
+    }
+
+    public List<InstructorData> getInstructors() {
+        return instructors;
+    }
+}

--- a/src/test/java/teammates/test/cases/webapi/GetInstructorsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetInstructorsActionTest.java
@@ -1,0 +1,198 @@
+package teammates.test.cases.webapi;
+
+import java.util.List;
+
+import org.apache.http.HttpStatus;
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.datatransfer.attributes.StudentAttributes;
+import teammates.common.exception.EntityNotFoundException;
+import teammates.common.exception.InvalidHttpParameterException;
+import teammates.common.util.Const;
+import teammates.ui.webapi.action.GetInstructorsAction;
+import teammates.ui.webapi.action.Intent;
+import teammates.ui.webapi.action.JsonResult;
+import teammates.ui.webapi.output.InstructorData;
+import teammates.ui.webapi.output.InstructorsData;
+import teammates.ui.webapi.output.JoinState;
+
+/**
+ * SUT: {@link GetInstructorsAction}.
+ */
+public class GetInstructorsActionTest extends BaseActionTest<GetInstructorsAction> {
+
+    @Override
+    protected String getActionUri() {
+        return Const.ResourceURIs.INSTRUCTORS;
+    }
+
+    @Override
+    protected String getRequestMethod() {
+        return GET;
+    }
+
+    @Test
+    @Override
+    protected void testExecute() throws Exception {
+        InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        loginAsInstructor(instructor.getGoogleId());
+
+        ______TS("Invalid parameters");
+        // no parameters
+        verifyHttpParameterFailure();
+
+        ______TS("unknown intent");
+        assertThrows(InvalidHttpParameterException.class, () -> {
+            String[] submissionParams = new String[] {
+                    Const.ParamsNames.COURSE_ID, instructor.courseId,
+                    Const.ParamsNames.INTENT, "Unknown",
+            };
+
+            GetInstructorsAction action = getAction(submissionParams);
+            getJsonResult(action);
+        });
+    }
+
+    @Test
+    public void testExecute_withoutIntent_shouldReturnPartialData() {
+        StudentAttributes studentAttributes = typicalBundle.students.get("student1InCourse1");
+        loginAsStudent(studentAttributes.googleId);
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, studentAttributes.getCourse(),
+                Const.ParamsNames.TEAM_NAME, studentAttributes.getTeam(),
+        };
+        GetInstructorsAction action = getAction(submissionParams);
+        JsonResult jsonResult = getJsonResult(action);
+        assertEquals(HttpStatus.SC_OK, jsonResult.getStatusCode());
+
+        InstructorsData output = (InstructorsData) jsonResult.getOutput();
+        List<InstructorData> instructors = output.getInstructors();
+
+        // the #instructors is 5
+        assertEquals(5, logic.getInstructorsForCourse(studentAttributes.getCourse()).size());
+        // with information hiding, it is 4 instead
+        assertEquals(4, instructors.size());
+        InstructorData typicalInstructor = instructors.get(0);
+        assertEquals("idOfTypicalCourse1", typicalInstructor.getCourseId());
+        assertEquals("instructorNotYetJoinedCourse1@email.tmt", typicalInstructor.getEmail());
+        assertEquals("Instructor Not Yet Joined Course 1", typicalInstructor.getName());
+        assertEquals("Instructor", typicalInstructor.getDisplayedToStudentsAs());
+        assertNull(typicalInstructor.getIsDisplayedToStudents());
+        assertNull(typicalInstructor.getJoinState()); // information is hidden
+    }
+
+    @Test
+    public void testExecute_withFullDetailIntent_shouldReturnDataWithFullDetail() {
+        InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        loginAsInstructor(instructor.getGoogleId());
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.courseId,
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+
+        GetInstructorsAction action = getAction(submissionParams);
+        JsonResult jsonResult = getJsonResult(action);
+        assertEquals(HttpStatus.SC_OK, jsonResult.getStatusCode());
+
+        InstructorsData output = (InstructorsData) jsonResult.getOutput();
+        List<InstructorData> instructors = output.getInstructors();
+
+        // the #instructors is 5
+        assertEquals(5, logic.getInstructorsForCourse(instructor.getCourseId()).size());
+        // without information hiding, it is still 5
+        assertEquals(5, instructors.size());
+        InstructorData typicalInstructor = instructors.get(0);
+        assertEquals("idOfTypicalCourse1", typicalInstructor.getCourseId());
+        assertEquals("helper@course1.tmt", typicalInstructor.getEmail());
+        assertEquals("Helper Course1", typicalInstructor.getName());
+        assertEquals("Helper", typicalInstructor.getDisplayedToStudentsAs());
+        assertFalse(typicalInstructor.getIsDisplayedToStudents());
+        assertEquals(JoinState.JOINED, typicalInstructor.getJoinState());
+    }
+
+    @Test
+    @Override
+    protected void testAccessControl() throws Exception {
+        ______TS("course not exist");
+        InstructorAttributes instructor = typicalBundle.instructors.get("instructor1OfCourse1");
+        loginAsInstructor(instructor.getGoogleId());
+        assertThrows(EntityNotFoundException.class, () -> {
+            String[] submissionParams = new String[] {
+                    Const.ParamsNames.COURSE_ID, "randomId",
+                    Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+            };
+            GetInstructorsAction action = getAction(submissionParams);
+            action.checkAccessControl();
+        });
+
+        StudentAttributes studentAttributes = typicalBundle.students.get("student1InCourse1");
+        loginAsStudent(studentAttributes.googleId);
+        assertThrows(EntityNotFoundException.class, () -> {
+            String[] submissionParams = new String[] {
+                    Const.ParamsNames.COURSE_ID, "randomId",
+            };
+            GetInstructorsAction action = getAction(submissionParams);
+            action.checkAccessControl();
+        });
+
+        ______TS("unknown login entity");
+        loginAsUnregistered("unregistered");
+        String[] params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+        verifyCannotAccess(params);
+
+        params = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+        };
+        verifyCannotAccess(params);
+
+        ______TS("unknown intent");
+        loginAsInstructor(instructor.getGoogleId());
+        assertThrows(InvalidHttpParameterException.class, () -> {
+            String[] submissionParams = new String[] {
+                    Const.ParamsNames.COURSE_ID, instructor.getCourseId(),
+                    Const.ParamsNames.INTENT, "Unknown",
+            };
+
+            GetInstructorsAction action = getAction(submissionParams);
+            action.checkAccessControl();
+        });
+    }
+
+    @Test
+    public void testAccessControl_withFullDetailIntent_shouldDoAuthenticationOfInstructor() {
+        InstructorAttributes instructor1OfCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
+
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId,
+                Const.ParamsNames.INTENT, Intent.FULL_DETAIL.toString(),
+        };
+        verifyOnlyInstructorsOfTheSameCourseCanAccess(submissionParams);
+    }
+
+    @Test
+    public void testAccessControl_withoutIntent_shouldDoAuthenticationOfStudent() {
+        StudentAttributes studentAttributes = typicalBundle.students.get("student1InCourse1");
+        loginAsStudent(studentAttributes.googleId);
+
+        // try to access instructors in his own course
+        String[] submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, studentAttributes.getCourse(),
+        };
+        verifyCanAccess(submissionParams);
+
+        // try to access instructors in other course
+        StudentAttributes otherStudent = typicalBundle.students.get("student1InCourse2");
+        assertNotEquals(otherStudent.getCourse(), studentAttributes.getCourse());
+        submissionParams = new String[] {
+                Const.ParamsNames.COURSE_ID, otherStudent.getCourse(),
+        };
+        verifyCannotAccess(submissionParams);
+    }
+
+}

--- a/src/web/app/Instructor.ts
+++ b/src/web/app/Instructor.ts
@@ -1,6 +1,0 @@
-/**
- * An instructor.
- */
-export interface Instructor {
-  name: string;
-}

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.html
@@ -51,8 +51,10 @@
         <button class="btn btn-primary" [disabled]="emailOfStudentToPreview.length === 0" (click)="previewAsStudent()">Preview as Student</button>
       </div>
       <div class="col-5" ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
-        <select class="form-control preview_select"></select>
-        <button class="btn btn-primary">Preview as Instructor</button>
+        <select class="form-control preview_select" [(ngModel)]="emailOfInstructorToPreview">
+          <option *ngFor="let instructor of instructorsCanBePreviewedAs" [ngValue]="instructor.email">{{ instructor.name }}</option>
+        </select>
+        <button class="btn btn-primary" [disabled]="emailOfInstructorToPreview.length === 0" (click)="previewAsInstructor()">Preview as Instructor</button>
       </div>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -847,7 +847,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
    * Previews the submission of the feedback session as a student.
    */
   previewAsStudent(): void {
-    window.open(`${environment.frontendUrl}/web/student/sessions/submission`
+    window.open(`${environment.frontendUrl}/web/sessions/submission`
         + `?courseid=${this.courseId}&fsname=${this.feedbackSessionName}&previewas=${this.emailOfStudentToPreview}`);
   }
 

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.ts
@@ -18,7 +18,7 @@ import {
   FeedbackQuestionType,
   FeedbackSession,
   FeedbackSessionPublishStatus, FeedbackSessions,
-  FeedbackSessionSubmissionStatus, FeedbackTextQuestionDetails,
+  FeedbackSessionSubmissionStatus, FeedbackTextQuestionDetails, Instructor, Instructors,
   NumberOfEntitiesToGiveFeedbackToSetting,
   ResponseVisibleSetting,
   SessionVisibleSetting, Student, Students,
@@ -144,6 +144,9 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   // all students of the course
   studentsOfCourse: Student[] = [];
   emailOfStudentToPreview: string = '';
+  // instructors which can be previewed as
+  instructorsCanBePreviewedAs: Instructor[] = [];
+  emailOfInstructorToPreview: string = '';
 
   constructor(router: Router, httpRequestService: HttpRequestService,
               statusMessageService: StatusMessageService, navigationService: NavigationService,
@@ -162,6 +165,7 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
       this.loadFeedbackSession();
       this.loadFeedbackQuestions();
       this.getAllStudentsOfCourse();
+      this.getAllInstructorsCanBePreviewedAs();
     });
   }
 
@@ -813,11 +817,46 @@ export class InstructorSessionEditPageComponent extends InstructorSessionBasePag
   }
 
   /**
+   * Gets all instructors of a course which can be previewed as.
+   */
+  getAllInstructorsCanBePreviewedAs(): void {
+    const paramMap: { [key: string]: string } = {
+      courseid: this.courseId,
+      intent: Intent.FULL_DETAIL,
+    };
+    this.httpRequestService.get('/instructors', paramMap)
+        .subscribe((instructors: Instructors) => {
+          this.instructorsCanBePreviewedAs = instructors.instructors;
+
+          // TODO use privilege API to filter instructors who has INSTRUCTOR_PERMISSION_SUBMIT_SESSION_IN_SECTIONS
+          // in the feedback session
+
+          // sort the instructor list based on name
+          this.instructorsCanBePreviewedAs.sort((a: Instructor, b: Instructor): number => {
+            return a.name.localeCompare(b.name);
+          });
+
+          // select the first instructor
+          if (this.instructorsCanBePreviewedAs.length >= 1) {
+            this.emailOfInstructorToPreview = this.instructorsCanBePreviewedAs[0].email;
+          }
+        }, (resp: ErrorMessageOutput) => { this.statusMessageService.showErrorMessage(resp.error.message); });
+  }
+
+  /**
    * Previews the submission of the feedback session as a student.
    */
   previewAsStudent(): void {
     window.open(`${environment.frontendUrl}/web/student/sessions/submission`
         + `?courseid=${this.courseId}&fsname=${this.feedbackSessionName}&previewas=${this.emailOfStudentToPreview}`);
+  }
+
+  /**
+   * Previews the submission of the feedback session as an instructor.
+   */
+  previewAsInstructor(): void {
+    window.open(`${environment.frontendUrl}/web/instructor/sessions/submission`
+        + `?courseid=${this.courseId}&fsname=${this.feedbackSessionName}&previewas=${this.emailOfInstructorToPreview}`);
   }
 
   private deepCopy<T>(obj: T): T {

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -16,7 +16,7 @@ import {
   FeedbackResponse,
   FeedbackSession,
   FeedbackSessionSubmissionStatus,
-  NumberOfEntitiesToGiveFeedbackToSetting, Student,
+  Instructor, NumberOfEntitiesToGiveFeedbackToSetting, Student,
 } from '../../../types/api-output';
 import {
   FeedbackResponseRecipient,
@@ -25,7 +25,6 @@ import {
   QuestionSubmissionFormModel,
 } from '../../components/question-submission-form/question-submission-form-model';
 import { ErrorMessageOutput } from '../../error-message-output';
-import { Instructor } from '../../Instructor';
 import { Intent } from '../../Intent';
 import {
   FeedbackSessionClosedModalComponent,


### PR DESCRIPTION
Part of #9494

**Outline of Solution**

There are only two ways to use the API.

* Get all instructors of a course with full details (no information hiding) (by instructor)
* Get all instructors of a course with information hiding (by students)

The second commit also fix part of #9460
