### PR TITLE
[#9564] Standardize the naming convention of request DTO

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/ActionFactory.java
+++ b/src/main/java/teammates/ui/webapi/action/ActionFactory.java
@@ -75,7 +75,7 @@ public class ActionFactory {
         map(ResourceURIs.SESSIONS_ONGOING, GET, GetOngoingSessionsAction.class);
         map(ResourceURIs.SESSION_STATS, GET, GetSessionResponseStatsAction.class);
         map(ResourceURIs.SESSION, GET, GetFeedbackSessionAction.class);
-        map(ResourceURIs.SESSION, PUT, SaveFeedbackSessionAction.class);
+        map(ResourceURIs.SESSION, PUT, UpdateFeedbackSessionAction.class);
         map(ResourceURIs.SESSION, POST, CreateFeedbackSessionAction.class);
         map(ResourceURIs.SESSION, DELETE, DeleteFeedbackSessionAction.class);
         map(ResourceURIs.SESSION_PUBLISH, POST, PublishFeedbackSessionAction.class);
@@ -88,12 +88,12 @@ public class ActionFactory {
         map(ResourceURIs.BIN_SESSION, DELETE, RestoreFeedbackSessionAction.class);
         map(ResourceURIs.QUESTIONS, GET, GetFeedbackQuestionsAction.class);
         map(ResourceURIs.QUESTION, POST, CreateFeedbackQuestionAction.class);
-        map(ResourceURIs.QUESTION, PUT, SaveFeedbackQuestionAction.class);
+        map(ResourceURIs.QUESTION, PUT, UpdateFeedbackQuestionAction.class);
         map(ResourceURIs.QUESTION, DELETE, DeleteFeedbackQuestionAction.class);
         map(ResourceURIs.QUESTION_RECIPIENTS, GET, GetFeedbackQuestionRecipientsAction.class);
         map(ResourceURIs.RESPONSES, GET, GetFeedbackResponsesAction.class);
         map(ResourceURIs.RESPONSE, POST, CreateFeedbackResponseAction.class);
-        map(ResourceURIs.RESPONSE, PUT, SaveFeedbackResponseAction.class);
+        map(ResourceURIs.RESPONSE, PUT, UpdateFeedbackResponseAction.class);
         map(ResourceURIs.RESPONSE, DELETE, DeleteFeedbackResponseAction.class);
         map(ResourceURIs.SUBMISSION_CONFIRMATION, POST, ConfirmFeedbackSessionSubmissionAction.class);
         map(ResourceURIs.LOCAL_DATE_TIME, GET, GetLocalDateTimeInfoAction.class);

--- a/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
@@ -15,7 +15,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
-import teammates.ui.webapi.request.FeedbackResponseCommentUpdateRequest;
+import teammates.ui.webapi.request.FeedbackResponseCommentCreateRequest;
 
 /**
  * Creates a new feedback response comment.
@@ -52,18 +52,7 @@ public class CreateFeedbackResponseCommentAction extends Action {
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);
 
-        FeedbackResponseCommentUpdateRequest comment = getAndValidateRequestBody(FeedbackResponseCommentUpdateRequest.class);
-
-        // String giverEmail = response.giver;
-        // String recipientEmail = response.recipient;
-
-        // String giverName = bundle.getGiverNameForResponse(response);
-        // String giverTeamName = bundle.getTeamNameForEmail(giverEmail);
-        // data.giverName = bundle.appendTeamNameToName(giverName, giverTeamName);
-
-        // String recipientName = bundle.getRecipientNameForResponse(response);
-        // String recipientTeamName = bundle.getTeamNameForEmail(recipientEmail);
-        // data.recipientName = bundle.appendTeamNameToName(recipientName, recipientTeamName);
+        FeedbackResponseCommentCreateRequest comment = getAndValidateRequestBody(FeedbackResponseCommentCreateRequest.class);
 
         String commentText = comment.getCommentText();
         if (commentText.trim().isEmpty()) {

--- a/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/CreateFeedbackResponseCommentAction.java
@@ -15,7 +15,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
-import teammates.ui.webapi.request.FeedbackResponseCommentSaveRequest;
+import teammates.ui.webapi.request.FeedbackResponseCommentUpdateRequest;
 
 /**
  * Creates a new feedback response comment.
@@ -52,7 +52,7 @@ public class CreateFeedbackResponseCommentAction extends Action {
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);
 
-        FeedbackResponseCommentSaveRequest comment = getAndValidateRequestBody(FeedbackResponseCommentSaveRequest.class);
+        FeedbackResponseCommentUpdateRequest comment = getAndValidateRequestBody(FeedbackResponseCommentUpdateRequest.class);
 
         // String giverEmail = response.giver;
         // String recipientEmail = response.recipient;

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
@@ -16,7 +16,7 @@ import teammates.ui.webapi.request.FeedbackQuestionSaveRequest;
 /**
  * Save a feedback question.
  */
-public class SaveFeedbackQuestionAction extends Action {
+public class UpdateFeedbackQuestionAction extends Action {
 
     @Override
     protected AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackQuestionAction.java
@@ -11,10 +11,10 @@ import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackQuestionData;
-import teammates.ui.webapi.request.FeedbackQuestionSaveRequest;
+import teammates.ui.webapi.request.FeedbackQuestionUpdateRequest;
 
 /**
- * Save a feedback question.
+ * Updates a feedback question.
  */
 public class UpdateFeedbackQuestionAction extends Action {
 
@@ -42,22 +42,22 @@ public class UpdateFeedbackQuestionAction extends Action {
         String feedbackQuestionId = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_QUESTION_ID);
         FeedbackQuestionAttributes oldQuestion = logic.getFeedbackQuestion(feedbackQuestionId);
 
-        FeedbackQuestionSaveRequest saveRequest = getAndValidateRequestBody(FeedbackQuestionSaveRequest.class);
+        FeedbackQuestionUpdateRequest updateRequest = getAndValidateRequestBody(FeedbackQuestionUpdateRequest.class);
 
         // update old value based on current request
-        oldQuestion.setQuestionNumber(saveRequest.getQuestionNumber());
-        oldQuestion.setQuestionDescription(saveRequest.getQuestionDescription());
+        oldQuestion.setQuestionNumber(updateRequest.getQuestionNumber());
+        oldQuestion.setQuestionDescription(updateRequest.getQuestionDescription());
 
-        oldQuestion.setQuestionDetails(saveRequest.getQuestionDetails());
+        oldQuestion.setQuestionDetails(updateRequest.getQuestionDetails());
 
-        oldQuestion.setGiverType(saveRequest.getGiverType());
-        oldQuestion.setRecipientType(saveRequest.getRecipientType());
+        oldQuestion.setGiverType(updateRequest.getGiverType());
+        oldQuestion.setRecipientType(updateRequest.getRecipientType());
 
-        oldQuestion.setNumberOfEntitiesToGiveFeedbackTo(saveRequest.getNumberOfEntitiesToGiveFeedbackTo());
+        oldQuestion.setNumberOfEntitiesToGiveFeedbackTo(updateRequest.getNumberOfEntitiesToGiveFeedbackTo());
 
-        oldQuestion.setShowResponsesTo(saveRequest.getShowResponsesTo());
-        oldQuestion.setShowGiverNameTo(saveRequest.getShowGiverNameTo());
-        oldQuestion.setShowRecipientNameTo(saveRequest.getShowRecipientNameTo());
+        oldQuestion.setShowResponsesTo(updateRequest.getShowResponsesTo());
+        oldQuestion.setShowGiverNameTo(updateRequest.getShowGiverNameTo());
+        oldQuestion.setShowRecipientNameTo(updateRequest.getShowRecipientNameTo());
 
         // validate questions (giver & recipient)
         String err = oldQuestion.getQuestionDetails().validateGiverRecipientVisibility(oldQuestion);

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
@@ -15,10 +15,10 @@ import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackResponseData;
-import teammates.ui.webapi.request.FeedbackResponseSaveRequest;
+import teammates.ui.webapi.request.FeedbackResponseUpdateRequest;
 
 /**
- * Save a feedback response.
+ * Updates a feedback response.
  */
 public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction {
 
@@ -67,8 +67,8 @@ public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
 
-        FeedbackResponseSaveRequest saveRequest = getAndValidateRequestBody(FeedbackResponseSaveRequest.class);
-        if (!recipientsOfTheQuestion.containsKey(saveRequest.getRecipientIdentifier())) {
+        FeedbackResponseUpdateRequest updateRequest = getAndValidateRequestBody(FeedbackResponseUpdateRequest.class);
+        if (!recipientsOfTheQuestion.containsKey(updateRequest.getRecipientIdentifier())) {
             throw new UnauthorizedAccessException("The recipient is not a valid recipient of the question");
         }
     }
@@ -99,14 +99,14 @@ public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction 
             throw new InvalidHttpParameterException("Unknown intent " + intent);
         }
 
-        FeedbackResponseSaveRequest saveRequest = getAndValidateRequestBody(FeedbackResponseSaveRequest.class);
+        FeedbackResponseUpdateRequest updateRequest = getAndValidateRequestBody(FeedbackResponseUpdateRequest.class);
         feedbackResponse.giver = giverIdentifier;
         feedbackResponse.giverSection = giverSection;
-        feedbackResponse.recipient = saveRequest.getRecipientIdentifier();
+        feedbackResponse.recipient = updateRequest.getRecipientIdentifier();
         feedbackResponse.recipientSection =
                 getRecipientSection(feedbackQuestion.getCourseId(),
-                        feedbackQuestion.getRecipientType(), saveRequest.getRecipientIdentifier());
-        feedbackResponse.responseDetails = saveRequest.getResponseDetails();
+                        feedbackQuestion.getRecipientType(), updateRequest.getRecipientIdentifier());
+        feedbackResponse.responseDetails = updateRequest.getResponseDetails();
 
         validResponseOfQuestion(feedbackQuestion, feedbackResponse);
 

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseAction.java
@@ -20,7 +20,7 @@ import teammates.ui.webapi.request.FeedbackResponseSaveRequest;
 /**
  * Save a feedback response.
  */
-public class SaveFeedbackResponseAction extends BasicFeedbackSubmissionAction {
+public class UpdateFeedbackResponseAction extends BasicFeedbackSubmissionAction {
 
     @Override
     protected AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseCommentAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackResponseCommentAction.java
@@ -17,10 +17,10 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;
-import teammates.ui.webapi.request.FeedbackResponseCommentSaveRequest;
+import teammates.ui.webapi.request.FeedbackResponseCommentUpdateRequest;
 
 /**
- * Edits a feedback response comment.
+ * Updates a feedback response comment.
  */
 public class UpdateFeedbackResponseCommentAction extends Action {
 
@@ -73,7 +73,7 @@ public class UpdateFeedbackResponseCommentAction extends Action {
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);
 
-        FeedbackResponseCommentSaveRequest comment = getAndValidateRequestBody(FeedbackResponseCommentSaveRequest.class);
+        FeedbackResponseCommentUpdateRequest comment = getAndValidateRequestBody(FeedbackResponseCommentUpdateRequest.class);
 
         // Edit comment text
         String commentText = comment.getCommentText();

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackSessionAction.java
@@ -8,10 +8,10 @@ import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.ui.webapi.output.FeedbackSessionData;
-import teammates.ui.webapi.request.FeedbackSessionSaveRequest;
+import teammates.ui.webapi.request.FeedbackSessionUpdateRequest;
 
 /**
- * Save a feedback session.
+ * Updates a feedback session.
  */
 public class UpdateFeedbackSessionAction extends Action {
 
@@ -37,20 +37,20 @@ public class UpdateFeedbackSessionAction extends Action {
         String courseId = getNonNullRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getNonNullRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
 
-        FeedbackSessionSaveRequest saveRequest =
-                getAndValidateRequestBody(FeedbackSessionSaveRequest.class);
+        FeedbackSessionUpdateRequest updateRequest =
+                getAndValidateRequestBody(FeedbackSessionUpdateRequest.class);
 
         try {
             FeedbackSessionAttributes updateFeedbackSession = logic.updateFeedbackSession(
                     FeedbackSessionAttributes.updateOptionsBuilder(feedbackSessionName, courseId)
-                            .withInstructions(saveRequest.getInstructions())
-                            .withStartTime(saveRequest.getSubmissionStartTime())
-                            .withEndTime(saveRequest.getSubmissionEndTime())
-                            .withGracePeriod(saveRequest.getGracePeriod())
-                            .withSessionVisibleFromTime(saveRequest.getSessionVisibleFromTime())
-                            .withResultsVisibleFromTime(saveRequest.getResultsVisibleFromTime())
-                            .withIsClosingEmailEnabled(saveRequest.isClosingEmailEnabled())
-                            .withIsPublishedEmailEnabled(saveRequest.isPublishedEmailEnabled())
+                            .withInstructions(updateRequest.getInstructions())
+                            .withStartTime(updateRequest.getSubmissionStartTime())
+                            .withEndTime(updateRequest.getSubmissionEndTime())
+                            .withGracePeriod(updateRequest.getGracePeriod())
+                            .withSessionVisibleFromTime(updateRequest.getSessionVisibleFromTime())
+                            .withResultsVisibleFromTime(updateRequest.getResultsVisibleFromTime())
+                            .withIsClosingEmailEnabled(updateRequest.isClosingEmailEnabled())
+                            .withIsPublishedEmailEnabled(updateRequest.isPublishedEmailEnabled())
                             .build());
 
             return new JsonResult(new FeedbackSessionData(updateFeedbackSession));

--- a/src/main/java/teammates/ui/webapi/action/UpdateFeedbackSessionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/UpdateFeedbackSessionAction.java
@@ -13,7 +13,7 @@ import teammates.ui.webapi.request.FeedbackSessionSaveRequest;
 /**
  * Save a feedback session.
  */
-public class SaveFeedbackSessionAction extends Action {
+public class UpdateFeedbackSessionAction extends Action {
 
     @Override
     protected AuthType getMinAuthLevel() {

--- a/src/main/java/teammates/ui/webapi/request/FeedbackQuestionSaveRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackQuestionSaveRequest.java
@@ -1,7 +1,0 @@
-package teammates.ui.webapi.request;
-
-/**
- * The save request of a feedback question.
- */
-public class FeedbackQuestionSaveRequest extends FeedbackQuestionBasicRequest {
-}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackQuestionUpdateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackQuestionUpdateRequest.java
@@ -1,0 +1,7 @@
+package teammates.ui.webapi.request;
+
+/**
+ * The update request of a feedback question.
+ */
+public class FeedbackQuestionUpdateRequest extends FeedbackQuestionBasicRequest {
+}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentBasicRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentBasicRequest.java
@@ -1,0 +1,38 @@
+package teammates.ui.webapi.request;
+
+import javax.annotation.Nullable;
+
+/**
+ * The basic request of modifying a feedback response comment.
+ */
+public class FeedbackResponseCommentBasicRequest extends BasicRequest {
+
+    private String commentText;
+    @Nullable
+    private String showCommentTo;
+    @Nullable
+    private String showGiverNameTo;
+
+    public FeedbackResponseCommentBasicRequest(String commentText, String showCommentTo, String showGiverNameTo) {
+        this.commentText = commentText;
+        this.showCommentTo = showCommentTo;
+        this.showGiverNameTo = showGiverNameTo;
+    }
+
+    public String getCommentText() {
+        return commentText;
+    }
+
+    public String getShowCommentTo() {
+        return showCommentTo;
+    }
+
+    public String getShowGiverNameTo() {
+        return showGiverNameTo;
+    }
+
+    @Override
+    public void validate() {
+        // TODO decide what to validate
+    }
+}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentCreateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentCreateRequest.java
@@ -1,0 +1,11 @@
+package teammates.ui.webapi.request;
+
+/**
+ * The create request of a feedback response comment.
+ */
+public class FeedbackResponseCommentCreateRequest extends FeedbackResponseCommentBasicRequest {
+
+    public FeedbackResponseCommentCreateRequest(String commentText, String showCommentTo, String showGiverNameTo) {
+        super(commentText, showCommentTo, showGiverNameTo);
+    }
+}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentUpdateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentUpdateRequest.java
@@ -1,39 +1,11 @@
 package teammates.ui.webapi.request;
 
-import javax.annotation.Nullable;
-
 /**
  * The update request of a feedback response comment.
  */
-public class FeedbackResponseCommentUpdateRequest extends BasicRequest {
-
-    private String commentText;
-    @Nullable
-    private String showCommentTo;
-    @Nullable
-    private String showGiverNameTo;
+public class FeedbackResponseCommentUpdateRequest extends FeedbackResponseCommentBasicRequest {
 
     public FeedbackResponseCommentUpdateRequest(String commentText, String showCommentTo, String showGiverNameTo) {
-        this.commentText = commentText;
-        this.showCommentTo = showCommentTo;
-        this.showGiverNameTo = showGiverNameTo;
+        super(commentText, showCommentTo, showGiverNameTo);
     }
-
-    public String getCommentText() {
-        return commentText;
-    }
-
-    public String getShowCommentTo() {
-        return showCommentTo;
-    }
-
-    public String getShowGiverNameTo() {
-        return showGiverNameTo;
-    }
-
-    @Override
-    public void validate() {
-        // TODO decide what to validate
-    }
-
 }

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentUpdateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseCommentUpdateRequest.java
@@ -3,9 +3,9 @@ package teammates.ui.webapi.request;
 import javax.annotation.Nullable;
 
 /**
- * The save request of a feedback response comment.
+ * The update request of a feedback response comment.
  */
-public class FeedbackResponseCommentSaveRequest extends BasicRequest {
+public class FeedbackResponseCommentUpdateRequest extends BasicRequest {
 
     private String commentText;
     @Nullable
@@ -13,7 +13,7 @@ public class FeedbackResponseCommentSaveRequest extends BasicRequest {
     @Nullable
     private String showGiverNameTo;
 
-    public FeedbackResponseCommentSaveRequest(String commentText, String showCommentTo, String showGiverNameTo) {
+    public FeedbackResponseCommentUpdateRequest(String commentText, String showCommentTo, String showGiverNameTo) {
         this.commentText = commentText;
         this.showCommentTo = showCommentTo;
         this.showGiverNameTo = showGiverNameTo;

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseSaveRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseSaveRequest.java
@@ -1,7 +1,0 @@
-package teammates.ui.webapi.request;
-
-/**
- * The save request of a feedback response.
- */
-public class FeedbackResponseSaveRequest extends FeedbackResponseBasicRequest {
-}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackResponseUpdateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackResponseUpdateRequest.java
@@ -1,0 +1,7 @@
+package teammates.ui.webapi.request;
+
+/**
+ * The update request of a feedback response.
+ */
+public class FeedbackResponseUpdateRequest extends FeedbackResponseBasicRequest {
+}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackSessionSaveRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackSessionSaveRequest.java
@@ -1,8 +1,0 @@
-package teammates.ui.webapi.request;
-
-/**
- * The request body format for saving of feedback session.
- */
-public class FeedbackSessionSaveRequest extends FeedbackSessionBasicRequest {
-
-}

--- a/src/main/java/teammates/ui/webapi/request/FeedbackSessionUpdateRequest.java
+++ b/src/main/java/teammates/ui/webapi/request/FeedbackSessionUpdateRequest.java
@@ -1,0 +1,8 @@
+package teammates.ui.webapi.request;
+
+/**
+ * The update request of a feedback session.
+ */
+public class FeedbackSessionUpdateRequest extends FeedbackSessionBasicRequest {
+
+}

--- a/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -18,7 +18,7 @@ import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.ui.webapi.action.CreateFeedbackResponseCommentAction;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.MessageOutput;
-import teammates.ui.webapi.request.FeedbackResponseCommentSaveRequest;
+import teammates.ui.webapi.request.FeedbackResponseCommentUpdateRequest;
 
 /**
  * SUT: {@link CreateFeedbackResponseCommentAction}.
@@ -62,8 +62,8 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        FeedbackResponseCommentSaveRequest requestBody =
-                new FeedbackResponseCommentSaveRequest("Comment to first response", null, "GIVER,INSTRUCTORS");
+        FeedbackResponseCommentUpdateRequest requestBody =
+                new FeedbackResponseCommentUpdateRequest("Comment to first response", null, "GIVER,INSTRUCTORS");
         CreateFeedbackResponseCommentAction action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -82,7 +82,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Empty giver permissions", null, "");
+        requestBody = new FeedbackResponseCommentUpdateRequest("Empty giver permissions", null, "");
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -92,7 +92,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Null comment permissions", null, null);
+        requestBody = new FeedbackResponseCommentUpdateRequest("Null comment permissions", null, null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -100,7 +100,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Empty comment permissions", "", "");
+        requestBody = new FeedbackResponseCommentUpdateRequest("Empty comment permissions", "", "");
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -108,7 +108,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Comment shown to giver", "GIVER", null);
+        requestBody = new FeedbackResponseCommentUpdateRequest("Comment shown to giver", "GIVER", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -116,7 +116,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Comment shown to receiver", "RECEIVER", null);
+        requestBody = new FeedbackResponseCommentUpdateRequest("Comment shown to receiver", "RECEIVER", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -124,7 +124,8 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Comment shown to own team members", "OWN_TEAM_MEMBERS", null);
+        requestBody =
+                new FeedbackResponseCommentUpdateRequest("Comment shown to own team members", "OWN_TEAM_MEMBERS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -132,7 +133,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 "Comment shown to receiver team members", "RECEIVER_TEAM_MEMBERS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -141,7 +142,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("Comment shown to students", "STUDENTS", null);
+        requestBody = new FeedbackResponseCommentUpdateRequest("Comment shown to students", "STUDENTS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -152,7 +153,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 "Comment to first response, published session", "GIVER,INSTRUCTORS", "GIVER,INSTRUCTORS");
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -171,7 +172,7 @@ public class CreateFeedbackResponseCommentActionTest extends BaseActionTest<Crea
                 Const.ParamsNames.FEEDBACK_RESPONSE_ID, response.getId(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest("", null, null);
+        requestBody = new FeedbackResponseCommentUpdateRequest("", null, null);
         action = getAction(requestBody, submissionParams);
         JsonResult result = getJsonResult(action);
         MessageOutput output = (MessageOutput) result.getOutput();

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackQuestionActionTest.java
@@ -21,16 +21,16 @@ import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.storage.api.FeedbackResponsesDb;
 import teammates.ui.webapi.action.JsonResult;
-import teammates.ui.webapi.action.SaveFeedbackQuestionAction;
+import teammates.ui.webapi.action.UpdateFeedbackQuestionAction;
 import teammates.ui.webapi.output.FeedbackQuestionData;
 import teammates.ui.webapi.output.FeedbackVisibilityType;
 import teammates.ui.webapi.output.NumberOfEntitiesToGiveFeedbackToSetting;
 import teammates.ui.webapi.request.FeedbackQuestionSaveRequest;
 
 /**
- * SUT: {@link SaveFeedbackQuestionAction}.
+ * SUT: {@link UpdateFeedbackQuestionAction}.
  */
-public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQuestionAction> {
+public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedbackQuestionAction> {
 
     @Override
     protected String getActionUri() {
@@ -64,7 +64,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         };
         FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -124,7 +124,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         saveRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM);
         saveRequest.setCustomNumberOfEntitiesToGiveFeedbackTo(10);
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -152,7 +152,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         saveRequest.setShowGiverNameTo(Arrays.asList());
         saveRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -184,7 +184,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         saveRequest.setShowGiverNameTo(Arrays.asList());
         saveRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -225,7 +225,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -258,7 +258,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
         saveRequest.setQuestionNumber(-1);
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
             getJsonResult(a);
@@ -288,7 +288,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         // set recommended length as a negative integer
         textQuestionDetails.setRecommendedLength(-1);
         saveRequest.setQuestionDetails(textQuestionDetails);
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> getJsonResult(a));
 
@@ -317,7 +317,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         saveRequest.setGiverType(FeedbackParticipantType.TEAMS);
         saveRequest.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS);
 
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
             getJsonResult(a);
@@ -364,7 +364,7 @@ public class SaveFeedbackQuestionActionTest extends BaseActionTest<SaveFeedbackQ
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        SaveFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
         getJsonResult(a);
 
         // TODO first comment was there before, but the second one seems to be the one happening?

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackQuestionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackQuestionActionTest.java
@@ -25,7 +25,7 @@ import teammates.ui.webapi.action.UpdateFeedbackQuestionAction;
 import teammates.ui.webapi.output.FeedbackQuestionData;
 import teammates.ui.webapi.output.FeedbackVisibilityType;
 import teammates.ui.webapi.output.NumberOfEntitiesToGiveFeedbackToSetting;
-import teammates.ui.webapi.request.FeedbackQuestionSaveRequest;
+import teammates.ui.webapi.request.FeedbackQuestionUpdateRequest;
 
 /**
  * SUT: {@link UpdateFeedbackQuestionAction}.
@@ -62,9 +62,9 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -109,7 +109,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
     }
 
     @Test
-    public void testExecute_customerNumberOfRecipient_shouldSaveSuccessfully() {
+    public void testExecute_customizedNumberOfRecipient_shouldUpdateSuccessfully() {
         InstructorAttributes instructor1ofCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackSessionAttributes session = typicalBundle.feedbackSessions.get("session1InCourse1");
         FeedbackQuestionAttributes typicalQuestion =
@@ -120,11 +120,11 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM);
-        saveRequest.setCustomNumberOfEntitiesToGiveFeedbackTo(10);
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM);
+        updateRequest.setCustomNumberOfEntitiesToGiveFeedbackTo(10);
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -134,7 +134,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
     }
 
     @Test
-    public void testExecute_anonymousTeamSession_shouldSaveSuccessfully() {
+    public void testExecute_anonymousTeamSession_shouldUpdateSuccessfully() {
         InstructorAttributes instructor1ofCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackSessionAttributes session = typicalBundle.feedbackSessions.get("session1InCourse1");
         FeedbackQuestionAttributes typicalQuestion =
@@ -145,14 +145,14 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.TEAMS);
-        saveRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
-        saveRequest.setShowGiverNameTo(Arrays.asList());
-        saveRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.TEAMS);
+        updateRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
+        updateRequest.setShowGiverNameTo(Arrays.asList());
+        updateRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -166,7 +166,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
     }
 
     @Test
-    public void testExecute_selfFeedback_shouldSaveSuccessfully() {
+    public void testExecute_selfFeedback_shouldUpdateSuccessfully() {
         InstructorAttributes instructor1ofCourse1 = typicalBundle.instructors.get("instructor1OfCourse1");
         FeedbackSessionAttributes session = typicalBundle.feedbackSessions.get("session1InCourse1");
         FeedbackQuestionAttributes typicalQuestion =
@@ -177,14 +177,14 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.SELF);
-        saveRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
-        saveRequest.setShowGiverNameTo(Arrays.asList());
-        saveRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.SELF);
+        updateRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
+        updateRequest.setShowGiverNameTo(Arrays.asList());
+        updateRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.RECIPIENT));
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -198,7 +198,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
     }
 
     @Test
-    public void testExecute_editingContributionTypeQuestion_shouldSaveSuccessfully() {
+    public void testExecute_editingContributionTypeQuestion_shouldUpdateSuccessfully() {
         DataBundle dataBundle = loadDataBundle("/FeedbackSessionQuestionTypeTest.json");
         removeAndRestoreDataBundle(dataBundle);
 
@@ -216,16 +216,16 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         // There are already responses for this question
         assertFalse(frDb.getFeedbackResponsesForQuestion(fq.getId()).isEmpty());
 
-        FeedbackQuestionSaveRequest saveRequest = getTypicalContributionQuestionSaveRequest();
-        saveRequest.setQuestionNumber(fq.getQuestionNumber());
-        saveRequest.setGiverType(fq.getGiverType());
-        saveRequest.setRecipientType(fq.getRecipientType());
-        saveRequest.setQuestionDetails(fq.getQuestionDetails());
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalContributionQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(fq.getQuestionNumber());
+        updateRequest.setGiverType(fq.getGiverType());
+        updateRequest.setRecipientType(fq.getRecipientType());
+        updateRequest.setQuestionDetails(fq.getQuestionDetails());
 
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -236,7 +236,7 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         ______TS("Edit: Invalid recipient type");
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
-            FeedbackQuestionSaveRequest request = getTypicalContributionQuestionSaveRequest();
+            FeedbackQuestionUpdateRequest request = getTypicalContributionQuestionUpdateRequest();
             request.setQuestionNumber(fq.getQuestionNumber());
             request.setRecipientType(FeedbackParticipantType.STUDENTS);
             getJsonResult(getAction(request, param));
@@ -255,10 +255,10 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setQuestionNumber(-1);
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(-1);
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
             getJsonResult(a);
@@ -283,12 +283,12 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
 
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
         FeedbackTextQuestionDetails textQuestionDetails = new FeedbackTextQuestionDetails();
         // set recommended length as a negative integer
         textQuestionDetails.setRecommendedLength(-1);
-        saveRequest.setQuestionDetails(textQuestionDetails);
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        updateRequest.setQuestionDetails(textQuestionDetails);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> getJsonResult(a));
 
@@ -313,11 +313,11 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, typicalQuestion.getFeedbackQuestionId(),
         };
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setGiverType(FeedbackParticipantType.TEAMS);
-        saveRequest.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS);
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setGiverType(FeedbackParticipantType.TEAMS);
+        updateRequest.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS);
 
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
             getJsonResult(a);
@@ -354,17 +354,17 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
 
         FeedbackQuestionAttributes fq =
                 logic.getFeedbackQuestion(fs.getFeedbackSessionName(), fs.getCourseId(), 1);
-        FeedbackQuestionSaveRequest saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setQuestionNumber(fq.getQuestionNumber());
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM);
-        saveRequest.setCustomNumberOfEntitiesToGiveFeedbackTo(1);
+        FeedbackQuestionUpdateRequest updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(fq.getQuestionNumber());
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM);
+        updateRequest.setCustomNumberOfEntitiesToGiveFeedbackTo(1);
 
         String[] param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        UpdateFeedbackQuestionAction a = getAction(saveRequest, param);
+        UpdateFeedbackQuestionAction a = getAction(updateRequest, param);
         getJsonResult(a);
 
         // TODO first comment was there before, but the second one seems to be the one happening?
@@ -380,15 +380,15 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
                 + "response rate changed");
 
         fq = logic.getFeedbackQuestion(fs.getFeedbackSessionName(), fs.getCourseId(), 3);
-        saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setQuestionNumber(fq.getQuestionNumber());
-        saveRequest.setGiverType(fq.getGiverType());
-        saveRequest.setRecipientType(FeedbackParticipantType.STUDENTS);
+        updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(fq.getQuestionNumber());
+        updateRequest.setGiverType(fq.getGiverType());
+        updateRequest.setRecipientType(FeedbackParticipantType.STUDENTS);
 
         param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        a = getAction(saveRequest, param);
+        a = getAction(updateRequest, param);
         getJsonResult(a);
 
         // Response rate should decrease by 1 because the response of the unique instructor respondent is deleted
@@ -400,15 +400,15 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         ______TS("Change the feedback path of a question so that some possible respondents are removed");
 
         fq = logic.getFeedbackQuestion(fs.getFeedbackSessionName(), fs.getCourseId(), 4);
-        saveRequest = getTypicalTextQuestionSaveRequest();
-        saveRequest.setQuestionNumber(fq.getQuestionNumber());
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.NONE);
+        updateRequest = getTypicalTextQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(fq.getQuestionNumber());
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.NONE);
 
         param = new String[] {
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, fq.getFeedbackQuestionId(),
         };
-        a = getAction(saveRequest, param);
+        a = getAction(updateRequest, param);
         getJsonResult(a);
 
         // Total possible respondents should decrease because instructors
@@ -419,44 +419,44 @@ public class UpdateFeedbackQuestionActionTest extends BaseActionTest<UpdateFeedb
         assertEquals(totalStudents + 1, details.stats.expectedTotal);
     }
 
-    private FeedbackQuestionSaveRequest getTypicalTextQuestionSaveRequest() {
-        FeedbackQuestionSaveRequest saveRequest = new FeedbackQuestionSaveRequest();
-        saveRequest.setQuestionNumber(2);
-        saveRequest.setQuestionBrief("this is the brief");
-        saveRequest.setQuestionDescription("this is the description");
+    private FeedbackQuestionUpdateRequest getTypicalTextQuestionUpdateRequest() {
+        FeedbackQuestionUpdateRequest updateRequest = new FeedbackQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(2);
+        updateRequest.setQuestionBrief("this is the brief");
+        updateRequest.setQuestionDescription("this is the description");
         FeedbackTextQuestionDetails textQuestionDetails = new FeedbackTextQuestionDetails();
         textQuestionDetails.setRecommendedLength(800);
-        saveRequest.setQuestionDetails(textQuestionDetails);
-        saveRequest.setQuestionType(FeedbackQuestionType.TEXT);
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.INSTRUCTORS);
-        saveRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED);
+        updateRequest.setQuestionDetails(textQuestionDetails);
+        updateRequest.setQuestionType(FeedbackQuestionType.TEXT);
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.INSTRUCTORS);
+        updateRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED);
 
-        saveRequest.setShowResponsesTo(new ArrayList<>());
-        saveRequest.setShowGiverNameTo(new ArrayList<>());
-        saveRequest.setShowRecipientNameTo(new ArrayList<>());
+        updateRequest.setShowResponsesTo(new ArrayList<>());
+        updateRequest.setShowGiverNameTo(new ArrayList<>());
+        updateRequest.setShowRecipientNameTo(new ArrayList<>());
 
-        return saveRequest;
+        return updateRequest;
     }
 
-    private FeedbackQuestionSaveRequest getTypicalContributionQuestionSaveRequest() {
-        FeedbackQuestionSaveRequest saveRequest = new FeedbackQuestionSaveRequest();
-        saveRequest.setQuestionNumber(1);
-        saveRequest.setQuestionBrief("this is the brief for contribution question");
-        saveRequest.setQuestionDescription("this is the description for contribution question");
+    private FeedbackQuestionUpdateRequest getTypicalContributionQuestionUpdateRequest() {
+        FeedbackQuestionUpdateRequest updateRequest = new FeedbackQuestionUpdateRequest();
+        updateRequest.setQuestionNumber(1);
+        updateRequest.setQuestionBrief("this is the brief for contribution question");
+        updateRequest.setQuestionDescription("this is the description for contribution question");
         FeedbackContributionQuestionDetails textQuestionDetails = new FeedbackContributionQuestionDetails();
         textQuestionDetails.setNotSureAllowed(false);
-        saveRequest.setQuestionDetails(textQuestionDetails);
-        saveRequest.setQuestionType(FeedbackQuestionType.CONTRIB);
-        saveRequest.setGiverType(FeedbackParticipantType.STUDENTS);
-        saveRequest.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF);
-        saveRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED);
+        updateRequest.setQuestionDetails(textQuestionDetails);
+        updateRequest.setQuestionType(FeedbackQuestionType.CONTRIB);
+        updateRequest.setGiverType(FeedbackParticipantType.STUDENTS);
+        updateRequest.setRecipientType(FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF);
+        updateRequest.setNumberOfEntitiesToGiveFeedbackToSetting(NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED);
 
-        saveRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
-        saveRequest.setShowGiverNameTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
-        saveRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
+        updateRequest.setShowResponsesTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
+        updateRequest.setShowGiverNameTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
+        updateRequest.setShowRecipientNameTo(Arrays.asList(FeedbackVisibilityType.INSTRUCTORS));
 
-        return saveRequest;
+        return updateRequest;
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseActionTest.java
@@ -3,12 +3,12 @@ package teammates.test.cases.webapi;
 import org.testng.annotations.Test;
 
 import teammates.common.util.Const;
-import teammates.ui.webapi.action.SaveFeedbackResponseAction;
+import teammates.ui.webapi.action.UpdateFeedbackResponseAction;
 
 /**
- * SUT: {@link SaveFeedbackResponseAction}.
+ * SUT: {@link UpdateFeedbackResponseAction}.
  */
-public class SaveFeedbackResponseActionTest extends BaseActionTest<SaveFeedbackResponseAction> {
+public class UpdateFeedbackResponseActionTest extends BaseActionTest<UpdateFeedbackResponseAction> {
 
     @Override
     protected String getActionUri() {

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
@@ -15,7 +15,7 @@ import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.action.UpdateFeedbackResponseCommentAction;
 import teammates.ui.webapi.output.MessageOutput;
-import teammates.ui.webapi.request.FeedbackResponseCommentSaveRequest;
+import teammates.ui.webapi.request.FeedbackResponseCommentUpdateRequest;
 
 /**
  * SUT: {@link UpdateFeedbackResponseCommentAction}.
@@ -64,7 +64,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        FeedbackResponseCommentSaveRequest requestBody = new FeedbackResponseCommentSaveRequest(
+        FeedbackResponseCommentUpdateRequest requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "GIVER,INSTRUCTORS", "GIVER,INSTRUCTORS");
         UpdateFeedbackResponseCommentAction action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -82,7 +82,8 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(feedbackResponseComment.commentText + " (Edited)", null, null);
+        requestBody =
+                new FeedbackResponseCommentUpdateRequest(feedbackResponseComment.commentText + " (Edited)", null, null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -92,7 +93,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(feedbackResponseComment.commentText + " (Edited)", "", "");
+        requestBody = new FeedbackResponseCommentUpdateRequest(feedbackResponseComment.commentText + " (Edited)", "", "");
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -102,7 +103,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(feedbackResponseComment.commentText + " (Edited)", "", null);
+        requestBody = new FeedbackResponseCommentUpdateRequest(feedbackResponseComment.commentText + " (Edited)", "", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
 
@@ -110,7 +111,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "GIVER", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -119,7 +120,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "RECEIVER", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -128,7 +129,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "OWN_TEAM_MEMBERS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -137,7 +138,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "RECEIVER_TEAM_MEMBERS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -146,7 +147,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "STUDENTS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -157,7 +158,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, "123123123123123",
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "GIVER,INSTRUCTORS", "GIVER,INSTRUCTORS");
         action = getAction(requestBody, submissionParams);
         UpdateFeedbackResponseCommentAction action0 = action;
@@ -171,7 +172,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited)", "GIVER,INSTRUCTORS", "GIVER,INSTRUCTORS");
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -196,7 +197,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 feedbackResponseComment.commentText + " (Edited for published session)", "GIVER,INSTRUCTORS", null);
         action = getAction(requestBody, submissionParams);
         getJsonResult(action);
@@ -214,7 +215,7 @@ public class UpdateFeedbackResponseCommentActionTest extends BaseActionTest<Upda
                 Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_ID, feedbackResponseComment.getId().toString(),
         };
 
-        requestBody = new FeedbackResponseCommentSaveRequest(
+        requestBody = new FeedbackResponseCommentUpdateRequest(
                 "", null, null);
         action = getAction(requestBody, submissionParams);
         JsonResult result = getJsonResult(action);

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackSessionActionTest.java
@@ -15,7 +15,7 @@ import teammates.ui.webapi.action.UpdateFeedbackSessionAction;
 import teammates.ui.webapi.output.FeedbackSessionData;
 import teammates.ui.webapi.output.ResponseVisibleSetting;
 import teammates.ui.webapi.output.SessionVisibleSetting;
-import teammates.ui.webapi.request.FeedbackSessionSaveRequest;
+import teammates.ui.webapi.request.FeedbackSessionUpdateRequest;
 
 /**
  * SUT: {@link UpdateFeedbackSessionAction}.
@@ -52,9 +52,9 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
 
-        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -113,11 +113,12 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
-        saveRequest.setCustomSessionVisibleTimestamp(saveRequest.getSubmissionStartTime().plusSeconds(10).toEpochMilli());
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        updateRequest.setCustomSessionVisibleTimestamp(
+                updateRequest.getSubmissionStartTime().plusSeconds(10).toEpochMilli());
 
         InvalidHttpRequestBodyException ihrbe = assertThrows(InvalidHttpRequestBodyException.class, () -> {
-            UpdateFeedbackSessionAction a = getAction(saveRequest, param);
+            UpdateFeedbackSessionAction a = getAction(updateRequest, param);
             getJsonResult(a);
         });
 
@@ -145,11 +146,11 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
-        saveRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
-        saveRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        updateRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
+        updateRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
 
-        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -169,10 +170,10 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        saveRequest = getTypicalFeedbackSessionSaveRequest();
-        saveRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
+        updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        updateRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
 
-        a = getAction(saveRequest, param);
+        a = getAction(updateRequest, param);
         r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -194,10 +195,10 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
         param = addUserIdToParams(instructor1ofCourse1.getGoogleId(), param);
-        FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
-        saveRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        updateRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
 
-        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(updateRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -214,33 +215,33 @@ public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedba
                 Const.ParamsNames.COURSE_ID, session.getCourseId(),
                 Const.ParamsNames.FEEDBACK_SESSION_NAME, session.getFeedbackSessionName(),
         };
-        FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
-        saveRequest.setInstructions(null);
+        FeedbackSessionUpdateRequest updateRequest = getTypicalFeedbackSessionUpdateRequest();
+        updateRequest.setInstructions(null);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
-            UpdateFeedbackSessionAction a = getAction(saveRequest, param);
+            UpdateFeedbackSessionAction a = getAction(updateRequest, param);
             getJsonResult(a);
         });
     }
 
-    private FeedbackSessionSaveRequest getTypicalFeedbackSessionSaveRequest() {
-        FeedbackSessionSaveRequest saveRequest = new FeedbackSessionSaveRequest();
-        saveRequest.setInstructions("instructions");
+    private FeedbackSessionUpdateRequest getTypicalFeedbackSessionUpdateRequest() {
+        FeedbackSessionUpdateRequest updateRequest = new FeedbackSessionUpdateRequest();
+        updateRequest.setInstructions("instructions");
 
-        saveRequest.setSubmissionStartTimestamp(1444003051000L);
-        saveRequest.setSubmissionEndTimestamp(1546003051000L);
-        saveRequest.setGracePeriod(5);
+        updateRequest.setSubmissionStartTimestamp(1444003051000L);
+        updateRequest.setSubmissionEndTimestamp(1546003051000L);
+        updateRequest.setGracePeriod(5);
 
-        saveRequest.setSessionVisibleSetting(SessionVisibleSetting.CUSTOM);
-        saveRequest.setCustomSessionVisibleTimestamp(1440003051000L);
+        updateRequest.setSessionVisibleSetting(SessionVisibleSetting.CUSTOM);
+        updateRequest.setCustomSessionVisibleTimestamp(1440003051000L);
 
-        saveRequest.setResponseVisibleSetting(ResponseVisibleSetting.CUSTOM);
-        saveRequest.setCustomResponseVisibleTimestamp(1547003051000L);
+        updateRequest.setResponseVisibleSetting(ResponseVisibleSetting.CUSTOM);
+        updateRequest.setCustomResponseVisibleTimestamp(1547003051000L);
 
-        saveRequest.setClosingEmailEnabled(false);
-        saveRequest.setPublishedEmailEnabled(false);
+        updateRequest.setClosingEmailEnabled(false);
+        updateRequest.setPublishedEmailEnabled(false);
 
-        return saveRequest;
+        return updateRequest;
     }
 
     @Override

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackSessionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackSessionActionTest.java
@@ -11,16 +11,16 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.util.Const;
 import teammates.ui.webapi.action.JsonResult;
-import teammates.ui.webapi.action.SaveFeedbackSessionAction;
+import teammates.ui.webapi.action.UpdateFeedbackSessionAction;
 import teammates.ui.webapi.output.FeedbackSessionData;
 import teammates.ui.webapi.output.ResponseVisibleSetting;
 import teammates.ui.webapi.output.SessionVisibleSetting;
 import teammates.ui.webapi.request.FeedbackSessionSaveRequest;
 
 /**
- * SUT: {@link SaveFeedbackSessionAction}.
+ * SUT: {@link UpdateFeedbackSessionAction}.
  */
-public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSessionAction> {
+public class UpdateFeedbackSessionActionTest extends BaseActionTest<UpdateFeedbackSessionAction> {
 
     @Override
     protected String getActionUri() {
@@ -54,7 +54,7 @@ public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSe
         };
         FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
 
-        SaveFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -117,7 +117,7 @@ public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSe
         saveRequest.setCustomSessionVisibleTimestamp(saveRequest.getSubmissionStartTime().plusSeconds(10).toEpochMilli());
 
         InvalidHttpRequestBodyException ihrbe = assertThrows(InvalidHttpRequestBodyException.class, () -> {
-            SaveFeedbackSessionAction a = getAction(saveRequest, param);
+            UpdateFeedbackSessionAction a = getAction(saveRequest, param);
             getJsonResult(a);
         });
 
@@ -149,7 +149,7 @@ public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSe
         saveRequest.setSessionVisibleSetting(SessionVisibleSetting.AT_OPEN);
         saveRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
 
-        SaveFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -197,7 +197,7 @@ public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSe
         FeedbackSessionSaveRequest saveRequest = getTypicalFeedbackSessionSaveRequest();
         saveRequest.setResponseVisibleSetting(ResponseVisibleSetting.LATER);
 
-        SaveFeedbackSessionAction a = getAction(saveRequest, param);
+        UpdateFeedbackSessionAction a = getAction(saveRequest, param);
         JsonResult r = getJsonResult(a);
 
         assertEquals(HttpStatus.SC_OK, r.getStatusCode());
@@ -218,7 +218,7 @@ public class SaveFeedbackSessionActionTest extends BaseActionTest<SaveFeedbackSe
         saveRequest.setInstructions(null);
 
         assertThrows(InvalidHttpRequestBodyException.class, () -> {
-            SaveFeedbackSessionAction a = getAction(saveRequest, param);
+            UpdateFeedbackSessionAction a = getAction(saveRequest, param);
             getJsonResult(a);
         });
     }

--- a/src/web/services/feedback-questions.service.ts
+++ b/src/web/services/feedback-questions.service.ts
@@ -12,7 +12,7 @@ import {
   FeedbackVisibilityType,
   NumberOfEntitiesToGiveFeedbackToSetting,
 } from '../types/api-output';
-import { FeedbackQuestionCreateRequest, FeedbackQuestionSaveRequest } from '../types/api-request';
+import { FeedbackQuestionCreateRequest, FeedbackQuestionUpdateRequest } from '../types/api-request';
 import { VisibilityControl } from '../types/visibility-control';
 import { HttpRequestService } from './http-request.service';
 import { VisibilityStateMachine } from './visibility-state-machine';
@@ -323,7 +323,8 @@ export class FeedbackQuestionsService {
   /**
    * Saves a feedback question by calling API.
    */
-  saveFeedbackQuestion(feedbackQuestionId: string, request: FeedbackQuestionSaveRequest): Observable<FeedbackQuestion> {
+  saveFeedbackQuestion(feedbackQuestionId: string, request: FeedbackQuestionUpdateRequest):
+      Observable<FeedbackQuestion> {
     const paramMap: { [key: string]: string } = { questionid: feedbackQuestionId };
 
     return this.httpRequestService.put('/question', paramMap, request);

--- a/src/web/services/feedback-responses.service.ts
+++ b/src/web/services/feedback-responses.service.ts
@@ -8,7 +8,7 @@ import {
   FeedbackResponseDetails,
   FeedbackTextResponseDetails,
 } from '../types/api-output';
-import { FeedbackResponseCreateRequest, FeedbackResponseSaveRequest } from '../types/api-request';
+import { FeedbackResponseCreateRequest, FeedbackResponseUpdateRequest } from '../types/api-request';
 import {
   CONTRIBUTION_POINT_NOT_SUBMITTED,
   NUMERICAL_SCALE_ANSWER_NOT_SUBMITTED,
@@ -84,7 +84,7 @@ export class FeedbackResponsesService {
    * Updates a feedback response by calling API.
    */
   updateFeedbackResponse(responseId: string, additionalParams: { [key: string]: string } = {},
-                         request: FeedbackResponseSaveRequest): Observable<FeedbackResponse> {
+                         request: FeedbackResponseUpdateRequest): Observable<FeedbackResponse> {
     return this.httpRequestService.put('/response', {
       responseid: responseId,
       ...additionalParams,

--- a/src/web/services/feedback-sessions.service.ts
+++ b/src/web/services/feedback-sessions.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { default as templateSessions } from '../data/template-sessions.json';
 import { FeedbackQuestion, FeedbackSession, OngoingSessions } from '../types/api-output';
-import { FeedbackSessionCreateRequest, FeedbackSessionSaveRequest } from '../types/api-request';
+import { FeedbackSessionCreateRequest, FeedbackSessionUpdateRequest } from '../types/api-request';
 import { HttpRequestService } from './http-request.service';
 
 /**
@@ -41,8 +41,8 @@ export class FeedbackSessionsService {
   /**
    * Updates a feedback session by calling API.
    */
-  updateFeedbackSession(
-      courseId: string, feedbackSessionName: string, request: FeedbackSessionSaveRequest): Observable<FeedbackSession> {
+  updateFeedbackSession(courseId: string, feedbackSessionName: string, request: FeedbackSessionUpdateRequest):
+      Observable<FeedbackSession> {
     const paramMap: { [key: string]: string } = { courseid: courseId, fsname: feedbackSessionName };
     return this.httpRequestService.put('/session', paramMap, request);
   }


### PR DESCRIPTION
Part of #9564 

**Outline of Solution**

After consulting with the maintainer, we need to standardize the naming convention of request DTO.
This PR mainly rename `SaveXXAction` and `SaveXXRequest` to `UpdateXXAction` and `UpdateXXRequest`.

Note:
The `CreateFeedbackResponseAction` used to use `FeedbackResponseCommentSaveRequest` because "save" can either represent "create" or "update". After the renaming, this is not applicable any more. Therefore, `FeedbackResponseCommentCreateRequest` is used although it is same as `FeedbackResponseCommentUpdateRequest`
