### PR TITLE
[#9573]  Add student profile photo feature

### DIFF
--- a/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
@@ -135,6 +135,8 @@ public class StudentProfilePage extends AppPage {
     public void uploadPicture() {
         click(uploadPictureSubmit);
         waitForPageToLoad();
+        click(editPictureSubmit);
+        waitForPageToLoad();
         click(uploadEditModal.findElement(By.className("close")));
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
@@ -44,9 +44,6 @@ public class StudentProfilePage extends AppPage {
     @FindBy(className = "upload-edit-photo")
     private WebElement uploadPopupButton;
 
-    @FindBy(className = "profile-upload-picture-submit")
-    private WebElement uploadPictureSubmit;
-
     @FindBy(tagName = "tm-upload-edit-profile-picture-modal")
     private WebElement uploadEditModal;
 
@@ -133,11 +130,8 @@ public class StudentProfilePage extends AppPage {
     }
 
     public void uploadPicture() {
-        click(uploadPictureSubmit);
-        waitForPageToLoad();
         waitForPageToLoad();
         click(editPictureSubmit);
-        waitForPageToLoad();
         click(uploadEditModal.findElement(By.className("close")));
     }
 

--- a/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
+++ b/src/e2e/java/teammates/e2e/pageobjects/StudentProfilePage.java
@@ -135,6 +135,7 @@ public class StudentProfilePage extends AppPage {
     public void uploadPicture() {
         click(uploadPictureSubmit);
         waitForPageToLoad();
+        waitForPageToLoad();
         click(editPictureSubmit);
         waitForPageToLoad();
         click(uploadEditModal.findElement(By.className("close")));

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.html
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.html
@@ -22,12 +22,9 @@
         <p class="form-text">
           Max Size: 5 MB
         </p>
-        <button type="button" class="btn btn-primary profile-upload-picture-submit" [disabled]="!isFileSelected" (click)="uploadPicture(false)">
-          Upload Picture
-        </button>
       </div>
     </div>
-    <div *ngIf="pictureKey" class="col-8 border-left-gray">
+    <div *ngIf="imageToShow" class="col-8 border-left-gray">
       <div class="profile-pic-edit">
         <div class="alert alert-info">
           Adjust the cropper to crop your image to the desired area.
@@ -64,7 +61,7 @@
         Save Edited Photo
       </button>
     </div>
-    <div *ngIf="!pictureKey" class="col-8 border-left-gray">
+    <div *ngIf="!imageToShow" class="col-8 border-left-gray">
       <div class="alert alert-warning align-middle">
         Please upload a photo to start editing.
       </div>

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.html
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.html
@@ -22,7 +22,7 @@
         <p class="form-text">
           Max Size: 5 MB
         </p>
-        <button type="button" class="btn btn-primary profile-upload-picture-submit" [disabled]="!isFileSelected" (click)="uploadPicture()">
+        <button type="button" class="btn btn-primary profile-upload-picture-submit" [disabled]="!isFileSelected" (click)="uploadPicture(false)">
           Upload Picture
         </button>
       </div>

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
@@ -70,7 +70,7 @@ export class UploadEditProfilePictureModalComponent implements OnInit {
   /**
    * Uploads the picture that has been newly uploaded/edited.
    */
-  uploadPicture(): void {
+  uploadPicture(refreshProfilePic: boolean): void {
     const paramsMap: { [key: string]: string } = {
       user: this.user,
     };
@@ -83,7 +83,9 @@ export class UploadEditProfilePictureModalComponent implements OnInit {
           // Gets the updated picture as blob to be filled in the image cropper
           this.getProfilePicture().subscribe((resp: any) => {
             this.blobToBase64Image(resp);
-            this.imageUpdated.emit(this.pictureKey);
+            if (refreshProfilePic) {
+              this.imageUpdated.emit(this.pictureKey);
+            }
           });
 
           // Reset upload section
@@ -99,7 +101,7 @@ export class UploadEditProfilePictureModalComponent implements OnInit {
    */
   saveEditedPhoto(): void {
     this.populateFormData(this.croppedImage);
-    this.uploadPicture();
+    this.uploadPicture(true);
   }
 
   /**

--- a/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
+++ b/src/web/app/pages-student/student-profile-page/upload-edit-profile-picture-modal/upload-edit-profile-picture-modal.component.ts
@@ -64,6 +64,7 @@ export class UploadEditProfilePictureModalComponent implements OnInit {
       this.fileName = file.name;
       this.isFileSelected = true;
       this.populateFormData(file);
+      this.blobToBase64Image(file);
     }
   }
 


### PR DESCRIPTION
Fixes #9573 

This is still work-in-progress.

**Outline of Solution**

So far I modified uploadPicture method to accept a boolean value that update the old photo only  when "Save edited photo" button is clicked and it doesn't if "Upload Picture" is clicked.

Making the photo available in the cropper right after being chosen is still pending.

