### PR TITLE
[#9675] Cannot archive courses in the instructor home page

### DIFF
--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -10,7 +10,8 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
-  Course, CourseArchive,
+  Course,
+  CourseArchive,
   Courses,
   FeedbackSession,
   FeedbackSessions,

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -10,12 +10,11 @@ import { StatusMessageService } from '../../../services/status-message.service';
 import { StudentService } from '../../../services/student.service';
 import { TimezoneService } from '../../../services/timezone.service';
 import {
-  Course,
+  Course, CourseArchive,
   Courses,
   FeedbackSession,
   FeedbackSessions,
   InstructorPrivilege,
-  MessageOutput,
 } from '../../../types/api-output';
 import { DEFAULT_INSTRUCTOR_PRIVILEGE } from '../../../types/instructor-privilege';
 import {
@@ -128,13 +127,15 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
    * Archives the entire course from the instructor
    */
   archiveCourse(courseId: string): void {
-    this.httpRequestService.put('/course', { courseid: courseId, archive: 'true' })
-      .subscribe((resp: MessageOutput) => {
-        this.loadCourses();
-        this.statusMessageService.showSuccessMessage(resp.message);
-      }, (resp: ErrorMessageOutput) => {
-        this.statusMessageService.showErrorMessage(resp.error.message);
-      });
+    this.courseService.changeArchiveStatus(courseId, {
+      archiveStatus: true,
+    }).subscribe((courseArchive: CourseArchive) => {
+      this.loadCourses();
+      this.statusMessageService.showSuccessMessage(`The course ${courseArchive.courseId} has been archived.
+          You can retrieve it from the Courses page.`);
+    }, (resp: ErrorMessageOutput) => {
+      this.statusMessageService.showErrorMessage(resp.error.message);
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes #9675

**Outline of Solution**
- Update the `archiveCourse` method in `instructor-home-page`.
- Make use of the `courseService` to make the API call.
