### PR TITLE
[#9574] Clicking Save Edited Photo does not close the modal in Student Profile page

### DIFF
--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
@@ -100,6 +100,7 @@ export class UploadEditProfilePictureModalComponent implements OnInit {
   saveEditedPhoto(): void {
     this.populateFormData(this.croppedImage);
     this.uploadPicture();
+    this.activeModal.close();
   }
 
   /**


### PR DESCRIPTION
Fixes #9574 

**Outline of Solution**

Now is called `this.activeModal.close()` in `saveEditedPhoto()` to close modal after save the photo.