### PR TITLE
[#9764] Feedback Session Page: Remind modal not divide student and instructor properly

### DIFF
--- a/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.html
+++ b/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.html
@@ -1,14 +1,14 @@
 <div class="modal-header">
   <div>
     <h5 class="modal-title">
-      <i class="fas fa-exclamation-circle"></i>Remind Particular Students {{ feedbackSessionName }}
-      <small>(select the student(s) you want to remind)</small>
+      <i class="fas fa-exclamation-circle"></i>Remind Particular Students or Instructors in {{ feedbackSessionName }}
+      <small>(select the student(s) or instructor(s) you want to remind)</small>
     </h5>
-    <div class="form-check form-check-inline">
+    <div class="form-check form-check-inline" *ngIf="studentStatusTableRows.length > 0">
       <input id="remindAll" class="form-check-input" type="checkbox" [(ngModel)]="checkAll" (change)="checkAllStudentsHandler()"/>
-      <label for="remindAll" class="remind-all form-check-label">Select all respondents</label>
-      <input id="remindNotSubmitted" class="form-check-input" type="checkbox" [(ngModel)]="checkAllYetSubmitted" (change)="checkAllYetSubmittedStudents(); bindSelectedCheckboxes()"/>
-      <label for="remindNotSubmitted" class="form-check-label">Select all respondents not yet submitted</label>
+      <label for="remindAll" class="remind-all form-check-label">Select all student respondents</label>
+      <input id="remindNotSubmitted" class="form-check-input" type="checkbox" [(ngModel)]="checkAllYetSubmitted" (change)="checkAllYetSubmittedStudents(); bindSelectedStudentsCheckboxes()"/>
+      <label for="remindNotSubmitted" class="form-check-label">Select all student respondents not yet submitted</label>
     </div>
   </div>
   <button type="button" class="close" (click)="activeModal.dismiss()"><i class="fas fa-times"></i></button>
@@ -54,9 +54,9 @@
         <ng-container *ngIf="!remindStudentRow.feedbackSessionStudentResponse.responseStatus">
           <tr class="bg-warning">
             <td class="align-center">
-                <label>
-                  <input type="checkbox" (change)="bindSelectedCheckboxes()" [(ngModel)]="remindStudentRow.isChecked">
-                </label>
+              <label>
+                <input type="checkbox" (change)="bindSelectedCheckboxes()" [(ngModel)]="remindStudentRow.isChecked">
+              </label>
             </td>
             <td>
               {{ remindStudentRow.feedbackSessionStudentResponse.sectionName }}
@@ -104,9 +104,87 @@
       </ng-container>
     </table>
   </div>
+  <div>
+    <div class="form-check form-check-inline" *ngIf="instructorStatusTableRows.length > 0">
+      <input id="remindAllInstructor" class="form-check-input" type="checkbox" [(ngModel)]="checkAllIns" (change)="checkAllInstructorsHandler()"/>
+      <label for="remindAllInstructor" class="remind-all form-check-label">Select all instructor respondents</label>
+      <input id="remindNotSubmittedInstructor" class="form-check-input" type="checkbox" [(ngModel)]="checkAllYetSubmittedIns" (change)="checkAllYetSubmittedInstructors(); bindSelectedInstructorsCheckboxes()"/>
+      <label for="remindNotSubmittedInstructor" class="form-check-label">Select all instructor respondents not yet submitted</label>
+    </div>
+  </div>
+  <div class="table-responsive" *ngIf="instructorStatusTableRows.length > 0; else noInstructorsToRemind">
+    <table class="table table-bordered">
+      <tr class="background-color-medium-gray">
+        <th></th>
+        <th (click)="sortInstructorsTableRows(SortBy.STUDENT_NAME)" class="clickable">
+          Instructor Name
+          <span *ngIf="instructorsTableRowSortBy !== SortBy.STUDENT_NAME"><i class="fas fa-sort"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.STUDENT_NAME && instructorsTableRowSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.STUDENT_NAME && instructorsTableRowSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+        </th>
+        <th (click)="sortInstructorsTableRows(SortBy.STUDENT_EMAIL)" class="clickable">
+          Email
+          <span *ngIf="instructorsTableRowSortBy !== SortBy.STUDENT_EMAIL"><i class="fas fa-sort"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.STUDENT_EMAIL && instructorsTableRowSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.STUDENT_EMAIL && instructorsTableRowSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+        </th>
+        <th (click)="sortInstructorsTableRows(SortBy.SUBMIT_STATUS)" class="clickable">
+          Submitted?
+          <span *ngIf="instructorsTableRowSortBy !== SortBy.SUBMIT_STATUS"><i class="fas fa-sort"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.SUBMIT_STATUS && instructorsTableRowSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+          <span *ngIf="instructorsTableRowSortBy === SortBy.SUBMIT_STATUS && instructorsTableRowSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+        </th>
+      </tr>
+      <ng-container *ngFor="let remindStudentRow of instructorStatusTableRows">
+        <ng-container *ngIf="!remindStudentRow.feedbackSessionStudentResponse.responseStatus">
+          <tr class="bg-warning">
+            <td class="align-center">
+              <label>
+                <input type="checkbox" (change)="bindSelectedCheckboxes()" [(ngModel)]="remindStudentRow.isChecked">
+              </label>
+            </td>
+            <td>
+              {{ remindStudentRow.feedbackSessionStudentResponse.name }}
+            </td>
+            <td>
+              {{ remindStudentRow.feedbackSessionStudentResponse.email }}
+            </td>
+            <td>
+              No
+            </td>
+          </tr>
+        </ng-container>
+        <ng-container *ngIf="remindStudentRow.feedbackSessionStudentResponse.responseStatus">
+          <tr class="bg-light">
+            <td class="align-center">
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" (change)="bindSelectedCheckboxes()" [(ngModel)]="remindStudentRow.isChecked">
+                </label>
+              </div>
+            </td>
+            <td>
+              {{ remindStudentRow.feedbackSessionStudentResponse.name }}
+            </td>
+            <td>
+              {{ remindStudentRow.feedbackSessionStudentResponse.email }}
+            </td>
+            <td>
+              Yes
+            </td>
+          </tr>
+        </ng-container>
+      </ng-container>
+    </table>
+  </div>
   <ng-template #noStudentsToRemind>
     <h4 class="p-2 bg-info text-white">
       There are no students enrolled to remind.
+    </h4>
+  </ng-template>
+  <ng-template #noInstructorsToRemind>
+    <h4 class="p-2 bg-info text-white">
+      There are no instructors enrolled to remind.
     </h4>
   </ng-template>
   <div *ngIf="!isAjaxSuccess">
@@ -117,5 +195,5 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">Cancel</button>
-  <button type="button" class="btn btn-primary" (click)="activeModal.close(collateStudentsToSendHandler())">Remind</button>
+  <button type="button" class="btn btn-primary" (click)="activeModal.close(collateStudentsInstructorsToSendHandler())">Remind</button>
 </div>

--- a/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.ts
+++ b/src/web/app/components/sessions-table/send-reminders-to-student-modal/send-reminders-to-student-modal.component.ts
@@ -24,6 +24,8 @@ export class SendRemindersToStudentModalComponent extends StudentListInfoBaseMod
 
   checkAll: boolean = false;
   checkAllYetSubmitted: boolean = false;
+  checkAllIns: boolean = false;
+  checkAllYetSubmittedIns: boolean = false;
 
   constructor(public activeModal: NgbActiveModal, httpRequestService: HttpRequestService,
               statusMessageService: StatusMessageService) {
@@ -66,9 +68,28 @@ export class SendRemindersToStudentModalComponent extends StudentListInfoBaseMod
   }
 
   /**
+   * Check all instructors checkbox to all instructors.
+   */
+  checkAllInstructorsHandler(): void {
+    this.checkAllInstructors(this.instructorStatusTableRows, this.checkAllIns);
+    this.checkAllYetSubmittedIns = this.checkAllIns;
+  }
+
+  /**
+   * Check all yet to submit instructors checkbox to respective instructors.
+   */
+  checkAllYetSubmittedInstructors(): void {
+    for (const remindStudentRow of this.instructorStatusTableRows) {
+      if (!remindStudentRow.feedbackSessionStudentResponse.responseStatus) {
+        remindStudentRow.isChecked = this.checkAllYetSubmittedIns;
+      }
+    }
+  }
+
+  /**
    * Bind individual checkboxes to all submitted and all yet submitted students checkbox.
    */
-  bindSelectedCheckboxes(): void {
+  bindSelectedStudentsCheckboxes(): void {
     this.checkAll = this.studentStatusTableRows.every((tableRow: StudentStatusTableRowModel) => {
       return tableRow.isChecked;
     });
@@ -81,9 +102,24 @@ export class SendRemindersToStudentModalComponent extends StudentListInfoBaseMod
   }
 
   /**
+   * Bind individual checkboxes to all submitted and all yet submitted instructors checkbox.
+   */
+  bindSelectedInstructorsCheckboxes(): void {
+    this.checkAllIns = this.instructorStatusTableRows.every((tableRow: StudentStatusTableRowModel) => {
+      return tableRow.isChecked;
+    });
+
+    this.checkAllYetSubmittedIns = this.instructorStatusTableRows.filter(
+        (tableRow: StudentStatusTableRowModel) => !tableRow.feedbackSessionStudentResponse.responseStatus,
+    ).every((tableRow: StudentStatusTableRowModel) => {
+      return tableRow.isChecked && !tableRow.feedbackSessionStudentResponse.responseStatus;
+    });
+  }
+
+  /**
    * Collates a list of selected students with selected checkbox.
    */
-  collateStudentsToSendHandler(): FeedbackSessionStudentRemindRequest {
-    return this.collateStudentsToSend(this.studentStatusTableRows);
+  collateStudentsInstructorsToSendHandler(): FeedbackSessionStudentRemindRequest {
+    return this.collateStudentsInstructorsToSend(this.studentStatusTableRows, this.instructorStatusTableRows);
   }
 }

--- a/src/web/app/components/sessions-table/student-list-info-base-modal.component.ts
+++ b/src/web/app/components/sessions-table/student-list-info-base-modal.component.ts
@@ -45,6 +45,7 @@ export abstract class StudentListInfoBaseModalComponent {
           });
         this.sortStudentsTableRows(SortBy.SUBMIT_STATUS);
         this.separateInstructorRows();
+        this.sortInstructorsTableRows(SortBy.SUBMIT_STATUS);
       }, (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorMessage(resp.error.message);
         this.isAjaxSuccess = false;


### PR DESCRIPTION
Fixes #9764 

**Outline of Solution**
add another table to list the instructors need to be reminded. Shown as below:
![Captureccc](https://user-images.githubusercontent.com/28641908/59250035-c0baf780-8c58-11e9-8446-34f009429c13.PNG)
<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->

