### PR TITLE
[#9850] Set default locale for date time parsing

### DIFF
--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -12,6 +12,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.zone.ZoneRulesProvider;
+import java.util.Locale;
 
 import teammates.common.exception.TeammatesException;
 import teammates.common.util.Const.SystemParams;
@@ -302,7 +303,7 @@ public final class TimeHelper {
      * @throws AssertionError if there is a parsing error
      */
     public static Instant parseInstant(String dateTimeString) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(SystemParams.DEFAULT_DATE_TIME_FORMAT, Locale.ROOT);
         try {
             return ZonedDateTime.parse(dateTimeString, formatter).toInstant();
         } catch (DateTimeParseException e) {


### PR DESCRIPTION
Fixes #9850 

 `Locale.ROOT` is used as the language/country neutral locale, which can solve the wrong date format problem caused by different languages.