### PR TITLE
 [#9799] Tinymce rich text box editor too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ngx-clipboard": "^12.0.0",
     "ngx-image-cropper": "^1.3.9",
     "rxjs": "~6.3.3",
-    "tinymce": "^5.0.4",
+    "tinymce": "^5.0.8",
     "topojson": "^3.0.2",
     "tslib": "^1.9.3",
     "ua-parser-js": "^0.7.19",


### PR DESCRIPTION
Fixes #9799 

TINYMCE was grouping toolbars incorrectly, causing the editor to expand to the page's border.
Learn more from this issue: [https://github.com/tinymce/tinymce/issues/4819](url)

![Screenshot from 2019-08-25 22-22-30](https://user-images.githubusercontent.com/29384504/63661959-a0e09d80-c78a-11e9-98a4-a2db40ee13cf.png)

This bug was patched in TINYMCE v5.0.8. The changes in this pull request change the minimum
required version for TINYMCE in packages.json to v5.0.8.
