### PR TITLE
[#4854] Validate Instructor Institution

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -370,6 +370,13 @@ public class Logic {
         return accountsLogic.joinCourseForInstructor(encryptedKey, googleId, institute);
     }
 
+    public AccountAttributes createAccount(AccountAttributes accountData)
+            throws InvalidParametersException, EntityAlreadyExistsException {
+        Assumption.assertNotNull(accountData);
+
+        return accountsLogic.createAccount(accountData);
+    }
+
     /**
      * Downgrades an instructor account to student account.
      *

--- a/src/main/java/teammates/logic/core/AccountsLogic.java
+++ b/src/main/java/teammates/logic/core/AccountsLogic.java
@@ -119,6 +119,8 @@ public final class AccountsLogic {
             throws InvalidParametersException, EntityDoesNotExistException, EntityAlreadyExistsException {
         InstructorAttributes instructor = validateInstructorJoinRequest(encryptedKey, googleId);
 
+        validateInstructorInstitute(instructor, institute);
+
         // Register the instructor
         instructor.googleId = googleId;
         try {
@@ -160,6 +162,16 @@ public final class AccountsLogic {
         }
 
         return instructor;
+    }
+
+    private void validateInstructorInstitute (InstructorAttributes instructor, String institute)
+            throws InvalidParametersException {
+        assert instructor != null : "Should have been checked in validateInstructorJoinRequest() method.";
+        AccountAttributes account = getAccount(instructor.email);
+
+        if (account != null && !account.institute.equals(institute)) {
+            throw new InvalidParametersException("Instructor institute manually modified.");
+        }
     }
 
     private InstructorAttributes validateInstructorJoinRequest(String encryptedKey, String googleId)

--- a/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/AccountsLogicTest.java
@@ -259,6 +259,17 @@ public class AccountsLogicTest extends BaseLogicTest {
                 instructorsLogic.getEncryptedKeyForInstructor(instructor.courseId, instructor.email),
         };
 
+        ______TS("failure: institute string different from account value");
+
+        accountsLogic.createAccount(AccountAttributes.builder(encryptedKey[0])
+                .withEmail(instructor.email).withInstitute("NUS").withName(instructor.name).build());
+
+        InvalidParametersException ipe = assertThrows(InvalidParametersException.class,
+                () -> accountsLogic.joinCourseForInstructor(encryptedKey[0], loggedInGoogleId, "NTU"));
+        assertEquals("Instructor institute manually modified.", ipe.getMessage());
+
+        accountsLogic.deleteAccountCascade(encryptedKey[0]);
+
         ______TS("failure: googleID belongs to an existing instructor in the course");
 
         EntityAlreadyExistsException eaee = assertThrows(EntityAlreadyExistsException.class,


### PR DESCRIPTION
Fixes #4854 

**Outline of Solution**

1) First, create a temp account when generating the join link with the google ID set to the encrypted key generated as part of the join link email generation.

2) When the join link is clicked and an actual account is created, use details from temp account and subsequently delete the temp account.

3) Retain branch conditions of original code to ensure that join links already sent (without associated temp accounts) will follow the original logic flow.

**Key Considerations**

This is the only way I can think of to solve the issue without extensive changes to the data schema. The tradeoff for this fix is that additional account information gets generated in the datastore. If this tradeoff is not considered to be worth solving this issue, do let me know. Thanks!
