### PR TITLE
[#9705] Rich text box: Unable to put text box in focus when clicked anywhere but the top-most line of the box

### DIFF
--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.html
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.html
@@ -1,4 +1,6 @@
-<editor class="editor" [ngClass]="{ 'editor-disabled': isDisabled }" [ngStyle]="{ 'min-height.px': minHeightInPx }"
-        [init]="init" [disabled]="isDisabled" [inline]="isInlineMode"
-        [ngModel]="richText" (ngModelChange)="richTextChange.emit($event)" [attr.placeholder]="placeholderText">
-</editor>
+<div [attr.placeholder]="placeholderText">
+  <div class="editor"
+     [ngClass]="{ 'editor-disabled': isDisabled }"
+     [ngStyle]="{ 'min-height.px': minHeightInPx }"
+  ></div>
+</div>

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -69,14 +69,14 @@ export class RichTextEditorComponent implements AfterViewInit, OnDestroy {
         + '| alignleft aligncenter alignright alignjustify '
         + '| bullist numlist outdent indent | link image',
     toolbar2: 'print | forecolor backcolor | fontsizeselect fontselect | emoticons | fullscreen',
-    setup: (editor: any) => {
+    setup: (editor: any): void => {
       this.editor = editor;
       editor.on('keyup change', () => {
-        const content = editor.getContent();
+        const content: any = editor.getContent();
         this.richTextChange.emit(content);
       });
     },
-    init_instance_callback: (editor: any) => editor.setContent(this.richText),
+    init_instance_callback: (editor: any): void => editor.setContent(this.richText),
   };
 
   constructor() { }
@@ -85,7 +85,7 @@ export class RichTextEditorComponent implements AfterViewInit, OnDestroy {
     tinymce.init({ ...this.init, readonly: this.isDisabled, inline: this.isInlineMode });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     tinymce.remove(this.editor);
   }
 }

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -71,9 +71,8 @@ export class RichTextEditorComponent implements AfterViewInit, OnDestroy {
     toolbar2: 'print | forecolor backcolor | fontsizeselect fontselect | emoticons | fullscreen',
     setup: (editor: any): void => {
       this.editor = editor;
-      editor.on('keyup change', () => {
-        const content: any = editor.getContent();
-        this.richTextChange.emit(content);
+      editor.on('keyup change undo redo', () => {
+        this.richTextChange.emit(editor.getContent());
       });
     },
     init_instance_callback: (editor: any): void => editor.setContent(this.richText),

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+declare var tinymce: any;
 
 /**
  * A rich text editor.
@@ -8,7 +9,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
   templateUrl: './rich-text-editor.component.html',
   styleUrls: ['./rich-text-editor.component.scss'],
 })
-export class RichTextEditorComponent implements OnInit {
+export class RichTextEditorComponent implements AfterViewInit, OnDestroy {
 
   @Input()
   isDisabled: boolean = false;
@@ -28,10 +29,13 @@ export class RichTextEditorComponent implements OnInit {
   @Output()
   richTextChange: EventEmitter<string> = new EventEmitter();
 
+  editor: any = '';
+
   // the argument passed to tinymce.init() in native JavaScript
   readonly init: any = {
     skin_url: '/tinymce/skins/ui/oxide',
     resize: false,
+    selector: '.editor',
     fontsize_formats: '8pt 9pt 10pt 11pt 12pt 14pt 16pt 18pt 20pt 24pt 26pt 28pt 36pt 48pt 72pt',
     font_formats: 'Andale Mono=andale mono,times;'
         + 'Arial=arial,helvetica,sans-serif;'
@@ -65,10 +69,23 @@ export class RichTextEditorComponent implements OnInit {
         + '| alignleft aligncenter alignright alignjustify '
         + '| bullist numlist outdent indent | link image',
     toolbar2: 'print | forecolor backcolor | fontsizeselect fontselect | emoticons | fullscreen',
+    setup: (editor: any) => {
+      this.editor = editor;
+      editor.on('keyup change', () => {
+        const content = editor.getContent();
+        this.richTextChange.emit(content);
+      });
+    },
+    init_instance_callback: (editor: any) => editor.setContent(this.richText),
   };
 
   constructor() { }
 
-  ngOnInit(): void {
+  ngAfterViewInit(): void {
+    tinymce.init({ ...this.init, readonly: this.isDisabled, inline: this.isInlineMode });
+  }
+
+  ngOnDestroy() {
+    tinymce.remove(this.editor);
   }
 }

--- a/src/web/app/components/rich-text-editor/rich-text-editor.module.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.module.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { EditorModule } from '@tinymce/tinymce-angular';
 import { RichTextEditorComponent } from './rich-text-editor.component';
 
 /**
@@ -12,7 +11,6 @@ import { RichTextEditorComponent } from './rich-text-editor.component';
   imports: [
     CommonModule,
     FormsModule,
-    EditorModule,
   ],
   exports: [
     RichTextEditorComponent,

--- a/src/web/jest.config.js
+++ b/src/web/jest.config.js
@@ -7,4 +7,5 @@ module.exports = {
   ],
   coverageDirectory: './coverage',
   coverageReporters: ['lcov', 'text-summary'],
+  setupFiles : ['../../node_modules/tinymce/tinymce.js'],
 };


### PR DESCRIPTION
Fixes #9705

**In progress**

The implementation does not use the `tinymce-angular` wrapper. Instead it initializes the tinymce directly and makes use of the `selector` attribute to convert the editor form to the tinymce editor.

Currently facing an issue on how to declare it in tests.