### PR TITLE
Create JMeter Test plan using Java API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,8 +85,11 @@ dependencies {
                     // For supporting authorization code flow locally
                     "com.google.oauth-client:google-oauth-client-jetty:1.27.0",
                     // For using Gmail API
-                    "com.google.apis:google-api-services-gmail:v1-rev20180904-1.27.0"
-
+                    "com.google.apis:google-api-services-gmail:v1-rev20180904-1.27.0",
+                    "org.apache.jmeter:ApacheJMeter_core:5.1.1",
+                    "org.apache.jmeter:ApacheJMeter_http:5.1.1",
+                    "org.apache.jmeter:ApacheJMeter_java:5.1.1",
+                    "org.apache.jmeter:jorphan:5.1.1"
 }
 
 sourceSets {

--- a/src/e2e/java/teammates/e2e/cases/e2e/Temp.java
+++ b/src/e2e/java/teammates/e2e/cases/e2e/Temp.java
@@ -1,0 +1,185 @@
+package teammates.e2e.cases.e2e;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.config.CSVDataSet;
+import org.apache.jmeter.config.gui.ArgumentsPanel;
+import org.apache.jmeter.control.LoopController;
+import org.apache.jmeter.control.OnceOnlyController;
+import org.apache.jmeter.control.gui.LoopControlPanel;
+import org.apache.jmeter.control.gui.TestPlanGui;
+import org.apache.jmeter.protocol.http.control.CookieManager;
+import org.apache.jmeter.protocol.http.control.gui.HttpTestSampleGui;
+import org.apache.jmeter.protocol.http.sampler.HTTPSampler;
+import org.apache.jmeter.protocol.http.sampler.HTTPSamplerProxy;
+import org.apache.jmeter.protocol.java.control.gui.JavaTestSamplerGui;
+import org.apache.jmeter.protocol.java.sampler.JavaSampler;
+import org.apache.jmeter.save.SaveService;
+import org.apache.jmeter.testelement.TestElement;
+import org.apache.jmeter.testelement.TestPlan;
+import org.apache.jmeter.testelement.property.StringProperty;
+import org.apache.jmeter.threads.SetupThreadGroup;
+import org.apache.jmeter.threads.ThreadGroup;
+import org.apache.jmeter.threads.gui.ThreadGroupGui;
+import org.apache.jorphan.collections.HashTree;
+
+/**
+ * temp.
+ */
+public class Temp {
+
+    protected HashTree getTestPlan() throws IOException {
+        // JMeter Test Plan, basically JOrphan HashTree
+        HashTree testPlanTree = new HashTree();
+
+        // First HTTP Sampler - open example.com
+        HTTPSamplerProxy examplecomSampler = new HTTPSamplerProxy();
+        examplecomSampler.setDomain("example.com");
+        examplecomSampler.setPort(80);
+        examplecomSampler.setPath("/");
+        examplecomSampler.setMethod("GET");
+        examplecomSampler.setName("Open example.com");
+        examplecomSampler.setProperty(TestElement.TEST_CLASS, HTTPSamplerProxy.class.getName());
+        examplecomSampler.setProperty(TestElement.GUI_CLASS, HttpTestSampleGui.class.getName());
+
+        // Second HTTP Sampler - open blazemeter.com
+        HTTPSamplerProxy blazemetercomSampler = new HTTPSamplerProxy();
+        blazemetercomSampler.setDomain("blazemeter.com");
+        blazemetercomSampler.setPort(80);
+        blazemetercomSampler.setPath("/");
+        blazemetercomSampler.setMethod("GET");
+        blazemetercomSampler.setName("Open blazemeter.com");
+        blazemetercomSampler.setProperty(TestElement.TEST_CLASS, HTTPSamplerProxy.class.getName());
+        blazemetercomSampler.setProperty(TestElement.GUI_CLASS, HttpTestSampleGui.class.getName());
+
+        // Loop Controller
+        LoopController loopController = new LoopController();
+        loopController.setLoops(1);
+        loopController.setFirst(true);
+        loopController.setProperty(TestElement.TEST_CLASS, LoopController.class.getName());
+        loopController.setProperty(TestElement.GUI_CLASS, LoopControlPanel.class.getName());
+        loopController.initialize();
+
+        // Thread Group
+        ThreadGroup threadGroup = new ThreadGroup();
+        threadGroup.setName("Example Thread Group");
+        threadGroup.setNumThreads(1);
+        threadGroup.setRampUp(1);
+        threadGroup.setSamplerController(loopController);
+        threadGroup.setProperty(TestElement.TEST_CLASS, ThreadGroup.class.getName());
+        threadGroup.setProperty(TestElement.GUI_CLASS, ThreadGroupGui.class.getName());
+
+        // Test Plan
+        TestPlan testPlan = new TestPlan("Create JMeter Script From Java Code");
+        testPlan.setProperty(TestElement.TEST_CLASS, TestPlan.class.getName());
+        testPlan.setProperty(TestElement.GUI_CLASS, TestPlanGui.class.getName());
+        testPlan.setUserDefinedVariables((Arguments) new ArgumentsPanel().createTestElement());
+
+        // Construct Test Plan from previously initialized elements
+        testPlanTree.add(testPlan);
+        HashTree threadGroupHashTree = testPlanTree.add(testPlan, threadGroup);
+        threadGroupHashTree.add(blazemetercomSampler);
+        threadGroupHashTree.add(examplecomSampler);
+
+        // save generated test plan to JMeter's .jmx file format
+        SaveService.saveTree(testPlanTree, new FileOutputStream("aaaaaa.jmx"));
+
+        return testPlanTree;
+    }
+
+    // WIP
+    protected HashTree getTree(String jmxFile) throws IOException {
+        // TestPlan
+        TestPlan testPlan = new TestPlan();
+        testPlan.setName("Test Plan");
+        testPlan.setEnabled(true);
+        testPlan.setProperty(TestElement.TEST_CLASS, TestPlan.class.getName());
+        testPlan.setProperty(TestElement.GUI_CLASS, TestPlanGui.class.getName());
+
+        HashTree hashTree = new HashTree();
+
+        // ThreadGroup controller
+        LoopController loopController = new LoopController();
+        loopController.setEnabled(true);
+        loopController.setLoops(1);
+        loopController.setProperty(TestElement.TEST_CLASS, LoopController.class.getName());
+        loopController.setProperty(TestElement.GUI_CLASS, LoopControlPanel.class.getName());
+        // controller.setContinueForever(false);
+        // controller.setProperty(new BooleanProperty(TestElement.ENABLED, true));
+
+        // Thread Group
+        SetupThreadGroup threadGroup = new SetupThreadGroup();
+        threadGroup.setNumThreads(100);
+        threadGroup.setRampUp(2);
+        threadGroup.setProperty(new StringProperty(ThreadGroup.ON_SAMPLE_ERROR, ThreadGroup.ON_SAMPLE_ERROR_CONTINUE));
+        threadGroup.setSamplerController(loopController);
+        threadGroup.setProperty(TestElement.TEST_CLASS, ThreadGroup.class.getName());
+        threadGroup.setProperty(TestElement.GUI_CLASS, ThreadGroupGui.class.getName());
+
+        // CSVConfig
+        CSVDataSet csvDataSet = new CSVDataSet();
+        csvDataSet.setProperty(new StringProperty("filename", "src/e2e/resources/data/studentProfileConfig.csv"));
+        // csvDataSet.setProperty(new StringProperty("variableNames", "USER_NAME"));
+        csvDataSet.setProperty(new StringProperty("delimiter", "|"));
+        csvDataSet.setProperty(new StringProperty("shareMode", "shareMode.all"));
+        csvDataSet.setProperty("ignoreFirstLine", true);
+        csvDataSet.setProperty("quoted", true);
+        csvDataSet.setProperty("recycle", true);
+        csvDataSet.setProperty("stopThread", false);
+
+        // CookieManager
+        CookieManager cookieManager = new CookieManager();
+        cookieManager.setClearEachIteration(false);
+        cookieManager.setCookiePolicy("standard");
+
+        // HTTP Sampler
+        HTTPSampler httpSampler = new HTTPSampler();
+
+        // HTTP Request Defaults
+        httpSampler.setDomain("localhost");
+        httpSampler.setPort(8080);
+
+        // Login HTTP Request
+        OnceOnlyController onceOnlyController = new OnceOnlyController();
+
+        httpSampler.setPath("_ah/login?action=Log+In&email=${email}&isAdmin=${isAdmin}&continue=http://localhost:8080/webapi/auth?frontendUrl=http://localhost:4200");
+        httpSampler.setMethod("POST");
+        httpSampler.setFollowRedirects(true);
+        httpSampler.setUseKeepAlive(true);
+
+        // JavaSampler
+        JavaSampler javaSampler = new JavaSampler();
+        javaSampler.setClassname("my.example.java.sampler");
+        javaSampler.setEnabled(true);
+        javaSampler.setProperty(TestElement.TEST_CLASS, JavaSampler.class.getName());
+        javaSampler.setProperty(TestElement.GUI_CLASS, JavaTestSamplerGui.class.getName());
+
+        // Test plan
+        // TestPlan testPlan = new TestPlan("MY TEST PLAN");
+        // hashTree.add("testPlan", testPlan);
+        // hashTree.add("loopCtrl", loopCtrl);
+        // hashTree.add("threadGroup", threadGroup);
+        // hashTree.add("httpSampler", httpSampler);
+
+        // Create TestPlan hash tree
+        HashTree testPlanHashTree = new HashTree();
+        testPlanHashTree.add(testPlan);
+        testPlanHashTree.add(csvDataSet);
+
+        // Add ThreadGroup to TestPlan hash tree
+        HashTree threadGroupHashTree = new HashTree();
+        threadGroupHashTree = testPlanHashTree.add(testPlan, threadGroup);
+
+        // Add Java Sampler to ThreadGroup hash tree
+        HashTree javaSamplerHashTree = new HashTree();
+        javaSamplerHashTree = threadGroupHashTree.add(javaSampler);
+
+        // Save to jmx file
+        SaveService.saveTree(testPlanHashTree, new FileOutputStream("TEAMMATES.jmx"));
+
+        return hashTree;
+    }
+
+}


### PR DESCRIPTION
After looking at the [JMeter API](https://jmeter.apache.org/api/index.html), it seems that pretty much anything we create using the GUI can be done with Java. The test plan in Java is just a tree which can be parsed from or written to a `.jmx` file. This tree is stored as a JOrphan `HashTree`, which implements `Map<Object, HashTree>`.

So, using Java, we are **essentially creating the XML tree** of the `.jmx` file (i.e. `Map` of `Map` of `Map`...).

Even if the API doesn't include the relevant attribute or setter method, from what I've seen, it can be added in Java via `setProperty(JMeterProperty property)` methods. Just that the relevant element type (eg. ThreadGroup, HTTP Request, CSV Data Set Config etc.) should be present in the API. For example, `csvDataSet.setProperty(new StringProperty("delimiter", ","));`

The code will just be configuring the property values and inserting it as a child of the correct parent node in the tree.

[This example's](https://bitbucket.org/blazemeter/jmeter-from-code/src/57cef9e2b1c952f669417163b4f0c4a679353719/src/main/java/com/blazemeter/demo/JMeterFromScratch.java?at=master&fileviewer=file-view-default) code will be converted to the `.jmx` file structure shown below:
```java
// 1. Test Plan: Create JMeter Script From Java Code
TestPlan testPlan = new TestPlan("Create JMeter Script From Java Code");
//... 

// 2. Thread Group: Example Thread Group
ThreadGroup threadGroup = new ThreadGroup();
threadGroup.setName("Example Thread Group");
//... 

// 3. First HTTP Sampler: Open example.com
HTTPSamplerProxy examplecomSampler = new HTTPSamplerProxy();
examplecomSampler.setName("Open example.com");
//... 

// 4. Second HTTP Sampler- Open blazemeter.com
HTTPSamplerProxy blazemetercomSampler = new HTTPSamplerProxy();
blazemetercomSampler.setName("Open blazemeter.com");
//... 

// ...

// Construct Test Plan from previously initialized elements
testPlanTree.add(testPlan);
HashTree threadGroupHashTree = testPlanTree.add(testPlan, threadGroup);
threadGroupHashTree.add(blazemetercomSampler);
threadGroupHashTree.add(examplecomSampler);
```

Resultant (equivalent) JMeter test:
<img width="400" alt="2019-03-31_21h15_32" src="https://user-images.githubusercontent.com/29021586/55289491-20e02280-53fa-11e9-8215-66525f1d9341.png">

