### PR TITLE
[#9356] Show loading spinner when fetching authentication details is ongoing

### DIFF
--- a/src/web/app/components/loading-spinner/loading-spinner.component.html
+++ b/src/web/app/components/loading-spinner/loading-spinner.component.html
@@ -1,0 +1,5 @@
+<div class="loading-container">
+  <div class="spinner-border text-primary" role="status">
+    <span class="sr-only">Loading...</span>
+  </div>
+</div>

--- a/src/web/app/components/loading-spinner/loading-spinner.component.scss
+++ b/src/web/app/components/loading-spinner/loading-spinner.component.scss
@@ -1,0 +1,13 @@
+.loading-container {
+  margin: 0;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+}
+
+.spinner-border {
+  width: 3rem;
+  height: 3rem;
+}

--- a/src/web/app/components/loading-spinner/loading-spinner.component.scss
+++ b/src/web/app/components/loading-spinner/loading-spinner.component.scss
@@ -3,8 +3,6 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  -ms-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
 }
 
 .spinner-border {

--- a/src/web/app/components/loading-spinner/loading-spinner.component.spec.ts
+++ b/src/web/app/components/loading-spinner/loading-spinner.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoadingSpinnerComponent } from './loading-spinner.component';
+
+describe('LoadingSpinnerComponent', () => {
+  let component: LoadingSpinnerComponent;
+  let fixture: ComponentFixture<LoadingSpinnerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [LoadingSpinnerComponent],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoadingSpinnerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/loading-spinner/loading-spinner.component.ts
+++ b/src/web/app/components/loading-spinner/loading-spinner.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+/**
+ * Loading spinner to show when waiting for request.
+ */
+@Component({
+  selector: 'tm-loading-spinner',
+  templateUrl: './loading-spinner.component.html',
+  styleUrls: ['./loading-spinner.component.scss'],
+})
+export class LoadingSpinnerComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -20,7 +20,7 @@
       </ng-template>
     </ul>
     <ul class="nav navbar-nav mr-auto" *ngIf="!isValidUser"></ul>
-    <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo">
+    <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
       <li class="nav-item dropdown" ngbDropdown placement="bottom-right" *ngIf="!user">
         <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>Login</a>
         <div class="dropdown-menu" ngbDropdownMenu>

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -41,7 +41,8 @@
     </ul>
   </div>
 </nav>
-<div id="main-content" class="container main-content">
+<tm-loading-spinner *ngIf="isFetchingAuthDetails"></tm-loading-spinner>
+<div *ngIf="!isFetchingAuthDetails" id="main-content" class="container main-content">
   <div *ngIf="isUnsupportedBrowser">
     <div class="alert alert-danger" role="alert">
       <i class="fas fa-exclamation-circle"></i>&nbsp;You are currently using {{ browser }}. This web browser is not officially supported by TEAMMATES.

--- a/src/web/app/page.component.spec.ts
+++ b/src/web/app/page.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
 import { PageComponent } from './page.component';
 
@@ -10,7 +11,10 @@ describe('PageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [PageComponent],
+      declarations: [
+        PageComponent,
+        LoadingSpinnerComponent,
+      ],
       imports: [
         NgbModule,
         RouterTestingModule,

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -21,6 +21,7 @@ const DEFAULT_TITLE: string = 'TEAMMATES - Online Peer Feedback/Evaluation Syste
 })
 export class PageComponent implements OnInit {
 
+  @Input() isFetchingAuthDetails: boolean = true;
   @Input() studentLoginUrl: string = '';
   @Input() instructorLoginUrl: string = '';
   @Input() user: string = '';

--- a/src/web/app/pages-admin/admin-page.component.html
+++ b/src/web/app/pages-admin/admin-page.component.html
@@ -5,5 +5,6 @@
     [isValidUser]="isAdmin"
     [isInstructor]="isInstructor"
     [isStudent]="isStudent"
-    [isAdmin]="isAdmin">
+    [isAdmin]="isAdmin"
+    [isFetchingAuthDetails]="isFetchingAuthDetails">
 </tm-page>

--- a/src/web/app/pages-admin/admin-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-page.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
 import { PageComponent } from '../page.component';
 import { AdminPageComponent } from './admin-page.component';
@@ -15,6 +16,7 @@ describe('AdminPageComponent', () => {
       declarations: [
         PageComponent,
         AdminPageComponent,
+        LoadingSpinnerComponent,
       ],
       imports: [
         NgbModule,

--- a/src/web/app/pages-admin/admin-page.component.ts
+++ b/src/web/app/pages-admin/admin-page.component.ts
@@ -38,6 +38,7 @@ export class AdminPageComponent implements OnInit {
       display: 'Timezone Listing',
     },
   ];
+  isFetchingAuthDetails: boolean = true;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -64,6 +65,7 @@ export class AdminPageComponent implements OnInit {
       } else {
         window.location.href = `${this.backendUrl}${res.adminLoginUrl}`;
       }
+      this.isFetchingAuthDetails = false;
     }, () => {
       // TODO
     });

--- a/src/web/app/pages-instructor/instructor-page.component.html
+++ b/src/web/app/pages-instructor/instructor-page.component.html
@@ -5,5 +5,6 @@
     [isValidUser]="isInstructor"
     [isInstructor]="isInstructor"
     [isStudent]="isStudent"
-    [isAdmin]="isAdmin">
+    [isAdmin]="isAdmin"
+    [isFetchingAuthDetails]="isFetchingAuthDetails">
 </tm-page>

--- a/src/web/app/pages-instructor/instructor-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
 import { PageComponent } from '../page.component';
 import { InstructorPageComponent } from './instructor-page.component';
@@ -15,6 +16,7 @@ describe('InstructorPageComponent', () => {
       declarations: [
         PageComponent,
         InstructorPageComponent,
+        LoadingSpinnerComponent,
       ],
       imports: [
         NgbModule,

--- a/src/web/app/pages-instructor/instructor-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.ts
@@ -45,6 +45,7 @@ export class InstructorPageComponent implements OnInit {
       display: 'Help',
     },
   ];
+  isFetchingAuthDetails: boolean = true;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -65,6 +66,7 @@ export class InstructorPageComponent implements OnInit {
         } else {
           window.location.href = `${this.backendUrl}${res.instructorLoginUrl}`;
         }
+        this.isFetchingAuthDetails = false;
       }, () => {
         // TODO
       });

--- a/src/web/app/pages-static/static-page.component.html
+++ b/src/web/app/pages-static/static-page.component.html
@@ -7,5 +7,6 @@
     [isValidUser]="true"
     [isInstructor]="isInstructor"
     [isStudent]="isStudent"
-    [isAdmin]="isAdmin">
+    [isAdmin]="isAdmin"
+    [isFetchingAuthDetails]="isFetchingAuthDetails">
 </tm-page>

--- a/src/web/app/pages-static/static-page.component.spec.ts
+++ b/src/web/app/pages-static/static-page.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
 import { PageComponent } from '../page.component';
 import { StaticPageComponent } from './static-page.component';
@@ -15,6 +16,7 @@ describe('StaticPageComponent', () => {
       declarations: [
         PageComponent,
         StaticPageComponent,
+        LoadingSpinnerComponent,
       ],
       imports: [
         NgbModule,

--- a/src/web/app/pages-static/static-page.component.ts
+++ b/src/web/app/pages-static/static-page.component.ts
@@ -55,6 +55,7 @@ export class StaticPageComponent implements OnInit {
       ],
     },
   ];
+  isFetchingAuthDetails: boolean = true;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -73,6 +74,7 @@ export class StaticPageComponent implements OnInit {
         this.studentLoginUrl = `${this.backendUrl}${res.studentLoginUrl}`;
         this.instructorLoginUrl = `${this.backendUrl}${res.instructorLoginUrl}`;
       }
+      this.isFetchingAuthDetails = false;
     }, () => {
       // TODO
     });

--- a/src/web/app/pages-student/student-page.component.html
+++ b/src/web/app/pages-student/student-page.component.html
@@ -5,5 +5,6 @@
     [isValidUser]="isStudent"
     [isInstructor]="isInstructor"
     [isStudent]="isStudent"
-    [isAdmin]="isAdmin">
+    [isAdmin]="isAdmin"
+    [isFetchingAuthDetails]="isFetchingAuthDetails">
 </tm-page>

--- a/src/web/app/pages-student/student-page.component.spec.ts
+++ b/src/web/app/pages-student/student-page.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from '../components/status-message/status-message.module';
 import { PageComponent } from '../page.component';
 import { StudentPageComponent } from './student-page.component';
@@ -15,6 +16,7 @@ describe('StudentPageComponent', () => {
       declarations: [
         PageComponent,
         StudentPageComponent,
+        LoadingSpinnerComponent,
       ],
       imports: [
         NgbModule,

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -33,6 +33,7 @@ export class StudentPageComponent implements OnInit {
       display: 'Help',
     },
   ];
+  isFetchingAuthDetails: boolean = true;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -53,6 +54,7 @@ export class StudentPageComponent implements OnInit {
         } else {
           window.location.href = `${this.backendUrl}${res.studentLoginUrl}`;
         }
+        this.isFetchingAuthDetails = false;
       }, () => {
         // TODO
       });

--- a/src/web/app/pages.module.ts
+++ b/src/web/app/pages.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ErrorReportModule } from './components/error-report/error-report.module';
+import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
 import { Intent } from './Intent';
 import { PageNotFoundModule } from './page-not-found/page-not-found.module';
@@ -98,6 +99,7 @@ const routes: Routes = [
     StudentPageComponent,
     InstructorPageComponent,
     AdminPageComponent,
+    LoadingSpinnerComponent,
   ],
 })
 export class PagesModule {}

--- a/src/web/app/public-page.component.spec.ts
+++ b/src/web/app/public-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { LoadingSpinnerComponent } from './components/loading-spinner/loading-spinner.component';
 import { StatusMessageModule } from './components/status-message/status-message.module';
 import { PageComponent } from './page.component';
 import { PublicPageComponent } from './public-page.component';
@@ -14,6 +15,7 @@ describe('PublicPageComponent', () => {
       declarations: [
         PageComponent,
         PublicPageComponent,
+        LoadingSpinnerComponent,
       ],
       imports: [
         NgbModule,


### PR DESCRIPTION
Part of #9356 

**Outline of Solution**
How the page looks when the http request is incomplete:
![image](https://user-images.githubusercontent.com/35655790/53636537-8b673c80-3c5b-11e9-9d04-2465cd2bc19e.png)

I added a component for the loading spinner and use it in `admin-page`, `instructor-page`, `student-page` and `static-page`. Used a boolean flag to decide whether to show the loading spinner or not.
