### PR TITLE
[#9516] Instructor Course: Fix restoring a deleted course functionality

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -960,7 +960,6 @@ public final class Const {
 
         public static final String INSTRUCTOR_HOME = "/instrutor/home";
         public static final String INSTRUCTOR_COURSES = "/instructor/courses";
-        public static final String INSTRUCTOR_COURSES_RESTORE = "/instructor/courses/restore";
         public static final String INSTRUCTOR_COURSES_PERMANENTLY_DELETE = "/instructor/courses/permanentlyDelete";
         public static final String INSTRUCTOR_COURSES_PERMANENTLY_DELETE_ALL = "/instructor/courses/permanentlyDeleteAll";
         public static final String INSTRUCTOR_COURSES_RESTORE_ALL = "/instructor/courses/restoreAll";

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -298,7 +298,7 @@ export class InstructorCoursesPageComponent implements OnInit {
       courseid: courseId,
       user: this.user,
     };
-    this.httpRequestService.put('/instructor/courses/restore', paramMap).subscribe((resp: MessageOutput) => {
+    this.httpRequestService.delete('/bin/course', paramMap).subscribe((resp: MessageOutput) => {
       this.loadInstructorCourses();
       this.statusMessageService.showSuccessMessage(resp.message);
     }, (resp: ErrorMessageOutput) => {


### PR DESCRIPTION
Fixes #9516

**Outline of Solution**
I updated the endpoint to restore deleted course after the API consolidation.
