### PR TITLE
[#9673] Feedback sessions with + in their name get replaced by ' ' when requested

### DIFF
--- a/src/web/app/app.module.ts
+++ b/src/web/app/app.module.ts
@@ -3,9 +3,16 @@ import { NgModule } from '@angular/core';
 import { MatSnackBarModule } from '@angular/material';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterModule, Routes } from '@angular/router';
+import { RouterModule, Routes, UrlSerializer } from '@angular/router';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AppComponent } from './app.component';
+import { CustomUrlSerializer } from './custom-url-serializer';
+
+const customUrlSerializer: CustomUrlSerializer = new CustomUrlSerializer();
+const customUrlSerializerProvider: any = {
+  provide: UrlSerializer,
+  useValue: customUrlSerializer,
+};
 
 const routes: Routes = [
   {
@@ -32,7 +39,7 @@ const routes: Routes = [
     NgbModule,
     RouterModule.forRoot(routes),
   ],
-  providers: [],
+  providers: [customUrlSerializerProvider],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/web/app/custom-url-serializer.spec.ts
+++ b/src/web/app/custom-url-serializer.spec.ts
@@ -1,0 +1,28 @@
+import { CustomUrlSerializer } from './custom-url-serializer';
+import {DefaultUrlSerializer, UrlTree} from "@angular/router";
+
+describe('Custom Url Serializer', () => {
+
+  let serializer: CustomUrlSerializer;
+  let dus: DefaultUrlSerializer;
+
+  beforeEach(() => {
+    serializer = new CustomUrlSerializer();
+    dus = new DefaultUrlSerializer();
+  });
+
+  it('should convert plus sign to white space using default url serializer', () => {
+    const urlTree: UrlTree =
+        dus.parse('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test+session');
+    const url: string = dus.serialize(urlTree);
+    expect(url).toEqual('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test%20session');
+  });
+
+  it('should reserve the plus sign in the url using custom url serializer', () => {
+    const urlTree: UrlTree =
+        serializer.parse('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test+session');
+    const url: string = serializer.serialize(urlTree);
+    expect(url).toEqual('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test+session');
+  });
+
+});

--- a/src/web/app/custom-url-serializer.spec.ts
+++ b/src/web/app/custom-url-serializer.spec.ts
@@ -1,17 +1,13 @@
+import { DefaultUrlSerializer, UrlTree } from '@angular/router';
 import { CustomUrlSerializer } from './custom-url-serializer';
-import {DefaultUrlSerializer, UrlTree} from "@angular/router";
 
 describe('Custom Url Serializer', () => {
 
   let serializer: CustomUrlSerializer;
   let dus: DefaultUrlSerializer;
 
-  beforeEach(() => {
-    serializer = new CustomUrlSerializer();
-    dus = new DefaultUrlSerializer();
-  });
-
   it('should convert plus sign to white space using default url serializer', () => {
+    dus = new DefaultUrlSerializer();
     const urlTree: UrlTree =
         dus.parse('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test+session');
     const url: string = dus.serialize(urlTree);
@@ -19,6 +15,7 @@ describe('Custom Url Serializer', () => {
   });
 
   it('should reserve the plus sign in the url using custom url serializer', () => {
+    serializer = new CustomUrlSerializer();
     const urlTree: UrlTree =
         serializer.parse('/localhost:8080/web/instructor/sessions/edit?courseid=C01&fsname=test+session');
     const url: string = serializer.serialize(urlTree);

--- a/src/web/app/custom-url-serializer.ts
+++ b/src/web/app/custom-url-serializer.ts
@@ -1,0 +1,16 @@
+import { DefaultUrlSerializer, UrlSerializer, UrlTree } from '@angular/router';
+
+/**
+ * Custom Url Serializer to handle plus sign related issues
+ */
+export class CustomUrlSerializer implements UrlSerializer {
+  parse(url: any): UrlTree {
+    const dus: DefaultUrlSerializer = new DefaultUrlSerializer();
+    return dus.parse(url.replace(/\+/g, '%2B'));
+  }
+
+  serialize(tree: UrlTree): any {
+    const dus: DefaultUrlSerializer = new DefaultUrlSerializer();
+    return dus.serialize(tree).replace(/%2B/g, '+');
+  }
+}

--- a/src/web/services/http-request.service.ts
+++ b/src/web/services/http-request.service.ts
@@ -1,7 +1,41 @@
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParameterCodec, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
+
+/**
+ * Custom HttpParameter encoder
+ */
+class CustomEncoder implements HttpParameterCodec {
+
+  /**
+   * encode key
+   */
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+
+  /**
+   * encode value
+   */
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+
+  /**
+   * decode key
+   */
+  decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+
+  /**
+   * decode value
+   */
+  decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
+}
 
 /**
  * Handles HTTP requests to the application back-end.
@@ -22,7 +56,7 @@ export class HttpRequestService {
    * Builds an HttpParams object from a standard key-value mapping.
    */
   buildParams(paramsMap: { [key: string]: string }): HttpParams {
-    let params: HttpParams = new HttpParams();
+    let params: HttpParams = new HttpParams({ encoder: new CustomEncoder() });
     for (const key of Object.keys(paramsMap)) {
       if (paramsMap[key]) {
         params = params.append(key, paramsMap[key]);

--- a/src/web/services/http-request.service.ts
+++ b/src/web/services/http-request.service.ts
@@ -4,7 +4,8 @@ import { Observable } from 'rxjs';
 import { environment } from '../environments/environment';
 
 /**
- * Custom HttpParameter encoder
+ * Custom HttpParameter encoder, implements the default parameter encoder, to support encoding
+ * and decoding of plus sign
  */
 class CustomEncoder implements HttpParameterCodec {
 
@@ -25,14 +26,14 @@ class CustomEncoder implements HttpParameterCodec {
   }
 
   /**
-   * the same as default angular encoder.
+   * the same as angular's default encoder.
    */
   decodeKey(key: string): string {
     return decodeURIComponent(key);
   }
 
   /**
-   * the same as default angular encoder.
+   * the same as angular's default encoder.
    */
   decodeValue(value: string): string {
     return decodeURIComponent(value);

--- a/src/web/services/http-request.service.ts
+++ b/src/web/services/http-request.service.ts
@@ -9,28 +9,30 @@ import { environment } from '../environments/environment';
 class CustomEncoder implements HttpParameterCodec {
 
   /**
-   * encode key
+   * angular will ignore the encoding for plus sign, so override the default angular encoder
+   * to enable the encoding for plus sign. Refer to:
+   * https://github.com/angular/angular/blob/8.0.0/packages/common/http/src/params.ts#L33
    */
   encodeKey(key: string): string {
     return encodeURIComponent(key);
   }
 
   /**
-   * encode value
+   * the same reason as encode key above.
    */
   encodeValue(value: string): string {
     return encodeURIComponent(value);
   }
 
   /**
-   * decode key
+   * the same as default angular encoder.
    */
   decodeKey(key: string): string {
     return decodeURIComponent(key);
   }
 
   /**
-   * decode value
+   * the same as default angular encoder.
    */
   decodeValue(value: string): string {
     return decodeURIComponent(value);


### PR DESCRIPTION
Fixes #9673 

There is a related issue with angular: https://github.com/angular/angular/issues/11058

**Outline of Solution**

add custom http parameter encoder and url serializer to prevent plus sign getting replaced by whitespace

