### PR TITLE
[#9867] Chrome version in travis is mismatched with the driver version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,7 @@ jobs:
         - ./gradlew e2eTests
     - name: "E2E Tests - Chrome"
       addons:
-        apt:
-          sources:
-            - google-chrome
+        chrome: stable
       services:
         - xvfb
       before_script:


### PR DESCRIPTION
Fixes #9867

**Outline of Solution**

Update version according to the official documentation
https://docs.travis-ci.com/user/chrome
