### PR TITLE
[#9346] Use snackbar to show status message

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/compiler": "~7.1.4",
     "@angular/core": "~7.1.4",
     "@angular/forms": "~7.1.4",
+    "@angular/material": "^7.3.5",
     "@angular/platform-browser": "~7.1.4",
     "@angular/platform-browser-dynamic": "~7.1.4",
     "@angular/pwa": "~0.11.4",

--- a/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
@@ -56,7 +56,7 @@ public class StudentProfilePage extends AppPage {
     @FindBy(id = "profile-edit-picture-submit")
     private WebElement editPictureSubmit;
 
-    @FindBy(className = "alert-success")
+    @FindBy(className = "snackbar")
     private WebElement successStatusMessage;
 
     public StudentProfilePage(Browser browser) {
@@ -193,7 +193,6 @@ public class StudentProfilePage extends AppPage {
 
     public void verifyStatusMessage(String message) {
         assertTrue(successStatusMessage.getText().contains(message));
-        click(successStatusMessage.findElement(By.className("close")));
     }
 
     /**

--- a/src/web/app/app.module.ts
+++ b/src/web/app/app.module.ts
@@ -1,6 +1,8 @@
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { MatSnackBarModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule, Routes } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AppComponent } from './app.component';
@@ -24,6 +26,8 @@ const routes: Routes = [
   declarations: [AppComponent],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
+    MatSnackBarModule,
     HttpClientModule,
     NgbModule,
     RouterModule.forRoot(routes),

--- a/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.spec.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/mcq-field/mcq-field.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { McqFieldComponent } from './mcq-field.component';
 
 describe('McqFieldComponent', () => {
@@ -12,6 +13,7 @@ describe('McqFieldComponent', () => {
       declarations: [McqFieldComponent],
       imports: [
         FormsModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/components/sessions-table/resend-results-link-to-student-modal/resend-results-link-to-student-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/resend-results-link-to-student-modal/resend-results-link-to-student-modal.component.spec.ts
@@ -4,6 +4,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
+import { MatSnackBarModule } from '@angular/material';
 import { ResendResultsLinkToStudentModalComponent } from './resend-results-link-to-student-modal.component';
 
 @Component({ selector: 'tm-ajax-preload', template: '' })
@@ -22,6 +23,7 @@ describe('ResendResultsLinkToStudentModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         FormsModule,
+        MatSnackBarModule,
       ],
       providers: [NgbActiveModal],
     })

--- a/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.spec.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.spec.ts
@@ -3,6 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { SendRemindersToStudentModalComponent } from './send-reminders-to-student-modal.component';
 
@@ -22,6 +23,7 @@ describe('SendRemindersToStudentModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         FormsModule,
+        MatSnackBarModule,
       ],
       providers: [NgbActiveModal],
     })

--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -108,7 +108,6 @@
     </div>
   </div>
   <h1 *ngIf="pageTitle && isValidUser">{{ pageTitle }}</h1>
-  <tm-status-message [messages]="messageList"></tm-status-message>
   <router-outlet *ngIf="isValidUser"></router-outlet>
 </div>
 <div>

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -5,7 +5,6 @@ import {
   EventEmitter,
   HostListener,
   Input,
-  OnInit,
   Output,
 } from '@angular/core';
 import { Title } from '@angular/platform-browser';
@@ -26,7 +25,7 @@ const DEFAULT_TITLE: string = 'TEAMMATES - Online Peer Feedback/Evaluation Syste
   templateUrl: './page.component.html',
   styleUrls: ['./page.component.scss'],
 })
-export class PageComponent implements OnInit {
+export class PageComponent {
 
   @Input() isFetchingAuthDetails: boolean = false;
   @Input() studentLoginUrl: string = '';
@@ -97,9 +96,6 @@ export class PageComponent implements OnInit {
         || this.minimumVersions[browser.name] > parseInt(browser.major, 10);
     this.isCookieDisabled = !navigator.cookieEnabled;
   }
-
-  ngOnInit(): void { }
-
 }
 
 /**

--- a/src/web/app/page.component.ts
+++ b/src/web/app/page.component.ts
@@ -12,8 +12,6 @@ import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import uaParser from 'ua-parser-js';
 import { environment } from '../environments/environment';
-import { StatusMessageService } from '../services/status-message.service';
-import { StatusMessage } from './components/status-message/status-message';
 
 import { fromEvent, merge, Observable, of } from 'rxjs';
 import { mapTo } from 'rxjs/operators';
@@ -47,7 +45,6 @@ export class PageComponent implements OnInit {
   isUnsupportedBrowser: boolean = false;
   isCookieDisabled: boolean = false;
   browser: string = '';
-  messageList: StatusMessage[] = [];
   isNetworkOnline$: Observable<boolean>;
   version: string = environment.version;
   logoutUrl: string = `${environment.backendUrl}/logout`;
@@ -67,13 +64,11 @@ export class PageComponent implements OnInit {
     // Opera: ??
   };
 
-  constructor(private router: Router, private route: ActivatedRoute, private title: Title,
-      private statusMessageService: StatusMessageService) {
+  constructor(private router: Router, private route: ActivatedRoute, private title: Title) {
     this.checkBrowserVersion();
     this.router.events.subscribe((val: any) => {
       if (val instanceof NavigationEnd) {
         window.scrollTo(0, 0); // reset viewport
-        this.messageList = [];
         let r: ActivatedRoute = this.route;
         while (r.firstChild) {
           r = r.firstChild;
@@ -103,11 +98,7 @@ export class PageComponent implements OnInit {
     this.isCookieDisabled = !navigator.cookieEnabled;
   }
 
-  ngOnInit(): void {
-    this.statusMessageService.getAlertEvent().subscribe((result: StatusMessage) => {
-      this.messageList.push(result);
-    });
-  }
+  ngOnInit(): void { }
 
 }
 

--- a/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-accounts-page/admin-accounts-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AdminAccountsPageComponent } from './admin-accounts-page.component';
 
@@ -13,6 +14,7 @@ describe('AdminAccountsPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-admin/admin-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { LoadingSpinnerComponent } from '../components/loading-spinner/loading-spinner.component';
@@ -23,6 +24,7 @@ describe('AdminPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         StatusMessageModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-search-page/admin-search-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { AdminSearchPageComponent } from './admin-search-page.component';
 
 describe('AdminSearchPageComponent', () => {
@@ -13,6 +14,7 @@ describe('AdminSearchPageComponent', () => {
       imports: [
         FormsModule,
         HttpClientTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.spec.ts
+++ b/src/web/app/pages-admin/admin-sessions-page/admin-sessions-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AdminSessionsPageComponent } from './admin-sessions-page.component';
 
@@ -14,6 +15,7 @@ describe('AdminSessionsPageComponent', () => {
         NgbModule,
         FormsModule,
         HttpClientTestingModule,
+        MatSnackBarModule,
       ],
       declarations: [AdminSessionsPageComponent],
     })

--- a/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
+++ b/src/web/app/pages-help/session-links-recovery/session-links-recovery-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { NgxCaptchaModule } from 'ngx-captcha';
 import { SessionLinksRecoveryPageComponent } from './session-links-recovery-page.component';
 
@@ -15,6 +16,7 @@ describe('SessionLinksRecoveryPageComponent', () => {
         ReactiveFormsModule,
         HttpClientTestingModule,
         NgxCaptchaModule,
+        MatSnackBarModule,
       ],
     })
         .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ClipboardModule } from 'ngx-clipboard';
 import { InstructorCourseDetailsPageComponent } from './instructor-course-details-page.component';
@@ -42,6 +43,7 @@ describe('InstructorCourseDetailsPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         ClipboardModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-edit-page/instructor-course-edit-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InstructorCourseEditPageComponent } from './instructor-course-edit-page.component';
@@ -17,6 +18,7 @@ describe('InstructorCourseEditPageComponent', () => {
         RouterTestingModule,
         ReactiveFormsModule,
         HttpClientTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -14,6 +14,7 @@
         <strong>100</strong> students.<br>
       </p>
       <div class="col-md-12">
+        <tm-status-message [messages]="statusMessage"></tm-status-message>
         <div class="card card-default">
           <div class="card-header"
                (click)="toggleExistingStudentsPanel()">

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -14,9 +14,6 @@
         <strong>100</strong> students.<br>
       </p>
       <div class="col-md-12">
-        <tm-status-message
-            [messages]="statusMessage">
-        </tm-status-message>
         <div class="card card-default">
           <div class="card-header"
                (click)="toggleExistingStudentsPanel()">

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -152,10 +152,15 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     this.httpRequestService.post('/course/enrollSave', paramMap, this.enrollData)
         .subscribe((resp: EnrollResultPanelList) => {
           this.showEnrollResults = true;
+          this.statusMessage.pop(); // removes any existing error status message
           this.statusMessageService.showSuccessMessage('Enrollment successful. Summary given below.');
           this.enrollResultPanelList = resp.enrollResultPanelList;
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp.error.message);
+          this.statusMessage.pop(); // removes any existing error status message
+          this.statusMessage.push({
+            message: resp.error.message,
+            color: 'danger',
+          });
         });
   }
 
@@ -269,6 +274,7 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    */
   hideEnrollResults(): void {
     this.showEnrollResults = false;
+    this.statusMessage.pop();
     window.scroll(0, 0);
   }
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.ts
@@ -152,18 +152,10 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
     this.httpRequestService.post('/course/enrollSave', paramMap, this.enrollData)
         .subscribe((resp: EnrollResultPanelList) => {
           this.showEnrollResults = true;
-          this.statusMessage.pop(); // removes any existing status message
-          this.statusMessage.push({
-            message: 'Enrollment Successful. Summary given below',
-            color: 'success',
-          });
+          this.statusMessageService.showSuccessMessage('Enrollment successful. Summary given below.');
           this.enrollResultPanelList = resp.enrollResultPanelList;
         }, (resp: ErrorMessageOutput) => {
-          this.statusMessage.pop(); // removes any existing status message
-          this.statusMessage.push({
-            message: resp.error.message,
-            color: 'danger',
-          });
+          this.statusMessageService.showErrorMessage(resp.error.message);
         });
   }
 
@@ -277,7 +269,6 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
    */
   hideEnrollResults(): void {
     this.showEnrollResults = false;
-    this.statusMessage.pop();
     window.scroll(0, 0);
   }
 
@@ -289,12 +280,10 @@ export class InstructorCourseEnrollPageComponent implements OnInit {
       this.coursePresent = true;
       this.courseid = courseid;
       if (resp.hasResponses) {
-        this.statusMessage.push({
-          message: 'There are existing feedback responses for this course. Modifying records of enrolled students will '
-            + 'result in some existing responses from those modified students to be deleted. You may wish to download '
-            + 'the data before you make the changes.',
-          color: 'warning',
-        });
+        this.statusMessageService.showWarningMessage('There are existing feedback responses for this course. '
+            + 'Modifying records of enrolled students will result in some existing responses '
+            + 'from those modified students to be deleted. You may wish to download the data '
+            + 'before you make the changes.');
       }
     }, (resp: ErrorMessageOutput) => {
       this.coursePresent = false;

--- a/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-details-page/instructor-course-student-details-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StudentProfile } from '../student-profile/student-profile';
 import {
@@ -46,6 +47,7 @@ describe('InstructorCourseStudentDetailsPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   InstructorCourseStudentEditPageComponent,
@@ -17,6 +18,7 @@ describe('InstructorCourseStudentEditPageComponent', () => {
         RouterTestingModule,
         ReactiveFormsModule,
         HttpClientTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
@@ -39,7 +39,7 @@
   </div>
 </div>
 
-<ng-template #courseAddedMessageTemplate>
+<ng-template #newCourseMessageTemplate>
   The course has been added. Click <a href="/web/instructor/courses/enroll?courseid={{course.courseId}}">here</a>
   to add students to the course or click <a href="/web/instructor/courses/edit?courseid={{course.courseId}}">here</a>
   to add other instructors.<br>If you don't see the course in the list below,

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.html
@@ -38,3 +38,10 @@
     </div>
   </div>
 </div>
+
+<ng-template #courseAddedMessageTemplate>
+  The course has been added. Click <a href="/web/instructor/courses/enroll?courseid={{course.courseId}}">here</a>
+  to add students to the course or click <a href="/web/instructor/courses/edit?courseid={{course.courseId}}">here</a>
+  to add other instructors.<br>If you don't see the course in the list below,
+  please refresh the page after a few moments.
+</ng-template>

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AddCourseFormComponent } from './add-course-form.component';
@@ -19,6 +20,7 @@ describe('AddCourseFormComponent', () => {
         ReactiveFormsModule,
         RouterTestingModule,
         NgbModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
@@ -21,13 +21,13 @@ export class AddCourseFormComponent implements OnInit {
 
   @Input() isEnabled: boolean = true;
   @Output() courseAdded: EventEmitter<void> = new EventEmitter<void>();
-  @ViewChild('courseAddedMessageTemplate') courseAddedMessageTemplate!: TemplateRef<any>;
+  @ViewChild('newCourseMessageTemplate') newCourseMessageTemplate!: TemplateRef<any>;
 
   timezones: string[] = [];
   timezone: string = '';
   newCourseId: string = '';
   newCourseName: string = '';
-  course: any = null;
+  course!: Course;
 
   constructor(private route: ActivatedRoute,
               private statusMessageService: StatusMessageService,
@@ -76,7 +76,7 @@ export class AddCourseFormComponent implements OnInit {
     }).subscribe((course: Course) => {
       this.courseAdded.emit();
       this.course = course;
-      this.statusMessageService.showSuccessMessageTemplate(this.courseAddedMessageTemplate);
+      this.statusMessageService.showSuccessMessageTemplate(this.newCourseMessageTemplate);
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorMessage(resp.error.message);
     });

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import moment from 'moment-timezone';
 import { CourseService } from '../../../../services/course.service';
@@ -21,11 +21,13 @@ export class AddCourseFormComponent implements OnInit {
 
   @Input() isEnabled: boolean = true;
   @Output() courseAdded: EventEmitter<void> = new EventEmitter<void>();
+  @ViewChild('courseAddedMessageTemplate') courseAddedMessageTemplate: TemplateRef<any>;
 
   timezones: string[] = [];
   timezone: string = '';
   newCourseId: string = '';
   newCourseName: string = '';
+  course: any = null;
 
   constructor(private route: ActivatedRoute,
               private statusMessageService: StatusMessageService,
@@ -73,11 +75,8 @@ export class AddCourseFormComponent implements OnInit {
       courseId: this.newCourseId,
     }).subscribe((course: Course) => {
       this.courseAdded.emit();
-      this.statusMessageService.showSuccessMessage('The course has been added. '
-          + `Click <a href=\"/web/instructor/courses/enroll?courseid=${course.courseId}\">here</a> `
-          + `to add students to the course or click <a href=\"/web/instructor/courses/edit?courseid=${course.courseId}`
-          + '\">here</a> to add other instructors.'
-          + '<br>If you don\'t see the course in the list below, please refresh the page after a few moments.');
+      this.course = course;
+      this.statusMessageService.showSuccessMessageTemplate(this.courseAddedMessageTemplate);
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorMessage(resp.error.message);
     });

--- a/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/add-course-form/add-course-form.component.ts
@@ -21,7 +21,7 @@ export class AddCourseFormComponent implements OnInit {
 
   @Input() isEnabled: boolean = true;
   @Output() courseAdded: EventEmitter<void> = new EventEmitter<void>();
-  @ViewChild('courseAddedMessageTemplate') courseAddedMessageTemplate: TemplateRef<any>;
+  @ViewChild('courseAddedMessageTemplate') courseAddedMessageTemplate!: TemplateRef<any>;
 
   timezones: string[] = [];
   timezone: string = '';

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { InstructorCoursesPageComponent } from './instructor-courses-page.component';
@@ -84,6 +85,7 @@ describe('InstructorCoursesPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   Course, FeedbackSession, FeedbackSessionPublishStatus,
@@ -56,6 +57,7 @@ describe('InstructorHomePageComponent', () => {
         InstructorHomePageModule,
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { StudentListStudentData } from '../student-list/student-list-section-data';
 import { InstructorSearchPageComponent, SearchStudentsTable } from './instructor-search-page.component';
@@ -28,6 +29,7 @@ describe('InstructorSearchPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-edit-page/instructor-session-edit-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorSessionEditPageComponent } from './instructor-session-edit-page.component';
 import { InstructorSessionEditPageModule } from './instructor-session-edit-page.module';
@@ -14,6 +15,7 @@ describe('InstructorSessionEditPageComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         InstructorSessionEditPageModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -43,6 +44,7 @@ describe('InstructorSessionResultPageComponent', () => {
         GqrRqgViewResponsesModule,
         GrqRgqViewResponsesModule,
         PerQuestionViewResponsesModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorSessionsPageComponent } from './instructor-sessions-page.component';
 import { InstructorSessionsPageModule } from './instructor-sessions-page.module';
@@ -14,6 +15,7 @@ describe('InstructorSessionsPageComponent', () => {
         RouterTestingModule,
         HttpClientTestingModule,
         InstructorSessionsPageModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-list-page/instructor-student-list-page.component.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { InstructorStudentListPageComponent } from './instructor-student-list-page.component';
 
@@ -29,6 +30,7 @@ describe('InstructorStudentListPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         FormsModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { StudentProfile } from '../student-profile/student-profile';
@@ -33,6 +34,7 @@ describe('InstructorStudentRecordsPageComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/student-list/student-list.component.spec.ts
+++ b/src/web/app/pages-instructor/student-list/student-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { StudentListComponent } from './student-list.component';
@@ -15,6 +16,7 @@ describe('StudentListComponent', () => {
         HttpClientTestingModule,
         RouterTestingModule,
         NgbModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import {
   StudentViewResponsesModule,
@@ -18,6 +19,7 @@ describe('SessionResultPageComponent', () => {
         RouterTestingModule,
         StudentViewResponsesModule,
         QuestionTextWithInfoModule,
+        MatSnackBarModule,
       ],
       declarations: [SessionResultPageComponent],
     })

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { SessionSubmissionPageComponent } from './session-submission-page.component';
 import { SessionSubmissionPageModule } from './session-submission-page.module';
@@ -14,6 +15,7 @@ describe('SessionSubmissionPageComponent', () => {
         SessionSubmissionPageModule,
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.spec.ts
+++ b/src/web/app/pages-student/student-course-details-page/student-course-details-page.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Gender } from '../../../types/gender';
 import { StudentCourseDetailsPageComponent } from './student-course-details-page.component';
@@ -14,6 +15,7 @@ describe('StudentCourseDetailsPageComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.spec.ts
@@ -4,6 +4,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { StudentHomePageComponent } from './student-home-page.component';
 
+import { MatSnackBarModule } from '@angular/material';
 import { ResponseStatusPipe } from '../../pipes/session-response-status.pipe';
 import { SubmissionStatusPipe } from '../../pipes/session-submission-status.pipe';
 
@@ -22,6 +23,7 @@ describe('StudentHomePageComponent', () => {
         HttpClientTestingModule,
         NgbModule,
         RouterTestingModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-profile-page/student-profile-page.component.spec.ts
+++ b/src/web/app/pages-student/student-profile-page/student-profile-page.component.spec.ts
@@ -4,6 +4,7 @@ import { GenderFormatPipe } from './student-profile-gender.pipe';
 
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { environment } from '../../../environments/environment.prod';
 import { Gender } from '../../../types/gender';
@@ -25,6 +26,7 @@ describe('StudentProfilePageComponent', () => {
         ReactiveFormsModule,
         HttpClientTestingModule,
         TeammatesCommonModule,
+        MatSnackBarModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.spec.ts
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { UploadEditProfilePictureModalComponent } from './upload-edit-profile-picture-modal.component';
@@ -17,6 +18,7 @@ describe('UploadEditProfilePictureModalComponent', () => {
       imports: [
         HttpClientTestingModule,
         ImageCropperModule,
+        MatSnackBarModule,
       ],
       providers: [
         NgbActiveModal,

--- a/src/web/services/navigation.service.spec.ts
+++ b/src/web/services/navigation.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
+import { MatSnackBarModule } from '@angular/material';
 import { NavigationService } from './navigation.service';
 
 describe('NavigationService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      MatSnackBarModule,
+    ],
+  }));
 
   it('should be created', () => {
     const service: NavigationService = TestBed.get(NavigationService);

--- a/src/web/services/status-message.service.spec.ts
+++ b/src/web/services/status-message.service.spec.ts
@@ -1,9 +1,14 @@
 import { TestBed } from '@angular/core/testing';
 
+import { MatSnackBarModule } from '@angular/material';
 import { StatusMessageService } from './status-message.service';
 
 describe('StatusMessageService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  beforeEach(() => TestBed.configureTestingModule({
+    imports: [
+      MatSnackBarModule,
+    ],
+  }));
 
   it('should be created', () => {
     const service: StatusMessageService = TestBed.get(StatusMessageService);

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material';
 import { Observable, Subject } from 'rxjs';
 import { StatusMessage } from '../app/components/status-message/status-message';
 
@@ -12,7 +13,7 @@ export class StatusMessageService {
 
   private alertEvent: Subject<StatusMessage> = new Subject();
 
-  constructor() {}
+  constructor(private snackBar: MatSnackBar) {}
 
   /**
    * Gets the observable event of status messages.
@@ -27,7 +28,7 @@ export class StatusMessageService {
   showSuccessMessage(message: string): void {
     this.showMessage({
       message,
-      color: 'success',
+      color: 'snackbar-success',
     });
   }
 
@@ -37,7 +38,7 @@ export class StatusMessageService {
   showWarningMessage(message: string): void {
     this.showMessage({
       message,
-      color: 'warning',
+      color: 'snackbar-warning',
     });
   }
 
@@ -47,12 +48,17 @@ export class StatusMessageService {
   showErrorMessage(message: string): void {
     this.showMessage({
       message,
-      color: 'danger',
+      color: 'snackbar-danger',
     });
   }
 
   private showMessage(message: StatusMessage): void {
-    this.alertEvent.next(message);
+    // this.alertEvent.next(message);
+    this.snackBar.open(message.message, '', {
+      duration: 5000,
+      verticalPosition: 'top',
+      panelClass: ['snackbar', message.color],
+    });
   }
 
 }

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, TemplateRef } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
 import { StatusMessage } from '../app/components/status-message/status-message';
 
@@ -47,6 +47,35 @@ export class StatusMessageService {
       duration: 5000,
       verticalPosition: 'top',
       panelClass: ['snackbar', message.color],
+    });
+  }
+
+  /**
+   * Shows a success message containing HTML on the page
+   */
+  showSuccessMessageTemplate(template: TemplateRef<any>): void {
+    this.showTemplate(template, 'snackbar-success');
+  }
+
+  /**
+   * Shows a warning message containing HTML on the page
+   */
+  showWarningMessageTemplate(template: TemplateRef<any>): void {
+    this.showTemplate(template, 'snackbar-warning');
+  }
+
+  /**
+   * Shows an error message containing HTML on the page
+   */
+  showErrorMessageTemplate(template: TemplateRef<any>): void {
+    this.showTemplate(template, 'snackbar-danger');
+  }
+
+  private showTemplate(template: TemplateRef<any>, color: string): void {
+    this.snackBar.openFromTemplate(template, {
+      duration: 5000,
+      verticalPosition: 'top',
+      panelClass: ['snackbar', color],
     });
   }
 

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -57,20 +57,6 @@ export class StatusMessageService {
     this.showTemplate(template, 'snackbar-success');
   }
 
-  /**
-   * Shows a warning message containing HTML on the page
-   */
-  showWarningMessageTemplate(template: TemplateRef<any>): void {
-    this.showTemplate(template, 'snackbar-warning');
-  }
-
-  /**
-   * Shows an error message containing HTML on the page
-   */
-  showErrorMessageTemplate(template: TemplateRef<any>): void {
-    this.showTemplate(template, 'snackbar-danger');
-  }
-
   private showTemplate(template: TemplateRef<any>, color: string): void {
     this.snackBar.openFromTemplate(template, {
       duration: 5000,

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -44,7 +44,7 @@ export class StatusMessageService {
 
   private showMessage(message: StatusMessage): void {
     this.snackBar.open(message.message, '', {
-      duration: 5000,
+      duration: 10000,
       verticalPosition: 'top',
       panelClass: ['snackbar', message.color],
     });
@@ -59,7 +59,7 @@ export class StatusMessageService {
 
   private showTemplate(template: TemplateRef<any>, color: string): void {
     this.snackBar.openFromTemplate(template, {
-      duration: 5000,
+      duration: 10000,
       verticalPosition: 'top',
       panelClass: ['snackbar', color],
     });

--- a/src/web/services/status-message.service.ts
+++ b/src/web/services/status-message.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { MatSnackBar } from '@angular/material';
-import { Observable, Subject } from 'rxjs';
 import { StatusMessage } from '../app/components/status-message/status-message';
 
 /**
@@ -11,16 +10,7 @@ import { StatusMessage } from '../app/components/status-message/status-message';
 })
 export class StatusMessageService {
 
-  private alertEvent: Subject<StatusMessage> = new Subject();
-
   constructor(private snackBar: MatSnackBar) {}
-
-  /**
-   * Gets the observable event of status messages.
-   */
-  getAlertEvent(): Observable<StatusMessage> {
-    return this.alertEvent.asObservable();
-  }
 
   /**
    * Shows a success message on the page.
@@ -53,7 +43,6 @@ export class StatusMessageService {
   }
 
   private showMessage(message: StatusMessage): void {
-    // this.alertEvent.next(message);
     this.snackBar.open(message.message, '', {
       duration: 5000,
       verticalPosition: 'top',

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -3,10 +3,31 @@
 @import '~bootstrap/dist/css/bootstrap.css';
 @import '~@fortawesome/fontawesome-free/css/all.css';
 @import '~handsontable/dist/handsontable.full.css';
+@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';
 
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 15px;
+}
+
+.snackbar {
+  max-width: 100% !important;
+  margin-top: 60px !important;
+}
+
+.snackbar-danger {
+  background-color: #db4437;
+  color: white;
+}
+
+.snackbar-success {
+  background-color: #0f9d58;
+  color: white;
+}
+
+.snackbar-warning {
+  background-color: #fda50f;
+  color: #212121;
 }
 
 .btn {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -13,23 +13,29 @@ body {
 .snackbar {
   max-width: 100% !important;
   margin-top: 60px !important;
-  color: white;
-
-  a {
-    color: #3E3E3E;
-  }
 }
 
 .snackbar-danger {
-  background-color: #DB4437;
+  background-color: var(--danger);
+  color: var(--light);
+
+  a {
+    color: var(--dark);
+  }
 }
 
 .snackbar-success {
-  background-color: #0F9D58;
+  background-color: var(--success);
+  color: var(--light);
+
+  a {
+    color: var(--dark);
+  }
 }
 
 .snackbar-warning {
-  background-color: #FD9020;
+  background-color: var(--warning);
+  color: var(--dark);
 }
 
 .btn {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -13,21 +13,23 @@ body {
 .snackbar {
   max-width: 100% !important;
   margin-top: 60px !important;
+  color: white;
+
+  a {
+    color: #3E3E3E;
+  }
 }
 
 .snackbar-danger {
-  background-color: #db4437;
-  color: white;
+  background-color: #DB4437;
 }
 
 .snackbar-success {
-  background-color: #0f9d58;
-  color: white;
+  background-color: #0F9D58;
 }
 
 .snackbar-warning {
-  background-color: #fda50f;
-  color: #212121;
+  background-color: #FD9020;
 }
 
 .btn {

--- a/src/web/styles.scss
+++ b/src/web/styles.scss
@@ -20,7 +20,7 @@ body {
   color: var(--light);
 
   a {
-    color: var(--dark);
+    color: #000;
   }
 }
 
@@ -29,7 +29,7 @@ body {
   color: var(--light);
 
   a {
-    color: var(--dark);
+    color: #000;
   }
 }
 


### PR DESCRIPTION
Fixes #9346 

Status messages will be shown via snackbars (from angular material) so that it is visible to the users without them having to scroll up/down.

Success message:
![image](https://user-images.githubusercontent.com/35655790/55304294-5843e300-547d-11e9-95b1-a73837a106e5.png)


Warning message:
![image](https://user-images.githubusercontent.com/35655790/55251889-7dbdca80-528c-11e9-8d3f-e638d7160ec8.png)

Error message:
![image](https://user-images.githubusercontent.com/35655790/55251930-94642180-528c-11e9-8acd-7a627df6d803.png)

Long messages:
![image](https://user-images.githubusercontent.com/35655790/55251975-ae9dff80-528c-11e9-8e4e-31369adf2d95.png)