### PR TITLE
[#9740] Fix Instructor Homepage UI

### DIFF
--- a/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-home-page/__snapshots__/instructor-home-page.component.spec.ts.snap
@@ -55,7 +55,7 @@ exports[`InstructorHomePageComponent should snap with default fields 1`] = `
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -130,7 +130,7 @@ exports[`InstructorHomePageComponent should snap with one course with error load
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -292,7 +292,7 @@ exports[`InstructorHomePageComponent should snap with one course with one feedba
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -863,7 +863,7 @@ exports[`InstructorHomePageComponent should snap with one course with two feedba
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -1581,7 +1581,7 @@ exports[`InstructorHomePageComponent should snap with one course with unexpanded
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -1882,7 +1882,7 @@ exports[`InstructorHomePageComponent should snap with one course with unpopulate
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"
@@ -2203,7 +2203,7 @@ exports[`InstructorHomePageComponent should snap with one course without feedbac
       </div>
     </div>
   </div><div
-    class="row height-60px"
+    class="row"
   >
     <div
       class="col-4"

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -20,7 +20,7 @@
   </ng-container>
 </ng-template>
 
-<div class="row height-60px">
+<div class="row">
   <div class="col-4">
     <a routerLink="/web/instructor/courses" class="btn btn-primary text-white" [queryParams]="{isAddNewCourse: true}">Add New Course</a>
   </div>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.scss
@@ -6,10 +6,6 @@
   cursor: pointer;
 }
 
-.height-60px {
-  height: 60px;
-}
-
 .margin-bottom-15px {
   margin-bottom: 15px;
 }


### PR DESCRIPTION
Fixes #9740 

Removes static height definition for row to allow responsiveness in extra small screen sizes. Fix verified in local dev environment.