### PR TITLE
[#9805] MSQ: Selecting another option does not deselect "None of the above" option

### DIFF
--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -49,20 +49,21 @@ export class MsqQuestionEditAnswerFormComponent
   /**
    * Checks if None of the above option is enabled and disables it.
    */
-  disableNoneOfTheAboveOption(): void {
+  disableNoneOfTheAboveOption(answers: string[]): string[] {
     if (this.isNoneOfTheAboveEnabled) {
-      const newAnswers: string[] = this.responseDetails.answers.slice();
+      const newAnswers: string[] = answers.slice();
       newAnswers.splice(0 , 1);
-      this.triggerResponseDetailsChange('answers', newAnswers);
+      return newAnswers;
     }
+    return answers;
   }
 
   /**
    * Updates the answers to include/exclude the Msq option specified by the index.
    */
   updateSelectedAnswers(index: number): void {
-    this.disableNoneOfTheAboveOption();
-    const newAnswers: string[] = this.responseDetails.answers.slice();
+    let newAnswers: string[] = this.responseDetails.answers.slice();
+    newAnswers = this.disableNoneOfTheAboveOption(newAnswers);
     const indexInResponseArray: number = this.responseDetails.answers.indexOf(this.questionDetails.msqChoices[index]);
     if (indexInResponseArray > -1) {
       newAnswers.splice(indexInResponseArray, 1);
@@ -78,7 +79,7 @@ export class MsqQuestionEditAnswerFormComponent
   updateIsOtherOption(): void {
     const fieldsToUpdate: any = {};
     fieldsToUpdate.isOther = !this.responseDetails.isOther;
-    this.disableNoneOfTheAboveOption();
+    fieldsToUpdate.answers = this.disableNoneOfTheAboveOption(this.responseDetails.answers);
     if (!fieldsToUpdate.isOther) {
       fieldsToUpdate.otherFieldContent = '';
     } else {

--- a/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-answer-form/msq-question-edit-answer-form.component.ts
@@ -47,7 +47,8 @@ export class MsqQuestionEditAnswerFormComponent
   }
 
   /**
-   * Checks if None of the above option is enabled and disables it.
+   * Removes the "None of the above" option in an answers list if it's present
+   * then returns the altered list.
    */
   disableNoneOfTheAboveOption(answers: string[]): string[] {
     if (this.isNoneOfTheAboveEnabled) {


### PR DESCRIPTION
Fixes #9805 

**Outline of Solution**
In `updateSelectedAnswers()` and `updateIsOtherOption()` , the method `disableNoneOfTheAboveOption()` is called. `disableNoneOfTheAboveOption()` calls `triggerResponseDetailsChange` to update the responseDetails. 

However, the input response details has yet to change and the following line#65 `const newAnswers: string[] = this.responseDetails.answers.slice();` will still have the list of answers which has the "None of the above" option.

To fix this, remove the "None of the above" in an internal list first then call `triggerResponseDetailsChange` at the end of the update methods.