### PR TITLE
[#9542] Cannot load any public page

### DIFF
--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -21,7 +21,7 @@ const DEFAULT_TITLE: string = 'TEAMMATES - Online Peer Feedback/Evaluation Syste
 })
 export class PageComponent implements OnInit {
 
-  @Input() isFetchingAuthDetails: boolean = true;
+  @Input() isFetchingAuthDetails: boolean = false;
   @Input() studentLoginUrl: string = '';
   @Input() instructorLoginUrl: string = '';
   @Input() user: string = '';

--- a/src/web/app/pages-admin/admin-page.component.ts
+++ b/src/web/app/pages-admin/admin-page.component.ts
@@ -37,13 +37,14 @@ export class AdminPageComponent implements OnInit {
       display: 'Timezone Listing',
     },
   ];
-  isFetchingAuthDetails: boolean = true;
+  isFetchingAuthDetails: boolean = false;
 
   private backendUrl: string = environment.backendUrl;
 
   constructor(private router: Router, private authService: AuthService, private navigationService: NavigationService) {}
 
   ngOnInit(): void {
+    this.isFetchingAuthDetails = true;
     this.authService.getAuthUser().subscribe((res: AuthInfo) => {
       if (res.user) {
         this.user = res.user.id;

--- a/src/web/app/pages-instructor/instructor-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.ts
@@ -44,7 +44,7 @@ export class InstructorPageComponent implements OnInit {
       display: 'Help',
     },
   ];
-  isFetchingAuthDetails: boolean = true;
+  isFetchingAuthDetails: boolean = false;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -52,6 +52,7 @@ export class InstructorPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
+      this.isFetchingAuthDetails = true;
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user) {
           this.user = res.user.id + (res.masquerade ? ' (M)' : '');

--- a/src/web/app/pages-instructor/instructor-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-page.component.ts
@@ -51,8 +51,8 @@ export class InstructorPageComponent implements OnInit {
   constructor(private route: ActivatedRoute, private authService: AuthService) {}
 
   ngOnInit(): void {
+    this.isFetchingAuthDetails = true;
     this.route.queryParams.subscribe((queryParams: any) => {
-      this.isFetchingAuthDetails = true;
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user) {
           this.user = res.user.id + (res.masquerade ? ' (M)' : '');

--- a/src/web/app/pages-static/static-page.component.ts
+++ b/src/web/app/pages-static/static-page.component.ts
@@ -54,13 +54,14 @@ export class StaticPageComponent implements OnInit {
       ],
     },
   ];
-  isFetchingAuthDetails: boolean = true;
+  isFetchingAuthDetails: boolean = false;
 
   private backendUrl: string = environment.backendUrl;
 
   constructor(private authService: AuthService) {}
 
   ngOnInit(): void {
+    this.isFetchingAuthDetails = true;
     this.authService.getAuthUser().subscribe((res: AuthInfo) => {
       if (res.user) {
         this.user = res.user.id;

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -39,8 +39,8 @@ export class StudentPageComponent implements OnInit {
   constructor(private route: ActivatedRoute, private authService: AuthService) {}
 
   ngOnInit(): void {
+    this.isFetchingAuthDetails = true;
     this.route.queryParams.subscribe((queryParams: any) => {
-      this.isFetchingAuthDetails = true;
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user) {
           this.user = res.user.id + (res.masquerade ? ' (M)' : '');

--- a/src/web/app/pages-student/student-page.component.ts
+++ b/src/web/app/pages-student/student-page.component.ts
@@ -32,7 +32,7 @@ export class StudentPageComponent implements OnInit {
       display: 'Help',
     },
   ];
-  isFetchingAuthDetails: boolean = true;
+  isFetchingAuthDetails: boolean = false;
 
   private backendUrl: string = environment.backendUrl;
 
@@ -40,6 +40,7 @@ export class StudentPageComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
+      this.isFetchingAuthDetails = true;
       this.authService.getAuthUser(queryParams.user).subscribe((res: AuthInfo) => {
         if (res.user) {
           this.user = res.user.id + (res.masquerade ? ' (M)' : '');


### PR DESCRIPTION
Fixes #9542

**Outline of Solution**
Now `isFetchingAuthDetails` is set to `false` by default, only set to `true` just before the request is sent, and set back to `false` when the result is returned.

The public page is correctly shown:
`/web/sessions/result`
![image](https://user-images.githubusercontent.com/35655790/53875520-9c3ef600-403f-11e9-8798-07402e210fa2.png)

`/web/sessions/submission`
![image](https://user-images.githubusercontent.com/35655790/53875532-a95be500-403f-11e9-98fd-43f389a6dcb5.png)

