### PR TITLE
[#9781] Upgraded footer to include sponsor information

### DIFF
--- a/src/main/webapp/WEB-INF/tags/bodyFooter.tag
+++ b/src/main/webapp/WEB-INF/tags/bodyFooter.tag
@@ -9,9 +9,18 @@
       <div class="col-md-2">
         <span>[<a href="/">TEAMMATES</a> V<%= Config.getAppVersion() %>]</span>
       </div>
+
       <div class="col-md-8" <c:if test="${isAdmin}">id="adminInstitute"</c:if>>
-        <c:if test="${not empty data.account.institute}">[for <span class="highlight-white">${data.account.institute}</span>]</c:if>
+        <div class="row">
+          <span>
+            <c:if test="${not empty data.account.institute}">[for <span class="highlight-white">${data.account.institute}</span>]</c:if>
+            <br/>
+            Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
+            sponsor</a>)
+          </span>
+        </div>
       </div>
+
       <div class="col-md-2">
         <span>[Send <a class="link" href="/contact.jsp" target="_blank" rel="noopener noreferrer">Feedback</a>]</span>
       </div>

--- a/src/main/webapp/WEB-INF/tags/bodyFooter.tag
+++ b/src/main/webapp/WEB-INF/tags/bodyFooter.tag
@@ -6,23 +6,18 @@
 <div id="footerComponent" class="container-fluid">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>[<a href="/">TEAMMATES</a> V<%= Config.getAppVersion() %>]</span>
-      </div>
-
-      <div class="col-md-8" <c:if test="${isAdmin}">id="adminInstitute"</c:if>>
+      <div class="col-md-13" <c:if test="${isAdmin}">id="adminInstitute"</c:if>>
         <div class="row">
           <span>
-            <c:if test="${not empty data.account.institute}">[for <span class="highlight-white">${data.account.institute}</span>]</c:if>
+            <c:if test="${not empty data.account.institute}">serving: <span
+                    class="highlight-white">${data.account.institute}</span></c:if>
             <br/>
-            Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
-            sponsor</a>)
+            <a href="/">TEAMMATES</a> (v<%= Config.getAppVersion() %>) is sponsored by School of Computing, National
+            University of Singapore
+            [<a href="/contact.jsp">Become a sponsor</a>]
+            [Send <a class="link" href="/contact.jsp" target="_blank" rel="noopener noreferrer">Feedback</a>]
           </span>
         </div>
-      </div>
-
-      <div class="col-md-2">
-        <span>[Send <a class="link" href="/contact.jsp" target="_blank" rel="noopener noreferrer">Feedback</a>]</span>
       </div>
     </div>
   </div>

--- a/src/main/webapp/WEB-INF/tags/helpPage.tag
+++ b/src/main/webapp/WEB-INF/tags/helpPage.tag
@@ -32,7 +32,14 @@
             <span>[<a href="/">TEAMMATES</a>]</span>
           </div>
           <div class="col-md-8">
-            [hosted on <a href="https://cloud.google.com/appengine/" target="_blank" rel="noopener noreferrer">Google App Engine</a>]
+            <div class="row">
+              <span>
+                [hosted on <a href="https://cloud.google.com/appengine/" target="_blank" rel="noopener noreferrer">Google App Engine</a>]
+                <br/>
+                Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
+                sponsor</a>)
+              </span>
+            </div>
           </div>
           <div class="col-md-2">
             <span>[Send <a class="link" href="/contact.jsp" target="_blank" rel="noopener noreferrer">Feedback</a>]</span>

--- a/src/main/webapp/WEB-INF/tags/helpPage.tag
+++ b/src/main/webapp/WEB-INF/tags/helpPage.tag
@@ -34,8 +34,6 @@
           <div class="col-md-8">
             <div class="row">
               <span>
-                [hosted on <a href="https://cloud.google.com/appengine/" target="_blank" rel="noopener noreferrer">Google App Engine</a>]
-                <br/>
                 Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
                 sponsor</a>)
               </span>

--- a/src/main/webapp/WEB-INF/tags/staticPage.tag
+++ b/src/main/webapp/WEB-INF/tags/staticPage.tag
@@ -55,13 +55,9 @@
     <footer id="staticFooterComponent">
       <div class="container text-nowrap">
         <div class="row">
-          <div class="col-xs-6 col-sm-8 col-md-9">
+          <div class="col-xs-12 col-sm-12 col-md-12">
             Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
             sponsor</a>)
-          </div>
-
-          <div class="col-xs-6 col-sm-4 col-md-3">
-            Hosted on <a class="footer" href="https://cloud.google.com/appengine/" target="_blank" rel="noopener noreferrer">Google App Engine</a>
           </div>
         </div>
       </div>

--- a/src/main/webapp/WEB-INF/tags/staticPage.tag
+++ b/src/main/webapp/WEB-INF/tags/staticPage.tag
@@ -52,10 +52,15 @@
         <jsp:doBody />
       </div>
     </div>
-    <footer id="footerComponent">
+    <footer id="staticFooterComponent">
       <div class="container text-nowrap">
         <div class="row">
-          <div class="col-xs-12 col-sm-4 col-sm-offset-8 col-md-3 col-md-offset-9">
+          <div class="col-xs-6 col-sm-8 col-md-9">
+            Sponsored by School of Computing, National University of Singapore. (<a href="/contact.jsp">Become a
+            sponsor</a>)
+          </div>
+
+          <div class="col-xs-6 col-sm-4 col-md-3">
             Hosted on <a class="footer" href="https://cloud.google.com/appengine/" target="_blank" rel="noopener noreferrer">Google App Engine</a>
           </div>
         </div>

--- a/src/main/webapp/contact.jsp
+++ b/src/main/webapp/contact.jsp
@@ -22,5 +22,10 @@
     <p>
       <b>Interested in joining us?:</b> Visit our <a href="https://github.com/TEAMMATES/teammates">Developer Website</a>.
     </p>
+    <br>
+    <p>
+      <b>Becoming a sponsor</b>:
+      If you are interested to sponsor the TEAMMATES service for a period of time, please contact us at the above email address for details.
+    </p>
   </main>
 </t:staticPage>

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -1422,12 +1422,25 @@ Default to alert color for visibility titles used within an alert context.
 ////////////////////////// Footer //////////////////////////
 ///////////////////////////////////////////////////////// */
 
-#footerComponent {
+#staticFooterComponent {
     background-color: black;
     background-image: linear-gradient(to bottom, #3C3C3C 0, #222 100%);
     bottom: 0;
     color: gray;
     height: 20px;
+    margin: 0;
+    position: fixed;
+    text-align: center;
+    width: 100%;
+    z-index: 999;
+}
+
+#footerComponent {
+    background-color: black;
+    background-image: linear-gradient(to bottom, #3C3C3C 0, #222 100%);
+    bottom: 0;
+    color: gray;
+    height: 40px;
     margin: 0;
     position: fixed;
     text-align: center;

--- a/src/test/resources/pages/adminAccountDetails.html
+++ b/src/test/resources/pages/adminAccountDetails.html
@@ -253,24 +253,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      ${admin.institute}
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13" id="adminInstitute">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/adminHomePage.html
+++ b/src/test/resources/pages/adminHomePage.html
@@ -189,24 +189,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      ${admin.institute}
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13" id="adminInstitute">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/deadlineExceededErrorPage.html
+++ b/src/test/resources/pages/deadlineExceededErrorPage.html
@@ -107,25 +107,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/entityNotFoundPage.html
+++ b/src/test/resources/pages/entityNotFoundPage.html
@@ -133,25 +133,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/errorPage.html
+++ b/src/test/resources/pages/errorPage.html
@@ -107,25 +107,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/instructorCourseDetailsEmptyCourse.html
@@ -179,30 +179,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEditHelper.html
+++ b/src/test/resources/pages/instructorCourseEditHelper.html
@@ -1405,30 +1405,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEnrollPage.html
+++ b/src/test/resources/pages/instructorCourseEnrollPage.html
@@ -421,30 +421,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseEnrollPageResultAllFields.html
+++ b/src/test/resources/pages/instructorCourseEnrollPageResultAllFields.html
@@ -290,30 +290,28 @@ Section 1|Team 1|José Gómez|jose.gomez.tmns@gmail.tmt|This student name contai
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseJoinConfirmationHTML.html
+++ b/src/test/resources/pages/instructorCourseJoinConfirmationHTML.html
@@ -128,30 +128,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
+++ b/src/test/resources/pages/instructorCourseStudentDetailsRegistered.html
@@ -258,30 +258,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCourseStudentEditPage.html
+++ b/src/test/resources/pages/instructorCourseStudentEditPage.html
@@ -143,30 +143,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorCoursesNoCourse.html
+++ b/src/test/resources/pages/instructorCoursesNoCourse.html
@@ -212,30 +212,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute with Long Long Long Name
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute with Long Long Long Name
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackEditEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackEditEmpty.html
@@ -2851,30 +2851,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -983,30 +983,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -6982,30 +6982,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageAwaiting.html
@@ -414,30 +414,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/instructorHomeHTMLPersistenceCheck.html
@@ -184,25 +184,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorSearchPageDefault.html
+++ b/src/test/resources/pages/instructorSearchPageDefault.html
@@ -145,30 +145,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentListWithHelperView.html
+++ b/src/test/resources/pages/instructorStudentListWithHelperView.html
@@ -803,30 +803,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 5
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 5
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -960,30 +960,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 10
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 10
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/pageNotFound.html
+++ b/src/test/resources/pages/pageNotFound.html
@@ -105,25 +105,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentCourseDetailsWithTeammatesHTML.html
+++ b/src/test/resources/pages/studentCourseDetailsWithTeammatesHTML.html
@@ -181,30 +181,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentCourseJoinConfirmationHTML.html
+++ b/src/test/resources/pages/studentCourseJoinConfirmationHTML.html
@@ -110,30 +110,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageEmpty.html
@@ -132,30 +132,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageAwaiting.html
@@ -291,30 +291,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentHomeHTMLPersistenceCheck.html
+++ b/src/test/resources/pages/studentHomeHTMLPersistenceCheck.html
@@ -98,25 +98,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/studentProfilePageDefault.html
+++ b/src/test/resources/pages/studentProfilePageDefault.html
@@ -807,30 +807,28 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-        [for
-        <span class="highlight-white">
-          TEAMMATES Test Institute 1
-        </span>
-        ]
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            serving:
+            <span class="highlight-white">
+              TEAMMATES Test Institute 1
+            </span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/unauthorized.html
+++ b/src/test/resources/pages/unauthorized.html
@@ -105,25 +105,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageMCQ.html
@@ -421,25 +421,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPageOpen.html
@@ -5195,25 +5195,24 @@
 <div class="container-fluid" id="footerComponent">
   <div class="container">
     <div class="row">
-      <div class="col-md-2">
-        <span>
-          [
-          <a href="/">
-            TEAMMATES
-          </a>
-          V${version}]
-        </span>
-      </div>
-      <div class="col-md-8">
-      </div>
-      <div class="col-md-2">
-        <span>
-          [Send
-          <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
-            Feedback
-          </a>
-          ]
-        </span>
+      <div class="col-md-13">
+        <div class="row">
+          <span>
+            <br>
+            <a href="/">
+              TEAMMATES
+            </a>
+            (v6.0.0) is sponsored by School of Computing, National University of Singapore [
+            <a href="/contact.jsp">
+              Become a sponsor
+            </a>
+            ] [Send
+            <a class="link" href="/contact.jsp" rel="noopener noreferrer" target="_blank">
+              Feedback
+            </a>
+            ]
+          </span>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Part of #9781

Updates sponsor information for v6

Before Login:
<img width="1437" alt="Screenshot 2019-06-20 at 5 22 42 PM" src="https://user-images.githubusercontent.com/10579415/59837800-70dadf80-9380-11e9-8cba-4fe55611abda.png">

After Login:
<img width="1432" alt="Screenshot 2019-06-20 at 5 22 34 PM" src="https://user-images.githubusercontent.com/10579415/59837819-79cbb100-9380-11e9-9e52-d34f020ddd0c.png">

Contact us Page:
<img width="1397" alt="Screenshot 2019-06-20 at 5 22 55 PM" src="https://user-images.githubusercontent.com/10579415/59837845-8223ec00-9380-11e9-9848-5ef8ff95d5e0.png">
