### PR TITLE
[#9557] Standardise the way of deleting entities in storage component

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -129,9 +129,6 @@ Represented by these classes:
 
 ### Policies
 
-General:
-+ Null values should **not** be used as parameters to this API, except when following the KeepExisting policy (explained later).
-
 Access control:
 + Although this component provides methods to perform access control, the API itself is not access controlled. The UI is expected to check access control (using `GateKeeper` class) before calling a method in the `Logic`.
 
@@ -146,15 +143,12 @@ API for retrieving entities:
   - Returns `null` if the target entity not found. This way, read operations can be used easily for checking the existence of an entity.
 
 API for updating entities:
-+ Primary keys cannot be edited except: `Student.email`.
-+ KeepExistingPolicy: the new value of an optional attribute is specified as `null` or set to “Uninitialized”, the existing value will prevail. {This is not a good policy. To be reconsidered}.
-+ `Null` parameters: Throws an assertion error if that parameter cannot be null. Optional attributes follow KeepExistingPolicy.
++ Update is done using `*UpdateOptions` inside every `*Attributes`. The `UpdateOptions` will specify what is used to identify the entity to update and what will be updated.
 + Entity not found: Throws `EntityDoesNotExistException`.
 + Invalid parameters: Throws `InvalidParametersException`.
 
 API for deleting entities:
-+ `Null` parameters: Not expected. Results in assertion failure.
-+ FailDeleteSilentlyPolicy: In general, delete operation do not throw exceptions if the target entity does not exist. Instead, it logs a warning. This is because if it does not exist, it is as good as deleted.
++ FailDeleteSilentlyPolicy: In general, delete operation do not throw exceptions if the target entity does not exist. This is because if it does not exist, it is as good as deleted.
 + Cascade policy:   When a parent entity is deleted, entities that have referential integrity with the deleted entity should also be deleted.
   Refer to the API for the cascade logic.
 
@@ -191,10 +185,7 @@ Represented by the `*Db` classes. These classes act as the bridge to the GAE Dat
 Add and Delete operations try to wait until data is persisted in the datastore before returning. This is not enough to compensate for eventual consistency involving multiple servers in the GAE production enviornment. However, it is expected to avoid test failures caused by eventual consistency in dev server and reduce such problems in the live server.
 Note: 'Eventual consistency' here means it takes some time for a database operation to propagate across all serves of the Google's distributed datastore. As a result, the data may be in an inconsistent states for short periods of time although things should become consistent 'eventually'. For example, an object we deleted may appear to still exist for a short while.
 
-Implementation of Transaction Control has been decided against due to limitations of GAE environment and the nature of our data schema. Note that this decision was taken before 2014 and if the circumstances leading to that decision have changed, it may be reconsidered.
-
-General:
-+ If `Null` is passed as a parameter, the corresponding value is **NOT** modified, as per the KeepExistingPolicy that was previously mentioned.
+Implementation of Transaction Control has been minimized due to limitations of GAE environment and the nature of our data schema.
 
 API for creating:
 + Attempt to create an entity that already exists: Throws `EntityAlreadyExistsException`.

--- a/src/main/java/teammates/common/datatransfer/AttributesDeletionQuery.java
+++ b/src/main/java/teammates/common/datatransfer/AttributesDeletionQuery.java
@@ -1,0 +1,121 @@
+package teammates.common.datatransfer;
+
+import teammates.common.util.Assumption;
+
+/**
+ * The query for attributes deletion.
+ */
+public class AttributesDeletionQuery {
+
+    private String courseId;
+    private String feedbackSessionName;
+    private String questionId;
+    private String responseId;
+
+    private AttributesDeletionQuery() {
+        // use builder to construct query
+    }
+
+    public boolean isCourseIdPresent() {
+        return courseId != null;
+    }
+
+    public boolean isFeedbackSessionNamePresent() {
+        return feedbackSessionName != null;
+    }
+
+    public boolean isQuestionIdPresent() {
+        return questionId != null;
+    }
+
+    public boolean isResponseIdPresent() {
+        return responseId != null;
+    }
+
+    public String getCourseId() {
+        return courseId;
+    }
+
+    public String getFeedbackSessionName() {
+        return feedbackSessionName;
+    }
+
+    public String getQuestionId() {
+        return questionId;
+    }
+
+    public String getResponseId() {
+        return responseId;
+    }
+
+    /**
+     * Returns a builder for {@link AttributesDeletionQuery}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link AttributesDeletionQuery}.
+     */
+    public static class Builder {
+
+        private static final String INVALID_COMBINATION = "Invalid combination";
+
+        private AttributesDeletionQuery attributesDeletionQuery;
+
+        private Builder() {
+            attributesDeletionQuery = new AttributesDeletionQuery();
+        }
+
+        public Builder withCourseId(String courseId) {
+            Assumption.assertNotNull(courseId);
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isQuestionIdPresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isResponseIdPresent());
+
+            attributesDeletionQuery.courseId = courseId;
+            return this;
+        }
+
+        public Builder withFeedbackSessionName(String feedbackSessionName) {
+            Assumption.assertNotNull(feedbackSessionName);
+            Assumption.assertTrue("session name must come together with course ID",
+                    attributesDeletionQuery.isCourseIdPresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isQuestionIdPresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isResponseIdPresent());
+
+            attributesDeletionQuery.feedbackSessionName = feedbackSessionName;
+            return this;
+        }
+
+        public Builder withQuestionId(String questionId) {
+            Assumption.assertNotNull(questionId);
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isCourseIdPresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isFeedbackSessionNamePresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isResponseIdPresent());
+
+            attributesDeletionQuery.questionId = questionId;
+            return this;
+        }
+
+        public Builder withResponseId(String responseId) {
+            Assumption.assertNotNull(responseId);
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isCourseIdPresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isFeedbackSessionNamePresent());
+            Assumption.assertFalse(INVALID_COMBINATION, attributesDeletionQuery.isQuestionIdPresent());
+
+            attributesDeletionQuery.responseId = responseId;
+            return this;
+        }
+
+        public AttributesDeletionQuery build() {
+            Assumption.assertTrue(INVALID_COMBINATION,
+                    attributesDeletionQuery.isCourseIdPresent()
+                            || attributesDeletionQuery.isFeedbackSessionNamePresent()
+                            || attributesDeletionQuery.isQuestionIdPresent()
+                            || attributesDeletionQuery.isResponseIdPresent());
+
+            return attributesDeletionQuery;
+        }
+    }
+}

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1891,15 +1891,6 @@ public class Logic {
     }
 
     /**
-     * Removes document for the comment by given id.
-     *
-     * @see FeedbackResponseCommentsLogic#deleteDocumentByCommentId(long)
-     */
-    public void deleteDocumentByCommentId(long commentId) {
-        feedbackResponseCommentsLogic.deleteDocumentByCommentId(commentId);
-    }
-
-    /**
      * Search for FeedbackResponseComment. Preconditions: all parameters are non-null.
      * @param instructors   a list of InstructorAttributes associated to a googleId,
      *                      used for filtering of search result
@@ -1931,12 +1922,10 @@ public class Logic {
     }
 
     /**
-     * Preconditions: <br>
-     * * Id of comment is not null.
+     * Deletes a comment.
      */
-    public void deleteFeedbackResponseCommentById(Long commentId) {
-        Assumption.assertNotNull(commentId);
-        feedbackResponseCommentsLogic.deleteFeedbackResponseCommentById(commentId);
+    public void deleteFeedbackResponseComment(long commentId) {
+        feedbackResponseCommentsLogic.deleteFeedbackResponseComment(commentId);
     }
 
     public List<String> getArchivedCourseIds(List<CourseAttributes> allCourses,

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1507,12 +1507,16 @@ public class Logic {
     }
 
     /**
-     * Deletes the feedback question and the responses associated to it. Fails
-     * silently if there is no such feedback question. <br>
-     * Preconditions: <br>
+     * Deletes a feedback question cascade its responses and comments.
+     *
+     * <p>Silently fail if question does not exist.
+     *
+     * <p>The respondent lists will also be updated due the deletion of question.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteFeedbackQuestion(String questionId) {
+    public void deleteFeedbackQuestionCascade(String questionId) {
         Assumption.assertNotNull(questionId);
         feedbackQuestionsLogic.deleteFeedbackQuestionCascade(questionId);
     }

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -386,11 +386,14 @@ public class Logic {
     }
 
     /**
-     * Fails silently if no match found.
-     * Preconditions: <br>
+     * Deletes an instructor cascade its associated feedback responses and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteInstructor(String courseId, String email) {
+    public void deleteInstructorCascade(String courseId, String email) {
 
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(email);

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -95,14 +95,13 @@ public class Logic {
      * Deletes both instructor and student privileges, as long as the account and associated student profile.
      *
      * <ul>
-     * <li>Does not delete courses, which can result in orphan courses.</li>
      * <li>Fails silently if no such account.</li>
      * </ul>
      *
      * <p>Preconditions:</p>
      * * All parameters are non-null.
      */
-    public void deleteAccount(String googleId) {
+    public void deleteAccountCascade(String googleId) {
 
         Assumption.assertNotNull(googleId);
 

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -907,14 +907,14 @@ public class Logic {
     }
 
     /**
-     * Deletes the student from the course including any submissions to/from
-     * for this student in this course.
-     * Fails silently if no match found. <br>
-     * Preconditions: <br>
+     * Deletes a student cascade its associated feedback responses and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteStudent(String courseId, String studentEmail) {
-
+    public void deleteStudentCascade(String courseId, String studentEmail) {
         Assumption.assertNotNull(courseId);
         Assumption.assertNotNull(studentEmail);
 
@@ -922,14 +922,15 @@ public class Logic {
     }
 
     /**
-     * Deletes all the students in the course.
+     * Deletes all the students in the course cascade their associated responses and comments.
      *
-     * @param courseId course id for the students
+     * <br/>Preconditions: <br>
+     * * All parameters are non-null.
      */
-    public void deleteAllStudentsInCourse(String courseId) {
-
+    public void deleteStudentsInCourseCascade(String courseId) {
         Assumption.assertNotNull(courseId);
-        studentsLogic.deleteAllStudentsInCourse(courseId);
+
+        studentsLogic.deleteStudentsInCourseCascade(courseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1824,12 +1824,16 @@ public class Logic {
     }
 
     /**
-     * Preconditions: <br>
+     * Deletes a feedback response cascade its associated comments.
+     *
+     * <p>The respondent lists will NOT be updated.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteFeedbackResponse(FeedbackResponseAttributes feedbackResponse) {
-        Assumption.assertNotNull(feedbackResponse);
-        feedbackResponsesLogic.deleteFeedbackResponseAndCascade(feedbackResponse);
+    public void deleteFeedbackResponseCascade(String responseId) {
+        Assumption.assertNotNull(responseId);
+        feedbackResponsesLogic.deleteFeedbackResponseCascade(responseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1406,32 +1406,17 @@ public class Logic {
     }
 
     /**
-     * Permanently deletes the feedback session in Recycle Bin, but not the questions and
-     * responses associated to it.
-     * Fails silently if no such feedback session. <br>
-     * Preconditions: <br>
+     * Deletes a feedback session cascade to its associated questions, responses and comments.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteFeedbackSession(String feedbackSessionName, String courseId) {
+    public void deleteFeedbackSessionCascade(String feedbackSessionName, String courseId) {
 
         Assumption.assertNotNull(feedbackSessionName);
         Assumption.assertNotNull(courseId);
 
         feedbackSessionsLogic.deleteFeedbackSessionCascade(feedbackSessionName, courseId);
-    }
-
-    /**
-     * Permanently deletes feedback sessions in Recycle Bin, but not the questions and
-     * responses associated to them.
-     * Fails silently if no such feedback session. <br>
-     * Preconditions: <br>
-     * * All parameters are non-null.
-     */
-    public void deleteAllFeedbackSessions(List<InstructorAttributes> instructorList) {
-
-        Assumption.assertNotNull(instructorList);
-
-        feedbackSessionsLogic.deleteAllFeedbackSessionsCascade(instructorList);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -591,24 +591,16 @@ public class Logic {
     }
 
     /**
-     * Permanently deletes a course and all data related to the course
-     * (instructors, students, feedback sessions) from Recycle Bin.
-     * Fails silently if no such account. <br>
-     * Preconditions: <br>
+     * Deletes a course cascade its students, instructors, sessions, responses and comments.
+     *
+     * <p>Fails silently if no such course.
+     *
+     * <br/>Preconditions: <br/>
      * * All parameters are non-null.
      */
-    public void deleteCourse(String courseId) {
+    public void deleteCourseCascade(String courseId) {
         Assumption.assertNotNull(courseId);
         coursesLogic.deleteCourseCascade(courseId);
-    }
-
-    /**
-     * Permanently deletes all courses and all data related to these courses
-     * (instructors, students, feedback sessions) from Recycle Bin.
-     */
-    public void deleteAllCourses(List<InstructorAttributes> instructorList) {
-        Assumption.assertNotNull(instructorList);
-        coursesLogic.deleteAllCoursesCascade(instructorList);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -259,7 +259,7 @@ public final class AccountsLogic {
     public void deleteAccountCascade(String googleId) {
         profilesLogic.deleteStudentProfile(googleId);
         instructorsLogic.deleteInstructorsForGoogleIdAndCascade(googleId);
-        studentsLogic.deleteStudentsForGoogleIdAndCascade(googleId);
+        studentsLogic.deleteStudentsForGoogleIdCascade(googleId);
         accountsDb.deleteAccount(googleId);
         //TODO: deal with orphan courses, submissions etc.
     }

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -223,7 +223,7 @@ public final class AccountsLogic {
      * <p>Cascade deletes all instructors associated with the account.
      */
     public void downgradeInstructorToStudentCascade(String googleId) throws EntityDoesNotExistException {
-        instructorsLogic.deleteInstructorsForGoogleIdAndCascade(googleId);
+        instructorsLogic.deleteInstructorsForGoogleIdCascade(googleId);
 
         try {
             accountsDb.updateAccount(
@@ -258,7 +258,7 @@ public final class AccountsLogic {
      */
     public void deleteAccountCascade(String googleId) {
         profilesLogic.deleteStudentProfile(googleId);
-        instructorsLogic.deleteInstructorsForGoogleIdAndCascade(googleId);
+        instructorsLogic.deleteInstructorsForGoogleIdCascade(googleId);
         studentsLogic.deleteStudentsForGoogleIdCascade(googleId);
         accountsDb.deleteAccount(googleId);
         //TODO: deal with orphan courses, submissions etc.

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -252,16 +252,29 @@ public final class AccountsLogic {
      * Deletes both instructor and student privileges, as long as the account and associated student profile.
      *
      * <ul>
-     * <li>Does not delete courses, which can result in orphan courses.</li>
      * <li>Fails silently if no such account.</li>
      * </ul>
      */
     public void deleteAccountCascade(String googleId) {
+        if (accountsDb.getAccount(googleId) == null) {
+            return;
+        }
+
         profilesLogic.deleteStudentProfile(googleId);
+
+        // to prevent orphan course
+        List<InstructorAttributes> instructorsToDelete =
+                instructorsLogic.getInstructorsForGoogleId(googleId, false);
+        for (InstructorAttributes instructorToDelete : instructorsToDelete) {
+            if (instructorsLogic.getInstructorsForCourse(instructorToDelete.getCourseId()).size() <= 1) {
+                // the instructor is the last instructor in the course
+                coursesLogic.deleteCourseCascade(instructorToDelete.getCourseId());
+            }
+        }
+
         instructorsLogic.deleteInstructorsForGoogleIdCascade(googleId);
         studentsLogic.deleteStudentsForGoogleIdCascade(googleId);
         accountsDb.deleteAccount(googleId);
-        //TODO: deal with orphan courses, submissions etc.
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -659,17 +659,17 @@ public final class CoursesLogic {
             return;
         }
 
-        coursesDb.deleteCourse(courseId);
-
         AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                 .withCourseId(courseId)
                 .build();
-        instructorsLogic.deleteInstructors(query);
-        studentsLogic.deleteStudents(query);
-        feedbackSessionsLogic.deleteFeedbackSessions(query);
-        fqLogic.deleteFeedbackQuestions(query);
-        frLogic.deleteFeedbackResponses(query);
         frcLogic.deleteFeedbackResponseComments(query);
+        frLogic.deleteFeedbackResponses(query);
+        fqLogic.deleteFeedbackQuestions(query);
+        feedbackSessionsLogic.deleteFeedbackSessions(query);
+        studentsLogic.deleteStudents(query);
+        instructorsLogic.deleteInstructors(query);
+
+        coursesDb.deleteCourse(courseId);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -659,7 +659,6 @@ public final class CoursesLogic {
             return;
         }
 
-        studentsLogic.deleteStudentsForCourse(courseId);
         instructorsLogic.deleteInstructorsForCourse(courseId);
 
         coursesDb.deleteCourse(courseId);
@@ -667,6 +666,7 @@ public final class CoursesLogic {
         AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                 .withCourseId(courseId)
                 .build();
+        studentsLogic.deleteStudents(query);
         feedbackSessionsLogic.deleteFeedbackSessions(query);
         fqLogic.deleteFeedbackQuestions(query);
         frLogic.deleteFeedbackResponses(query);

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -659,13 +659,12 @@ public final class CoursesLogic {
             return;
         }
 
-        instructorsLogic.deleteInstructorsForCourse(courseId);
-
         coursesDb.deleteCourse(courseId);
 
         AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                 .withCourseId(courseId)
                 .build();
+        instructorsLogic.deleteInstructors(query);
         studentsLogic.deleteStudents(query);
         feedbackSessionsLogic.deleteFeedbackSessions(query);
         fqLogic.deleteFeedbackQuestions(query);

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseDetailsBundle;
 import teammates.common.datatransfer.CourseSummaryBundle;
 import teammates.common.datatransfer.FeedbackSessionDetailsBundle;
@@ -56,6 +57,9 @@ public final class CoursesLogic {
 
     private static final AccountsLogic accountsLogic = AccountsLogic.inst();
     private static final FeedbackSessionsLogic feedbackSessionsLogic = FeedbackSessionsLogic.inst();
+    private static final FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();
+    private static final FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
+    private static final FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
     private static final InstructorsLogic instructorsLogic = InstructorsLogic.inst();
     private static final StudentsLogic studentsLogic = StudentsLogic.inst();
 
@@ -652,7 +656,15 @@ public final class CoursesLogic {
     public void deleteCourseCascade(String courseId) {
         studentsLogic.deleteStudentsForCourse(courseId);
         instructorsLogic.deleteInstructorsForCourse(courseId);
-        feedbackSessionsLogic.deleteFeedbackSessionsForCourseCascade(courseId);
+
+        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build();
+        feedbackSessionsLogic.deleteFeedbackSessions(query);
+        fqLogic.deleteFeedbackQuestions(query);
+        frLogic.deleteFeedbackResponses(query);
+        frcLogic.deleteFeedbackResponseComments(query);
+
         coursesDb.deleteCourse(courseId);
     }
 

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -429,7 +429,6 @@ public final class DataBundleLogic {
             courseIds.add(course.getId());
         }
         if (!courseIds.isEmpty()) {
-            instructorsDb.deleteInstructorsForCourses(courseIds);
             courseIds.forEach(courseId -> {
                 coursesDb.deleteCourse(courseId);
 
@@ -441,6 +440,7 @@ public final class DataBundleLogic {
                 fqDb.deleteFeedbackQuestions(query);
                 fbDb.deleteFeedbackSessions(query);
                 studentsDb.deleteStudents(query);
+                instructorsDb.deleteInstructors(query);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -416,8 +416,9 @@ public final class DataBundleLogic {
         // We don't attempt to delete them again, to save time.
         deleteCourses(dataBundle.courses.values());
 
-        accountsDb.deleteAccounts(dataBundle.accounts.values());
-
+        dataBundle.accounts.values().forEach(account -> {
+            accountsDb.deleteAccount(account.getGoogleId());
+        });
         dataBundle.profiles.values().forEach(profile -> {
             profilesDb.deleteStudentProfile(profile.googleId);
         });

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -433,13 +433,13 @@ public final class DataBundleLogic {
             instructorsDb.deleteInstructorsForCourses(courseIds);
             studentsDb.deleteStudentsForCourses(courseIds);
             fbDb.deleteFeedbackSessionsForCourses(courseIds);
-            fqDb.deleteFeedbackQuestionsForCourses(courseIds);
             courseIds.forEach(courseId -> {
                 AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                         .withCourseId(courseId)
                         .build();
                 frDb.deleteFeedbackResponses(query);
                 fcDb.deleteFeedbackResponseComments(query);
+                fqDb.deleteFeedbackQuestions(query);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -429,10 +429,11 @@ public final class DataBundleLogic {
             courseIds.add(course.getId());
         }
         if (!courseIds.isEmpty()) {
-            coursesDb.deleteEntities(courses);
             instructorsDb.deleteInstructorsForCourses(courseIds);
             studentsDb.deleteStudentsForCourses(courseIds);
             courseIds.forEach(courseId -> {
+                coursesDb.deleteCourse(courseId);
+
                 AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                         .withCourseId(courseId)
                         .build();

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -417,10 +417,10 @@ public final class DataBundleLogic {
         deleteCourses(dataBundle.courses.values());
 
         accountsDb.deleteAccounts(dataBundle.accounts.values());
-        // delete associated profiles
-        // TODO: Remove the following line after tests have been run against LIVE server
-        dataBundle.accounts.values().forEach(account -> profilesDb.deleteStudentProfile(account.googleId));
-        profilesDb.deleteEntities(dataBundle.profiles.values());
+
+        dataBundle.profiles.values().forEach(profile -> {
+            profilesDb.deleteStudentProfile(profile.googleId);
+        });
     }
 
     private void deleteCourses(Collection<CourseAttributes> courses) {

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -431,17 +431,17 @@ public final class DataBundleLogic {
         }
         if (!courseIds.isEmpty()) {
             courseIds.forEach(courseId -> {
-                coursesDb.deleteCourse(courseId);
-
                 AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                         .withCourseId(courseId)
                         .build();
-                frDb.deleteFeedbackResponses(query);
                 fcDb.deleteFeedbackResponseComments(query);
+                frDb.deleteFeedbackResponses(query);
                 fqDb.deleteFeedbackQuestions(query);
                 fbDb.deleteFeedbackSessions(query);
                 studentsDb.deleteStudents(query);
                 instructorsDb.deleteInstructors(query);
+
+                coursesDb.deleteCourse(courseId);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -434,9 +434,12 @@ public final class DataBundleLogic {
             studentsDb.deleteStudentsForCourses(courseIds);
             fbDb.deleteFeedbackSessionsForCourses(courseIds);
             fqDb.deleteFeedbackQuestionsForCourses(courseIds);
-            frDb.deleteFeedbackResponsesForCourses(courseIds);
             courseIds.forEach(courseId -> {
-                fcDb.deleteFeedbackResponseComments(AttributesDeletionQuery.builder().withCourseId(courseId).build());
+                AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                        .withCourseId(courseId)
+                        .build();
+                frDb.deleteFeedbackResponses(query);
+                fcDb.deleteFeedbackResponseComments(query);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -434,7 +435,9 @@ public final class DataBundleLogic {
             fbDb.deleteFeedbackSessionsForCourses(courseIds);
             fqDb.deleteFeedbackQuestionsForCourses(courseIds);
             frDb.deleteFeedbackResponsesForCourses(courseIds);
-            fcDb.deleteFeedbackResponseCommentsForCourses(courseIds);
+            courseIds.forEach(courseId -> {
+                fcDb.deleteFeedbackResponseComments(AttributesDeletionQuery.builder().withCourseId(courseId).build());
+            });
         }
     }
 

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -430,7 +430,6 @@ public final class DataBundleLogic {
         }
         if (!courseIds.isEmpty()) {
             instructorsDb.deleteInstructorsForCourses(courseIds);
-            studentsDb.deleteStudentsForCourses(courseIds);
             courseIds.forEach(courseId -> {
                 coursesDb.deleteCourse(courseId);
 
@@ -441,6 +440,7 @@ public final class DataBundleLogic {
                 fcDb.deleteFeedbackResponseComments(query);
                 fqDb.deleteFeedbackQuestions(query);
                 fbDb.deleteFeedbackSessions(query);
+                studentsDb.deleteStudents(query);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/DataBundleLogic.java
+++ b/src/main/java/teammates/logic/core/DataBundleLogic.java
@@ -432,7 +432,6 @@ public final class DataBundleLogic {
             coursesDb.deleteEntities(courses);
             instructorsDb.deleteInstructorsForCourses(courseIds);
             studentsDb.deleteStudentsForCourses(courseIds);
-            fbDb.deleteFeedbackSessionsForCourses(courseIds);
             courseIds.forEach(courseId -> {
                 AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                         .withCourseId(courseId)
@@ -440,6 +439,7 @@ public final class DataBundleLogic {
                 frDb.deleteFeedbackResponses(query);
                 fcDb.deleteFeedbackResponseComments(query);
                 fqDb.deleteFeedbackQuestions(query);
+                fbDb.deleteFeedbackSessions(query);
             });
         }
     }

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.TeamDetailsBundle;
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -571,7 +572,7 @@ public final class FeedbackQuestionsLogic {
 
         // adjust responses
         if (oldQuestion.areResponseDeletionsRequiredForChanges(updatedQuestion)) {
-            frLogic.deleteFeedbackResponsesForQuestionCascade(oldQuestion.getId(), true);
+            frLogic.deleteFeedbackResponsesForQuestionCascade(oldQuestion.getId());
         }
 
         return updatedQuestion;
@@ -608,84 +609,40 @@ public final class FeedbackQuestionsLogic {
     }
 
     /**
-     * Cascade deletes all feedback questions for a session.
-     *
-     * <p>Silently fails if questions do not exist.
-     */
-    public void deleteFeedbackQuestionsCascadeForSession(String feedbackSessionName, String courseId) {
-        List<FeedbackQuestionAttributes> questions =
-                fqDb.getFeedbackQuestionsForSession(feedbackSessionName, courseId);
-
-        for (FeedbackQuestionAttributes question : questions) {
-            // Cascade delete responses for question.
-            frLogic.deleteFeedbackResponsesForQuestionCascade(question.getId(), false);
-        }
-        fqDb.deleteEntities(questions);
-    }
-
-    /**
-     * Deletes a question by its auto-generated ID. <br>
-     * Cascade the deletion of all existing responses for the question and then
-     * shifts larger question numbers down by one to preserve number order. The
-     * response rate of the feedback session is updated accordingly.
+     * Deletes a feedback question cascade its responses and comments.
      *
      * <p>Silently fail if question does not exist.
+     *
+     * <p>The respondent lists will also be updated due the deletion of question.
      */
     public void deleteFeedbackQuestionCascade(String feedbackQuestionId) {
-        FeedbackQuestionAttributes questionToDeleteById =
-                        getFeedbackQuestion(feedbackQuestionId);
-
-        if (questionToDeleteById == null) {
-            log.warning("Trying to delete question that does not exist: " + feedbackQuestionId);
-        } else {
-            deleteFeedbackQuestionCascade(questionToDeleteById.feedbackSessionName,
-                                            questionToDeleteById.courseId,
-                                            questionToDeleteById.questionNumber);
-        }
-    }
-
-    /**
-     * Deletes a question.
-     *
-     * <p>Question is identified by its question number, the feedback session name
-     * and the course ID of the question.
-     *
-     * <p>Can be used when the question ID is unknown.
-     *
-     * <p>Cascade the deletion of all existing responses for the question and then
-     * shifts larger question numbers down by one to preserve number order.
-     */
-    private void deleteFeedbackQuestionCascade(
-            String feedbackSessionName, String courseId, int questionNumber) {
-
         FeedbackQuestionAttributes questionToDelete =
-                getFeedbackQuestion(feedbackSessionName, courseId, questionNumber);
+                        getFeedbackQuestion(feedbackQuestionId);
 
         if (questionToDelete == null) {
             return; // Silently fail if question does not exist.
         }
-        // Cascade delete responses for question.
-        frLogic.deleteFeedbackResponsesForQuestionCascade(questionToDelete.getId(), true);
-        if (fsLogic.getFeedbackSession(feedbackSessionName, courseId) == null) {
-            Assumption.fail("Session disappeared.");
-        }
-        List<FeedbackQuestionAttributes> questionsToShiftQnNumber =
-                getFeedbackQuestionsForSession(feedbackSessionName, courseId);
-        fqDb.deleteEntity(questionToDelete);
 
+        // cascade delete responses for question.
+        frLogic.deleteFeedbackResponsesForQuestionCascade(questionToDelete.getId());
+
+        List<FeedbackQuestionAttributes> questionsToShiftQnNumber =
+                getFeedbackQuestionsForSession(questionToDelete.getFeedbackSessionName(), questionToDelete.getCourseId());
+
+        // delete question
+        fqDb.deleteFeedbackQuestion(feedbackQuestionId);
+
+        // adjust question numbers
         if (questionToDelete.questionNumber < questionsToShiftQnNumber.size()) {
             shiftQuestionNumbersDown(questionToDelete.questionNumber, questionsToShiftQnNumber);
         }
     }
 
     /**
-     * Deletes all feedback questions in all sessions of the course specified. This is
-     * a non-cascade delete. The responses to the questions and the comments of these responses
-     * should be handled.
-     *
+     * Deletes questions using {@link AttributesDeletionQuery}.
      */
-    public void deleteFeedbackQuestionsForCourse(String courseId) {
-        fqDb.deleteFeedbackQuestionsForCourse(courseId);
+    public void deleteFeedbackQuestions(AttributesDeletionQuery query) {
+        fqDb.deleteFeedbackQuestions(query);
     }
 
     // Shifts all question numbers after questionNumberToShiftFrom down by one.

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -571,7 +571,7 @@ public final class FeedbackQuestionsLogic {
 
         // adjust responses
         if (oldQuestion.areResponseDeletionsRequiredForChanges(updatedQuestion)) {
-            frLogic.deleteFeedbackResponsesForQuestionAndCascade(oldQuestion.getId(), true);
+            frLogic.deleteFeedbackResponsesForQuestionCascade(oldQuestion.getId(), true);
         }
 
         return updatedQuestion;
@@ -618,7 +618,7 @@ public final class FeedbackQuestionsLogic {
 
         for (FeedbackQuestionAttributes question : questions) {
             // Cascade delete responses for question.
-            frLogic.deleteFeedbackResponsesForQuestionAndCascade(question.getId(), false);
+            frLogic.deleteFeedbackResponsesForQuestionCascade(question.getId(), false);
         }
         fqDb.deleteEntities(questions);
     }
@@ -665,7 +665,7 @@ public final class FeedbackQuestionsLogic {
             return; // Silently fail if question does not exist.
         }
         // Cascade delete responses for question.
-        frLogic.deleteFeedbackResponsesForQuestionAndCascade(questionToDelete.getId(), true);
+        frLogic.deleteFeedbackResponsesForQuestionCascade(questionToDelete.getId(), true);
         if (fsLogic.getFeedbackSession(feedbackSessionName, courseId) == null) {
             Assumption.fail("Session disappeared.");
         }

--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackResponseCommentSearchResultBundle;
@@ -149,23 +150,18 @@ public final class FeedbackResponseCommentsLogic {
         return frcDb.search(queryString, instructors);
     }
 
-    public void deleteFeedbackResponseCommentsForCourse(String courseId) {
-        frcDb.deleteFeedbackResponseCommentsForCourse(courseId);
-    }
-
-    public void deleteFeedbackResponseCommentsForResponse(String responseId) {
-        frcDb.deleteFeedbackResponseCommentsForResponse(responseId);
-    }
-
-    public void deleteFeedbackResponseCommentById(Long commentId) {
-        frcDb.deleteCommentById(commentId);
+    /**
+     * Deletes a comment.
+     */
+    public void deleteFeedbackResponseComment(long commentId) {
+        frcDb.deleteFeedbackResponseComment(commentId);
     }
 
     /**
-     * Removes document for the comment with given id.
+     * Deletes comments using {@link AttributesDeletionQuery}.
      */
-    public void deleteDocumentByCommentId(long commentId) {
-        frcDb.deleteDocumentByCommentId(commentId);
+    public void deleteFeedbackResponseComments(AttributesDeletionQuery query) {
+        frcDb.deleteFeedbackResponseComments(query);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -723,8 +723,7 @@ public final class FeedbackResponsesLogic {
      *
      * <p>The respondent lists will also be updated.
      */
-    public void deleteFeedbackResponsesInvolvedStudentOfCourseCascade(String courseId, String studentEmail,
-                                                                      String studentTeam) {
+    public void deleteFeedbackResponsesInvolvedStudentOfCourseCascade(String courseId, String studentEmail) {
         // key is feedback session name, value is a set of student emails that need respondents update
         Map<String, Set<String>> studentEmailsNeedRespondentsUpdate = new HashMap<>();
         // key is feedback session name, value is a set of student emails that need respondents update
@@ -732,12 +731,6 @@ public final class FeedbackResponsesLogic {
 
         deleteFeedbackResponsesInvolvedEntityOfCourseCascade(courseId, studentEmail,
                 studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
-
-        // Delete responses to team as well if there is no student in team.
-        if (studentsLogic.getStudentsForTeam(studentTeam, courseId).size() == 0) {
-            deleteResponsesInvolvedTeam(courseId, studentTeam,
-                    studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
-        }
 
         // update respondents
         studentEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
@@ -748,6 +741,27 @@ public final class FeedbackResponsesLogic {
         });
 
         fsLogic.deleteStudentFromRespondentsList(courseId, studentEmail);
+    }
+
+    /**
+     * Deletes all feedback responses involved a team cascade its associated comments.
+     */
+    public void deleteFeedbackResponsesInvolvedTeamOfCourseCascade(String courseId, String teamName) {
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> studentEmailsNeedRespondentsUpdate = new HashMap<>();
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate = new HashMap<>();
+
+        deleteResponsesInvolvedTeam(courseId, teamName,
+                studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
+
+        // update respondents
+        studentEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteStudentFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+        instructorEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteInstructorFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.SectionDetail;
@@ -604,7 +605,10 @@ public final class FeedbackResponsesLogic {
     }
 
     public void deleteFeedbackResponseAndCascade(FeedbackResponseAttributes responseToDelete) {
-        frcLogic.deleteFeedbackResponseCommentsForResponse(responseToDelete.getId());
+        frcLogic.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withResponseId(responseToDelete.getId())
+                        .build());
         frDb.deleteEntity(responseToDelete);
     }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -1,8 +1,10 @@
 package teammates.logic.core;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -198,6 +200,9 @@ public final class FeedbackResponsesLogic {
         return frDb.getFeedbackResponsesFromGiverForSessionWithinRange(giverEmail, feedbackSessionName, courseId, range);
     }
 
+    /**
+     * Checks whether a giver has responded a session.
+     */
     public boolean hasGiverRespondedForSession(String userEmail, String feedbackSessionName, String courseId) {
 
         return !getFeedbackResponsesFromGiverForSessionWithinRange(userEmail, feedbackSessionName, courseId, 1).isEmpty();
@@ -435,66 +440,99 @@ public final class FeedbackResponsesLogic {
     }
 
     /**
-     * Updates responses for a student when his team changes. This is done by
-     * deleting responses that are no longer relevant to him in his new team.
+     * Updates responses for a student when his team changes.
+     *
+     * <p>This is done by deleting responses that are no longer relevant to him in his new team.
      */
     public void updateFeedbackResponsesForChangingTeam(
             String courseId, String userEmail, String oldTeam, String newTeam) {
-
-        deleteResponsesFromUserToTeam(courseId, userEmail);
-        deleteResponsesFromTeamToUser(courseId, userEmail);
-
-        boolean isOldTeamEmpty = studentsLogic.getStudentsForTeam(oldTeam, courseId).isEmpty();
-        if (isOldTeamEmpty) {
-            deleteTeamResponses(courseId, oldTeam);
-        }
-    }
-
-    /**
-     * Deletes all responses given by a team.
-     */
-    private void deleteTeamResponses(String courseId, String oldTeam) {
-        List<FeedbackResponseAttributes> responsesToOldTeam =
-                getFeedbackResponsesForReceiverForCourse(courseId, oldTeam);
-        for (FeedbackResponseAttributes response : responsesToOldTeam) {
-            deleteFeedbackResponseAndCascade(response);
-        }
-    }
-
-    /**
-     * Deletes all responses given other team members to the user.
-     */
-    private void deleteResponsesFromTeamToUser(String courseId, String userEmail) {
         FeedbackQuestionAttributes question;
-        List<FeedbackResponseAttributes> responsesToUser =
-                getFeedbackResponsesForReceiverForCourse(courseId, userEmail);
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> studentEmailsNeedRespondentsUpdate = new HashMap<>();
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate = new HashMap<>();
 
-        for (FeedbackResponseAttributes response : responsesToUser) {
-            question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
-            if (isRecipientTypeTeamMembers(question)) {
-                deleteFeedbackResponseAndCascade(response);
-                updateSessionResponseRateForDeletingStudentResponse(response.giver,
-                        response.feedbackSessionName, response.courseId);
-            }
-        }
-    }
-
-    /**
-     * Deletes all responses given by the user to team members or given by the user as a representative of a team.
-     */
-    private void deleteResponsesFromUserToTeam(String courseId, String userEmail) {
-        FeedbackQuestionAttributes question;
-
+        // deletes all responses given by the user to team members or given by the user as a representative of a team.
         List<FeedbackResponseAttributes> responsesFromUser =
                 getFeedbackResponsesFromGiverForCourse(courseId, userEmail);
-
         for (FeedbackResponseAttributes response : responsesFromUser) {
             question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
             if (question.giverType == FeedbackParticipantType.TEAMS
                     || isRecipientTypeTeamMembers(question)) {
-                deleteFeedbackResponseAndCascade(response);
-                updateSessionResponseRateForDeletingStudentResponse(response.giver,
-                        response.feedbackSessionName, response.courseId);
+                deleteFeedbackResponseCascade(response.getId());
+
+                studentEmailsNeedRespondentsUpdate
+                        .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                        .add(response.giver);
+            }
+        }
+
+        // Deletes all responses given by other team members to the user.
+        List<FeedbackResponseAttributes> responsesToUser =
+                getFeedbackResponsesForReceiverForCourse(courseId, userEmail);
+        for (FeedbackResponseAttributes response : responsesToUser) {
+            question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
+            if (isRecipientTypeTeamMembers(question)) {
+                deleteFeedbackResponseCascade(response.getId());
+
+                if (question.getGiverType() == FeedbackParticipantType.STUDENTS) {
+                    studentEmailsNeedRespondentsUpdate
+                            .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                            .add(response.giver);
+                }
+            }
+        }
+
+        boolean isOldTeamEmpty = studentsLogic.getStudentsForTeam(oldTeam, courseId).isEmpty();
+        if (isOldTeamEmpty) {
+            deleteResponsesInvolvedTeam(courseId, oldTeam,
+                    studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
+        }
+
+        // update respondents
+        studentEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteStudentFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+        instructorEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteInstructorFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+    }
+
+    /**
+     * Deletes all feedback response involved a team.
+     *
+     * @param courseId the course id
+     * @param teamName the team name
+     * @param studentEmailsNeedRespondentsUpdate map to keep track of deleted response for student respondents update
+     * @param instructorEmailsNeedRespondentsUpdate map to keep track of deleted response for instructor respondents update
+     */
+    private void deleteResponsesInvolvedTeam(String courseId, String teamName,
+                                             Map<String, Set<String>> studentEmailsNeedRespondentsUpdate,
+                                             Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate) {
+        // Deletes all responses given by the team.
+        List<FeedbackResponseAttributes> responsesFromOldTeam =
+                getFeedbackResponsesFromGiverForCourse(courseId, teamName);
+        for (FeedbackResponseAttributes response : responsesFromOldTeam) {
+            deleteFeedbackResponseCascade(response.getId());
+        }
+
+        // Deletes all responses received by the team.
+        List<FeedbackResponseAttributes> responsesToOldTeam =
+                getFeedbackResponsesForReceiverForCourse(courseId, teamName);
+        for (FeedbackResponseAttributes response : responsesToOldTeam) {
+            deleteFeedbackResponseCascade(response.getId());
+
+            FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
+            if (question.getGiverType() == FeedbackParticipantType.INSTRUCTORS
+                    || question.getGiverType() == FeedbackParticipantType.SELF) {
+                instructorEmailsNeedRespondentsUpdate
+                        .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                        .add(response.giver);
+            }
+            if (question.getGiverType() == FeedbackParticipantType.STUDENTS) {
+                studentEmailsNeedRespondentsUpdate
+                        .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                        .add(response.giver);
             }
         }
     }
@@ -545,16 +583,38 @@ public final class FeedbackResponsesLogic {
         }
     }
 
-    private void updateSessionResponseRateForDeletingStudentResponse(String studentEmail, String sessionName,
-            String courseId) {
-        try {
-            if (!hasGiverRespondedForSession(studentEmail, sessionName, courseId)) {
-                fsLogic.deleteStudentFromRespondentList(studentEmail, sessionName, courseId);
+    /**
+     * Delete student from session respondents if he does not have any responses for the session.
+     */
+    private void deleteStudentFromRespondentsIfNecessary(String courseId, String sessionName, String... studentEmails) {
+        for (String studentEmail : studentEmails) {
+            try {
+                if (!hasGiverRespondedForSession(studentEmail, sessionName, courseId)) {
+                    fsLogic.deleteStudentFromRespondentList(studentEmail, sessionName, courseId);
+                }
+            } catch (EntityDoesNotExistException | InvalidParametersException e) {
+                log.warning(String.format(
+                        "Cannot adjust response rate for student %s course %s feedbackSession %s because of %s",
+                        studentEmail, courseId, sessionName, TeammatesException.toStringWithStackTrace(e)));
             }
-        } catch (EntityDoesNotExistException | InvalidParametersException e) {
-            log.warning(String.format(
-                    "Cannot adjust response rate when for student %s course %s feedbackSession %s because of %s",
-                    studentEmail, courseId, sessionName, TeammatesException.toStringWithStackTrace(e)));
+        }
+    }
+
+    /**
+     * Delete instructor from session respondents if he does not have any responses for the session.
+     */
+    private void deleteInstructorFromRespondentsIfNecessary(
+            String courseId, String sessionName, String... instructorEmails) {
+        for (String instructorEmail : instructorEmails) {
+            try {
+                if (!hasGiverRespondedForSession(instructorEmail, sessionName, courseId)) {
+                    fsLogic.deleteInstructorRespondent(instructorEmail, sessionName, courseId);
+                }
+            } catch (EntityDoesNotExistException | InvalidParametersException e) {
+                log.warning(String.format(
+                        "Cannot adjust response rate for instructor %s course %s feedbackSession %s because of %s",
+                        instructorEmail, courseId, sessionName, TeammatesException.toStringWithStackTrace(e)));
+            }
         }
     }
 
@@ -604,15 +664,32 @@ public final class FeedbackResponsesLogic {
         }
     }
 
-    public void deleteFeedbackResponseAndCascade(FeedbackResponseAttributes responseToDelete) {
-        frcLogic.deleteFeedbackResponseComments(
-                AttributesDeletionQuery.builder()
-                        .withResponseId(responseToDelete.getId())
-                        .build());
-        frDb.deleteEntity(responseToDelete);
+    /**
+     * Deletes responses using {@link AttributesDeletionQuery}.
+     */
+    public void deleteFeedbackResponses(AttributesDeletionQuery query) {
+        frDb.deleteFeedbackResponses(query);
     }
 
-    public void deleteFeedbackResponsesForQuestionAndCascade(
+    /**
+     * Deletes a feedback response cascade its associated comments.
+     *
+     * <p>The respondent lists will NOT be updated.
+     */
+    public void deleteFeedbackResponseCascade(String responseId) {
+        frcLogic.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withResponseId(responseId)
+                        .build());
+        frDb.deleteFeedbackResponse(responseId);
+    }
+
+    /**
+     * Deletes all feedback responses of a question cascade its associated comments.
+     *
+     * <p>The respondent lists will also be updated.
+     */
+    public void deleteFeedbackResponsesForQuestionCascade(
             String feedbackQuestionId, boolean hasResponseRateUpdate) {
         List<FeedbackResponseAttributes> responsesForQuestion =
                 getFeedbackResponsesForQuestion(feedbackQuestionId);
@@ -620,7 +697,7 @@ public final class FeedbackResponsesLogic {
         Set<String> emails = new HashSet<>();
 
         for (FeedbackResponseAttributes response : responsesForQuestion) {
-            this.deleteFeedbackResponseAndCascade(response);
+            deleteFeedbackResponseCascade(response.getId());
             emails.add(response.giver);
         }
 
@@ -628,62 +705,114 @@ public final class FeedbackResponsesLogic {
             return;
         }
 
-        try {
-            FeedbackQuestionAttributes question = fqLogic
-                    .getFeedbackQuestion(feedbackQuestionId);
-            boolean isInstructor = question.giverType == FeedbackParticipantType.SELF
-                                   || question.giverType == FeedbackParticipantType.INSTRUCTORS;
-            for (String email : emails) {
-                boolean hasResponses = hasGiverRespondedForSession(email, question.feedbackSessionName, question.courseId);
-                if (!hasResponses) {
-                    if (isInstructor) {
-                        fsLogic.deleteInstructorRespondent(email,
-                                question.feedbackSessionName,
-                                question.courseId);
-                    } else {
-                        fsLogic.deleteStudentFromRespondentList(email,
-                                question.feedbackSessionName,
-                                question.courseId);
-                    }
-                }
-            }
-        } catch (InvalidParametersException | EntityDoesNotExistException e) {
-            Assumption.fail("Fail to delete respondent");
+        FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(feedbackQuestionId);
+        if (question.getGiverType() == FeedbackParticipantType.SELF
+                || question.getGiverType() == FeedbackParticipantType.INSTRUCTORS) {
+            deleteInstructorFromRespondentsIfNecessary(
+                    question.getCourseId(), question.getFeedbackSessionName(), emails.toArray(new String[0]));
         }
-    }
-
-    public void deleteFeedbackResponsesForStudentAndCascade(String courseId, String studentEmail) {
-
-        String studentTeam = "";
-        StudentAttributes student = studentsLogic.getStudentForEmail(courseId,
-                studentEmail);
-
-        if (student != null) {
-            studentTeam = student.team;
-        }
-
-        List<FeedbackResponseAttributes> responses =
-                getFeedbackResponsesFromGiverForCourse(courseId, studentEmail);
-        responses
-                .addAll(
-                getFeedbackResponsesForReceiverForCourse(courseId, studentEmail));
-        // Delete responses to team as well if student is last person in team.
-        if (studentsLogic.getStudentsForTeam(studentTeam, courseId).size() <= 1) {
-            responses.addAll(getFeedbackResponsesForReceiverForCourse(courseId, studentTeam));
-        }
-
-        for (FeedbackResponseAttributes response : responses) {
-            this.deleteFeedbackResponseAndCascade(response);
+        if (question.getGiverType() == FeedbackParticipantType.STUDENTS) {
+            deleteStudentFromRespondentsIfNecessary(
+                    question.getCourseId(), question.getFeedbackSessionName(), emails.toArray(new String[0]));
         }
     }
 
     /**
-     * Deletes all feedback responses in every feedback session in
-     * the specified course. This is a non-cascade delete and the
-     * feedback response comments are not deleted, and should be handled.
+     * Deletes all feedback responses involved a student cascade its associated comments.
+     *
+     * <p>The respondent lists will also be updated.
      */
-    public void deleteFeedbackResponsesForCourse(String courseId) {
-        frDb.deleteFeedbackResponsesForCourse(courseId);
+    public void deleteFeedbackResponsesInvolvedStudentOfCourseCascade(String courseId, String studentEmail,
+                                                                      String studentTeam) {
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> studentEmailsNeedRespondentsUpdate = new HashMap<>();
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate = new HashMap<>();
+
+        deleteFeedbackResponsesInvolvedEntityOfCourseCascade(courseId, studentEmail,
+                studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
+
+        // Delete responses to team as well if there is no student in team.
+        if (studentsLogic.getStudentsForTeam(studentTeam, courseId).size() == 0) {
+            deleteResponsesInvolvedTeam(courseId, studentTeam,
+                    studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
+        }
+
+        // update respondents
+        studentEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteStudentFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+        instructorEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteInstructorFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+
+        fsLogic.deleteStudentFromRespondentsList(courseId, studentEmail);
+    }
+
+    /**
+     * Deletes all feedback responses involved an instructor cascade its associated comments.
+     *
+     * <p>The respondent lists will also be updated.
+     */
+    public void deleteFeedbackResponsesInvolvedInstructorOfCourseCascade(String courseId, String instructorEmail) {
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> studentEmailsNeedRespondentsUpdate = new HashMap<>();
+        // key is feedback session name, value is a set of student emails that need respondents update
+        Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate = new HashMap<>();
+
+        deleteFeedbackResponsesInvolvedEntityOfCourseCascade(courseId, instructorEmail,
+                studentEmailsNeedRespondentsUpdate, instructorEmailsNeedRespondentsUpdate);
+
+        // update respondents
+        studentEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteStudentFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+        instructorEmailsNeedRespondentsUpdate.forEach((sessionName, emails) -> {
+            deleteInstructorFromRespondentsIfNecessary(courseId, sessionName, emails.toArray(new String[0]));
+        });
+
+        fsLogic.deleteInstructorFromRespondentsList(courseId, instructorEmail);
+    }
+
+    /**
+     * Deletes all feedback responses involved an entity cascade its associated comments.
+     *
+     * @param courseId the course id
+     * @param entityEmail the entity email
+     * @param studentEmailsNeedRespondentsUpdate map to keep track of deleted responses for student respondents update
+     * @param instructorEmailsNeedRespondentsUpdate map to keep track of deleted responses for instructor respondents update
+     */
+    private void deleteFeedbackResponsesInvolvedEntityOfCourseCascade(
+            String courseId, String entityEmail,
+            Map<String, Set<String>> studentEmailsNeedRespondentsUpdate,
+            Map<String, Set<String>> instructorEmailsNeedRespondentsUpdate) {
+        // delete responses from the entity
+        List<FeedbackResponseAttributes> responsesFromStudent =
+                getFeedbackResponsesFromGiverForCourse(courseId, entityEmail);
+        for (FeedbackResponseAttributes response : responsesFromStudent) {
+            deleteFeedbackResponseCascade(response.getId());
+        }
+
+        // delete responses to the entity
+        List<FeedbackResponseAttributes> responsesToStudent =
+                getFeedbackResponsesForReceiverForCourse(courseId, entityEmail);
+        FeedbackQuestionAttributes question;
+        for (FeedbackResponseAttributes response : responsesToStudent) {
+            question = fqLogic.getFeedbackQuestion(response.feedbackQuestionId);
+            deleteFeedbackResponseCascade(response.getId());
+
+            if (question.getGiverType() == FeedbackParticipantType.STUDENTS) {
+                studentEmailsNeedRespondentsUpdate
+                        .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                        .add(response.giver);
+            }
+            if (question.getGiverType() == FeedbackParticipantType.INSTRUCTORS
+                    || question.getGiverType() == FeedbackParticipantType.SELF) {
+                instructorEmailsNeedRespondentsUpdate
+                        .computeIfAbsent(response.feedbackSessionName, key -> new HashSet<>())
+                        .add(response.giver);
+            }
+        }
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -689,21 +689,22 @@ public final class FeedbackResponsesLogic {
      *
      * <p>The respondent lists will also be updated.
      */
-    public void deleteFeedbackResponsesForQuestionCascade(
-            String feedbackQuestionId, boolean hasResponseRateUpdate) {
+    public void deleteFeedbackResponsesForQuestionCascade(String feedbackQuestionId) {
         List<FeedbackResponseAttributes> responsesForQuestion =
                 getFeedbackResponsesForQuestion(feedbackQuestionId);
 
         Set<String> emails = new HashSet<>();
-
+        // record all giver and prepare respondents update
         for (FeedbackResponseAttributes response : responsesForQuestion) {
-            deleteFeedbackResponseCascade(response.getId());
             emails.add(response.giver);
         }
 
-        if (!hasResponseRateUpdate) {
-            return;
-        }
+        // delete all responses, comments of the question
+        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                .withQuestionId(feedbackQuestionId)
+                .build();
+        deleteFeedbackResponses(query);
+        frcLogic.deleteFeedbackResponseComments(query);
 
         FeedbackQuestionAttributes question = fqLogic.getFeedbackQuestion(feedbackQuestionId);
         if (question.getGiverType() == FeedbackParticipantType.SELF

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1375,9 +1375,9 @@ public final class FeedbackSessionsLogic {
                 .withCourseId(courseId)
                 .withFeedbackSessionName(feedbackSessionName)
                 .build();
-        fqLogic.deleteFeedbackQuestions(query);
-        frLogic.deleteFeedbackResponses(query);
         frcLogic.deleteFeedbackResponseComments(query);
+        frLogic.deleteFeedbackResponses(query);
+        fqLogic.deleteFeedbackQuestions(query);
 
         fsDb.deleteFeedbackSession(feedbackSessionName, courseId);
     }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1368,36 +1368,9 @@ public final class FeedbackSessionsLogic {
     }
 
     /**
-     * Deletes the feedback sessions in the course specified. The delete
-     * is cascaded, and feedback questions, feedback responses, and
-     * feedback response comments in the course are deleted.
-     */
-    public void deleteFeedbackSessionsForCourseCascade(String courseId) {
-        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
-                .withCourseId(courseId)
-                .build();
-        frcLogic.deleteFeedbackResponseComments(query);
-        frLogic.deleteFeedbackResponses(query);
-        fqLogic.deleteFeedbackQuestions(query);
-        deleteFeedbackSessionsForCourse(courseId);
-    }
-
-    /**
-     * Deletes all feedback sessions the course specified. This is
-     * a non-cascade delete.
-     *
-     * <p>The responses, questions and the comments of the responses
-     * should be handled.
-     */
-    public void deleteFeedbackSessionsForCourse(String courseId) {
-        fsDb.deleteFeedbackSessionsForCourse(courseId);
-    }
-
-    /**
-     * Permanently deletes a specific feedback session in Recycle Bin, and all its questions and responses.
+     * Deletes a feedback session cascade to its associated questions, responses and comments.
      */
     public void deleteFeedbackSessionCascade(String feedbackSessionName, String courseId) {
-
         AttributesDeletionQuery query = AttributesDeletionQuery.builder()
                 .withCourseId(courseId)
                 .withFeedbackSessionName(feedbackSessionName)
@@ -1406,24 +1379,14 @@ public final class FeedbackSessionsLogic {
         frLogic.deleteFeedbackResponses(query);
         frcLogic.deleteFeedbackResponseComments(query);
 
-        FeedbackSessionAttributes sessionToDelete =
-                FeedbackSessionAttributes.builder(feedbackSessionName, courseId).build();
-
-        fsDb.deleteEntity(sessionToDelete);
+        fsDb.deleteFeedbackSession(feedbackSessionName, courseId);
     }
 
     /**
-     * Permanently deletes all feedback sessions in Recycle Bin, and all their questions and responses.
+     * Deletes sessions using {@link AttributesDeletionQuery}.
      */
-    public void deleteAllFeedbackSessionsCascade(List<InstructorAttributes> instructorList) {
-        Assumption.assertNotNull("Supplied parameter was null", instructorList);
-
-        List<FeedbackSessionAttributes> feedbackSessionsList =
-                getSoftDeletedFeedbackSessionsListForInstructors(instructorList);
-
-        for (FeedbackSessionAttributes session : feedbackSessionsList) {
-            deleteFeedbackSessionCascade(session.getFeedbackSessionName(), session.getCourseId());
-        }
+    public void deleteFeedbackSessions(AttributesDeletionQuery query) {
+        fsDb.deleteFeedbackSessions(query);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -12,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionDetailsBundle;
@@ -1378,7 +1379,10 @@ public final class FeedbackSessionsLogic {
      * feedback response comments in the course are deleted.
      */
     public void deleteFeedbackSessionsForCourseCascade(String courseId) {
-        frcLogic.deleteFeedbackResponseCommentsForCourse(courseId);
+        frcLogic.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(courseId)
+                        .build());
         frLogic.deleteFeedbackResponsesForCourse(courseId);
         fqLogic.deleteFeedbackQuestionsForCourse(courseId);
         deleteFeedbackSessionsForCourse(courseId);

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1378,7 +1378,7 @@ public final class FeedbackSessionsLogic {
                 .build();
         frcLogic.deleteFeedbackResponseComments(query);
         frLogic.deleteFeedbackResponses(query);
-        fqLogic.deleteFeedbackQuestionsForCourse(courseId);
+        fqLogic.deleteFeedbackQuestions(query);
         deleteFeedbackSessionsForCourse(courseId);
     }
 
@@ -1398,7 +1398,13 @@ public final class FeedbackSessionsLogic {
      */
     public void deleteFeedbackSessionCascade(String feedbackSessionName, String courseId) {
 
-        fqLogic.deleteFeedbackQuestionsCascadeForSession(feedbackSessionName, courseId);
+        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .withFeedbackSessionName(feedbackSessionName)
+                .build();
+        fqLogic.deleteFeedbackQuestions(query);
+        frLogic.deleteFeedbackResponses(query);
+        frcLogic.deleteFeedbackResponseComments(query);
 
         FeedbackSessionAttributes sessionToDelete =
                 FeedbackSessionAttributes.builder(feedbackSessionName, courseId).build();

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1206,16 +1206,13 @@ public final class FeedbackSessionsLogic {
      * Deletes the instructor's email from the instructor respondents set of all feedback sessions
      * in the corresponding course.
      */
-    public void deleteInstructorFromRespondentsList(InstructorAttributes instructor) {
-        if (instructor == null || instructor.email == null) {
-            return;
-        }
+    public void deleteInstructorFromRespondentsList(String courseId, String email) {
         List<FeedbackSessionAttributes> sessionsToUpdate =
-                fsDb.getFeedbackSessionsForCourse(instructor.courseId);
+                fsDb.getFeedbackSessionsForCourse(courseId);
 
         for (FeedbackSessionAttributes session : sessionsToUpdate) {
             try {
-                deleteInstructorRespondent(instructor.email, session.getFeedbackSessionName(), session.getCourseId());
+                deleteInstructorRespondent(email, session.getFeedbackSessionName(), session.getCourseId());
             } catch (InvalidParametersException | EntityDoesNotExistException e) {
                 Assumption.fail(ASSUMPTION_FAIL_DELETE_INSTRUCTOR + session.getFeedbackSessionName());
             }
@@ -1226,16 +1223,13 @@ public final class FeedbackSessionsLogic {
      * Deletes the student's email from the student respondents set of all feedback sessions
      * in the corresponding course.
      */
-    public void deleteStudentFromRespondentsList(StudentAttributes student) {
-        if (student == null || student.email == null) {
-            return;
-        }
+    public void deleteStudentFromRespondentsList(String courseId, String email) {
         List<FeedbackSessionAttributes> sessionsToUpdate =
-                fsDb.getFeedbackSessionsForCourse(student.course);
+                fsDb.getFeedbackSessionsForCourse(courseId);
 
         for (FeedbackSessionAttributes session : sessionsToUpdate) {
             try {
-                deleteStudentFromRespondentList(student.email, session.getFeedbackSessionName(), session.getCourseId());
+                deleteStudentFromRespondentList(email, session.getFeedbackSessionName(), session.getCourseId());
             } catch (InvalidParametersException | EntityDoesNotExistException e) {
                 Assumption.fail(ASSUMPTION_FAIL_DELETE_INSTRUCTOR + session.getFeedbackSessionName());
             }
@@ -1379,11 +1373,11 @@ public final class FeedbackSessionsLogic {
      * feedback response comments in the course are deleted.
      */
     public void deleteFeedbackSessionsForCourseCascade(String courseId) {
-        frcLogic.deleteFeedbackResponseComments(
-                AttributesDeletionQuery.builder()
-                        .withCourseId(courseId)
-                        .build());
-        frLogic.deleteFeedbackResponsesForCourse(courseId);
+        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build();
+        frcLogic.deleteFeedbackResponseComments(query);
+        frLogic.deleteFeedbackResponses(query);
         fqLogic.deleteFeedbackQuestionsForCourse(courseId);
         deleteFeedbackSessionsForCourse(courseId);
     }

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -304,7 +304,7 @@ public final class InstructorsLogic {
     }
 
     public void deleteInstructorCascade(String courseId, String email) {
-        fsLogic.deleteInstructorFromRespondentsList(getInstructorForEmail(courseId, email));
+        fsLogic.deleteInstructorFromRespondentsList(courseId, email);
         instructorsDb.deleteInstructor(courseId, email);
     }
 

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -3,6 +3,7 @@ package teammates.logic.core;
 import java.util.ArrayList;
 import java.util.List;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
@@ -303,25 +304,38 @@ public final class InstructorsLogic {
         return instructorsDb.updateInstructorByEmail(updateOptions);
     }
 
+    /**
+     * Deletes instructors using {@link AttributesDeletionQuery}.
+     */
+    public void deleteInstructors(AttributesDeletionQuery query) {
+        instructorsDb.deleteInstructors(query);
+    }
+
+    /**
+     * Deletes an instructor cascade its associated feedback responses and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     */
     public void deleteInstructorCascade(String courseId, String email) {
-        fsLogic.deleteInstructorFromRespondentsList(courseId, email);
+        InstructorAttributes instructorAttributes = getInstructorForEmail(courseId, email);
+        if (instructorAttributes == null) {
+            return;
+        }
+
+        frLogic.deleteFeedbackResponsesInvolvedInstructorOfCourseCascade(courseId, email);
         instructorsDb.deleteInstructor(courseId, email);
     }
 
-    public void deleteInstructorsForGoogleIdAndCascade(String googleId) {
+    /**
+     * Deletes all instructors associated with a googleId and cascade delete its associated feedback responses and comments.
+     */
+    public void deleteInstructorsForGoogleIdCascade(String googleId) {
         List<InstructorAttributes> instructors = instructorsDb.getInstructorsForGoogleId(googleId, false);
 
-        //Cascade delete instructors
+        // cascade delete instructors
         for (InstructorAttributes instructor : instructors) {
             deleteInstructorCascade(instructor.courseId, instructor.email);
         }
-    }
-
-    // this method is only being used in course logic. cascade to comments is therefore not necessary
-    // as it it taken care of when deleting course
-    public void deleteInstructorsForCourse(String courseId) {
-
-        instructorsDb.deleteInstructorsForCourse(courseId);
     }
 
     public List<InstructorAttributes> getCoOwnersForCourse(String courseId) {

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -3,6 +3,7 @@ package teammates.logic.core;
 import java.util.ArrayList;
 import java.util.List;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseEnrollmentResult;
 import teammates.common.datatransfer.StudentAttributesFactory;
 import teammates.common.datatransfer.StudentEnrollDetails;
@@ -382,7 +383,10 @@ public final class StudentsLogic {
         return errorMessage.toString();
     }
 
-    public void deleteAllStudentsInCourse(String courseId) {
+    /**
+     * Deletes all the students in the course cascade their associated responses and comments.
+     */
+    public void deleteStudentsInCourseCascade(String courseId) {
         List<StudentAttributes> studentsInCourse = getStudentsForCourse(courseId);
         for (StudentAttributes student : studentsInCourse) {
             deleteStudentCascade(courseId, student.email);
@@ -390,7 +394,7 @@ public final class StudentsLogic {
     }
 
     /**
-     * Deletes a student cascade its associated feedback response and comments.
+     * Deletes a student cascade its associated feedback responses and comments.
      *
      * <p>Fails silently if the student does not exist.
      */
@@ -404,15 +408,10 @@ public final class StudentsLogic {
         frLogic.deleteFeedbackResponsesInvolvedStudentOfCourseCascade(courseId, studentEmail, student.getTeam());
     }
 
-    public void deleteStudentsForGoogleId(String googleId) {
-        List<StudentAttributes> students = studentsDb.getStudentsForGoogleId(googleId);
-        for (StudentAttributes student : students) {
-            fsLogic.deleteStudentFromRespondentsList(student.getCourse(), student.getEmail());
-        }
-        studentsDb.deleteStudentsForGoogleId(googleId);
-    }
-
-    public void deleteStudentsForGoogleIdAndCascade(String googleId) {
+    /**
+     * Deletes all students associated a googleId and cascade its associated feedback responses and comments.
+     */
+    public void deleteStudentsForGoogleIdCascade(String googleId) {
         List<StudentAttributes> students = studentsDb.getStudentsForGoogleId(googleId);
 
         // Cascade delete students
@@ -421,8 +420,11 @@ public final class StudentsLogic {
         }
     }
 
-    public void deleteStudentsForCourse(String courseId) {
-        studentsDb.deleteStudentsForCourse(courseId);
+    /**
+     * Deletes students using {@link AttributesDeletionQuery}.
+     */
+    public void deleteStudents(AttributesDeletionQuery query) {
+        studentsDb.deleteStudents(query);
     }
 
     /**

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -404,8 +404,12 @@ public final class StudentsLogic {
             return;
         }
 
+        frLogic.deleteFeedbackResponsesInvolvedStudentOfCourseCascade(courseId, studentEmail);
+        if (studentsDb.getStudentsForTeam(student.getTeam(), student.getCourse()).size() == 1) {
+            // the student is the only student in the team
+            frLogic.deleteFeedbackResponsesInvolvedTeamOfCourseCascade(student.getCourse(), student.getTeam());
+        }
         studentsDb.deleteStudent(courseId, studentEmail);
-        frLogic.deleteFeedbackResponsesInvolvedStudentOfCourseCascade(courseId, studentEmail, student.getTeam());
     }
 
     /**

--- a/src/main/java/teammates/logic/core/StudentsLogic.java
+++ b/src/main/java/teammates/logic/core/StudentsLogic.java
@@ -389,17 +389,25 @@ public final class StudentsLogic {
         }
     }
 
+    /**
+     * Deletes a student cascade its associated feedback response and comments.
+     *
+     * <p>Fails silently if the student does not exist.
+     */
     public void deleteStudentCascade(String courseId, String studentEmail) {
-        // delete responses before deleting the student as we need to know the student's team.
-        frLogic.deleteFeedbackResponsesForStudentAndCascade(courseId, studentEmail);
-        fsLogic.deleteStudentFromRespondentsList(getStudentForEmail(courseId, studentEmail));
+        StudentAttributes student = getStudentForEmail(courseId, studentEmail);
+        if (student == null) {
+            return;
+        }
+
         studentsDb.deleteStudent(courseId, studentEmail);
+        frLogic.deleteFeedbackResponsesInvolvedStudentOfCourseCascade(courseId, studentEmail, student.getTeam());
     }
 
     public void deleteStudentsForGoogleId(String googleId) {
         List<StudentAttributes> students = studentsDb.getStudentsForGoogleId(googleId);
         for (StudentAttributes student : students) {
-            fsLogic.deleteStudentFromRespondentsList(student);
+            fsLogic.deleteStudentFromRespondentsList(student.getCourse(), student.getEmail());
         }
         studentsDb.deleteStudentsForGoogleId(googleId);
     }

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -107,12 +106,6 @@ public class AccountsDb extends EntitiesDb<Account, AccountAttributes> {
     @Override
     protected Account getEntity(AccountAttributes entity) {
         return getAccountEntity(entity.googleId);
-    }
-
-    @Override
-    protected QueryKeys<Account> getEntityQueryKeys(AccountAttributes attributes) {
-        Key<Account> keyToFind = Key.create(Account.class, attributes.googleId);
-        return load().filterKey(keyToFind).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/AccountsDb.java
+++ b/src/main/java/teammates/storage/api/AccountsDb.java
@@ -2,7 +2,6 @@ package teammates.storage.api;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
-import java.util.Collection;
 import java.util.List;
 
 import com.googlecode.objectify.Key;
@@ -81,29 +80,14 @@ public class AccountsDb extends EntitiesDb<Account, AccountAttributes> {
     }
 
     /**
-     * Note: This is a non-cascade delete. <br>
-     *   <br> Fails silently if there is no such account.
-     * <br> Preconditions:
-     * <br> * {@code googleId} is not null.
+     * Deletes an account.
+     *
+     * <p>Fails silently if there is no such account.
      */
     public void deleteAccount(String googleId) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, googleId);
 
-        Account accountToDelete = getAccountEntity(googleId);
-
-        if (accountToDelete == null) {
-            return;
-        }
-
-        deleteEntityDirect(accountToDelete);
-    }
-
-    public void deleteAccounts(Collection<AccountAttributes> accounts) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, accounts);
-
-        for (AccountAttributes accountToDelete : accounts) {
-            deleteAccount(accountToDelete.googleId);
-        }
+        deleteEntity(Key.create(Account.class, googleId));
     }
 
     private Account getAccountEntity(String googleId) {

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -84,22 +84,12 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     }
 
     /**
-     * Permanently deletes the course from the Datastore.
-     *
-     * <p>Note: This is a non-cascade delete.<br>
-     *   <br> Fails silently if there is no such object.
-     * <br> Preconditions:
-     * <br> * {@code courseId} is not null.
+     * Deletes a course.
      */
     public void deleteCourse(String courseId) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
 
-        // only the courseId is important here, everything else are placeholders
-        deleteEntity(CourseAttributes
-                .builder(courseId)
-                .withName("Non-existent course")
-                .withTimezone(Const.DEFAULT_TIME_ZONE)
-                .build());
+        deleteEntity(Key.create(Course.class, courseId));
     }
 
     /**

--- a/src/main/java/teammates/storage/api/CoursesDb.java
+++ b/src/main/java/teammates/storage/api/CoursesDb.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -133,12 +132,6 @@ public class CoursesDb extends EntitiesDb<Course, CourseAttributes> {
     @Override
     protected Course getEntity(CourseAttributes attributes) {
         return getCourseEntity(attributes.getId());
-    }
-
-    @Override
-    protected QueryKeys<Course> getEntityQueryKeys(CourseAttributes attributes) {
-        Key<Course> keyToFind = Key.create(Course.class, attributes.getId());
-        return load().filterKey(keyToFind).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -152,18 +152,6 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
         ofy().save().entities(entitiesToSave).now();
     }
 
-    // TODO: use this method for subclasses.
-    /**
-     * Note: This is a non-cascade delete.<br>
-     *   <br> Fails silently if there is no such object.
-     */
-    public void deleteEntity(A entityToDelete) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entityToDelete);
-
-        ofy().delete().keys(getEntityQueryKeys(entityToDelete)).now();
-        log.info(entityToDelete.getBackupIdentifier());
-    }
-
     /**
      * Deletes entity by key.
      */
@@ -176,38 +164,6 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
                     key.getKind(), key.getId(), key.getName()));
         }
         ofy().delete().keys(keys).now();
-    }
-
-    public void deleteEntities(Collection<A> entitiesToDelete) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entitiesToDelete);
-
-        List<Key<E>> keysToDelete = new ArrayList<>();
-        for (A entityToDelete : entitiesToDelete) {
-            Key<E> keyToDelete = getEntityQueryKeys(entityToDelete).first().now();
-            if (keyToDelete == null) {
-                continue;
-            }
-            keysToDelete.add(keyToDelete);
-            log.info(entityToDelete.getBackupIdentifier());
-        }
-
-        ofy().delete().keys(keysToDelete).now();
-    }
-
-    protected void deleteEntityDirect(E entityToDelete) {
-        deleteEntityDirect(entityToDelete, makeAttributes(entityToDelete));
-    }
-
-    protected void deleteEntityDirect(E entityToDelete, A entityToDeleteAttributesForLogging) {
-        ofy().delete().entity(entityToDelete).now();
-        log.info(entityToDeleteAttributesForLogging.getBackupIdentifier());
-    }
-
-    protected void deleteEntitiesDirect(Collection<E> entitiesToDelete, Collection<A> entitiesToDeleteAttributesForLogging) {
-        for (A attributes : entitiesToDeleteAttributesForLogging) {
-            log.info(attributes.getBackupIdentifier());
-        }
-        ofy().delete().entities(entitiesToDelete).now();
     }
 
     protected abstract LoadType<E> load();

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -13,7 +13,6 @@ import com.google.appengine.api.search.ScoredDocument;
 import com.google.appengine.api.search.SearchQueryException;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.attributes.EntityAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -175,11 +174,6 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
      *             based on the default key identifiers.
      */
     protected abstract E getEntity(A attributes);
-
-    /**
-     * Gets the key query for entities which matches the given {@code attributes}.
-     */
-    protected abstract QueryKeys<E> getEntityQueryKeys(A attributes);
 
     protected abstract A makeAttributes(E entity);
 

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -164,6 +164,20 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
         log.info(entityToDelete.getBackupIdentifier());
     }
 
+    /**
+     * Deletes entity by key.
+     */
+    protected void deleteEntity(Key<?>... keys) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, (Object) keys);
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, (Object[]) keys);
+
+        for (Key<?> key : keys) {
+            log.info(String.format("Delete entity %s of key (id: %d, name: %s)",
+                    key.getKind(), key.getId(), key.getName()));
+        }
+        ofy().delete().keys(keys).now();
+    }
+
     public void deleteEntities(Collection<A> entitiesToDelete) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, entitiesToDelete);
 
@@ -279,11 +293,15 @@ public abstract class EntitiesDb<E extends BaseEntity, A extends EntityAttribute
         }
     }
 
-    protected void deleteDocument(String indexName, String documentId) {
+    /**
+     * Deletes document by documentId(s).
+     */
+    protected void deleteDocument(String indexName, String... documentIds) {
         try {
-            SearchManager.deleteDocument(indexName, documentId);
+            SearchManager.deleteDocument(indexName, documentIds);
         } catch (Exception e) {
-            log.info("Unable to delete document in the index: " + indexName + " with document id " + documentId);
+            log.info("Unable to delete document in the index: " + indexName
+                    + " with document Ids " + String.join(", ", documentIds));
         }
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -7,7 +7,6 @@ import java.util.List;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -200,23 +199,6 @@ public class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, FeedbackQu
         }
 
         return getFeedbackQuestionEntity(attributes.feedbackSessionName, attributes.courseId, attributes.questionNumber);
-    }
-
-    @Override
-    protected QueryKeys<FeedbackQuestion> getEntityQueryKeys(FeedbackQuestionAttributes attributes) {
-        Key<FeedbackQuestion> key = makeKeyOrNullFromWebSafeString(attributes.getId());
-
-        Query<FeedbackQuestion> query;
-        if (key == null) {
-            query = load()
-                    .filter("feedbackSessionName =", attributes.feedbackSessionName)
-                    .filter("courseId =", attributes.courseId)
-                    .filter("questionNumber =", attributes.questionNumber);
-        } else {
-            query = load().filterKey(key);
-        }
-
-        return query.keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -2,7 +2,6 @@ package teammates.storage.api;
 
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
-import java.util.Arrays;
 import java.util.List;
 
 import com.googlecode.objectify.Key;
@@ -10,6 +9,7 @@ import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
 import com.googlecode.objectify.cmd.QueryKeys;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -122,16 +122,31 @@ public class FeedbackQuestionsDb extends EntitiesDb<FeedbackQuestion, FeedbackQu
         return makeAttributes(feedbackQuestion);
     }
 
-    public void deleteFeedbackQuestionsForCourse(String courseId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
-
-        deleteFeedbackQuestionsForCourses(Arrays.asList(courseId));
+    /**
+     * Deletes a feedback question.
+     */
+    public void deleteFeedbackQuestion(String feedbackQuestionId) {
+        Key<FeedbackQuestion> feedbackQuestionKey = makeKeyOrNullFromWebSafeString(feedbackQuestionId);
+        if (feedbackQuestionKey != null) {
+            deleteEntity(feedbackQuestionKey);
+        }
     }
 
-    public void deleteFeedbackQuestionsForCourses(List<String> courseIds) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseIds);
+    /**
+     * Deletes questions using {@link AttributesDeletionQuery}.
+     */
+    public void deleteFeedbackQuestions(AttributesDeletionQuery query) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, query);
 
-        ofy().delete().keys(load().filter("courseId in", courseIds).keys()).now();
+        Query<FeedbackQuestion> entitiesToDelete = load().project();
+        if (query.isCourseIdPresent()) {
+            entitiesToDelete = entitiesToDelete.filter("courseId =", query.getCourseId());
+        }
+        if (query.isFeedbackSessionNamePresent()) {
+            entitiesToDelete = entitiesToDelete.filter("feedbackSessionName =", query.getFeedbackSessionName());
+        }
+
+        deleteEntity(entitiesToDelete.keys().list().toArray(new Key<?>[0]));
     }
 
     // Gets a question entity if its Key (feedbackQuestionId) is known.

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -14,7 +14,6 @@ import com.google.appengine.api.search.ScoredDocument;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackResponseCommentSearchResultBundle;
@@ -409,24 +408,6 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
         }
 
         return getFeedbackResponseCommentEntity(attributes.courseId, attributes.createdAt, attributes.commentGiver);
-    }
-
-    @Override
-    protected QueryKeys<FeedbackResponseComment> getEntityQueryKeys(FeedbackResponseCommentAttributes attributes) {
-        Long id = attributes.getId();
-
-        if (id != null) {
-            return getEntityQueryKeys(id);
-        }
-        return load()
-                .filter("feedbackResponseId =", attributes.feedbackResponseId)
-                .filter("createdAt =", attributes.createdAt)
-                .filter("giverEmail =", attributes.commentGiver)
-                .keys();
-    }
-
-    private QueryKeys<FeedbackResponseComment> getEntityQueryKeys(long commentId) {
-        return load().filterKey(Key.create(FeedbackResponseComment.class, commentId)).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponseCommentsDb.java
@@ -4,7 +4,6 @@ import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +16,7 @@ import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
 import com.googlecode.objectify.cmd.QueryKeys;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackResponseCommentSearchResultBundle;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -131,34 +131,6 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackResponseId);
 
         return makeAttributes(getFeedbackResponseCommentEntitiesForResponse(feedbackResponseId));
-    }
-
-    /*
-     * Remove response comments for the response Id
-     */
-    public void deleteFeedbackResponseCommentsForResponse(String responseId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, responseId);
-
-        ofy().delete().keys(getFeedbackResponseCommentsForResponseQuery(responseId).keys()).now();
-    }
-
-    /*
-     * Remove response comments for the course Ids
-     */
-    public void deleteFeedbackResponseCommentsForCourses(List<String> courseIds) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseIds);
-
-        ofy().delete().keys(getFeedbackResponseCommentsForCoursesQuery(courseIds).keys()).now();
-    }
-
-    public void deleteFeedbackResponseCommentsForCourse(String courseId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
-
-        deleteFeedbackResponseCommentsForCourses(Arrays.asList(courseId));
-    }
-
-    private Query<FeedbackResponseComment> getFeedbackResponseCommentsForCoursesQuery(List<String> courseIds) {
-        return load().filter("courseId in", courseIds);
     }
 
     /**
@@ -308,12 +280,38 @@ public class FeedbackResponseCommentsDb extends EntitiesDb<FeedbackResponseComme
     }
 
     /**
-     * Removes comment with given id.
-     *
-     * @param id ID of comment
+     * Deletes a comment.
      */
-    public void deleteCommentById(Long id) {
-        ofy().delete().keys(getEntityQueryKeys(id)).now();
+    public void deleteFeedbackResponseComment(long commentId) {
+        deleteEntity(Key.create(FeedbackResponseComment.class, commentId));
+        deleteDocumentByCommentId(commentId);
+    }
+
+    /**
+     * Deletes comments using {@link AttributesDeletionQuery}.
+     */
+    public void deleteFeedbackResponseComments(AttributesDeletionQuery query) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, query);
+
+        Query<FeedbackResponseComment> entitiesToDelete = load().project();
+        if (query.isCourseIdPresent()) {
+            entitiesToDelete = entitiesToDelete.filter("courseId =", query.getCourseId());
+        }
+        if (query.isFeedbackSessionNamePresent()) {
+            entitiesToDelete = entitiesToDelete.filter("feedbackSessionName =", query.getFeedbackSessionName());
+        }
+        if (query.isQuestionIdPresent()) {
+            entitiesToDelete = entitiesToDelete.filter("feedbackQuestionId =", query.getQuestionId());
+        }
+        if (query.isResponseIdPresent()) {
+            entitiesToDelete = entitiesToDelete.filter("feedbackResponseId =", query.getResponseId());
+        }
+
+        List<Key<FeedbackResponseComment>> keysToDelete = entitiesToDelete.keys().list();
+
+        deleteDocument(Const.SearchIndex.FEEDBACK_RESPONSE_COMMENT,
+                keysToDelete.stream().map(key -> String.valueOf(key.getId())).toArray(String[]::new));
+        deleteEntity(keysToDelete.toArray(new Key<?>[0]));
     }
 
     private FeedbackResponseComment getFeedbackResponseCommentEntity(String courseId, Instant createdAt, String giverEmail) {

--- a/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackResponsesDb.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.SectionDetail;
@@ -725,23 +724,6 @@ public class FeedbackResponsesDb extends EntitiesDb<FeedbackResponse, FeedbackRe
         }
 
         return getFeedbackResponseEntity(attributes.feedbackQuestionId, attributes.giver, attributes.recipient);
-    }
-
-    @Override
-    protected QueryKeys<FeedbackResponse> getEntityQueryKeys(FeedbackResponseAttributes attributes) {
-        String id = attributes.getId();
-
-        Query<FeedbackResponse> query;
-        if (id == null) {
-            query = load()
-                    .filter("feedbackQuestionId =", attributes.feedbackQuestionId)
-                    .filter("giverEmail =", attributes.giver)
-                    .filter("receiver =", attributes.recipient);
-        } else {
-            query = load().filterKey(Key.create(FeedbackResponse.class, id));
-        }
-
-        return query.keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -3,15 +3,16 @@ package teammates.storage.api;
 import static com.googlecode.objectify.ObjectifyService.ofy;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.VoidWork;
 import com.googlecode.objectify.cmd.LoadType;
+import com.googlecode.objectify.cmd.Query;
 import com.googlecode.objectify.cmd.QueryKeys;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -283,16 +284,28 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
         saveEntity(sessionEntity);
     }
 
-    public void deleteFeedbackSessionsForCourse(String courseId) {
+    /**
+     * Deletes a feedback session.
+     */
+    public void deleteFeedbackSession(String feedbackSessionName, String courseId) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, feedbackSessionName);
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
 
-        deleteFeedbackSessionsForCourses(Arrays.asList(courseId));
+        deleteEntity(Key.create(FeedbackSession.class, FeedbackSession.generateId(feedbackSessionName, courseId)));
     }
 
-    public void deleteFeedbackSessionsForCourses(List<String> courseIds) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseIds);
+    /**
+     * Deletes sessions using {@link AttributesDeletionQuery}.
+     */
+    public void deleteFeedbackSessions(AttributesDeletionQuery query) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, query);
 
-        ofy().delete().keys(load().filter("courseId in", courseIds).keys()).now();
+        Query<FeedbackSession> entitiesToDelete = load().project();
+        if (query.isCourseIdPresent()) {
+            entitiesToDelete = entitiesToDelete.filter("courseId =", query.getCourseId());
+        }
+
+        deleteEntity(entitiesToDelete.keys().list().toArray(new Key<?>[0]));
     }
 
     private List<FeedbackSession> getFeedbackSessionEntitiesForCourse(String courseId) {
@@ -330,7 +343,7 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
     }
 
     private FeedbackSession getFeedbackSessionEntity(String feedbackSessionName, String courseId) {
-        return load().id(feedbackSessionName + "%" + courseId).now();
+        return load().id(FeedbackSession.generateId(feedbackSessionName, courseId)).now();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackSessionsDb.java
@@ -10,7 +10,6 @@ import com.googlecode.objectify.Key;
 import com.googlecode.objectify.VoidWork;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
@@ -354,13 +353,6 @@ public class FeedbackSessionsDb extends EntitiesDb<FeedbackSession, FeedbackSess
     @Override
     protected FeedbackSession getEntity(FeedbackSessionAttributes attributes) {
         return getFeedbackSessionEntity(attributes.getFeedbackSessionName(), attributes.getCourseId());
-    }
-
-    @Override
-    protected QueryKeys<FeedbackSession> getEntityQueryKeys(FeedbackSessionAttributes attributes) {
-        return load()
-                .filter("feedbackSessionName =", attributes.getFeedbackSessionName())
-                .filter("courseId =", attributes.getCourseId()).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -9,7 +9,6 @@ import com.google.appengine.api.search.Results;
 import com.google.appengine.api.search.ScoredDocument;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
@@ -372,14 +371,6 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
     @Override
     protected Instructor getEntity(InstructorAttributes instructorToGet) {
         return getInstructorEntityForEmail(instructorToGet.courseId, instructorToGet.email);
-    }
-
-    @Override
-    protected QueryKeys<Instructor> getEntityQueryKeys(InstructorAttributes attributes) {
-        return load()
-                .filter("courseId =", attributes.courseId)
-                .filter("email =", attributes.email)
-                .keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -7,9 +7,11 @@ import java.util.List;
 
 import com.google.appengine.api.search.Results;
 import com.google.appengine.api.search.ScoredDocument;
+import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.QueryKeys;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -273,6 +275,8 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
 
     /**
      * Deletes the instructor specified by courseId and email.
+     *
+     * <p>Fails silently if the student does not exist.
      */
     public void deleteInstructor(String courseId, String email) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, email);
@@ -284,48 +288,29 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
             return;
         }
 
-        InstructorAttributes instructorToDeleteAttributes = makeAttributes(instructorToDelete);
-
         deleteDocumentByEncryptedInstructorKey(StringHelper.encrypt(instructorToDelete.getRegistrationKey()));
-        deleteEntityDirect(instructorToDelete, instructorToDeleteAttributes);
 
-        Instructor instructorCheck = getInstructorEntityForEmail(courseId, email);
-        if (instructorCheck != null) {
-            putDocument(makeAttributes(instructorCheck));
-        }
-
-        //TODO: reuse the method in the parent class instead
-    }
-
-    public void deleteInstructorsForCourses(List<String> courseIds) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseIds);
-
-        deleteInstructors(getInstructorEntitiesForCourses(courseIds));
+        deleteEntity(Key.create(Instructor.class, instructorToDelete.getUniqueId()));
     }
 
     /**
-     * Deletes all instructors with the given googleId.
+     * Deletes instructors using {@link AttributesDeletionQuery}.
      */
-    public void deleteInstructorsForGoogleId(String googleId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, googleId);
+    public void deleteInstructors(AttributesDeletionQuery query) {
+        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, query);
 
-        deleteInstructors(getInstructorEntitiesForGoogleId(googleId));
-    }
+        if (query.isCourseIdPresent()) {
+            List<Instructor> instructorsToDelete =
+                    load().filter("courseId =", query.getCourseId()).project("registrationKey").list();
+            deleteDocument(Const.SearchIndex.INSTRUCTOR,
+                    instructorsToDelete.stream()
+                            .map(i -> StringHelper.encrypt(i.getRegistrationKey()))
+                            .toArray(String[]::new));
 
-    /**
-     * Deletes all instructors for the course specified by courseId.
-     */
-    public void deleteInstructorsForCourse(String courseId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
-
-        deleteInstructors(getInstructorEntitiesForCourse(courseId));
-    }
-
-    private void deleteInstructors(List<Instructor> instructors) {
-        for (Instructor instructor : instructors) {
-            deleteDocumentByEncryptedInstructorKey(StringHelper.encrypt(instructor.getRegistrationKey()));
+            deleteEntity(instructorsToDelete.stream()
+                    .map(s -> Key.create(Instructor.class, s.getUniqueId()))
+                    .toArray(Key[]::new));
         }
-        ofy().delete().entities(instructors).now();
     }
 
     private Instructor getInstructorEntityForGoogleId(String courseId, String googleId) {
@@ -343,11 +328,7 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
     }
 
     private Instructor getInstructorEntityById(String courseId, String email) {
-        return load().id(email + '%' + courseId).now();
-    }
-
-    private List<Instructor> getInstructorEntitiesForCourses(List<String> courseIds) {
-        return load().filter("courseId in", courseIds).list();
+        return load().id(Instructor.generateId(email, courseId)).now();
     }
 
     private List<Instructor> getInstructorEntitiesThatAreDisplayedInCourse(String courseId) {

--- a/src/main/java/teammates/storage/api/ProfilesDb.java
+++ b/src/main/java/teammates/storage/api/ProfilesDb.java
@@ -95,7 +95,9 @@ public class ProfilesDb extends EntitiesDb<StudentProfile, StudentProfileAttribu
         if (!sp.getPictureKey().equals("")) {
             deletePicture(sp.getPictureKey());
         }
-        deleteEntityDirect(sp);
+        Key<Account> parentKey = Key.create(Account.class, googleId);
+        Key<StudentProfile> profileKey = Key.create(parentKey, StudentProfile.class, googleId);
+        deleteEntity(profileKey);
     }
 
     /**

--- a/src/main/java/teammates/storage/api/ProfilesDb.java
+++ b/src/main/java/teammates/storage/api/ProfilesDb.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.common.exception.InvalidParametersException;
@@ -149,13 +148,6 @@ public class ProfilesDb extends EntitiesDb<StudentProfile, StudentProfileAttribu
     protected StudentProfile getEntity(StudentProfileAttributes attributes) {
         // this method is never used and is here only for future expansion and completeness
         return getStudentProfileEntityFromDb(attributes.googleId);
-    }
-
-    @Override
-    protected QueryKeys<StudentProfile> getEntityQueryKeys(StudentProfileAttributes attributes) {
-        Key<Account> parentKey = Key.create(Account.class, attributes.googleId);
-        Key<StudentProfile> childKey = Key.create(parentKey, StudentProfile.class, attributes.googleId);
-        return load().filterKey(childKey).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -12,6 +12,7 @@ import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
 import com.googlecode.objectify.cmd.QueryKeys;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.StudentSearchResultBundle;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -291,10 +292,9 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
     }
 
     /**
-     * Fails silently if no such student. <br>
-     * Preconditions: <br>
-     *  * All parameters are non-null.
+     * Deletes a student in a course with email.
      *
+     * <p>Fails silently if there is no such student.
      */
     public void deleteStudent(String courseId, String email) {
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
@@ -302,40 +302,25 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
 
         CourseStudent courseStudentToDelete = getCourseStudentEntityForEmail(courseId, email);
         if (courseStudentToDelete != null) {
-            StudentAttributes courseStudentToDeleteAttributes = makeAttributes(courseStudentToDelete);
             deleteDocumentByStudentKey(courseStudentToDelete.getRegistrationKey());
-            deleteEntityDirect(courseStudentToDelete, courseStudentToDeleteAttributes);
+            deleteEntity(Key.create(CourseStudent.class, courseStudentToDelete.getUniqueId()));
         }
     }
 
     /**
-     * Fails silently if no such student. <br>
-     * Preconditions: <br>
-     *  * All parameters are non-null.
-     *
+     * Deletes students using {@link AttributesDeletionQuery}.
      */
+    public void deleteStudents(AttributesDeletionQuery query) {
+        if (query.isCourseIdPresent()) {
+            List<CourseStudent> studentsToDelete =
+                    getCourseStudentsForCourseQuery(query.getCourseId()).project("registrationKey").list();
+            deleteDocument(Const.SearchIndex.STUDENT,
+                    studentsToDelete.stream().map(CourseStudent::getRegistrationKey).toArray(String[]::new));
 
-    public void deleteStudentsForGoogleId(String googleId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, googleId);
-        deleteStudentsCascadeDocuments(getCourseStudentEntitiesForGoogleId(googleId));
-    }
-
-    /**
-     * Fails silently if no such student or no such course. <br>
-     * Preconditions: <br>
-     *  * All parameters are non-null.
-     *
-     */
-
-    public void deleteStudentsForCourse(String courseId) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseId);
-        deleteStudentsCascadeDocuments(getCourseStudentEntitiesForCourse(courseId));
-    }
-
-    public void deleteStudentsForCourses(List<String> courseIds) {
-        Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, courseIds);
-
-        ofy().delete().keys(getCourseStudentsForCoursesQuery(courseIds).keys());
+            deleteEntity(studentsToDelete.stream()
+                    .map(s -> Key.create(CourseStudent.class, s.getUniqueId()))
+                    .toArray(Key[]::new));
+        }
     }
 
     private Query<CourseStudent> getCourseStudentForEmailQuery(String courseId, String email) {
@@ -345,7 +330,7 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
     }
 
     private CourseStudent getCourseStudentEntityForEmail(String courseId, String email) {
-        return load().id(email + '%' + courseId).now();
+        return load().id(CourseStudent.generateId(email, courseId)).now();
     }
 
     private CourseStudent getCourseStudentEntityForRegistrationKey(String registrationKey) {
@@ -373,10 +358,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
 
     public List<CourseStudent> getCourseStudentEntitiesForCourse(String courseId) {
         return getCourseStudentsForCourseQuery(courseId).list();
-    }
-
-    private Query<CourseStudent> getCourseStudentsForCoursesQuery(List<String> courseIds) {
-        return load().filter("courseId in", courseIds);
     }
 
     private Query<CourseStudent> getCourseStudentsForGoogleIdQuery(String googleId) {
@@ -423,16 +404,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
                         CourseStudent.generateId(entityToCreate.getEmail(), entityToCreate.getCourse())))
                 .list()
                 .isEmpty();
-    }
-
-    private void deleteStudentsCascadeDocuments(List<CourseStudent> students) {
-        List<StudentAttributes> studentsAttributes = new ArrayList<>();
-        for (CourseStudent student : students) {
-            StudentAttributes studentAttributes = makeAttributes(student);
-            studentsAttributes.add(studentAttributes);
-            deleteDocumentByStudentKey(student.getRegistrationKey());
-        }
-        deleteEntitiesDirect(students, studentsAttributes);
     }
 
     @Override

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -10,7 +10,6 @@ import com.google.appengine.api.search.ScoredDocument;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.LoadType;
 import com.googlecode.objectify.cmd.Query;
-import com.googlecode.objectify.cmd.QueryKeys;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.StudentSearchResultBundle;
@@ -323,12 +322,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
         }
     }
 
-    private Query<CourseStudent> getCourseStudentForEmailQuery(String courseId, String email) {
-        return load()
-                .filter("courseId =", courseId)
-                .filter("email =", email);
-    }
-
     private CourseStudent getCourseStudentEntityForEmail(String courseId, String email) {
         return load().id(CourseStudent.generateId(email, courseId)).now();
     }
@@ -390,11 +383,6 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
     @Override
     protected CourseStudent getEntity(StudentAttributes studentToGet) {
         return getCourseStudentEntityForEmail(studentToGet.course, studentToGet.email);
-    }
-
-    @Override
-    protected QueryKeys<CourseStudent> getEntityQueryKeys(StudentAttributes attributes) {
-        return getCourseStudentForEmailQuery(attributes.course, attributes.email).keys();
     }
 
     @Override

--- a/src/main/java/teammates/storage/search/SearchManager.java
+++ b/src/main/java/teammates/storage/search/SearchManager.java
@@ -209,8 +209,8 @@ public final class SearchManager {
     /**
      * Deletes document by documentId.
      */
-    public static void deleteDocument(String indexName, String documentId) {
-        getIndex(indexName).deleteAsync(documentId);
+    public static void deleteDocument(String indexName, String... documentIds) {
+        getIndex(indexName).deleteAsync(documentIds);
     }
 
     private static Index getIndex(String indexName) {

--- a/src/main/java/teammates/ui/webapi/action/DeleteAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteAccountAction.java
@@ -26,7 +26,7 @@ public class DeleteAccountAction extends Action {
     @Override
     public ActionResult execute() {
         String instructorId = getNonNullRequestParamValue(Const.ParamsNames.INSTRUCTOR_ID);
-        logic.deleteAccount(instructorId);
+        logic.deleteAccountCascade(instructorId);
         return new JsonResult("Account is successfully deleted.", HttpStatus.SC_OK);
     }
 

--- a/src/main/java/teammates/ui/webapi/action/DeleteAllInstructorSoftDeletedCoursesAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteAllInstructorSoftDeletedCoursesAction.java
@@ -1,6 +1,7 @@
 package teammates.ui.webapi.action;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -40,7 +41,14 @@ public class DeleteAllInstructorSoftDeletedCoursesAction extends Action {
 
         instructorList = logic.getInstructorsForGoogleId(userInfo.id);
 
-        logic.deleteAllCourses(instructorList);
+        List<String> softDeletedCourseIdList = instructorList.stream()
+                .filter(instructor -> logic.getCourse(instructor.courseId).isCourseDeleted())
+                .map(InstructorAttributes::getCourseId)
+                .collect(Collectors.toList());
+
+        for (String courseId : softDeletedCourseIdList) {
+            logic.deleteCourseCascade(courseId);
+        }
 
         String statusMessage = "All courses in Recycle Bin have been permanently deleted.";
         return new JsonResult(statusMessage);

--- a/src/main/java/teammates/ui/webapi/action/DeleteCourseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteCourseAction.java
@@ -29,7 +29,7 @@ public class DeleteCourseAction extends Action {
     public ActionResult execute() {
         String idOfCourseToDelete = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        logic.deleteCourse(idOfCourseToDelete);
+        logic.deleteCourseCascade(idOfCourseToDelete);
 
         return new JsonResult(new MessageOutput("OK"));
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteFeedbackQuestionAction.java
@@ -33,7 +33,7 @@ public class DeleteFeedbackQuestionAction extends Action {
     public ActionResult execute() {
         String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
 
-        logic.deleteFeedbackQuestion(feedbackQuestionId);
+        logic.deleteFeedbackQuestionCascade(feedbackQuestionId);
 
         return new JsonResult("Feedback question deleted!");
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseAction.java
@@ -78,7 +78,7 @@ public class DeleteFeedbackResponseAction extends BasicFeedbackSubmissionAction 
         String feedbackResponseId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_ID);
         FeedbackResponseAttributes feedbackResponse = logic.getFeedbackResponse(feedbackResponseId);
 
-        logic.deleteFeedbackResponse(feedbackResponse);
+        logic.deleteFeedbackResponseCascade(feedbackResponse.getId());
 
         return new JsonResult("Feedback response deleted");
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteFeedbackResponseCommentAction.java
@@ -88,8 +88,7 @@ public class DeleteFeedbackResponseCommentAction extends Action {
     public ActionResult execute() {
         long feedbackResponseCommentId = getLongRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID);
 
-        logic.deleteDocumentByCommentId(feedbackResponseCommentId);
-        logic.deleteFeedbackResponseCommentById(feedbackResponseCommentId);
+        logic.deleteFeedbackResponseComment(feedbackResponseCommentId);
 
         return new JsonResult("Successfully deleted feedback response comment.");
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteFeedbackSessionAction.java
@@ -29,7 +29,7 @@ public class DeleteFeedbackSessionAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 
-        logic.deleteFeedbackSession(feedbackSessionName, courseId);
+        logic.deleteFeedbackSessionCascade(feedbackSessionName, courseId);
 
         return new JsonResult("The feedback session is deleted.");
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteInstructorAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteInstructorAction.java
@@ -51,7 +51,7 @@ public class DeleteInstructorAction extends Action {
                     + "Deleting the last instructor from the course is not allowed.", HttpStatus.SC_BAD_REQUEST);
         }
 
-        logic.deleteInstructor(courseId, instructor.email);
+        logic.deleteInstructorCascade(courseId, instructor.email);
 
         return new JsonResult("Instructor is successfully deleted.", HttpStatus.SC_OK);
     }

--- a/src/main/java/teammates/ui/webapi/action/DeleteStudentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteStudentAction.java
@@ -50,7 +50,7 @@ public class DeleteStudentAction extends Action {
 
         // if student is not found, fail silently
         if (studentEmail != null) {
-            logic.deleteStudent(courseId, studentEmail);
+            logic.deleteStudentCascade(courseId, studentEmail);
         }
 
         return new JsonResult("Student is successfully deleted.", HttpStatus.SC_OK);

--- a/src/main/java/teammates/ui/webapi/action/DeleteStudentsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/DeleteStudentsAction.java
@@ -31,7 +31,7 @@ public class DeleteStudentsAction extends Action {
     public ActionResult execute() {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
 
-        logic.deleteAllStudentsInCourse(courseId);
+        logic.deleteStudentsInCourseCascade(courseId);
 
         return new JsonResult("All the students have been removed from the course", HttpStatus.SC_OK);
     }

--- a/src/main/java/teammates/ui/webapi/action/ResetAccountAction.java
+++ b/src/main/java/teammates/ui/webapi/action/ResetAccountAction.java
@@ -75,7 +75,7 @@ public class ResetAccountAction extends Action {
         if (wrongGoogleId != null
                 && logic.getStudentsForGoogleId(wrongGoogleId).isEmpty()
                 && logic.getInstructorsForGoogleId(wrongGoogleId).isEmpty()) {
-            logic.deleteAccount(wrongGoogleId);
+            logic.deleteAccountCascade(wrongGoogleId);
         }
 
         return new JsonResult("Account is successfully reset.", HttpStatus.SC_OK);

--- a/src/test/java/teammates/test/cases/datatransfer/AttributesDeletionQueryTest.java
+++ b/src/test/java/teammates/test/cases/datatransfer/AttributesDeletionQueryTest.java
@@ -1,0 +1,199 @@
+package teammates.test.cases.datatransfer;
+
+import org.testng.annotations.Test;
+
+import teammates.common.datatransfer.AttributesDeletionQuery;
+import teammates.test.cases.BaseTestCase;
+
+/**
+ * SUT: {@link AttributesDeletionQuery}.
+ */
+public class AttributesDeletionQueryTest extends BaseTestCase {
+
+    @Test
+    public void testBuilder_invalidCombination_shouldThrowException() {
+        // nothing inside query
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder().build();
+        });
+
+        // course id with question id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withQuestionId("questionId")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withQuestionId("questionId")
+                    .withCourseId("courseId")
+                    .build();
+        });
+
+        // course id with response id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withResponseId("responseId")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withResponseId("responseId")
+                    .withCourseId("courseId")
+                    .build();
+        });
+
+        // session name without course id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withFeedbackSessionName("sessionName")
+                    .build();
+        });
+
+        // session name with question id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withFeedbackSessionName("sessionName")
+                    .withQuestionId("questionId")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withQuestionId("questionId")
+                    .withFeedbackSessionName("sessionName")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withQuestionId("questionId")
+                    .withCourseId("courseId")
+                    .withFeedbackSessionName("sessionName")
+                    .build();
+        });
+
+        // session name with response id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withFeedbackSessionName("sessionName")
+                    .withResponseId("responseId")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId("courseId")
+                    .withResponseId("responseId")
+                    .withFeedbackSessionName("sessionName")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withResponseId("responseId")
+                    .withCourseId("courseId")
+                    .withFeedbackSessionName("sessionName")
+                    .build();
+        });
+
+        // question id with response id
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withQuestionId("questionId")
+                    .withResponseId("responseId")
+                    .build();
+        });
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withResponseId("responseId")
+                    .withQuestionId("questionId")
+                    .build();
+        });
+    }
+
+    @Test
+    public void testBuilder_validCombination_shouldBuildCorrectQuery() {
+        // build deletion of course
+        AttributesDeletionQuery query = AttributesDeletionQuery.builder()
+                .withCourseId("courseId")
+                .build();
+
+        assertEquals("courseId", query.getCourseId());
+        assertNull(query.getFeedbackSessionName());
+        assertNull(query.getQuestionId());
+        assertNull(query.getResponseId());
+        assertTrue(query.isCourseIdPresent());
+        assertFalse(query.isFeedbackSessionNamePresent());
+        assertFalse(query.isQuestionIdPresent());
+        assertFalse(query.isResponseIdPresent());
+
+        // build deletion of session
+        query = AttributesDeletionQuery.builder()
+                .withCourseId("courseId")
+                .withFeedbackSessionName("sessionName")
+                .build();
+        assertEquals("courseId", query.getCourseId());
+        assertEquals("sessionName", query.getFeedbackSessionName());
+        assertNull(query.getQuestionId());
+        assertNull(query.getResponseId());
+        assertTrue(query.isCourseIdPresent());
+        assertTrue(query.isFeedbackSessionNamePresent());
+        assertFalse(query.isQuestionIdPresent());
+        assertFalse(query.isResponseIdPresent());
+
+        // build deletion of question
+        query = AttributesDeletionQuery.builder()
+                .withQuestionId("questionId")
+                .build();
+        assertNull(query.getCourseId());
+        assertNull(query.getFeedbackSessionName());
+        assertEquals("questionId", query.getQuestionId());
+        assertNull(query.getResponseId());
+        assertFalse(query.isCourseIdPresent());
+        assertFalse(query.isFeedbackSessionNamePresent());
+        assertTrue(query.isQuestionIdPresent());
+        assertFalse(query.isResponseIdPresent());
+
+        // build deletion of response
+        query = AttributesDeletionQuery.builder()
+                .withResponseId("responseId")
+                .build();
+        assertNull(query.getCourseId());
+        assertNull(query.getFeedbackSessionName());
+        assertNull(query.getQuestionId());
+        assertEquals("responseId", query.getResponseId());
+        assertFalse(query.isCourseIdPresent());
+        assertFalse(query.isFeedbackSessionNamePresent());
+        assertFalse(query.isQuestionIdPresent());
+        assertTrue(query.isResponseIdPresent());
+    }
+
+    @Test
+    public void testBuilder_nullInput_shouldThrowException() {
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withCourseId(null)
+                    .build();
+        });
+
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withFeedbackSessionName(null)
+                    .build();
+        });
+
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withQuestionId(null)
+                    .build();
+        });
+
+        assertThrows(AssertionError.class, () -> {
+            AttributesDeletionQuery.builder()
+                    .withResponseId(null)
+                    .build();
+        });
+    }
+}

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -92,7 +92,6 @@ public class CoursesLogicTest extends BaseLogicTest {
         testMoveCourseToRecycleBin();
         testRestoreCourseFromRecycleBin();
         testRestoreAllCoursesFromRecycleBin();
-        testDeleteCourse();
         testDeleteAllCourses();
         testUpdateCourseCascade();
     }
@@ -1042,7 +1041,8 @@ public class CoursesLogicTest extends BaseLogicTest {
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
-    private void testDeleteCourse() {
+    @Test
+    public void testDeleteCourseCascade() {
 
         ______TS("typical case");
 

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -14,6 +14,9 @@ import teammates.common.datatransfer.CourseSummaryBundle;
 import teammates.common.datatransfer.TeamDetailsBundle;
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.CourseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
@@ -23,6 +26,9 @@ import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.logic.core.AccountsLogic;
 import teammates.logic.core.CoursesLogic;
+import teammates.logic.core.FeedbackQuestionsLogic;
+import teammates.logic.core.FeedbackResponseCommentsLogic;
+import teammates.logic.core.FeedbackResponsesLogic;
 import teammates.logic.core.InstructorsLogic;
 import teammates.logic.core.StudentsLogic;
 import teammates.storage.api.AccountsDb;
@@ -92,7 +98,6 @@ public class CoursesLogicTest extends BaseLogicTest {
         testMoveCourseToRecycleBin();
         testRestoreCourseFromRecycleBin();
         testRestoreAllCoursesFromRecycleBin();
-        testDeleteAllCourses();
         testUpdateCourseCascade();
     }
 
@@ -1044,6 +1049,10 @@ public class CoursesLogicTest extends BaseLogicTest {
     @Test
     public void testDeleteCourseCascade() {
 
+        ______TS("non-existent");
+
+        coursesLogic.deleteCourseCascade("not_exist");
+
         ______TS("typical case");
 
         CourseAttributes course1OfInstructor = dataBundle.courses.get("typicalCourse1");
@@ -1060,7 +1069,21 @@ public class CoursesLogicTest extends BaseLogicTest {
         verifyPresentInDatastore(dataBundle.students.get("student5InCourse1"));
         verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse1"));
         verifyPresentInDatastore(dataBundle.feedbackSessions.get("session2InCourse1"));
-        assertEquals(course1OfInstructor.getId(), studentInCourse.course);
+        verifyPresentInDatastore(dataBundle.feedbackQuestions.get("qn1InSession1InCourse1"));
+        FeedbackResponseAttributes typicalResponse = dataBundle.feedbackResponses.get("response1ForQ1S1C1");
+        FeedbackQuestionAttributes typicalQuestion =
+                FeedbackQuestionsLogic.inst()
+                        .getFeedbackQuestion(typicalResponse.feedbackSessionName, typicalResponse.courseId,
+                                Integer.parseInt(typicalResponse.feedbackQuestionId));
+        typicalResponse = FeedbackResponsesLogic.inst()
+                .getFeedbackResponse(typicalQuestion.getId(), typicalResponse.giver, typicalResponse.recipient);
+        verifyPresentInDatastore(typicalResponse);
+        FeedbackResponseCommentAttributes typicalComment =
+                dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");
+        typicalComment = FeedbackResponseCommentsLogic.inst()
+                .getFeedbackResponseComment(typicalResponse.getId(),
+                        typicalComment.commentGiver, typicalComment.createdAt);
+        verifyPresentInDatastore(typicalComment);
 
         coursesLogic.deleteCourseCascade(course1OfInstructor.getId());
 
@@ -1073,42 +1096,14 @@ public class CoursesLogicTest extends BaseLogicTest {
         verifyAbsentInDatastore(dataBundle.students.get("student5InCourse1"));
         verifyAbsentInDatastore(dataBundle.feedbackSessions.get("session1InCourse1"));
         verifyAbsentInDatastore(dataBundle.feedbackSessions.get("session2InCourse1"));
-
-        ______TS("non-existent");
-
-        // try to delete again. Should fail silently.
-        coursesLogic.deleteCourseCascade(course1OfInstructor.getId());
+        verifyAbsentInDatastore(dataBundle.feedbackQuestions.get("qn1InSession1InCourse1"));
+        verifyAbsentInDatastore(typicalQuestion);
+        verifyAbsentInDatastore(typicalResponse);
+        verifyAbsentInDatastore(typicalComment);
 
         ______TS("null parameter");
 
         AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.deleteCourseCascade(null));
-        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-    }
-
-    private void testDeleteAllCourses() {
-
-        ______TS("typical case");
-
-        InstructorAttributes instructor1OfCourse3 = dataBundle.instructors.get("instructor1OfCourse3");
-
-        List<InstructorAttributes> instructors = new ArrayList<>();
-        instructors.add(instructor1OfCourse3);
-
-        // Ensure there are entities in the datastore under this course
-        verifyPresentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
-        verifyPresentInDatastore(dataBundle.students.get("student1InCourse3"));
-        verifyPresentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
-
-        coursesLogic.deleteAllCoursesCascade(instructors);
-
-        // Ensure the course and related entities are deleted
-        verifyAbsentInDatastore(dataBundle.instructors.get("instructor1OfCourse3"));
-        verifyAbsentInDatastore(dataBundle.students.get("student1InCourse3"));
-        verifyAbsentInDatastore(dataBundle.feedbackSessions.get("session1InCourse3"));
-
-        ______TS("null parameter");
-
-        AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.deleteAllCoursesCascade(null));
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -119,7 +119,7 @@ public class CoursesLogicTest extends BaseLogicTest {
         assertEquals(c.getId(), coursesLogic.getCourse(c.getId()).getId());
         assertEquals(c.getName(), coursesLogic.getCourse(c.getId()).getName());
 
-        coursesDb.deleteEntity(c);
+        coursesDb.deleteCourse(c.getId());
         ______TS("Null parameter");
 
         AssertionError ae = assertThrows(AssertionError.class, () -> coursesLogic.getCourse(null));

--- a/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackQuestionsLogicTest.java
@@ -8,8 +8,10 @@ import java.util.Map;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
+import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
@@ -28,10 +30,10 @@ import teammates.logic.core.FeedbackSessionsLogic;
  */
 public class FeedbackQuestionsLogicTest extends BaseLogicTest {
 
-    private static FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
     private static FeedbackQuestionsLogic fqLogic = FeedbackQuestionsLogic.inst();
     private static FeedbackResponsesLogic frLogic = FeedbackResponsesLogic.inst();
     private static FeedbackResponseCommentsLogic frcLogic = FeedbackResponseCommentsLogic.inst();
+    private static FeedbackSessionsLogic fsLogic = FeedbackSessionsLogic.inst();
 
     @Override
     protected void prepareTestData() {
@@ -45,49 +47,27 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testDeleteFeedbackQuestionsCascadeForSession_correspondingSessionNotInRecycleBin_shouldDoCascadeDeletion() {
-        FeedbackSessionAttributes fsa = dataBundle.feedbackSessions.get("session1InCourse1");
-        assertNotNull(fsLogic.getFeedbackSession(fsa.getFeedbackSessionName(), fsa.getCourseId()));
-        assertNull(fsLogic.getFeedbackSessionFromRecycleBin(fsa.getFeedbackSessionName(), fsa.getCourseId()));
-        assertFalse(
-                fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertFalse(
-                frLogic.getFeedbackResponsesForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertFalse(
-                frcLogic.getFeedbackResponseCommentForSession(fsa.getCourseId(), fsa.getFeedbackSessionName()).isEmpty());
-
-        fqLogic.deleteFeedbackQuestionsCascadeForSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
-
-        assertTrue(
-                fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertTrue(
-                frLogic.getFeedbackResponsesForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertTrue(
-                frcLogic.getFeedbackResponseCommentForSession(fsa.getCourseId(), fsa.getFeedbackSessionName()).isEmpty());
-    }
-
-    @Test
-    public void testDeleteFeedbackQuestionsCascadeForSession_correspondingSessionInRecycleBin_shouldDoCascadeDeletion()
-            throws InvalidParametersException, EntityDoesNotExistException {
+    public void testDeleteFeedbackQuestions_byCourseIdAndSessionName_shouldDeleteQuestions() {
         FeedbackSessionAttributes fsa = dataBundle.feedbackSessions.get("session1InCourse1");
         assertFalse(
                 fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
+        FeedbackSessionAttributes anotherFsa = dataBundle.feedbackSessions.get("session2InCourse1");
         assertFalse(
-                frLogic.getFeedbackResponsesForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertFalse(
-                frcLogic.getFeedbackResponseCommentForSession(fsa.getCourseId(), fsa.getFeedbackSessionName()).isEmpty());
-        fsLogic.moveFeedbackSessionToRecycleBin(fsa.getFeedbackSessionName(), fsa.getCourseId());
-        assertNull(fsLogic.getFeedbackSession(fsa.getFeedbackSessionName(), fsa.getCourseId()));
-        assertNotNull(fsLogic.getFeedbackSessionFromRecycleBin(fsa.getFeedbackSessionName(), fsa.getCourseId()));
+                fqLogic.getFeedbackQuestionsForSession(anotherFsa.getFeedbackSessionName(), anotherFsa.getCourseId())
+                        .isEmpty());
 
-        fqLogic.deleteFeedbackQuestionsCascadeForSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
+        fqLogic.deleteFeedbackQuestions(AttributesDeletionQuery.builder()
+                .withCourseId(fsa.getCourseId())
+                .withFeedbackSessionName(fsa.getFeedbackSessionName())
+                .build());
 
         assertTrue(
                 fqLogic.getFeedbackQuestionsForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertTrue(
-                frLogic.getFeedbackResponsesForSession(fsa.getFeedbackSessionName(), fsa.getCourseId()).isEmpty());
-        assertTrue(
-                frcLogic.getFeedbackResponseCommentForSession(fsa.getCourseId(), fsa.getFeedbackSessionName()).isEmpty());
+        // other sessions are not affected
+        assertFalse(
+                fqLogic.getFeedbackQuestionsForSession(anotherFsa.getFeedbackSessionName(), anotherFsa.getCourseId())
+                        .isEmpty());
+
     }
 
     @Test
@@ -98,8 +78,6 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         testIsQuestionHasResponses();
         testIsQuestionAnswered();
         testAddQuestion();
-        testDeleteQuestion();
-        testDeleteQuestionsForCourse();
     }
 
     private void testGetRecipientsForQuestion() throws Exception {
@@ -449,19 +427,77 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
                 ipe.getMessage());
     }
 
-    private void testDeleteQuestion() {
-        //Success case already tested in update
-        ______TS("question already does not exist, silently fail");
+    @Test
+    public void testDeleteFeedbackQuestionCascade_existentQuestion_shouldDoCascadeDeletion() {
+        FeedbackQuestionAttributes typicalQuestion = getQuestionFromDatastore("qn3InSession1InCourse1");
+        assertEquals(3, typicalQuestion.getQuestionNumber());
+        assertEquals(4, getQuestionFromDatastore("qn4InSession1InCourse1").getQuestionNumber());
 
-        fqLogic.deleteFeedbackQuestionCascade("non-existent-question-id");
-        //No error should be thrown.
+        // the question has some responses and comments
+        assertFalse(frLogic.getFeedbackResponsesForQuestion(typicalQuestion.getId()).isEmpty());
+        assertFalse(
+                frcLogic.getFeedbackResponseCommentForSession(
+                        typicalQuestion.getCourseId(), typicalQuestion.getFeedbackSessionName()).stream()
+                        .noneMatch(comment -> comment.feedbackQuestionId.equals(typicalQuestion.getId())));
 
+        fqLogic.deleteFeedbackQuestionCascade(typicalQuestion.getId());
+
+        assertNull(logic.getFeedbackQuestion(typicalQuestion.getId()));
+        // the responses and comments should gone
+        assertTrue(frLogic.getFeedbackResponsesForQuestion(typicalQuestion.getId()).isEmpty());
+        assertTrue(
+                frcLogic.getFeedbackResponseCommentForSession(
+                        typicalQuestion.getCourseId(), typicalQuestion.getFeedbackSessionName()).stream()
+                        .noneMatch(comment -> comment.feedbackQuestionId.equals(typicalQuestion.getId())));
+
+        // verify that questions are shifted
+        List<FeedbackQuestionAttributes> questionsOfSessions =
+                logic.getFeedbackQuestionsForSession(
+                        typicalQuestion.getFeedbackSessionName(), typicalQuestion.getCourseId());
+        for (int i = 1; i <= questionsOfSessions.size(); i++) {
+            assertEquals(i, questionsOfSessions.get(i - 1).getQuestionNumber());
+        }
     }
 
-    private void testDeleteQuestionsForCourse() throws EntityDoesNotExistException {
-        ______TS("standard case");
+    @Test
+    public void testDeleteFeedbackQuestionCascade_nonExistentQuestion_shouldFailSilently() {
+        fqLogic.deleteFeedbackQuestionCascade("non-existent-question-id");
 
-        // test that questions are deleted
+        // other questions not get affected
+        assertNotNull(getQuestionFromDatastore("qn3InSession1InCourse1"));
+    }
+
+    @Test
+    public void testDeleteFeedbackQuestionCascade_cascadeDeleteResponseOfStudent_shouldUpdateRespondents() throws Exception {
+        FeedbackResponseAttributes fra = dataBundle.feedbackResponses.get("response1ForQ1S1C1");
+        FeedbackQuestionAttributes fqa =
+                fqLogic.getFeedbackQuestion(fra.feedbackSessionName, fra.courseId, Integer.parseInt(fra.feedbackQuestionId));
+        FeedbackResponseAttributes responseInDb = frLogic.getFeedbackResponse(fqa.getId(), fra.giver, fra.recipient);
+        assertNotNull(responseInDb);
+
+        // the student only gives this response for the session
+        assertEquals(1, frLogic.getFeedbackResponsesFromGiverForCourse(responseInDb.courseId, responseInDb.giver).stream()
+                .filter(response -> response.feedbackSessionName.equals(responseInDb.feedbackSessionName))
+                .count());
+        // suppose he is in the respondents list
+        fsLogic.addStudentRespondent(responseInDb.giver, responseInDb.feedbackSessionName, responseInDb.courseId);
+        FeedbackSessionAttributes correspondingSession =
+                fsLogic.getFeedbackSession(responseInDb.feedbackSessionName, responseInDb.courseId);
+        assertTrue(correspondingSession.getRespondingStudentList().contains(responseInDb.giver));
+
+        // after deletion the question
+        fqLogic.deleteFeedbackQuestionCascade(responseInDb.feedbackQuestionId);
+
+        FeedbackSessionAttributes sessionAfter =
+                fsLogic.getFeedbackSession(responseInDb.feedbackSessionName, responseInDb.courseId);
+        // instructor respondents will not change
+        assertEquals(correspondingSession.getRespondingInstructorList(), sessionAfter.getRespondingInstructorList());
+        // the student should not in the respondents
+        assertFalse(sessionAfter.getRespondingStudentList().contains(responseInDb.giver));
+    }
+
+    @Test
+    public void testDeleteFeedbackQuestions_byCourseId_shouldDeleteQuestions() {
         String courseId = "idOfTypicalCourse2";
         FeedbackQuestionAttributes deletedQuestion = getQuestionFromDatastore("qn1InSession1InCourse2");
         assertNotNull(deletedQuestion);
@@ -470,7 +506,9 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
                 fqLogic.getFeedbackQuestionsForSession("Instructor feedback session", courseId);
         assertFalse(questions.isEmpty());
 
-        fqLogic.deleteFeedbackQuestionsForCourse(courseId);
+        fqLogic.deleteFeedbackQuestions(AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build());
         deletedQuestion = getQuestionFromDatastore("qn1InSession1InCourse2");
         assertNull(deletedQuestion);
 

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponseCommentsLogicTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
@@ -235,35 +236,40 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testDeleteFeedbackResponseCommentById() throws Exception {
+    public void testDeleteFeedbackResponseComment() throws Exception {
+        FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
+        FeedbackResponseCommentAttributes actualFrComment =
+                frcLogic.getFeedbackResponseCommentForSession(
+                        frComment.courseId, frComment.feedbackSessionName).get(1);
 
         ______TS("silent fail nothing to delete");
 
         assertNull(frcLogic.getFeedbackResponseComment(1234567L));
-        frcLogic.deleteFeedbackResponseCommentById(1234567L);
+        frcLogic.deleteFeedbackResponseComment(1234567L);
 
         ______TS("typical success case");
-        FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q1S1C1");
-        FeedbackResponseCommentAttributes actualFrComment =
-                frcLogic.getFeedbackResponseCommentForSession(
-                                 frComment.courseId, frComment.feedbackSessionName).get(1);
-        frcLogic.deleteFeedbackResponseCommentById(actualFrComment.getId());
+
+        verifyPresentInDatastore(actualFrComment);
+        frcLogic.deleteFeedbackResponseComment(actualFrComment.getId());
         verifyAbsentInDatastore(actualFrComment);
     }
 
     @Test
-    public void testDeleteFeedbackResponseCommentsForResponse() {
+    public void testDeleteFeedbackResponseComments_deleteByResponseId() {
 
         ______TS("typical success case");
 
         FeedbackResponseCommentAttributes frComment = restoreFrCommentFromDataBundle("comment1FromT1C1ToR1Q3S1C1");
         verifyPresentInDatastore(frComment);
-        frcLogic.deleteFeedbackResponseCommentsForResponse(frComment.feedbackResponseId);
+        frcLogic.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withResponseId(frComment.feedbackResponseId)
+                        .build());
         verifyAbsentInDatastore(frComment);
     }
 
     @Test
-    public void testDeleteFeedbackResponseCommentFromCourse() {
+    public void testDeleteFeedbackResponseComments_deleteByCourseId() {
 
         ______TS("typical case");
         String courseId = "idOfTypicalCourse1";
@@ -272,7 +278,10 @@ public class FeedbackResponseCommentsLogicTest extends BaseLogicTest {
                 frcLogic.getFeedbackResponseCommentForSession(courseId, "First feedback session");
         assertFalse(frcList.isEmpty());
 
-        frcLogic.deleteFeedbackResponseCommentsForCourse(courseId);
+        frcLogic.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(courseId)
+                        .build());
 
         frcList = frcLogic.getFeedbackResponseCommentForSession(courseId, "First feedback session");
         assertEquals(0, frcList.size());

--- a/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackResponsesLogicTest.java
@@ -696,7 +696,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         Set<String> instructorRespondentsBefore =
                 fsLogic.getFeedbackSession(fra.feedbackSessionName, fra.courseId).getRespondingInstructorList();
 
-        frLogic.deleteFeedbackResponsesForQuestionCascade(fra.feedbackQuestionId, true);
+        frLogic.deleteFeedbackResponsesForQuestionCascade(fra.feedbackQuestionId);
 
         Set<String> studentRespondentsAfter =
                 fsLogic.getFeedbackSession(fra.feedbackSessionName, fra.courseId).getRespondingStudentList();
@@ -726,7 +726,7 @@ public class FeedbackResponsesLogicTest extends BaseLogicTest {
         Set<String> studentRespondentsBefore =
                 fsLogic.getFeedbackSession(fra.feedbackSessionName, fra.courseId).getRespondingStudentList();
 
-        frLogic.deleteFeedbackResponsesForQuestionCascade(fra.feedbackQuestionId, true);
+        frLogic.deleteFeedbackResponsesForQuestionCascade(fra.feedbackQuestionId);
 
         Set<String> studentRespondentsAfter =
                 fsLogic.getFeedbackSession(fra.feedbackSessionName, fra.courseId).getRespondingStudentList();

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackSessionDetailsBundle;
@@ -120,6 +121,142 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
+    public void testDeleteFeedbackSessions_byCourseId_shouldDeleteAllSessionsUnderCourse() {
+        FeedbackSessionAttributes session1InCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        assertNotNull(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId()));
+        FeedbackSessionAttributes session2InCourse1 = dataBundle.feedbackSessions.get("session2InCourse1");
+        assertNotNull(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId()));
+        // they are in the same course
+        assertEquals(session1InCourse1.getCourseId(), session2InCourse1.getCourseId());
+        FeedbackSessionAttributes session1InCourse2 = dataBundle.feedbackSessions.get("session1InCourse2");
+        assertNotNull(
+                fsLogic.getFeedbackSession(session1InCourse2.getFeedbackSessionName(), session1InCourse2.getCourseId()));
+
+        // delete all session under the course
+        fsLogic.deleteFeedbackSessions(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(session1InCourse1.getCourseId())
+                        .build());
+
+        // they should gone
+        assertNull(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId()));
+        assertNull(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId()));
+        // sessions in different courses should not be affected
+        assertNotNull(
+                fsLogic.getFeedbackSession(session1InCourse2.getFeedbackSessionName(), session1InCourse2.getCourseId()));
+    }
+
+    @Test
+    public void testDeleteInstructorFromRespondentsList_typicalData_emailShouldBeRemoved() throws Exception {
+        FeedbackSessionAttributes session1InCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        fsLogic.addInstructorRespondent("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+        FeedbackSessionAttributes session2InCourse1 = dataBundle.feedbackSessions.get("session2InCourse1");
+        fsLogic.addInstructorRespondent("test@email.com",
+                session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId());
+        // they are in the same course
+        assertEquals(session1InCourse1.getCourseId(), session2InCourse1.getCourseId());
+        assertTrue(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+        assertTrue(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+
+        // remove email from all respondents list
+        fsLogic.deleteInstructorFromRespondentsList(session1InCourse1.getCourseId(), "test@email.com");
+
+        // the email should not appear
+        assertFalse(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+        assertFalse(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+    }
+
+    @Test
+    public void testDeleteStudentFromRespondentsList_typicalData_emailShouldBeRemoved() throws Exception {
+        FeedbackSessionAttributes session1InCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        fsLogic.addStudentRespondent("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+        FeedbackSessionAttributes session2InCourse1 = dataBundle.feedbackSessions.get("session2InCourse1");
+        fsLogic.addStudentRespondent("test@email.com",
+                session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId());
+        // they are in the same course
+        assertEquals(session1InCourse1.getCourseId(), session2InCourse1.getCourseId());
+        assertTrue(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+        assertTrue(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+
+        // remove email from all respondents list
+        fsLogic.deleteStudentFromRespondentsList(session1InCourse1.getCourseId(), "test@email.com");
+
+        // the email should not appear
+        assertFalse(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+        assertFalse(
+                fsLogic.getFeedbackSession(session2InCourse1.getFeedbackSessionName(), session2InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+    }
+
+    @Test
+    public void testDeleteInstructorRespondent_typicalData_shouldRemoveFromRespondentList() throws Exception {
+        FeedbackSessionAttributes session1InCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        fsLogic.addInstructorRespondent("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+        assertTrue(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+
+        // delete the instructor from the list
+        fsLogic.deleteInstructorRespondent("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+
+        assertFalse(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingInstructorList()
+                        .contains("test@email.com"));
+    }
+
+    @Test
+    public void testDeleteStudentRespondent_typicalData_shouldRemoveFromRespondentList() throws Exception {
+        FeedbackSessionAttributes session1InCourse1 = dataBundle.feedbackSessions.get("session1InCourse1");
+        fsLogic.addStudentRespondent("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+        assertTrue(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+
+        // delete the student from the list
+        fsLogic.deleteStudentFromRespondentList("test@email.com",
+                session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId());
+
+        assertFalse(
+                fsLogic.getFeedbackSession(session1InCourse1.getFeedbackSessionName(), session1InCourse1.getCourseId())
+                        .getRespondingStudentList()
+                        .contains("test@email.com"));
+    }
+
+    @Test
     public void testFeedbackSessionNotification() throws Exception {
         testGetFeedbackSessionsClosingWithinTimeLimit();
         testGetFeedbackSessionsClosedWithinThePastHour();
@@ -154,7 +291,6 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
         testMoveFeedbackSessionToRecycleBin();
         testRestoreFeedbackSessionFromRecycleBin();
         testRestoreAllFeedbackSessionsFromRecycleBin();
-        testDeleteFeedbackSessionsForCourse();
     }
 
     private void testGetFeedbackSessionsListForInstructor() {
@@ -1672,50 +1808,6 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
             verifyPresentInDatastore(fsa);
             assertFalse(fsa.isSessionDeleted());
         }
-    }
-
-    private void testDeleteFeedbackSessionsForCourse() {
-
-        assertFalse(fsLogic.getFeedbackSessionsForCourse("idOfTypicalCourse1").isEmpty());
-        fsLogic.deleteFeedbackSessionsForCourseCascade("idOfTypicalCourse1");
-        assertTrue(fsLogic.getFeedbackSessionsForCourse("idOfTypicalCourse1").isEmpty());
-    }
-
-    @Test
-    public void testDeleteAllFeedbackSessionsCascade_shouldDoCascadeDeletionCorrectly()
-            throws InvalidParametersException, EntityDoesNotExistException {
-        InstructorAttributes instructor = dataBundle.instructors.get("instructor1OfCourse1");
-        List<InstructorAttributes> instructors = new ArrayList<>();
-        instructors.add(instructor);
-
-        String feedbackSessionName1 = dataBundle.feedbackSessions.get("session1InCourse1").getFeedbackSessionName();
-        String feedbackSessionName2 = dataBundle.feedbackSessions.get("session2InCourse1").getFeedbackSessionName();
-        String courseId = dataBundle.courses.get("typicalCourse1").getId();
-        assertFalse(fqLogic.getFeedbackQuestionsForSession(feedbackSessionName1, courseId).isEmpty());
-        assertFalse(fqLogic.getFeedbackQuestionsForSession(feedbackSessionName2, courseId).isEmpty());
-        assertFalse(frLogic.getFeedbackResponsesForSession(feedbackSessionName1, courseId).isEmpty());
-        assertFalse(frLogic.getFeedbackResponsesForSession(feedbackSessionName2, courseId).isEmpty());
-        assertFalse(frcLogic.getFeedbackResponseCommentForSession(courseId, feedbackSessionName1).isEmpty());
-        fsLogic.moveFeedbackSessionToRecycleBin(feedbackSessionName1, courseId);
-        fsLogic.moveFeedbackSessionToRecycleBin(feedbackSessionName2, courseId);
-        assertNull(fsLogic.getFeedbackSession(feedbackSessionName1, courseId));
-        assertNull(fsLogic.getFeedbackSession(feedbackSessionName2, courseId));
-        assertNotNull(fsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName1, courseId));
-        assertNotNull(fsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName2, courseId));
-        assertEquals(2, fsLogic.getSoftDeletedFeedbackSessionsListForInstructors(instructors).size());
-
-        fsLogic.deleteAllFeedbackSessionsCascade(instructors);
-
-        assertNull(fsLogic.getFeedbackSession(feedbackSessionName1, courseId));
-        assertNull(fsLogic.getFeedbackSession(feedbackSessionName2, courseId));
-        assertNull(fsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName1, courseId));
-        assertNull(fsLogic.getFeedbackSessionFromRecycleBin(feedbackSessionName2, courseId));
-        assertTrue(fqLogic.getFeedbackQuestionsForSession(feedbackSessionName1, courseId).isEmpty());
-        assertTrue(fqLogic.getFeedbackQuestionsForSession(feedbackSessionName2, courseId).isEmpty());
-        assertTrue(frLogic.getFeedbackResponsesForSession(feedbackSessionName1, courseId).isEmpty());
-        assertTrue(frLogic.getFeedbackResponsesForSession(feedbackSessionName2, courseId).isEmpty());
-        assertTrue(frcLogic.getFeedbackResponseCommentForSession(courseId, feedbackSessionName1).isEmpty());
-        assertTrue(frcLogic.getFeedbackResponseCommentForSession(courseId, feedbackSessionName2).isEmpty());
     }
 
 }

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -67,7 +67,7 @@ public class FeedbackSessionsLogicTest extends BaseLogicTest {
     }
 
     @Test
-    public void testDeleteFeedbackSessionCascade_deleteDirectly_shouldDoCascadeDeletion()
+    public void testDeleteFeedbackSessionCascade_deleteSessionNotInRecycleBin_shouldDoCascadeDeletion()
             throws EntityDoesNotExistException {
         FeedbackSessionAttributes fsa = dataBundle.feedbackSessions.get("session1InCourse1");
         assertNotNull(fsLogic.getFeedbackSession(fsa.getFeedbackSessionName(), fsa.getCourseId()));

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -682,7 +682,7 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
         AssertionError ae = assertThrows(AssertionError.class,
                 () -> instructorsLogic.deleteInstructorCascade(courseId, null));
-        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
+        AssertHelper.assertContains(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
 
         ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructorCascade(null, email));
         AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());

--- a/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/InstructorsLogicTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
@@ -66,9 +67,6 @@ public class InstructorsLogicTest extends BaseLogicTest {
         testGetCoOwnersForCourse();
         testUpdateInstructorByGoogleIdCascade();
         testUpdateInstructorByEmail();
-        testDeleteInstructor();
-        testDeleteInstructorsForGoogleId();
-        testDeleteInstructorsForCourse();
     }
 
     private void testAddInstructor() throws Exception {
@@ -661,85 +659,148 @@ public class InstructorsLogicTest extends BaseLogicTest {
 
     }
 
-    private void testDeleteInstructor() throws Exception {
-
-        ______TS("typical case: delete an instructor for specific course");
+    @Test
+    public void testDeleteInstructorCascade() throws Exception {
 
         String courseId = "idOfTypicalCourse1";
-        String email = "instructor3@course1.tmt";
-
-        InstructorAttributes instructorDeleted = instructorsLogic.getInstructorForEmail(courseId, email);
-
-        instructorsLogic.deleteInstructorCascade(courseId, email);
-
-        verifyAbsentInDatastore(instructorDeleted);
+        String email = "instructor1@course1.tmt";
 
         ______TS("typical case: delete a non-existent instructor");
 
         instructorsLogic.deleteInstructorCascade(courseId, "non-existent@course1.tmt");
 
+        ______TS("typical case: delete an instructor for specific course");
+
+        InstructorAttributes instructorDeleted = instructorsLogic.getInstructorForEmail(courseId, email);
+        assertNotNull(instructorDeleted);
+        // the instructors has some responses in course
+        assertFalse(FeedbackResponsesLogic.inst().getFeedbackResponsesFromGiverForCourse(courseId, email).isEmpty());
+        assertFalse(FeedbackResponsesLogic.inst().getFeedbackResponsesForReceiverForCourse(courseId, email).isEmpty());
+
+        instructorsLogic.deleteInstructorCascade(courseId, email);
+
+        verifyAbsentInDatastore(instructorDeleted);
+        // there should be no response of the instructor
+        assertTrue(FeedbackResponsesLogic.inst().getFeedbackResponsesFromGiverForCourse(courseId, email).isEmpty());
+        assertTrue(FeedbackResponsesLogic.inst().getFeedbackResponsesForReceiverForCourse(courseId, email).isEmpty());
+
         ______TS("failure: null parameter");
 
         AssertionError ae = assertThrows(AssertionError.class,
                 () -> instructorsLogic.deleteInstructorCascade(courseId, null));
-        AssertHelper.assertContains(Const.StatusCodes.NULL_PARAMETER, ae.getMessage());
+        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
         ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructorCascade(null, email));
         AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
-
-        // restore deleted instructor
-        instructorsLogic.createInstructor(instructorDeleted);
     }
 
-    private void testDeleteInstructorsForGoogleId() throws Exception {
-        ______TS("typical case: delete all instructors for a given googleId");
+    @Test
+    public void testDeleteInstructors_byCourseId_shouldDeleteInstructorsAssociatedWithTheCourse() {
 
-        String googleId = "idOfInstructor1";
+        ______TS("typical case: delete all instructors for a non-existent course");
 
-        List<InstructorAttributes> instructors = instructorsLogic.getInstructorsForGoogleId(googleId);
-
-        instructorsLogic.deleteInstructorsForGoogleIdAndCascade(googleId);
-
-        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(googleId);
-        assertTrue(instructorList.isEmpty());
-
-        ______TS("typical case: delete an non-existent googleId");
-
-        instructorsLogic.deleteInstructorsForGoogleIdAndCascade("non-existent");
-
-        ______TS("failure: null parameter");
-
-        AssertionError ae = assertThrows(AssertionError.class,
-                () -> instructorsLogic.deleteInstructorsForGoogleIdAndCascade(null));
-        AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
-
-        // restore deleted instructors
-        for (InstructorAttributes instructor : instructors) {
-            instructorsLogic.createInstructor(instructor);
-        }
-    }
-
-    private void testDeleteInstructorsForCourse() {
+        instructorsLogic.deleteInstructors(AttributesDeletionQuery.builder()
+                .withCourseId("non-existent")
+                .build());
 
         ______TS("typical case: delete all instructors of a given course");
 
         String courseId = "idOfTypicalCourse1";
 
-        instructorsLogic.deleteInstructorsForCourse(courseId);
+        // the course is not empty at the beginning
+        assertFalse(instructorsLogic.getInstructorsForCourse(courseId).isEmpty());
+
+        instructorsLogic.deleteInstructors(AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build());
 
         List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForCourse(courseId);
-
         assertTrue(instructorList.isEmpty());
 
-        ______TS("typical case: delete all instructors for a non-existent course");
-
-        instructorsLogic.deleteInstructorsForCourse("non-existent");
+        // other course is not affected
+        assertFalse(instructorsLogic.getInstructorsForCourse("idOfTypicalCourse2").isEmpty());
 
         ______TS("failure case: null parameter");
 
-        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructorsForCourse(null));
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsLogic.deleteInstructors(null));
         AssertHelper.assertContains("Supplied parameter was null", ae.getMessage());
 
+    }
+
+    @Test
+    public void testDeleteInstructorsForGoogleIdCascade_archivedInstructor_shouldDeleteAlso() throws Exception {
+        InstructorAttributes instructor5 = dataBundle.instructors.get("instructor5");
+
+        assertNotNull(instructor5.getGoogleId());
+        logic.setArchiveStatusOfInstructor(instructor5.getGoogleId(), instructor5.getCourseId(), true);
+
+        // this is an archived instructor
+        assertTrue(
+                logic.getInstructorForEmail(instructor5.getCourseId(), instructor5.getEmail()).isArchived);
+
+        instructorsLogic.deleteInstructorsForGoogleIdCascade(instructor5.getGoogleId());
+
+        // the instructor should be deleted also
+        assertNull(instructorsLogic.getInstructorForEmail(instructor5.getCourseId(), instructor5.getEmail()));
+    }
+
+    @Test
+    public void testDeleteInstructorsForGoogleIdCascade() throws Exception {
+
+        ______TS("typical case: delete non-existent googleId");
+
+        instructorsLogic.deleteInstructorsForGoogleIdCascade("not_exist");
+
+        ______TS("typical case: delete all instructors of a given googleId");
+
+        InstructorAttributes instructor1OfCourse1 = dataBundle.instructors.get("instructor1OfCourse1");
+        InstructorAttributes instructor1OfCourse2 = dataBundle.instructors.get("instructor1OfCourse2");
+        // make instructor1OfCourse1 to have the same googleId with instructor1OfCourse2
+        logic.updateInstructor(
+                InstructorAttributes
+                        .updateOptionsWithEmailBuilder(instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail())
+                        .withGoogleId(instructor1OfCourse2.getGoogleId())
+                        .build());
+
+        instructor1OfCourse1 = instructorsLogic.getInstructorForEmail(
+                instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail());
+        assertNotNull(instructor1OfCourse1);
+
+        // instructor1OfCourse1 has some responses in course
+        assertFalse(
+                FeedbackResponsesLogic.inst().getFeedbackResponsesFromGiverForCourse(
+                        instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail())
+                .isEmpty());
+        assertFalse(
+                FeedbackResponsesLogic.inst().getFeedbackResponsesForReceiverForCourse(
+                        instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail())
+                .isEmpty());
+
+        instructor1OfCourse2 = instructorsLogic.getInstructorForEmail(
+                instructor1OfCourse2.getCourseId(), instructor1OfCourse2.getEmail());
+        assertNotNull(instructor1OfCourse2);
+
+        // the two instructors have the same googleId but in different courses
+        assertEquals(instructor1OfCourse1.getGoogleId(), instructor1OfCourse2.getGoogleId());
+        assertNotEquals(instructor1OfCourse1.getCourseId(), instructor1OfCourse2.getCourseId());
+
+        // delete instructors for google ID
+        instructorsLogic.deleteInstructorsForGoogleIdCascade(instructor1OfCourse1.getGoogleId());
+
+        // the two instructors should gone
+        assertNull(instructorsLogic.getInstructorForEmail(
+                instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail()));
+        // instructor1OfCourse1's responses should be deleted also
+        assertTrue(
+                FeedbackResponsesLogic.inst().getFeedbackResponsesFromGiverForCourse(
+                        instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail())
+                .isEmpty());
+        assertTrue(
+                FeedbackResponsesLogic.inst().getFeedbackResponsesForReceiverForCourse(
+                        instructor1OfCourse1.getCourseId(), instructor1OfCourse1.getEmail())
+                .isEmpty());
+        assertNull(instructorsLogic.getInstructorForEmail(
+                instructor1OfCourse2.getCourseId(), instructor1OfCourse2.getEmail()));
     }
 
     private void verifySameInstructor(InstructorAttributes instructor1, InstructorAttributes instructor2) {

--- a/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/FeedbackResponseCommentSearchTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.FeedbackParticipantType;
 import teammates.common.datatransfer.FeedbackResponseCommentSearchResultBundle;
 import teammates.common.datatransfer.attributes.FeedbackQuestionAttributes;
@@ -184,5 +185,31 @@ public class FeedbackResponseCommentSearchTest extends BaseSearchTest {
         assertEquals(1, bundle.numberOfResults);
         assertEquals("commentABCDE",
                 bundle.comments.get(response1ForQ1S1C1.getId()).get(0).getCommentText());
+    }
+
+    @Test
+    public void testSearchComment_commentsDeletedByBatch_shouldReturnNoResult() {
+        // perform normal search
+        FeedbackResponseCommentAttributes frc1I3Q1S2C2 =
+                dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S2C2");
+        List<InstructorAttributes> instructors = new ArrayList<>();
+        instructors.add(dataBundle.instructors.get("instructor3OfCourse2"));
+        FeedbackResponseCommentSearchResultBundle bundle =
+                commentsDb.search("\"Instructor 3 comment to instr1C2 response to student1C2\"", instructors);
+        verifySearchResults(bundle, frc1I3Q1S2C2);
+
+        // delete comments inside the session
+        commentsDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(frc1I3Q1S2C2.courseId)
+                        .withFeedbackSessionName(frc1I3Q1S2C2.feedbackSessionName)
+                        .build());
+
+        // document deleted, should have no search result
+        bundle = commentsDb.search("\"Instructor 3 comment to instr1C2 response to student1C2\"", instructors);
+        assertEquals(0, bundle.comments.size());
+        assertEquals(0, bundle.responses.size());
+        assertEquals(0, bundle.questions.size());
+        assertEquals(0, bundle.sessions.size());
     }
 }

--- a/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
@@ -128,7 +128,7 @@ public class InstructorSearchTest extends BaseSearchTest {
         ______TS("success: search for instructors in whole system; deleting instructor without deleting document:"
                 + "document deleted during search, instructor unsearchable");
 
-        instructorsDb.deleteEntity(ins2InCourse1);
+        instructorsDb.deleteInstructor(ins2InCourse1.getCourseId(), ins2InCourse1.getEmail());
         results = instructorsDb.searchInstructorsInWholeSystem("instructor2");
         verifySearchResults(results, ins2InCourse2, ins2InCourse3);
     }

--- a/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
+++ b/src/test/java/teammates/test/cases/search/InstructorSearchTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.attributes.CourseAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -155,6 +156,36 @@ public class InstructorSearchTest extends BaseSearchTest {
         bundle = instructorsDb.searchInstructorsInWholeSystem("instructorABCDE");
         assertEquals(1, bundle.numberOfResults);
         assertEquals("instructorABCDE", bundle.instructorList.get(0).getName());
+    }
+
+    @Test
+    public void testSearchInstructor_deleteAfterSearch_shouldNotBeSearchable() {
+        InstructorsDb instructorsDb = new InstructorsDb();
+
+        InstructorAttributes ins1InCourse2 = dataBundle.instructors.get("instructor1OfCourse2");
+        InstructorAttributes ins2InCourse2 = dataBundle.instructors.get("instructor2OfCourse2");
+        InstructorAttributes ins3InCourse2 = dataBundle.instructors.get("instructor3OfCourse2");
+
+        // there is search result before deletion
+        InstructorSearchResultBundle results = instructorsDb.searchInstructorsInWholeSystem("idOfTypicalCourse2");
+        verifySearchResults(results, ins1InCourse2, ins2InCourse2, ins3InCourse2);
+
+        // delete a student
+        instructorsDb.deleteInstructor(ins1InCourse2.getCourseId(), ins1InCourse2.getEmail());
+
+        // the search result will change
+        results = instructorsDb.searchInstructorsInWholeSystem("idOfTypicalCourse2");
+        verifySearchResults(results, ins2InCourse2, ins3InCourse2);
+
+        // delete all instructors in course 2
+        instructorsDb.deleteInstructors(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(ins2InCourse2.getCourseId())
+                        .build());
+
+        // there should be no search result
+        results = instructorsDb.searchInstructorsInWholeSystem("idOfTypicalCourse2");
+        verifySearchResults(results);
     }
 
     /*

--- a/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/AccountsDbTest.java
@@ -127,6 +127,11 @@ public class AccountsDbTest extends BaseComponentTestCase {
     public void testDeleteAccount() throws Exception {
         AccountAttributes a = createNewAccount();
 
+        ______TS("silent deletion of non-existent account");
+
+        accountsDb.deleteAccount("not_exist");
+        assertNotNull(accountsDb.getAccount(a.googleId));
+
         ______TS("typical success case");
         AccountAttributes newAccount = accountsDb.getAccount(a.googleId);
         assertNotNull(newAccount);
@@ -139,7 +144,7 @@ public class AccountsDbTest extends BaseComponentTestCase {
         ______TS("silent deletion of same account");
         accountsDb.deleteAccount(a.googleId);
 
-        ______TS("failure null paramter");
+        ______TS("failure null parameter");
 
         AssertionError ae = assertThrows(AssertionError.class,
                 () -> accountsDb.deleteAccount(null));

--- a/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/CoursesDbTest.java
@@ -171,6 +171,13 @@ public class CoursesDbTest extends BaseComponentTestCase {
     @Test
     public void testDeleteCourse() throws InvalidParametersException {
         CourseAttributes c = createNewCourse();
+        assertNotNull(coursesDb.getCourse(c.getId()));
+
+        ______TS("Failure: delete a non-existent courses");
+
+        // Should fail silently
+        coursesDb.deleteCourse("not_exist");
+        assertNotNull(coursesDb.getCourse(c.getId()));
 
         ______TS("Success: delete an existing course");
 
@@ -179,10 +186,10 @@ public class CoursesDbTest extends BaseComponentTestCase {
         CourseAttributes deleted = coursesDb.getCourse(c.getId());
         assertNull(deleted);
 
-        ______TS("Failure: delete a non-existent courses");
+        ______TS("Delete it again");
 
-        // Should fail silently
         coursesDb.deleteCourse(c.getId());
+        assertNull(coursesDb.getCourse(c.getId()));
 
         ______TS("Failure: null parameter");
 

--- a/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/EntitiesDbTest.java
@@ -48,7 +48,7 @@ public class EntitiesDbTest extends BaseComponentTestCase {
                 () -> coursesDb.createEntity(c));
         assertEquals(
                 String.format(EntitiesDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, c.toString()), eaee.getMessage());
-        coursesDb.deleteEntity(c);
+        coursesDb.deleteCourse(c.getId());
 
         ______TS("fails: invalid parameters");
         CourseAttributes invalidCourse = CourseAttributes

--- a/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackQuestionsDbTest.java
@@ -35,7 +35,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         FeedbackQuestionAttributes fq = getNewFeedbackQuestionAttributes();
 
         // remove possibly conflicting entity from the database
-        fqDb.deleteEntity(fq);
+        deleteFeedbackQuestion(fq);
 
         fqDb.createEntity(fq);
         verifyPresentInDatastore(fq);
@@ -214,7 +214,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
 
         // remove possibly conflicting entity from the database
-        fqDb.deleteEntity(fqa);
+        deleteFeedbackQuestion(fqa);
 
         fqDb.createEntity(fqa);
         verifyPresentInDatastore(fqa);
@@ -224,11 +224,6 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class, () -> fqDb.createEntity(fqa));
         assertEquals(
                 String.format(FeedbackQuestionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, fqa.toString()), eaee.getMessage());
-
-        ______TS("delete - with id specified");
-
-        fqDb.deleteEntity(fqa);
-        verifyAbsentInDatastore(fqa);
 
         ______TS("null params");
 
@@ -252,7 +247,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         FeedbackQuestionAttributes expected = getNewFeedbackQuestionAttributes();
 
         // remove possibly conflicting entity from the database
-        fqDb.deleteEntity(expected);
+        deleteFeedbackQuestion(expected);
 
         fqDb.createEntity(expected);
 
@@ -335,7 +330,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
 
         // remove possibly conflicting entity from the database
-        fqDb.deleteEntity(fqa);
+        deleteFeedbackQuestion(fqa);
 
         int[] numOfQuestions = createNewQuestionsForDifferentRecipientTypes();
 
@@ -397,7 +392,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         ______TS("invalid feedback question attributes");
 
         FeedbackQuestionAttributes invalidFqa = getNewFeedbackQuestionAttributes();
-        fqDb.deleteEntity(invalidFqa);
+        deleteFeedbackQuestion(invalidFqa);
         fqDb.createEntity(invalidFqa);
         invalidFqa.setId(fqDb.getFeedbackQuestion(invalidFqa.feedbackSessionName, invalidFqa.courseId,
                                                   invalidFqa.questionNumber).getId());
@@ -426,7 +421,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         ______TS("standard success case");
 
         FeedbackQuestionAttributes modifiedQuestion = getNewFeedbackQuestionAttributes();
-        fqDb.deleteEntity(modifiedQuestion);
+        deleteFeedbackQuestion(modifiedQuestion);
         fqDb.createEntity(modifiedQuestion);
         verifyPresentInDatastore(modifiedQuestion);
 
@@ -449,7 +444,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         assertEquals("New question text!", modifiedQuestion.getQuestionDetails().getQuestionText());
         assertEquals("New question text!", updatedQuestion.getQuestionDetails().getQuestionText());
 
-        fqDb.deleteEntity(modifiedQuestion);
+        deleteFeedbackQuestion(modifiedQuestion);
     }
 
     private FeedbackQuestionAttributes getNewFeedbackQuestionAttributes() {
@@ -478,7 +473,7 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
             fqa.questionNumber = i;
 
             // remove possibly conflicting entity from the database
-            fqDb.deleteEntity(fqa);
+            deleteFeedbackQuestion(fqa);
 
             fqDb.createEntity(fqa);
             returnVal.add(fqa);
@@ -534,7 +529,15 @@ public class FeedbackQuestionsDbTest extends BaseComponentTestCase {
         FeedbackQuestionAttributes fqa = getNewFeedbackQuestionAttributes();
         for (int i = 1; i <= numToDelete; i++) {
             fqa.questionNumber = i;
-            fqDb.deleteEntity(fqa);
+            deleteFeedbackQuestion(fqa);
+        }
+    }
+
+    private void deleteFeedbackQuestion(FeedbackQuestionAttributes attributes) {
+        FeedbackQuestionAttributes fq = fqDb.getFeedbackQuestion(
+                attributes.getFeedbackSessionName(), attributes.getCourseId(), attributes.getQuestionNumber());
+        if (fq != null) {
+            fqDb.deleteFeedbackQuestion(fq.getId());
         }
     }
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
@@ -4,9 +4,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.attributes.FeedbackResponseCommentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -24,23 +25,41 @@ import teammates.test.driver.AssertHelper;
 public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
     private static final FeedbackResponseCommentsDb frcDb = new FeedbackResponseCommentsDb();
-    private DataBundle dataBundle = getTypicalDataBundle();
 
-    private FeedbackResponseCommentAttributes frcaData =
-            dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");
-    private String frId = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1").feedbackResponseId;
-    private FeedbackResponseCommentAttributes anotherFrcaData =
-            dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q2S1C1");
-    private List<FeedbackResponseCommentAttributes> frcasData = new ArrayList<>();
+    private DataBundle dataBundle;
+    private FeedbackResponseCommentAttributes frcaData;
+    private String frId;
+    private FeedbackResponseCommentAttributes anotherFrcaData;
+    private List<FeedbackResponseCommentAttributes> frcasData;
 
-    @BeforeClass
-    public void classSetup() throws Exception {
+    @BeforeMethod
+    public void beforeMethod() throws Exception {
+        dataBundle = getTypicalDataBundle();
+
+        frcaData = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1");
+        frId = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q1S1C1").feedbackResponseId;
+        anotherFrcaData = dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q2S1C1");
+        frcasData = new ArrayList<>();
+
+        FeedbackResponseCommentAttributes oldFrcaData =
+                frcDb.getFeedbackResponseComment(frcaData.feedbackResponseId, frcaData.commentGiver, frcaData.createdAt);
+        if (oldFrcaData != null) {
+            frcDb.deleteFeedbackResponseComment(oldFrcaData.getId());
+        }
         frcDb.createEntity(frcaData);
-        frcDb.createEntity(anotherFrcaData);
         frcaData = frcDb.getFeedbackResponseComment(frcaData.feedbackResponseId,
-                                 frcaData.commentGiver, frcaData.createdAt);
+                frcaData.commentGiver, frcaData.createdAt);
+
+        FeedbackResponseCommentAttributes oldAnotherFrcaData =
+                frcDb.getFeedbackResponseComment(
+                        anotherFrcaData.feedbackResponseId, anotherFrcaData.commentGiver, anotherFrcaData.createdAt);
+        if (oldAnotherFrcaData != null) {
+            frcDb.deleteFeedbackResponseComment(oldAnotherFrcaData.getId());
+        }
+        frcDb.createEntity(anotherFrcaData);
         anotherFrcaData = frcDb.getFeedbackResponseComment(anotherFrcaData.feedbackResponseId,
-                                        anotherFrcaData.commentGiver, anotherFrcaData.createdAt);
+                anotherFrcaData.commentGiver, anotherFrcaData.createdAt);
+
         frcasData.add(frcaData);
         frcasData.add(anotherFrcaData);
     }
@@ -63,9 +82,6 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
         testGetFeedbackResponseCommentsForSession();
 
         testUpdateFeedbackResponseCommentsGiverEmail();
-
-        testDeleteFeedbackResponseCommentsForResponse();
-
     }
 
     private void testEntityCreationAndDeletion() throws Exception {
@@ -306,8 +322,41 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 
-    private void testDeleteFeedbackResponseCommentsForResponse()
+    @Test
+    public void testDeleteFeedbackResponseComment() {
+
+        ______TS("delete non-existent comment");
+
+        assertNull(frcDb.getFeedbackResponseComment(-123L));
+
+        frcDb.deleteDocumentByCommentId(-123L);
+
+        ______TS("typical success case");
+
+        assertNotNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+
+        frcDb.deleteFeedbackResponseComment(frcaData.getId());
+
+        assertNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+
+        ______TS("delete again same comment");
+
+        frcDb.deleteFeedbackResponseComment(frcaData.getId());
+
+        assertNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+    }
+
+    @Test
+    public void testDeleteFeedbackResponseComments_byResponseId()
             throws InvalidParametersException, EntityAlreadyExistsException {
+
+        ______TS("non-existent response id");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withResponseId("not_exist")
+                        .build());
 
         ______TS("typical success case");
 
@@ -323,12 +372,137 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
         tempFrcaData.feedbackResponseId = responseId;
         frcDb.createEntity(tempFrcaData);
 
-        frcDb.deleteFeedbackResponseCommentsForResponse(responseId);
-        assertEquals(frcDb.getFeedbackResponseCommentsForResponse(responseId).size(), 0);
+        // two comments exist in the DB
+        assertFalse(frcDb.getFeedbackResponseCommentsForResponse(responseId).isEmpty());
+        assertNotNull(frcDb.getFeedbackResponseComment(anotherFrcaData.getId()));
 
-        ______TS("null parameter");
+        // delete one
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withResponseId(responseId)
+                        .build());
 
-        AssertionError ae = assertThrows(AssertionError.class, () -> frcDb.deleteFeedbackResponseCommentsForResponse(null));
+        assertEquals(0, frcDb.getFeedbackResponseCommentsForResponse(responseId).size());
+        // other irrelevant comment remains
+        assertNotNull(frcDb.getFeedbackResponseComment(anotherFrcaData.getId()));
+    }
+
+    @Test
+    public void testDeleteFeedbackResponseComments_byQuestionId() {
+        ______TS("non-existent question id");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withQuestionId("not_exist")
+                        .build());
+
+        ______TS("typical success case");
+
+        assertNotNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withQuestionId(frcaData.feedbackQuestionId)
+                        .build());
+
+        // comment deleted
+        assertNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+        // other irrelevant comment remains
+        assertNotNull(frcDb.getFeedbackResponseComment(anotherFrcaData.getId()));
+    }
+
+    @Test
+    public void testDeleteFeedbackResponseComments_byCourseIdAndSessionName() {
+        ______TS("non-existent course");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId("course_not_exist")
+                        .withFeedbackSessionName(frcaData.feedbackSessionName)
+                        .build());
+
+        ______TS("non-existent session");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(frcaData.courseId)
+                        .withFeedbackSessionName("session_not_exist")
+                        .build());
+
+        ______TS("non-existent course and session");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId("course_not_exist")
+                        .withFeedbackSessionName("session_not_exist")
+                        .build());
+
+        ______TS("typical success case");
+
+        assertFalse(
+                frcDb.getFeedbackResponseCommentsForSession(frcaData.courseId, frcaData.feedbackSessionName).isEmpty());
+
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(frcaData.courseId)
+                        .withFeedbackSessionName(frcaData.feedbackSessionName)
+                        .build());
+
+        assertEquals(0,
+                frcDb.getFeedbackResponseCommentsForSession(frcaData.courseId, frcaData.feedbackSessionName).size());
+    }
+
+    @Test
+    public void testDeleteFeedbackResponseComments_byCourseId() throws Exception {
+
+        ______TS("non-existent course");
+
+        // should pass silently
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId("course_not_exist")
+                        .build());
+
+        ______TS("typical success case");
+
+        assertFalse(
+                frcDb.getFeedbackResponseCommentsForSession(frcaData.courseId, frcaData.feedbackSessionName).isEmpty());
+        // the two existing comment are in the same course
+        assertEquals(frcaData.courseId, anotherFrcaData.courseId);
+        assertNotNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+        assertNotNull(frcDb.getFeedbackResponseComment(anotherFrcaData.getId()));
+
+        // create another comments different course
+        FeedbackResponseCommentAttributes tempFrcaData =
+                dataBundle.feedbackResponseComments.get("comment1FromT1C1ToR1Q2S1C1");
+        tempFrcaData.feedbackResponseId = "randomId";
+        tempFrcaData.courseId = "anotherCourse";
+        frcDb.createEntity(tempFrcaData);
+        tempFrcaData = frcDb.getFeedbackResponseComment(tempFrcaData.feedbackResponseId,
+                tempFrcaData.commentGiver, tempFrcaData.createdAt);
+        assertNotNull(tempFrcaData);
+
+        frcDb.deleteFeedbackResponseComments(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(frcaData.courseId)
+                        .build());
+
+        assertTrue(
+                frcDb.getFeedbackResponseCommentsForSession(frcaData.courseId, frcaData.feedbackSessionName).isEmpty());
+        // same course's comments are deleted
+        assertNull(frcDb.getFeedbackResponseComment(frcaData.getId()));
+        assertNull(frcDb.getFeedbackResponseComment(anotherFrcaData.getId()));
+        // other course's data is not affected
+        assertNotNull(frcDb.getFeedbackResponseComment(tempFrcaData.getId()));
+    }
+
+    @Test
+    public void testDeleteFeedbackResponseComments_nullInput_shouldThrowException() {
+        AssertionError ae = assertThrows(AssertionError.class, () -> frcDb.deleteFeedbackResponseComments(null));
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
     }
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponseCommentsDbTest.java
@@ -97,7 +97,10 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
 
         ______TS("Entity deletion");
 
-        frcDb.deleteEntity(frcaTemp);
+        frcaTemp = frcDb.getFeedbackResponseComment(
+                frcaTemp.feedbackResponseId, frcaTemp.commentGiver, frcaTemp.createdAt);
+        assertNotNull(frcaTemp);
+        frcDb.deleteFeedbackResponseComment(frcaTemp.getId());
         verifyAbsentInDatastore(frcaTemp);
     }
 
@@ -239,7 +242,7 @@ public class FeedbackResponseCommentsDbTest extends BaseComponentTestCase {
         assertEquals(frcaExpected.courseId, frcaActual.courseId);
         assertEquals(frcaExpected.commentText, frcaActual.commentText);
 
-        frcDb.deleteEntity(frcaTemp);
+        frcDb.deleteFeedbackResponseComment(frcaActual.getId());
 
         ______TS("non-existent comment");
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackResponsesDbTest.java
@@ -76,7 +76,7 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         FeedbackResponseAttributes fra = getNewFeedbackResponseAttributes();
 
         // remove possibly conflicting entity from the database
-        frDb.deleteEntity(fra);
+        deleteResponse(fra);
 
         frDb.createEntity(fra);
         verifyPresentInDatastore(fra);
@@ -265,7 +265,7 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
         FeedbackResponseAttributes fra = getNewFeedbackResponseAttributes();
 
         // remove possibly conflicting entity from the database
-        frDb.deleteEntity(fra);
+        deleteResponse(fra);
 
         frDb.createEntity(fra);
 
@@ -280,7 +280,7 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
 
         ______TS("delete - with id specified");
 
-        frDb.deleteEntity(fra);
+        deleteResponse(fra);
         verifyAbsentInDatastore(fra);
 
         ______TS("null params");
@@ -912,7 +912,15 @@ public class FeedbackResponsesDbTest extends BaseComponentTestCase {
     private void deleteResponsesFromDb() {
         Set<String> keys = dataBundle.feedbackResponses.keySet();
         for (String i : keys) {
-            frDb.deleteEntity(dataBundle.feedbackResponses.get(i));
+            deleteResponse(dataBundle.feedbackResponses.get(i));
+        }
+    }
+
+    private void deleteResponse(FeedbackResponseAttributes attributes) {
+        FeedbackResponseAttributes feedbackResponse =
+                frDb.getFeedbackResponse(attributes.feedbackQuestionId, attributes.giver, attributes.recipient);
+        if (feedbackResponse != null) {
+            frDb.deleteFeedbackResponse(feedbackResponse.getId());
         }
     }
 

--- a/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
@@ -46,9 +46,11 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
     public void deleteSessionsFromDb() {
         Set<String> keys = dataBundle.feedbackSessions.keySet();
         for (String i : keys) {
-            fsDb.deleteEntity(dataBundle.feedbackSessions.get(i));
+            FeedbackSessionAttributes sessionToDelete = dataBundle.feedbackSessions.get(i);
+            fsDb.deleteFeedbackSession(sessionToDelete.getFeedbackSessionName(), sessionToDelete.getCourseId());
         }
-        fsDb.deleteEntity(getNewFeedbackSession());
+        FeedbackSessionAttributes sessionToDelete = getNewFeedbackSession();
+        fsDb.deleteFeedbackSession(sessionToDelete.getFeedbackSessionName(), sessionToDelete.getCourseId());
     }
 
     @Test
@@ -149,7 +151,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
         assertEquals(
                 String.format(FeedbackSessionsDb.ERROR_CREATE_ENTITY_ALREADY_EXISTS, fsa.toString()), eaee.getMessage());
 
-        fsDb.deleteEntity(fsa);
+        fsDb.deleteFeedbackSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
         verifyAbsentInDatastore(fsa);
 
         ______TS("null params");
@@ -412,7 +414,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         ______TS("invalid feedback session attributes");
         FeedbackSessionAttributes invalidFs = getNewFeedbackSession();
-        fsDb.deleteEntity(invalidFs);
+        fsDb.deleteFeedbackSession(invalidFs.getFeedbackSessionName(), invalidFs.getCourseId());
         fsDb.createEntity(invalidFs);
         Instant afterEndTime = invalidFs.getEndTime().plus(Duration.ofDays(30));
         invalidFs.setStartTime(afterEndTime);
@@ -442,7 +444,7 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
 
         ______TS("standard success case");
         FeedbackSessionAttributes modifiedSession = getNewFeedbackSession();
-        fsDb.deleteEntity(modifiedSession);
+        fsDb.deleteFeedbackSession(modifiedSession.getFeedbackSessionName(), modifiedSession.getCourseId());
         fsDb.createEntity(modifiedSession);
         verifyPresentInDatastore(modifiedSession);
         modifiedSession.setInstructions("new instructions");

--- a/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/FeedbackSessionsDbTest.java
@@ -13,6 +13,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
@@ -57,6 +58,80 @@ public class FeedbackSessionsDbTest extends BaseComponentTestCase {
         List<FeedbackSessionAttributes> actualAttributesList = fsDb.getAllOngoingSessions(rangeStart, rangeEnd);
         assertEquals("should not return more than 13 sessions as there are only 13 distinct sessions in the range",
                 13, actualAttributesList.size());
+    }
+
+    @Test
+    public void testDeleteFeedbackSession() throws Exception {
+        FeedbackSessionAttributes fsa = getNewFeedbackSession();
+        fsDb.createEntity(fsa);
+        fsa = fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName());
+        assertNotNull(fsa);
+
+        ______TS("non-existent course ID");
+
+        fsDb.deleteFeedbackSession(fsa.getFeedbackSessionName(), "not_exist");
+
+        assertNotNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+
+        ______TS("non-existent session name");
+
+        fsDb.deleteFeedbackSession("not_exist", fsa.getCourseId());
+
+        assertNotNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+
+        ______TS("non-existent course ID and session name");
+
+        fsDb.deleteFeedbackSession("not_exist", "not_exist");
+
+        assertNotNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+
+        ______TS("standard success case");
+
+        fsDb.deleteFeedbackSession(fsa.getFeedbackSessionName(), fsa.getCourseId());
+
+        assertNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+    }
+
+    @Test
+    public void testDeleteFeedbackSessions_byCourseId() throws Exception {
+        FeedbackSessionAttributes fsa = getNewFeedbackSession();
+        fsDb.createEntity(fsa);
+        fsa = fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName());
+        assertNotNull(fsa);
+
+        FeedbackSessionAttributes anotherFas = getNewFeedbackSession();
+        anotherFas.setCourseId("courseId");
+        fsDb.createEntity(anotherFas);
+        anotherFas = fsDb.getFeedbackSession(anotherFas.getCourseId(), anotherFas.getFeedbackSessionName());
+        assertNotNull(anotherFas);
+
+        ______TS("non-existent course ID");
+
+        fsDb.deleteFeedbackSessions(
+                AttributesDeletionQuery.builder()
+                        .withCourseId("non_exist")
+                        .build());
+
+        assertNotNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+        assertNotNull(fsDb.getFeedbackSession(anotherFas.getCourseId(), anotherFas.getFeedbackSessionName()));
+
+        ______TS("standard success case");
+
+        fsDb.deleteFeedbackSessions(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(fsa.getCourseId())
+                        .build());
+
+        assertNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+        assertNotNull(fsDb.getFeedbackSession(anotherFas.getCourseId(), anotherFas.getFeedbackSessionName()));
+
+        fsDb.deleteFeedbackSessions(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(anotherFas.getCourseId())
+                        .build());
+
+        assertNull(fsDb.getFeedbackSession(fsa.getCourseId(), fsa.getFeedbackSessionName()));
+        assertNull(fsDb.getFeedbackSession(anotherFas.getCourseId(), anotherFas.getFeedbackSessionName()));
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -64,7 +64,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
                 .withPrivileges(privileges)
                 .build();
 
-        instructorsDb.deleteEntity(i);
+        instructorsDb.deleteInstructor(i.getCourseId(), i.getEmail());
         instructorsDb.createEntity(i);
 
         verifyPresentInDatastore(i);
@@ -546,7 +546,8 @@ public class InstructorsDbTest extends BaseComponentTestCase {
     private void deleteInstructorsFromDb() {
         Set<String> keys = dataBundle.instructors.keySet();
         for (String i : keys) {
-            instructorsDb.deleteEntity(dataBundle.instructors.get(i));
+            InstructorAttributes instructorToDelete = dataBundle.instructors.get(i);
+            instructorsDb.deleteInstructor(instructorToDelete.getCourseId(), instructorToDelete.getEmail());
         }
     }
 }

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.InstructorPrivileges;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -462,6 +463,19 @@ public class InstructorsDbTest extends BaseComponentTestCase {
     public void testDeleteInstructor() {
         InstructorAttributes i = dataBundle.instructors.get("instructorWithOnlyOneSampleCourse");
 
+        assertNotNull(instructorsDb.getInstructorForEmail(i.getCourseId(), i.getEmail()));
+
+        ______TS("Delete non-existent instructor");
+
+        instructorsDb.deleteInstructor("not_exist", i.getEmail());
+        assertNotNull(instructorsDb.getInstructorForEmail(i.getCourseId(), i.getEmail()));
+
+        instructorsDb.deleteInstructor(i.getCourseId(), "notExistent@email.com");
+        assertNotNull(instructorsDb.getInstructorForEmail(i.getCourseId(), i.getEmail()));
+
+        instructorsDb.deleteInstructor("not_exist", "notExistent@email.com");
+        assertNotNull(instructorsDb.getInstructorForEmail(i.getCourseId(), i.getEmail()));
+
         ______TS("Success: delete an instructor");
 
         instructorsDb.deleteInstructor(i.courseId, i.email);
@@ -469,9 +483,10 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         InstructorAttributes deleted = instructorsDb.getInstructorForEmail(i.courseId, i.email);
         assertNull(deleted);
 
-        ______TS("Failure: delete a non-exist instructor, should fail silently");
+        ______TS("Failure: delete instructor again, should fail silently");
 
         instructorsDb.deleteInstructor(i.courseId, i.email);
+        assertNull(instructorsDb.getInstructorForEmail(i.getCourseId(), i.getEmail()));
 
         ______TS("Failure: null parameters");
 
@@ -481,46 +496,44 @@ public class InstructorsDbTest extends BaseComponentTestCase {
     }
 
     @Test
-    public void testDeleteInstructorsForGoogleId() {
-
-        ______TS("Success: delete instructors with specific googleId");
-
-        String googleId = "instructorWithOnlyOneSampleCourse";
-        instructorsDb.deleteInstructorsForGoogleId(googleId);
-
-        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForGoogleId(googleId, false);
-        assertEquals(0, retrieved.size());
-
-        ______TS("Failure: try to delete where there's no instructors associated with the googleId, should fail silently");
-
-        instructorsDb.deleteInstructorsForGoogleId(googleId);
-
-        ______TS("Failure: null parameters");
-
-        AssertionError ae = assertThrows(AssertionError.class,
-                () -> instructorsDb.deleteInstructorsForGoogleId(null));
-        assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-
-    }
-
-    @Test
-    public void testDeleteInstructorsForCourse() {
+    public void testDeleteInstructors_byCourseId_shouldDeleteInstructorsAssociatedWithTheCourse() {
 
         ______TS("Success: delete instructors of a specific course");
 
         String courseId = "idOfArchivedCourse";
-        instructorsDb.deleteInstructorsForCourse(courseId);
+        instructorsDb.deleteInstructors(AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build());
 
         List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForCourse(courseId);
         assertEquals(0, retrieved.size());
 
+        // other course is not affected
+        assertFalse(instructorsDb.getInstructorsForCourse("idOfTypicalCourse2").isEmpty());
+
+        ______TS("Failure: non-existent course, should fail silently");
+
+        instructorsDb.deleteInstructors(AttributesDeletionQuery.builder()
+                .withCourseId("not-exist")
+                .build());
+
+        // other course is not affected
+        assertFalse(instructorsDb.getInstructorsForCourse("idOfTypicalCourse2").isEmpty());
+
         ______TS("Failure: no instructor exists for the course, should fail silently");
 
-        instructorsDb.deleteInstructorsForCourse(courseId);
+        instructorsDb.deleteInstructors(AttributesDeletionQuery.builder()
+                .withCourseId(courseId)
+                .build());
+
+        assertEquals(0, instructorsDb.getInstructorsForCourse(courseId).size());
+
+        // other course is not affected
+        assertFalse(instructorsDb.getInstructorsForCourse("idOfTypicalCourse2").isEmpty());
 
         ______TS("Failure: null parameters");
 
-        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.deleteInstructorsForCourse(null));
+        AssertionError ae = assertThrows(AssertionError.class, () -> instructorsDb.deleteInstructors(null));
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
     }

--- a/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/ProfilesDbTest.java
@@ -48,8 +48,8 @@ public class ProfilesDbTest extends BaseComponentTestCase {
     @AfterMethod
     public void deleteTypicalData() {
         // delete entity
-        profilesDb.deleteEntity(typicalProfileWithPicture);
-        profilesDb.deleteEntity(typicalProfileWithoutPicture);
+        profilesDb.deleteStudentProfile(typicalProfileWithPicture.googleId);
+        profilesDb.deleteStudentProfile(typicalProfileWithoutPicture.googleId);
         verifyAbsentInDatastore(typicalProfileWithPicture);
         verifyAbsentInDatastore(typicalProfileWithoutPicture);
 
@@ -86,7 +86,7 @@ public class ProfilesDbTest extends BaseComponentTestCase {
         assertEquals("Test", createdSpa.shortName);
 
         // tear down
-        profilesDb.deleteEntity(spa);
+        profilesDb.deleteStudentProfile(spa.googleId);
     }
 
     @Test

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -5,6 +5,7 @@ import static teammates.common.util.FieldValidator.REASON_INCORRECT_FORMAT;
 
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.exception.EntityAlreadyExistsException;
 import teammates.common.exception.EntityDoesNotExistException;
@@ -98,6 +99,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
         AssertionError ae = assertThrows(AssertionError.class, () -> studentsDb.createEntity(null));
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
 
+        studentsDb.deleteStudent(s.getCourse(), s.getEmail());
     }
 
     @Test
@@ -131,7 +133,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
                 StudentAttributes.updateOptionsBuilder(s2.course, s2.email)
                         .withGoogleId(s2.googleId)
                         .build());
-        studentsDb.deleteStudentsForGoogleId(s2.googleId);
+        studentsDb.deleteStudent(s2.getCourse(), s2.getEmail());
 
         assertNull(studentsDb.getStudentForGoogleId(s2.course, s2.googleId));
 
@@ -205,6 +207,9 @@ public class StudentsDbTest extends BaseComponentTestCase {
                         .build();
         assertThrows(EntityAlreadyExistsException.class, () -> studentsDb.updateStudent(updateOptionsForS2));
 
+        // clean up
+        studentsDb.deleteStudent(s2.getCourse(), s2.getEmail());
+
         ______TS("typical success case");
         String originalEmail = s.email;
         s.name = "new-name-2";
@@ -234,34 +239,70 @@ public class StudentsDbTest extends BaseComponentTestCase {
         assertEquals("this are new comments", updatedStudent.getComments());
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     public void testDeleteStudent() throws Exception {
         StudentAttributes s = createNewStudent();
-        s.googleId = "validGoogleId";
 
-        studentsDb.updateStudent(
-                StudentAttributes.updateOptionsBuilder(s.course, s.email)
-                        .withGoogleId(s.googleId)
-                        .build());
+        // delete student not exist
+        studentsDb.deleteStudent("not-exist", s.getEmail());
+        assertNotNull(studentsDb.getStudentForEmail(s.getCourse(), s.getEmail()));
 
-        // Delete
+        studentsDb.deleteStudent(s.getCourse(), "not_exist@email.com");
+        assertNotNull(studentsDb.getStudentForEmail(s.getCourse(), s.getEmail()));
+
+        studentsDb.deleteStudent("not-exist", "not_exist@email.com");
+        assertNotNull(studentsDb.getStudentForEmail(s.getCourse(), s.getEmail()));
+
+        // delete by course and email
         studentsDb.deleteStudent(s.course, s.email);
-
         StudentAttributes deleted = studentsDb.getStudentForEmail(s.course, s.email);
-
         assertNull(deleted);
-        studentsDb.deleteStudentsForGoogleId(s.googleId);
-        assertNull(studentsDb.getStudentForGoogleId(s.course, s.googleId));
-        s = createNewStudent();
-        createNewStudent("secondStudent@mail.com");
-        assertEquals(2, studentsDb.getStudentsForCourse(s.course).size());
-        studentsDb.deleteStudentsForCourse(s.course);
-        assertEquals(0, studentsDb.getStudentsForCourse(s.course).size());
+
         // delete again - should fail silently
         studentsDb.deleteStudent(s.course, s.email);
+        assertNull(studentsDb.getStudentForEmail(s.getCourse(), s.getEmail()));
 
-        // Null params check:
+        s = createNewStudent();
+
+        // delete all students in non-existent course
+        studentsDb.deleteStudents(
+                AttributesDeletionQuery.builder()
+                        .withCourseId("not_exist")
+                        .build());
+
+        // should pass, others students remain
+        assertEquals(1, studentsDb.getStudentsForCourse(s.course).size());
+
+        // delete all students in a course
+
+        // create another student in different course
+        StudentAttributes anotherStudent = StudentAttributes
+                .builder("valid-course2", "email@email.com")
+                .withName("valid student 2")
+                .withComment("")
+                .withTeamName("valid team name")
+                .withSectionName("valid section name")
+                .withGoogleId("")
+                .build();
+        studentsDb.createEntity(anotherStudent);
+        assertNotNull(studentsDb.getStudentForEmail(anotherStudent.getCourse(), anotherStudent.getEmail()));
+
+        // there are students in the course
+        assertFalse(studentsDb.getStudentsForCourse(s.course).isEmpty());
+
+        studentsDb.deleteStudents(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(s.course)
+                        .build());
+
+        assertEquals(0, studentsDb.getStudentsForCourse(s.course).size());
+        // other course should remain
+        assertEquals(1, studentsDb.getStudentsForCourse(anotherStudent.getCourse()).size());
+
+        // clean up
+        studentsDb.deleteStudent(anotherStudent.getCourse(), anotherStudent.getEmail());
+
+        // null params check:
         StudentAttributes[] finalStudent = new StudentAttributes[] { s };
         AssertionError ae = assertThrows(AssertionError.class,
                 () -> studentsDb.deleteStudent(null, finalStudent[0].email));
@@ -270,12 +311,9 @@ public class StudentsDbTest extends BaseComponentTestCase {
         ae = assertThrows(AssertionError.class,
                 () -> studentsDb.deleteStudent(finalStudent[0].course, null));
         assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, ae.getMessage());
-
-        studentsDb.deleteStudent(s.course, s.email);
-
     }
 
-    private StudentAttributes createNewStudent() throws InvalidParametersException {
+    private StudentAttributes createNewStudent() throws Exception {
         StudentAttributes s = StudentAttributes
                 .builder("valid-course", "valid@email.com")
                 .withName("valid student")
@@ -285,17 +323,13 @@ public class StudentsDbTest extends BaseComponentTestCase {
                 .withGoogleId("")
                 .build();
 
-        try {
-            studentsDb.createEntity(s);
-        } catch (EntityAlreadyExistsException e) {
-            // Okay if it's already inside
-            ignorePossibleException();
-        }
+        studentsDb.deleteStudent(s.getCourse(), s.getEmail());
+        studentsDb.createEntity(s);
 
         return s;
     }
 
-    private StudentAttributes createNewStudent(String email) throws InvalidParametersException {
+    private StudentAttributes createNewStudent(String email) throws Exception {
         StudentAttributes s = StudentAttributes
                 .builder("valid-course", email)
                 .withName("valid student 2")
@@ -305,12 +339,8 @@ public class StudentsDbTest extends BaseComponentTestCase {
                 .withGoogleId("")
                 .build();
 
-        try {
-            studentsDb.createEntity(s);
-        } catch (EntityAlreadyExistsException e) {
-            // Okay if it's already inside
-            ignorePossibleException();
-        }
+        studentsDb.deleteStudent(s.getCourse(), s.getEmail());
+        studentsDb.createEntity(s);
 
         return s;
     }

--- a/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -184,8 +184,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
     @Override
     @Test
     protected void testAccessControl() throws Exception {
-        FeedbackResponseCommentsDb frcDb = new FeedbackResponseCommentsDb();
-
         int questionNumber = 1;
         FeedbackSessionAttributes fs = typicalBundle.feedbackSessions.get("session1InCourse1");
         FeedbackQuestionAttributes question = logic.getFeedbackQuestion(
@@ -214,9 +212,6 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
         verifyInaccessibleForStudents(submissionParams);
         verifyAccessibleForInstructorsOfTheSameCourse(submissionParams);
         verifyAccessibleForAdminToMasqueradeAsInstructor(submissionParams);
-
-        // remove the comment
-        frcDb.deleteEntity(comment);
     }
 
     /**

--- a/src/test/java/teammates/test/cases/webapi/DeleteAllInstructorSoftDeletedCoursesActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/DeleteAllInstructorSoftDeletedCoursesActionTest.java
@@ -46,17 +46,25 @@ public class DeleteAllInstructorSoftDeletedCoursesActionTest
         if (CoursesLogic.inst().isCoursePresent("new-course")) {
             CoursesLogic.inst().deleteCourseCascade("new-course");
         }
+        if (CoursesLogic.inst().isCoursePresent("not-in-recycle-bin")) {
+            CoursesLogic.inst().deleteCourseCascade("not-in-recycle-bin");
+        }
 
         CoursesLogic.inst().createCourseAndInstructor(instructorId,
                 CourseAttributes.builder("new-course")
                         .withName("New course")
                         .withTimezone(ZoneId.of("UTC"))
                         .build());
+        CoursesLogic.inst().createCourseAndInstructor(instructorId,
+                CourseAttributes.builder("not-in-recycle-bin")
+                        .withName("Course Not In Recycle Bin")
+                        .withTimezone(ZoneId.of("UTC"))
+                        .build());
         loginAsInstructor(instructorId);
-        assertEquals(2, CoursesLogic.inst().getCoursesForInstructor(instructorId).size());
+        assertEquals(3, CoursesLogic.inst().getCoursesForInstructor(instructorId).size());
         CoursesLogic.inst().moveCourseToRecycleBin(courseId);
         CoursesLogic.inst().moveCourseToRecycleBin("new-course");
-        assertEquals(0, CoursesLogic.inst().getCoursesForInstructor(instructorId).size());
+        assertEquals(1, CoursesLogic.inst().getCoursesForInstructor(instructorId).size());
 
         DeleteAllInstructorSoftDeletedCoursesAction action = getAction(submissionParams);
         JsonResult result = getJsonResult(action);
@@ -65,6 +73,18 @@ public class DeleteAllInstructorSoftDeletedCoursesActionTest
         assertEquals(HttpStatus.SC_OK, result.getStatusCode());
         assertEquals("All courses in Recycle Bin have been permanently deleted.", message.getMessage());
 
+        // should not delete course not in recycle bin
+        assertNotNull(logic.getCourse("not-in-recycle-bin"));
+        // should delete the courses
+        assertNull(logic.getCourse(courseId));
+        assertNull(logic.getCourse("new-course"));
+
+        // cascade deletion should be done properly
+        assertEquals(0, logic.getFeedbackSessionsForCourse(courseId).size());
+        String typicalFeedbackSessionName = "First feedback session";
+        assertNull(logic.getFeedbackSession(typicalFeedbackSessionName, courseId));
+        assertEquals(0, logic.getStudentsForCourse(courseId).size());
+        assertEquals(0, logic.getInstructorsForCourse(courseId).size());
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/PostCourseEnrollSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/PostCourseEnrollSaveActionTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.testng.annotations.Test;
 
+import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.StudentAttributesFactory;
 import teammates.common.datatransfer.StudentUpdateStatus;
 import teammates.common.datatransfer.attributes.CourseAttributes;
@@ -281,7 +282,10 @@ public class PostCourseEnrollSaveActionTest extends BaseActionTest<PostCourseEnr
         verifyNoTasksAdded(a);
 
         CoursesLogic.inst().deleteCourseCascade("new-course");
-        StudentsLogic.inst().deleteStudentsForCourse(instructor1OfCourse1.courseId);
+        StudentsLogic.inst().deleteStudents(
+                AttributesDeletionQuery.builder()
+                        .withCourseId(instructor1OfCourse1.courseId)
+                        .build());
     }
 
     /**


### PR DESCRIPTION
Fixes #9557 

**Outline of Solution**

- Issue deletion query directly when key is available
- Introduce `AttributesDeletionQuery` to solve the problem of telescoping deletion methods
- Make use of `AttributesDeletionQuery` and delete entities by batch for cascade deletion
    - For cascade deletion involving responses, there is no way to do batch deletion (we have to do it one by one) because we need update the respondents lists.
- Write full documentations for each deletion method
- Full tests are written for each deletion method
