### PR TITLE
[#9598] Bug fix: Cannot delete all courses in recycle bin

### DIFF
--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -299,8 +299,7 @@ public class InstructorsDb extends EntitiesDb<Instructor, InstructorAttributes> 
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, query);
 
         if (query.isCourseIdPresent()) {
-            List<Instructor> instructorsToDelete =
-                    load().filter("courseId =", query.getCourseId()).project("registrationKey").list();
+            List<Instructor> instructorsToDelete = load().filter("courseId =", query.getCourseId()).list();
             deleteDocument(Const.SearchIndex.INSTRUCTOR,
                     instructorsToDelete.stream()
                             .map(i -> StringHelper.encrypt(i.getRegistrationKey()))

--- a/src/main/java/teammates/storage/api/StudentsDb.java
+++ b/src/main/java/teammates/storage/api/StudentsDb.java
@@ -311,8 +311,7 @@ public class StudentsDb extends EntitiesDb<CourseStudent, StudentAttributes> {
      */
     public void deleteStudents(AttributesDeletionQuery query) {
         if (query.isCourseIdPresent()) {
-            List<CourseStudent> studentsToDelete =
-                    getCourseStudentsForCourseQuery(query.getCourseId()).project("registrationKey").list();
+            List<CourseStudent> studentsToDelete = getCourseStudentsForCourseQuery(query.getCourseId()).list();
             deleteDocument(Const.SearchIndex.STUDENT,
                     studentsToDelete.stream().map(CourseStudent::getRegistrationKey).toArray(String[]::new));
 


### PR DESCRIPTION
Fixes #9598 

**Outline of Solution**

It turns out that we need index for projection query. It may be unecessary to create a new index (courseId, regKey) just for deletion. Thus, I just remove it.
