### PR TITLE
[#9797] Student All Records page: display feedback session details

### DIFF
--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.html
@@ -1,6 +1,7 @@
 <h1>{{studentName}}'s Records<small class="text-muted"> - {{courseId}}</small></h1>
 <tm-student-profile [studentProfile]="studentProfile" [photoUrl]="photoUrl"></tm-student-profile>
 <tm-more-info [studentName]="studentName" [moreInfoText]="studentProfile?.moreInfo"></tm-more-info>
+<h2>Records in feedback sessions</h2>
 <div *ngFor="let session of sessions" class="card card-default mb-4">
   <div class="card-header font-weight-bold cursor-pointer" (click)="session.isCollapsed = !session.isCollapsed">
     Feedback Session : {{session.name}}
@@ -8,6 +9,15 @@
       [ngClass]="{'fa-chevron-up': !session.isCollapsed, 'fa-chevron-down': session.isCollapsed}"></span>
   </div>
   <div class="card-body" [ngbCollapse]="session.isCollapsed">
-    TODO
+    <tm-grq-rgq-view-responses *ngIf="session.questions.length > 0" [responses]="session.questions" [section]="" [sectionType]=""
+                               [groupByTeam]="false" [showStatistics]="true" [isGrq]="true"
+                               style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
+    <div *ngIf="session.questions.length > 0; else noRelatedFeedback">
+    </div>
   </div>
+  <ng-template #noRelatedFeedback>
+    <h4 class="p-1 bg-info text-white">
+      No feedback responses related to {{studentName}}({{studentSection}}) in {{session.name}} found.
+    </h4>
+  </ng-template>
 </div>

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
@@ -4,11 +4,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { StudentProfile } from '../student-profile/student-profile';
-import { InstructorStudentRecordsPageComponent } from './instructor-student-records-page.component';
 import {
   GrqRgqViewResponsesModule,
 } from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module';
+import { StudentProfile } from '../student-profile/student-profile';
+import { InstructorStudentRecordsPageComponent } from './instructor-student-records-page.component';
 
 @Component({ selector: 'tm-student-profile', template: '' })
 class StudentProfileStubComponent {

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.spec.ts
@@ -6,6 +6,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { StudentProfile } from '../student-profile/student-profile';
 import { InstructorStudentRecordsPageComponent } from './instructor-student-records-page.component';
+import {
+  GrqRgqViewResponsesModule,
+} from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module';
 
 @Component({ selector: 'tm-student-profile', template: '' })
 class StudentProfileStubComponent {
@@ -36,6 +39,7 @@ describe('InstructorStudentRecordsPageComponent', () => {
         RouterTestingModule,
         NgbModule,
         MatSnackBarModule,
+        GrqRgqViewResponsesModule,
       ],
     })
     .compileComponents();

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.component.ts
@@ -3,7 +3,9 @@ import { ActivatedRoute } from '@angular/router';
 import { environment } from '../../../environments/environment';
 import { HttpRequestService } from '../../../services/http-request.service';
 import { StatusMessageService } from '../../../services/status-message.service';
+import { QuestionOutput, ResponseOutput, SessionResults, Student } from '../../../types/api-output';
 import { ErrorMessageOutput } from '../../error-message-output';
+import { Intent } from '../../Intent';
 import { StudentProfile } from '../student-profile/student-profile';
 
 interface StudentRecords {
@@ -16,6 +18,7 @@ interface StudentRecords {
 
 interface Session {
   name: string;
+  questions: QuestionOutput[];
   isCollapsed: boolean;
 }
 
@@ -34,11 +37,12 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
   studentName: string = '';
   studentEmail: string = '';
   studentProfile?: StudentProfile ;
+  studentSection: string = '';
   sessions: Session[] = [];
   photoUrl: string = '';
 
   constructor(private route: ActivatedRoute, private httpRequestService: HttpRequestService,
-    private statusMessageService: StatusMessageService) { }
+              private statusMessageService: StatusMessageService) { }
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
@@ -57,18 +61,39 @@ export class InstructorStudentRecordsPageComponent implements OnInit {
    */
   loadStudentRecords(courseid: string, studentemail: string): void {
     const paramMap: { [key: string]: string } = { courseid, studentemail };
+    this.httpRequestService.get('/student', paramMap).subscribe((resp: Student) => {
+      this.studentSection = resp.sectionName;
+    });
     this.httpRequestService.get('/students/records', paramMap).subscribe((resp: StudentRecords) => {
       this.courseId = resp.courseId;
       this.studentName = resp.studentName;
       this.studentEmail = resp.studentEmail;
       this.studentProfile = resp.studentProfile;
-      this.sessions = resp.sessionNames.map((sessionName: string) => ({ name: sessionName, isCollapsed: false }));
       if (!this.studentProfile) {
         this.statusMessageService.showWarningMessage(
                 'Normally, we would show the student\'s profile here. '
                 + 'However, either this student has not created a profile yet, '
                 + 'or you do not have access to view this student\'s profile.');
       }
+
+      resp.sessionNames.forEach((fsname: string) => {
+        const resultParamMap: { [key: string]: string } = {
+          courseid,
+          fsname,
+          frgroupbysection: this.studentSection,
+          intent: Intent.INSTRUCTOR_RESULT,
+        };
+        this.httpRequestService.get('/result', resultParamMap).subscribe((res: SessionResults) => {
+          res.questions.forEach((q: QuestionOutput) => {
+            q.allResponses = q.allResponses.filter((response: ResponseOutput) =>
+                response.giver === this.studentName || response.recipient === this.studentName);
+          });
+          const questions: QuestionOutput[] = res.questions.filter((q: QuestionOutput) => q.allResponses.length > 0);
+          this.sessions.push({ questions, name: fsname, isCollapsed: questions.length === 0 });
+        }, (res: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorMessage(res.error.message);
+        });
+      });
     }, (resp: ErrorMessageOutput) => {
       this.statusMessageService.showErrorMessage(resp.error.message);
     });

--- a/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.module.ts
+++ b/src/web/app/pages-instructor/instructor-student-records-page/instructor-student-records-page.module.ts
@@ -1,6 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import {
+  GrqRgqViewResponsesModule,
+} from '../../components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.module';
 import { StudentProfileModule } from '../student-profile/student-profile.module';
 import { InstructorStudentRecordsPageComponent } from './instructor-student-records-page.component';
 
@@ -18,6 +21,7 @@ import { InstructorStudentRecordsPageComponent } from './instructor-student-reco
     CommonModule,
     StudentProfileModule,
     NgbModule,
+    GrqRgqViewResponsesModule,
   ],
 })
 export class InstructorStudentRecordsPageModule { }


### PR DESCRIPTION
Fixes #9797 

**Outline of Solution**
reuse the components for displaying in session result page and filter unrelated responses for current student
