### PR TITLE
[#9678] Instructor: Course Page: Improve status message after archiving a course

### DIFF
--- a/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
+++ b/src/test/resources/pages/instructorHomeCourseArchiveSuccessful.html
@@ -27,9 +27,7 @@
   <br>
   <div id="statusMessagesToUser">
     <div class="overflow-auto alert alert-success icon-success statusMessage">
-      The course CHomeUiT.CS1101 has been archived. It will not appear in the home page any more. You can access archived courses from the 'Courses' tab.
-      <br>
-      Go there to undo the archiving and bring the course back to the home page.
+      The course CHomeUiT.CS1101 has been archived. Archived courses can be accessed/unarchived from the 'Courses' tab.
     </div>
   </div>
   <script defer="" src="/js/statusMessage.js" type="text/javascript">

--- a/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-courses-page/instructor-courses-page.component.ts
@@ -173,9 +173,7 @@ export class InstructorCoursesPageComponent implements OnInit {
     }).subscribe((courseArchive: CourseArchive) => {
       this.loadInstructorCourses();
       if (courseArchive.isArchived) {
-        this.statusMessageService.showSuccessMessage(`The course has been archived.
-          It will not appear in the home page any more. You can access archived courses from the 'Courses' tab.
-          Go there to undo the archiving and bring the course back to the home page.`);
+        this.statusMessageService.showSuccessMessage(`The course has been archived. Archived courses can be accessed/unarchived from the 'Courses' tab.`);
       } else {
         this.statusMessageService.showSuccessMessage('The course has been unarchived.');
       }


### PR DESCRIPTION
The message displayed on successful archiving of a course was lengthier than necessary and reduces eye tracking while not adding much value. The message has been edited to be more concise.

Fixes #9678 

**PR Checklist**