### PR TITLE
[#9737] ArchitectureTest not failing even with violations

### DIFF
--- a/src/test/java/teammates/test/cases/architecture/ArchitectureTest.java
+++ b/src/test/java/teammates/test/cases/architecture/ArchitectureTest.java
@@ -21,299 +21,255 @@ public class ArchitectureTest {
     @Deprecated
     private static final String LEGACY_BROWSERTESTS_PACKAGE = "teammates.test.cases.browsertests";
 
-    private static final JavaClasses ALL_CLASSES = new ClassFileImporter().importPackages("teammates");
+    private static final JavaClasses ALL_CLASSES = forClasses("teammates");
 
     private static final String COMMON_PACKAGE = "teammates.common";
-    private static final JavaClasses COMMON_CLASSES =
-            new ClassFileImporter().importPackages(COMMON_PACKAGE);
 
     private static final String STORAGE_PACKAGE = "teammates.storage";
-    private static final JavaClasses STORAGE_CLASSES =
-            new ClassFileImporter().importPackages(STORAGE_PACKAGE);
-
     private static final String STORAGE_API_PACKAGE = STORAGE_PACKAGE + ".api";
-
     private static final String STORAGE_ENTITY_PACKAGE = STORAGE_PACKAGE + ".entity";
-    private static final JavaClasses STORAGE_ENTITY_CLASSES =
-            new ClassFileImporter().importPackages(STORAGE_ENTITY_PACKAGE);
-
     private static final String STORAGE_SEARCH_PACKAGE = STORAGE_PACKAGE + ".search";
-    private static final JavaClasses STORAGE_SEARCH_CLASSES =
-            new ClassFileImporter().importPackages(STORAGE_SEARCH_PACKAGE);
 
     private static final String LOGIC_PACKAGE = "teammates.logic";
-    private static final JavaClasses LOGIC_CLASSES =
-            new ClassFileImporter().importPackages(LOGIC_PACKAGE);
 
     private static final String LOGIC_CORE_PACKAGE = LOGIC_PACKAGE + ".core";
-    private static final JavaClasses LOGIC_CORE_CLASSES =
-            new ClassFileImporter().importPackages(LOGIC_CORE_PACKAGE);
-
     private static final String LOGIC_API_PACKAGE = LOGIC_PACKAGE + ".api";
 
     private static final String UI_PACKAGE = "teammates.ui";
-    private static final JavaClasses UI_CLASSES =
-            new ClassFileImporter().importPackages(UI_PACKAGE);
-
     private static final String UI_AUTOMATED_PACKAGE = UI_PACKAGE + ".automated";
-    private static final JavaClasses UI_AUTOMATED_CLASSES =
-            new ClassFileImporter().importPackages(UI_AUTOMATED_PACKAGE);
-
     private static final String UI_WEBAPI_PACKAGE = UI_PACKAGE + ".webapi.action";
-    private static final JavaClasses UI_WEBAPI_CLASSES =
-            new ClassFileImporter().importPackages(UI_WEBAPI_PACKAGE);
-
     private static final String UI_OUTPUT_PACKAGE = UI_PACKAGE + ".webapi.output";
-    private static final JavaClasses UI_OUTPUT_CLASSES =
-            new ClassFileImporter().importPackages(UI_OUTPUT_PACKAGE);
-
     private static final String UI_REQUEST_PACKAGE = UI_PACKAGE + ".webapi.request";
-    private static final JavaClasses UI_REQUEST_CLASSES =
-            new ClassFileImporter().importPackages(UI_REQUEST_PACKAGE);
 
     private static final String TEST_PACKAGE = "teammates.test";
-    private static final JavaClasses TEST_CLASSES =
-            new ClassFileImporter().importPackages(TEST_PACKAGE);
 
     private static final String TEST_CASES_PACKAGE = TEST_PACKAGE + ".cases";
-    private static final JavaClasses TEST_CASES =
-            new ClassFileImporter().importPackages(TEST_CASES_PACKAGE);
-
     private static final String TEST_DRIVER_PACKAGE = TEST_PACKAGE + ".driver";
-    private static final JavaClasses TEST_DRIVER_CLASSES =
-            new ClassFileImporter().importPackages(TEST_DRIVER_PACKAGE);
 
     private static final String E2E_PACKAGE = "teammates.e2e";
-    private static final JavaClasses E2E_CLASSES =
-            new ClassFileImporter().importPackages(E2E_PACKAGE);
 
     private static final String E2E_CASES_PACKAGE = E2E_PACKAGE + ".cases";
-    private static final JavaClasses E2E_TEST_CASES =
-            new ClassFileImporter().importPackages(E2E_CASES_PACKAGE);
-
     private static final String E2E_PAGEOBJECTS_PACKAGE = E2E_PACKAGE + ".pageobjects";
-
     private static final String E2E_UTIL_PACKAGE = E2E_PACKAGE + ".util";
-    private static final JavaClasses E2E_UTIL_CLASSES =
-            new ClassFileImporter().importPackages(E2E_UTIL_PACKAGE);
 
     private static final String CLIENT_PACKAGE = "teammates.client";
-    private static final JavaClasses CLIENT_CLASSES =
-            new ClassFileImporter().importPackages(CLIENT_PACKAGE);
-
     private static final String CLIENT_REMOTEAPI_PACKAGE = CLIENT_PACKAGE + ".remoteapi";
-    private static final JavaClasses CLIENT_REMOTEAPI_CLASSES =
-            new ClassFileImporter().importPackages(CLIENT_REMOTEAPI_PACKAGE);
-
     private static final String CLIENT_SCRIPTS_PACKAGE = CLIENT_PACKAGE + ".scripts";
-
     private static final String CLIENT_UTIL_PACKAGE = CLIENT_PACKAGE + ".util";
-    private static final JavaClasses CLIENT_UTIL_CLASSES =
-            new ClassFileImporter().importPackages(CLIENT_UTIL_PACKAGE);
 
     private static String includeSubpackages(String pack) {
         return pack + "..";
     }
 
+    private static JavaClasses forClasses(String... packageNames) {
+        return new ClassFileImporter().importPackages(packageNames);
+    }
+
     @Test
     public void testArchitecture_uiShouldNotTouchStorage() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(STORAGE_PACKAGE)
-                .check(UI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_PACKAGE))
+                .check(forClasses(UI_PACKAGE, STORAGE_PACKAGE));
     }
 
     @Test
     public void testArchitecture_logicShouldNotTouchUi() {
-        noClasses().that().resideInAPackage(LOGIC_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_PACKAGE)
-                .check(LOGIC_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(LOGIC_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .check(forClasses(LOGIC_PACKAGE, UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_storageShouldNotTouchLogic() {
-        noClasses().that().resideInAPackage(STORAGE_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(LOGIC_PACKAGE)
-                .check(STORAGE_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(STORAGE_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_PACKAGE))
+                .check(forClasses(STORAGE_PACKAGE, LOGIC_PACKAGE));
     }
 
     @Test
     public void testArchitecture_storageShouldNotTouchUi() {
-        noClasses().that().resideInAPackage(STORAGE_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_PACKAGE)
-                .check(STORAGE_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(STORAGE_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .check(forClasses(STORAGE_PACKAGE, UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_commonShouldNotTouchLogic() {
-        noClasses().that().resideInAPackage(COMMON_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(COMMON_PACKAGE))
                 // TODO fix these violations
                 .and().doNotHaveSimpleName("FeedbackMcqQuestionDetails")
                 .and().doNotHaveSimpleName("FeedbackMsqQuestionDetails")
                 .and().doNotHaveSimpleName("FeedbackConstantSumQuestionDetails")
-                .should().accessClassesThat().resideInAPackage(LOGIC_PACKAGE)
-                .check(COMMON_CLASSES);
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_PACKAGE))
+                .check(forClasses(COMMON_PACKAGE, LOGIC_PACKAGE));
     }
 
     @Test
     public void testArchitecture_commonShouldNotTouchStorage() {
-        noClasses().that().resideInAPackage(COMMON_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(STORAGE_API_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(STORAGE_SEARCH_PACKAGE)
-                .check(COMMON_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(COMMON_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_API_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_SEARCH_PACKAGE))
+                .check(forClasses(COMMON_PACKAGE, STORAGE_PACKAGE));
 
-        noClasses().that().resideInAPackage(COMMON_PACKAGE)
-                .and().resideOutsideOfPackage(COMMON_PACKAGE + ".datatransfer.attributes")
-                .should().accessClassesThat().resideInAPackage(STORAGE_ENTITY_PACKAGE)
-                .check(COMMON_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(COMMON_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(COMMON_PACKAGE + ".datatransfer.attributes"))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
+                .check(forClasses(COMMON_PACKAGE, STORAGE_PACKAGE));
     }
 
     @Test
     public void testArchitecture_commonShouldNotTouchUi() {
-        noClasses().that().resideInAPackage(COMMON_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(COMMON_PACKAGE))
                 // TODO fix this violation
                 .and().haveSimpleNameNotEndingWith("QuestionDetails")
-                .should().accessClassesThat().resideInAPackage(UI_PACKAGE)
-                .check(COMMON_CLASSES);
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .check(forClasses(COMMON_PACKAGE, UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_uiShouldNotTouchLogicExceptForApi() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_AUTOMATED_PACKAGE)
-                .and().resideOutsideOfPackage(UI_WEBAPI_PACKAGE)
-                .and().resideOutsideOfPackage(LEGACY_UI_CONTROLLER_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(LOGIC_API_PACKAGE)
-                .check(UI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(LEGACY_UI_CONTROLLER_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_API_PACKAGE))
+                .check(forClasses(UI_PACKAGE, LOGIC_PACKAGE));
 
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(LOGIC_CORE_PACKAGE)
-                .check(UI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_CORE_PACKAGE))
+                .check(forClasses(UI_PACKAGE, LOGIC_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_onlyWebApiCanTouchOutput() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_WEBAPI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_REQUEST_PACKAGE)
-                .and().resideOutsideOfPackage(UI_OUTPUT_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_OUTPUT_PACKAGE)
-                .check(UI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_OUTPUT_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_OUTPUT_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_onlyWebApiCanTouchRequest() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_WEBAPI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_REQUEST_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_REQUEST_PACKAGE)
-                .check(UI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_apiRequestCanOnlyTouchRequestAndOutput() {
-        noClasses().that().resideInAPackage(UI_REQUEST_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_AUTOMATED_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(UI_WEBAPI_PACKAGE)
-                .check(UI_REQUEST_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_apiOutputCanOnlyTouchOutput() {
-        noClasses().that().resideInAPackage(UI_OUTPUT_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_AUTOMATED_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(UI_WEBAPI_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(UI_REQUEST_PACKAGE)
-                .check(UI_OUTPUT_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_OUTPUT_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_controllerShouldBeSelfContained() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_WEBAPI_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_WEBAPI_PACKAGE)
-                .check(UI_WEBAPI_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_automatedActionsShouldBeSelfContained() {
-        noClasses().that().resideInAPackage(UI_PACKAGE)
-                .and().resideOutsideOfPackage(UI_AUTOMATED_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_AUTOMATED_PACKAGE)
-                .check(UI_AUTOMATED_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_ui_automatedActionsShouldNotTouchOtherUiClasses() {
-        noClasses().that().resideInAPackage(UI_AUTOMATED_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(UI_WEBAPI_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(UI_OUTPUT_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(UI_REQUEST_PACKAGE)
-                .check(UI_AUTOMATED_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(UI_OUTPUT_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(UI_REQUEST_PACKAGE))
+                .check(forClasses(UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_logic_logicCanOnlyAccessStorageApi() {
-        noClasses().that().resideInAPackage(LOGIC_PACKAGE)
-                .and().resideOutsideOfPackage(LOGIC_CORE_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(STORAGE_PACKAGE)
-                .check(LOGIC_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(LOGIC_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(LOGIC_CORE_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_PACKAGE))
+                .check(forClasses(LOGIC_PACKAGE, STORAGE_PACKAGE));
 
-        noClasses().that().resideInAPackage(LOGIC_CORE_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(STORAGE_ENTITY_PACKAGE)
-                .orShould().accessClassesThat().resideInAPackage(STORAGE_SEARCH_PACKAGE)
-                .check(LOGIC_CORE_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(LOGIC_CORE_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
+                .orShould().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_SEARCH_PACKAGE))
+                .check(forClasses(LOGIC_PACKAGE, STORAGE_PACKAGE));
     }
 
     @Test
     public void testArchitecture_logic_coreLogicCanOnlyAccessItsCorrespondingDb() {
-        for (JavaClass coreLogicClass : LOGIC_CORE_CLASSES) {
+        for (JavaClass coreLogicClass : forClasses(LOGIC_CORE_PACKAGE)) {
             String logicClassName = coreLogicClass.getSimpleName();
             if ("DataBundleLogic".equals(logicClassName)) {
                 continue;
             }
             String dbClassName = logicClassName.replace("Logic", "Db");
 
-            noClasses().should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
-                @Override
-                public boolean apply(JavaClass input) {
-                    return input.getPackageName().equals(STORAGE_API_PACKAGE)
-                            && !input.getSimpleName().equals(dbClassName);
-                }
-            }).check(new ClassFileImporter().importClasses(coreLogicClass.reflect()));
+            noClasses()
+                    .that().resideInAPackage(includeSubpackages(LOGIC_CORE_PACKAGE))
+                    .and().doNotHaveSimpleName(logicClassName)
+                    .and().doNotHaveSimpleName("DataBundleLogic")
+                    .should()
+                    .accessClassesThat(new DescribedPredicate<JavaClass>("") {
+                        @Override
+                        public boolean apply(JavaClass input) {
+                            return input.getPackageName().startsWith(STORAGE_API_PACKAGE)
+                                    && input.getSimpleName().equals(dbClassName);
+                        }
+                    })
+                    .check(forClasses(LOGIC_CORE_PACKAGE, STORAGE_API_PACKAGE));
         }
     }
 
     @Test
     public void testArchitecture_logic_coreLogicShouldNotTouchApiLogic() {
-        noClasses().that().resideInAPackage(LOGIC_CORE_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(LOGIC_API_PACKAGE)
-                .check(LOGIC_CORE_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(LOGIC_CORE_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(LOGIC_API_PACKAGE))
+                .check(forClasses(LOGIC_PACKAGE));
     }
 
     @Test
     public void testArchitecture_storage_storageSearchShouldNotTouchStorageEntity() {
-        noClasses().that().resideInAPackage(STORAGE_SEARCH_PACKAGE)
-                .should().accessClassesThat().resideInAPackage(STORAGE_ENTITY_PACKAGE)
-                .check(STORAGE_SEARCH_CLASSES);
+        noClasses().that().resideInAPackage(includeSubpackages(STORAGE_SEARCH_PACKAGE))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
+                .check(forClasses(STORAGE_PACKAGE));
     }
 
     @Test
     public void testArchitecture_storage_storageEntityShouldNotTouchOtherStoragePackages() {
-        noClasses().that().resideInAPackage(STORAGE_ENTITY_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
                 .should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
                     @Override
                     public boolean apply(JavaClass input) {
                         return input.getPackageName().startsWith(STORAGE_PACKAGE)
                                 && !input.getPackageName().equals(STORAGE_ENTITY_PACKAGE);
                     }
-                }).check(STORAGE_ENTITY_CLASSES);
+                }).check(forClasses(STORAGE_PACKAGE));
     }
 
     @Test
     public void testArchitecture_common_assumptionClassCanOnlyBeAccessedByProductionCode() {
         noClasses().that().resideInAPackage(includeSubpackages(TEST_PACKAGE))
-                .and().resideInAPackage(E2E_PACKAGE)
-                .and().resideInAPackage(CLIENT_PACKAGE)
+                .and().resideInAPackage(includeSubpackages(E2E_PACKAGE))
+                .and().resideInAPackage(includeSubpackages(CLIENT_PACKAGE))
                 .should().accessClassesThat().haveSimpleName("Assumption")
                 .check(ALL_CLASSES);
     }
@@ -332,51 +288,51 @@ public class ArchitectureTest {
                         && !input.getSimpleName().startsWith("Base")
                         && !input.isInnerClass();
             }
-        }).check(TEST_CASES);
+        }).check(forClasses(TEST_CASES_PACKAGE));
     }
 
     @Test
     public void testArchitecture_testClasses_onlySomeTestClassesCanAccessEntities() {
         noClasses().that().resideInAPackage(includeSubpackages(TEST_PACKAGE))
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".datatransfer")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".storage")
-                .should().accessClassesThat().resideInAPackage(STORAGE_ENTITY_PACKAGE)
-                .check(TEST_CLASSES);
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".datatransfer"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".storage"))
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
+                .check(forClasses(TEST_PACKAGE, STORAGE_ENTITY_PACKAGE));
     }
 
     @Test
     public void testArchitecture_testClasses_onlySomeTestClassesCanAccessLogic() {
         noClasses().that().resideInAPackage(includeSubpackages(TEST_PACKAGE))
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".storage")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".logic")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".action")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".webapi")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".automated")
-                .and().resideOutsideOfPackage(TEST_CASES_PACKAGE + ".search")
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".storage"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".logic"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".action"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".webapi"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".automated"))
+                .and().resideOutsideOfPackage(includeSubpackages(TEST_CASES_PACKAGE + ".search"))
                 .and().doNotHaveSimpleName("BaseComponentTestCase")
                 .and().doNotHaveSimpleName("BaseTestCaseWithMinimalGaeEnvironment")
                 .should().accessClassesThat().haveSimpleName("GaeSimulation")
                 .orShould().accessClassesThat().haveSimpleName("Logic")
-                .check(TEST_CLASSES);
+                .check(ALL_CLASSES);
     }
 
     @Test
     public void testArchitecture_testClasses_driverShouldNotHaveAnyDependency() {
-        noClasses().that().resideInAPackage(TEST_DRIVER_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(TEST_DRIVER_PACKAGE))
                 .should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
                     @Override
                     public boolean apply(JavaClass input) {
                         return input.getPackageName().startsWith(TEST_PACKAGE)
                                 && !input.getPackageName().equals(TEST_DRIVER_PACKAGE);
                     }
-                }).check(TEST_DRIVER_CLASSES);
+                }).check(forClasses(TEST_PACKAGE));
     }
 
     @Test
     public void testArchitecture_e2e_e2eShouldBeSelfContained() {
         noClasses().that().resideOutsideOfPackage(includeSubpackages(E2E_PACKAGE))
-                .and().resideOutsideOfPackage(LEGACY_PAGEOBJECT_PACKAGE)
-                .and().resideOutsideOfPackage(LEGACY_BROWSERTESTS_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(LEGACY_PAGEOBJECT_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(LEGACY_BROWSERTESTS_PACKAGE))
                 .should().accessClassesThat().resideInAPackage(includeSubpackages(E2E_PACKAGE))
                 .check(ALL_CLASSES);
     }
@@ -393,7 +349,7 @@ public class ArchitectureTest {
                                 && !input.getPackageName().equals(UI_OUTPUT_PACKAGE)
                                 && !input.getPackageName().equals(UI_REQUEST_PACKAGE);
                     }
-                }).check(E2E_CLASSES);
+                }).check(ALL_CLASSES);
     }
 
     @Test
@@ -410,28 +366,28 @@ public class ArchitectureTest {
                         && !input.getSimpleName().startsWith("Base")
                         && !input.isInnerClass();
             }
-        }).check(E2E_TEST_CASES);
+        }).check(forClasses(E2E_CASES_PACKAGE));
     }
 
     @Test
     public void testArchitecture_e2e_onlyE2ETestsCanAccessPageObjects() {
         noClasses().that().resideInAPackage(includeSubpackages(E2E_PACKAGE))
-                .and().resideOutsideOfPackage(E2E_PAGEOBJECTS_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(E2E_PAGEOBJECTS_PACKAGE))
                 .and().resideOutsideOfPackage(includeSubpackages(E2E_CASES_PACKAGE))
-                .should().accessClassesThat().resideInAPackage(E2E_PAGEOBJECTS_PACKAGE)
-                .check(E2E_CLASSES);
+                .should().accessClassesThat().resideInAPackage(includeSubpackages(E2E_PAGEOBJECTS_PACKAGE))
+                .check(forClasses(E2E_PACKAGE));
     }
 
     @Test
     public void testArchitecture_e2e_utilShouldNotHaveAnyDependency() {
-        noClasses().that().resideInAPackage(E2E_UTIL_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(E2E_UTIL_PACKAGE))
                 .should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
                     @Override
                     public boolean apply(JavaClass input) {
                         return input.getPackageName().startsWith(E2E_PACKAGE)
                                 && !input.getPackageName().equals(E2E_UTIL_PACKAGE);
                     }
-                }).check(E2E_UTIL_CLASSES);
+                }).check(forClasses(E2E_PACKAGE));
     }
 
     @Test
@@ -445,26 +401,26 @@ public class ArchitectureTest {
     public void testArchitecture_client_clientShouldNotTouchUiComponent() {
         noClasses().that().resideInAPackage(includeSubpackages(CLIENT_PACKAGE))
                 .should().accessClassesThat().resideInAPackage(includeSubpackages(UI_PACKAGE))
-                .check(CLIENT_CLASSES);
+                .check(forClasses(CLIENT_PACKAGE, UI_PACKAGE));
     }
 
     @Test
     public void testArchitecture_client_remoteApiShouldNotTouchScripts() {
-        noClasses().that().resideInAPackage(CLIENT_REMOTEAPI_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(CLIENT_REMOTEAPI_PACKAGE))
                 .should().accessClassesThat().resideInAPackage(includeSubpackages(CLIENT_SCRIPTS_PACKAGE))
-                .check(CLIENT_REMOTEAPI_CLASSES);
+                .check(forClasses(CLIENT_PACKAGE));
     }
 
     @Test
     public void testArchitecture_client_utilShouldNotHaveAnyDependency() {
-        noClasses().that().resideInAPackage(CLIENT_UTIL_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(CLIENT_UTIL_PACKAGE))
                 .should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
                     @Override
                     public boolean apply(JavaClass input) {
                         return input.getPackageName().startsWith(CLIENT_PACKAGE)
                                 && !input.getPackageName().equals(CLIENT_UTIL_PACKAGE);
                     }
-                }).check(CLIENT_UTIL_CLASSES);
+                }).check(forClasses(CLIENT_PACKAGE));
     }
 
     @Test
@@ -476,9 +432,9 @@ public class ArchitectureTest {
 
     @Test
     public void testArchitecture_externalApi_searchApiCanOnlyBeAccessedBySomePackages() {
-        noClasses().that().resideOutsideOfPackage(STORAGE_API_PACKAGE)
-                .and().resideOutsideOfPackage(STORAGE_SEARCH_PACKAGE)
-                .and().resideOutsideOfPackage(CLIENT_SCRIPTS_PACKAGE)
+        noClasses().that().resideOutsideOfPackage(includeSubpackages(STORAGE_API_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(STORAGE_SEARCH_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(CLIENT_SCRIPTS_PACKAGE))
                 .should().accessClassesThat().resideInAPackage("com.google.appengine.api.search..")
                 .check(ALL_CLASSES);
     }
@@ -486,7 +442,7 @@ public class ArchitectureTest {
     @Test
     public void testArchitecture_externalApi_gcsApiCanOnlyBeAccessedByGcsHelper() {
         noClasses().that().doNotHaveSimpleName("GoogleCloudStorageHelper")
-                .and().resideOutsideOfPackage(CLIENT_SCRIPTS_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(CLIENT_SCRIPTS_PACKAGE))
                 .should().accessClassesThat().resideInAPackage("com.google.appengine.tools.cloudstorage..")
                 .check(ALL_CLASSES);
     }
@@ -494,18 +450,18 @@ public class ArchitectureTest {
     @Test
     public void testArchitecture_externalApi_blobstoreApiCanOnlyBeAccessedByGcsHelper() {
         noClasses().that().doNotHaveSimpleName("GoogleCloudStorageHelper")
-                .and().resideOutsideOfPackage(STORAGE_ENTITY_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
                 .should().accessClassesThat().resideInAPackage("com.google.appengine.api.blobstore..")
                 .check(ALL_CLASSES);
 
-        noClasses().that().resideInAPackage(STORAGE_ENTITY_PACKAGE)
+        noClasses().that().resideInAPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
                 .should().accessClassesThat(new DescribedPredicate<JavaClass>("") {
                     @Override
                     public boolean apply(JavaClass input) {
                         return !"BlobKey".equals(input.getSimpleName())
                                 && input.getPackageName().startsWith("com.google.appengine.api.blobstore");
                     }
-                }).check(STORAGE_ENTITY_CLASSES);
+                }).check(ALL_CLASSES);
     }
 
     @Test
@@ -524,9 +480,9 @@ public class ArchitectureTest {
 
     @Test
     public void testArchitecture_externalApi_objectifyApiCanOnlyBeAccessedBySomePackages() {
-        noClasses().that().resideOutsideOfPackage(STORAGE_API_PACKAGE)
-                .and().resideOutsideOfPackage(STORAGE_ENTITY_PACKAGE)
-                .and().resideOutsideOfPackage(CLIENT_REMOTEAPI_PACKAGE)
+        noClasses().that().resideOutsideOfPackage(includeSubpackages(STORAGE_API_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(CLIENT_REMOTEAPI_PACKAGE))
                 .and().resideOutsideOfPackage(includeSubpackages(CLIENT_SCRIPTS_PACKAGE))
                 .and().doNotHaveSimpleName("BaseTestCaseWithObjectifyAccess")
                 .should().accessClassesThat().resideInAPackage("com.googlecode.objectify..")
@@ -535,7 +491,7 @@ public class ArchitectureTest {
 
     @Test
     public void testArchitecture_externalApi_datastoreTypesCanOnlyBeAccessedByEntityClasses() {
-        noClasses().that().resideOutsideOfPackage(STORAGE_ENTITY_PACKAGE)
+        noClasses().that().resideOutsideOfPackage(includeSubpackages(STORAGE_ENTITY_PACKAGE))
                 .should().accessClassesThat().haveFullyQualifiedName("com.google.appengine.api.datastore.Text")
                 .check(ALL_CLASSES);
     }
@@ -551,21 +507,21 @@ public class ArchitectureTest {
                 .and().doNotHaveSimpleName("MockHttpServletRequest")
                 .and().doNotHaveSimpleName("MockHttpServletResponse")
                 .and().doNotHaveSimpleName("MockPart")
-                .and().resideOutsideOfPackage(UI_AUTOMATED_PACKAGE)
-                .and().resideOutsideOfPackage(UI_WEBAPI_PACKAGE)
-                .and().resideOutsideOfPackage(LEGACY_UI_CONTROLLER_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(UI_AUTOMATED_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(UI_WEBAPI_PACKAGE))
+                .and().resideOutsideOfPackage(includeSubpackages(LEGACY_UI_CONTROLLER_PACKAGE))
                 .should().accessClassesThat().haveFullyQualifiedName("javax.servlet..")
                 .check(ALL_CLASSES);
     }
 
     @Test
     public void testArchitecture_externalApi_assertionApiCanOnlyBeAccessedBySomePackages() {
-        noClasses().that().resideOutsideOfPackage(E2E_PAGEOBJECTS_PACKAGE)
+        noClasses().that().resideOutsideOfPackage(includeSubpackages(E2E_PAGEOBJECTS_PACKAGE))
                 .and().doNotHaveSimpleName("BaseTestCase")
                 .and().doNotHaveSimpleName("AssertHelper")
                 .and().doNotHaveSimpleName("CsvChecker")
                 .and().doNotHaveSimpleName("EmailChecker")
-                .and().resideOutsideOfPackage(LEGACY_PAGEOBJECT_PACKAGE)
+                .and().resideOutsideOfPackage(includeSubpackages(LEGACY_PAGEOBJECT_PACKAGE))
                 // TODO remove the next after migration
                 .and().doNotHaveSimpleName("GaeSimulation")
                 .should().accessClassesThat().haveFullyQualifiedName("org.junit.Assert")


### PR DESCRIPTION
Fixes #9737

**Outline of Solution**

- Use `includeSubpackages` when necessary
- Extend the range of classes for checking. See below as an example.
https://github.com/TEAMMATES/teammates/blob/08f6d8541022ddaf17ace15a6c97a196965b5a47/src/test/java/teammates/test/cases/architecture/ArchitectureTest.java#L118-L123
The above test won't fail even with `includeSubpackages` used because the range is limited to `.check(UI_CLASSES);`. Inside the range, it is impossible to have any violations and thus the test won't fail.
