### PR TITLE
[#9636] - Resolved the error in resending reminder emails

### DIFF
--- a/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-sessions-page/instructor-sessions-page.component.ts
@@ -451,14 +451,14 @@ export class InstructorSessionsPageComponent extends InstructorSessionBasePageCo
    * Sends e-mails to remind students on the published results link.
    */
   resendResultsLinkToStudentsEventHandler(remindInfo: any): void {
-    this.resendResultsLinkToStudents(this.sessionsTableRowModels[remindInfo.row], remindInfo.students);
+    this.resendResultsLinkToStudents(this.sessionsTableRowModels[remindInfo.row], remindInfo.request);
   }
 
   /**
    * Sends e-mails to remind students who have not submitted their feedback.
    */
   sendRemindersToStudentsEventHandler(remindInfo: any): void {
-    this.sendRemindersToStudents(this.sessionsTableRowModels[remindInfo.row], remindInfo.users);
+    this.sendRemindersToStudents(this.sessionsTableRowModels[remindInfo.row], remindInfo.request);
   }
 
   /**


### PR DESCRIPTION
Fixes #9636 
Ready for review

**Outline of Solution**
In the InstructorSessionPageComponent.ts file, changed the argument passed inside the methods 
resendResultsLinkToStudentsEventHandler and sendRemindersToStudentsEventHandler to remindInfo.request. 



<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
