### PR TITLE
[#9886] Login Dropdown is Not Positioned Properly

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -23,7 +23,7 @@
     <ul class="nav navbar-nav pull-right" *ngIf="!hideAuthInfo && !isFetchingAuthDetails">
       <li class="nav-item dropdown" ngbDropdown placement="bottom-right" *ngIf="!user">
         <a class="nav-link dropdown-toggle" data-toggle="dropdown" ngbDropdownToggle>Login</a>
-        <div class="dropdown-menu" ngbDropdownMenu>
+        <div class="dropdown-menu-right" ngbDropdownMenu>
           <a class="dropdown-item" id="student-login-btn" [href]="studentLoginUrl">Student Login</a>
           <a class="dropdown-item" id="instructor-login-btn" [href]="instructorLoginUrl">Instructor Login</a>
         </div>

--- a/src/web/app/page.component.scss
+++ b/src/web/app/page.component.scss
@@ -62,6 +62,11 @@ footer a {
   margin-right: 20px;
 }
 
+.dropdown-menu-right {
+  right: -20px;
+  left: auto;
+}
+
 @media (max-width: 992px) {
   .navbar-collapse {
     padding: 15px 0;


### PR DESCRIPTION
Fixes #9886 

Changed the login dropdown to right-oriented so it is not off-screen. There is a known bug in bootstrap with the class for dropdown-menu-right missing so the CSS must also be added for this to function. 
