### PR TITLE
[#9946] Migration to new RESTful search endpoints - Instructor search service

### DIFF
--- a/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-search-page/__snapshots__/instructor-search-page.component.spec.ts.snap
@@ -2,12 +2,11 @@
 
 exports[`InstructorSearchPageComponent should snap with a search key 1`] = `
 <tm-instructor-search-page
-  fbSessionDataTables={[Function Array]}
   loadingBarService={[Function LoadingBarService]}
   route={[Function ActivatedRoute]}
   searchKey={[Function String]}
+  searchService={[Function SearchService]}
   statusMessageService={[Function StatusMessageService]}
-  studentService={[Function StudentService]}
   studentTables={[Function Array]}
 >
   <tm-instructor-search-bar
@@ -18,12 +17,11 @@ exports[`InstructorSearchPageComponent should snap with a search key 1`] = `
 
 exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
 <tm-instructor-search-page
-  fbSessionDataTables={[Function Array]}
   loadingBarService={[Function LoadingBarService]}
   route={[Function ActivatedRoute]}
   searchKey=""
+  searchService={[Function SearchService]}
   statusMessageService={[Function StatusMessageService]}
-  studentService={[Function StudentService]}
   studentTables={[Function Array]}
 >
   <tm-instructor-search-bar
@@ -36,12 +34,11 @@ exports[`InstructorSearchPageComponent should snap with a student table 1`] = `
 
 exports[`InstructorSearchPageComponent should snap with default fields 1`] = `
 <tm-instructor-search-page
-  fbSessionDataTables={[Function Array]}
   loadingBarService={[Function LoadingBarService]}
   route={[Function ActivatedRoute]}
   searchKey=""
+  searchService={[Function SearchService]}
   statusMessageService={[Function StatusMessageService]}
-  studentService={[Function StudentService]}
   studentTables={[Function Array]}
 >
   <tm-instructor-search-bar

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.html
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.html
@@ -16,23 +16,5 @@
           </div>
       </div>
     </div>
-    <div>
-      <div class="form-check form-check-inline">
-        <input id="students-check" class="form-check-input" type="checkbox" [(ngModel)]="searchStudents"/>
-        <label class="form-check-label" for="students-check">
-          Students
-        </label>
-      </div>
-      <div class="form-check form-check-inline">
-        <input id="search-feedback-sessions-data-check" type="checkbox"
-            class="form-check-input" [(ngModel)]="searchFeedbackSessionData"/>
-        <label class="form-check-label" for="search-feedback-sessions-data-check">
-          Questions, responses, comments on responses
-        </label>
-      </div>
-      <span ngbTooltip="Tick the checkboxes to limit your search to certain categories"
-          class="fas fa-info-circle">
-      </span>
-    </div>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-bar/instructor-search-bar.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { SearchQuery } from '../instructor-search-page.component';
 
 /**
  * Search bar on instructor search page
@@ -10,26 +9,17 @@ import { SearchQuery } from '../instructor-search-page.component';
   styleUrls: ['./instructor-search-bar.component.scss'],
 })
 export class InstructorSearchBarComponent implements OnInit {
-
   @Input() searchKey: string = '';
-  searchStudents: boolean = true;
-  searchFeedbackSessionData: boolean = false;
-  @Output() searched: EventEmitter<SearchQuery> = new EventEmitter<SearchQuery>();
+  @Output() searched: EventEmitter<string> = new EventEmitter<string>();
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit(): void {
-  }
+  ngOnInit(): void {}
 
   /**
    * send the search data to parent for processing
    */
   search(): void {
-    this.searched.emit({
-      searchKey: this.searchKey,
-      searchStudents: this.searchStudents,
-      searchFeedbackSessionData: this.searchFeedbackSessionData,
-    });
+    this.searched.emit(this.searchKey);
   }
-
 }

--- a/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-search-page/instructor-search-page.component.ts
@@ -2,22 +2,13 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { finalize } from 'rxjs/operators';
 import { LoadingBarService } from '../../../services/loading-bar.service';
+import {
+  InstructorSearchResult,
+  SearchService,
+} from '../../../services/search.service';
 import { StatusMessageService } from '../../../services/status-message.service';
-import { StudentService } from '../../../services/student.service';
 import { ErrorMessageOutput } from '../../error-message-output';
 import { StudentListSectionData } from '../student-list/student-list-section-data';
-
-/**
- * Search result object from student search query.
- */
-export interface SearchResult {
-  searchFeedbackSessionDataTables: SearchFeedbackSessionDataTable[];
-  searchStudentsTables: SearchStudentsTable[];
-}
-
-interface SearchFeedbackSessionDataTable {
-  something: any;
-}
 
 /**
  * Data object for communication with the child student result component
@@ -25,15 +16,6 @@ interface SearchFeedbackSessionDataTable {
 export interface SearchStudentsTable {
   courseId: string;
   sections: StudentListSectionData[];
-}
-
-/**
- * Data object for communciation with the child search bar component
- */
-export interface SearchQuery {
-  searchKey: string;
-  searchStudents: boolean;
-  searchFeedbackSessionData: boolean;
 }
 
 /**
@@ -45,15 +27,15 @@ export interface SearchQuery {
   styleUrls: ['./instructor-search-page.component.scss'],
 })
 export class InstructorSearchPageComponent implements OnInit {
-
   searchKey: string = '';
   studentTables: SearchStudentsTable[] = [];
-  fbSessionDataTables: SearchFeedbackSessionDataTable[] = [];
 
-  constructor(private route: ActivatedRoute,
-              private studentService: StudentService,
-              private statusMessageService: StatusMessageService,
-              private loadingBarService: LoadingBarService) { }
+  constructor(
+    private route: ActivatedRoute,
+    private statusMessageService: StatusMessageService,
+    private loadingBarService: LoadingBarService,
+    private searchService: SearchService,
+  ) {}
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((queryParams: any) => {
@@ -61,11 +43,7 @@ export class InstructorSearchPageComponent implements OnInit {
         this.searchKey = queryParams.studentSearchkey;
       }
       if (this.searchKey) {
-        this.search({
-          searchKey: this.searchKey,
-          searchStudents: true,
-          searchFeedbackSessionData: false,
-        });
+        this.search(this.searchKey);
       }
     });
   }
@@ -73,25 +51,24 @@ export class InstructorSearchPageComponent implements OnInit {
   /**
    * Searches for students and questions/responses/comments matching the search query.
    */
-  search(searchQuery: SearchQuery): void {
+  search(searchKey: string): void {
     this.loadingBarService.showLoadingBar();
-    this.studentService.searchForStudents({
-      searchKey: searchQuery.searchKey,
-      searchStudents: searchQuery.searchStudents.toString(),
-      searchFeedbackSessionData: searchQuery.searchFeedbackSessionData.toString(),
-    })
-        .pipe(finalize(() => this.loadingBarService.hideLoadingBar()))
-        .subscribe((resp: SearchResult) => {
+    this.searchService
+      .searchInstructor(searchKey)
+      .pipe(finalize(() => this.loadingBarService.hideLoadingBar()))
+      .subscribe(
+        (resp: InstructorSearchResult) => {
           this.studentTables = resp.searchStudentsTables;
-          this.fbSessionDataTables = resp.searchFeedbackSessionDataTables;
-          const hasStudents: boolean = !!(this.studentTables && this.studentTables.length);
-          const hasFbSessionData: boolean = !!(this.fbSessionDataTables && this.fbSessionDataTables.length);
-          if (!hasStudents && !hasFbSessionData) {
+          const hasStudents: boolean = !!(
+            this.studentTables && this.studentTables.length
+          );
+          if (!hasStudents) {
             this.statusMessageService.showWarningMessage('No results found.');
           }
-        }, (resp: ErrorMessageOutput) => {
+        },
+        (resp: ErrorMessageOutput) => {
           this.statusMessageService.showErrorMessage(resp.error.message);
-        });
+        },
+      );
   }
-
 }

--- a/src/web/services/search.service.spec.ts
+++ b/src/web/services/search.service.spec.ts
@@ -1,0 +1,150 @@
+import { TestBed } from '@angular/core/testing';
+
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { SearchStudentsTable } from '../app/pages-instructor/instructor-search-page/instructor-search-page.component';
+import { StudentListSectionData } from '../app/pages-instructor/student-list/student-list-section-data';
+import { ResourceEndpoints } from '../types/api-endpoints';
+import { InstructorPrivilege, JoinState, Student, Students } from '../types/api-output';
+import { HttpRequestService } from './http-request.service';
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let spyHttpRequestService: any;
+  let service: SearchService;
+
+  const mockStudents: Students = {
+    students: [
+      {
+        email: 'alice@example.com',
+        courseId: 'CS3281',
+        name: 'Alice',
+        joinState: JoinState.JOINED,
+        teamName: 'Team 1',
+        sectionName: 'Section 1',
+      },
+      {
+        email: 'bob@example.com',
+        courseId: 'CS3281',
+        name: 'Bob',
+        joinState: JoinState.JOINED,
+        teamName: 'Team 1',
+        sectionName: 'Section 1',
+      },
+      {
+        email: 'chloe@example.com',
+        courseId: 'CS3281',
+        name: 'Chloe',
+        joinState: JoinState.JOINED,
+        teamName: 'Team 1',
+        sectionName: 'Section 2',
+      },
+      {
+        email: 'david@example.com',
+        courseId: 'CS3282',
+        name: 'David',
+        joinState: JoinState.JOINED,
+        teamName: 'Team 1',
+        sectionName: 'Section 2',
+      },
+    ],
+  };
+  let coursesWithSections: SearchStudentsTable[];
+
+  beforeEach(() => {
+    spyHttpRequestService = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+    };
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: HttpRequestService, useValue: spyHttpRequestService },
+      ],
+    });
+    service = TestBed.get(SearchService);
+    coursesWithSections = service.getCoursesWithSections(mockStudents);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should execute GET when searching for students', () => {
+    service.getStudents('Alice');
+    const paramMap: { [key: string]: string } = {
+      searchkey: 'Alice',
+    };
+    expect(spyHttpRequestService.get).toHaveBeenCalledWith(
+      '/search/students',
+      paramMap,
+    );
+  });
+
+  it('should parse students into courses with sections correctly', () => {
+    const { students }: { students: Student[] } = mockStudents;
+
+    // Number of courses should match
+    expect(coursesWithSections.length).toEqual(
+      Array.from(new Set(students.map((s: Student) => s.courseId))).length,
+    );
+
+    // Number of sections in a course should match
+    expect(
+      coursesWithSections.filter((t: SearchStudentsTable) => t.courseId === students[0].courseId)[0]
+        .sections.length,
+    ).toEqual(
+      Array.from(
+        new Set(
+          students
+            .filter((s: Student) => s.courseId === students[0].courseId)
+            .map((s: Student) => s.sectionName),
+        ),
+      ).length,
+    );
+
+    // Number of students in a section should match
+    expect(
+      coursesWithSections
+        .filter((t: SearchStudentsTable) => t.courseId === students[0].courseId)[0]
+        .sections.filter((s: StudentListSectionData) => s.sectionName === students[0].sectionName)[0]
+        .students.length,
+    ).toEqual(
+      students.filter((s: Student) => s.sectionName === students[0].sectionName).length,
+    );
+  });
+
+  it('should execute GET and parse response correctly when fetching privileges', () => {
+    spyHttpRequestService.get.mockImplementation((endpoint: string) => {
+      expect(endpoint).toEqual(ResourceEndpoints.INSTRUCTOR_PRIVILEGE);
+      return of<InstructorPrivilege>({
+        canModifyCourse: true,
+        canModifySession: true,
+        canModifyStudent: true,
+        canModifyInstructor: true,
+        canViewStudentInSections: true,
+        canModifySessionCommentsInSections: true,
+        canViewSessionInSections: true,
+        canSubmitSessionInSections: true,
+      });
+    });
+    service.getPrivileges(coursesWithSections);
+
+    for (const course of coursesWithSections) {
+      for (const section of course.sections) {
+        expect(spyHttpRequestService.get).toHaveBeenCalledWith(
+          ResourceEndpoints.INSTRUCTOR_PRIVILEGE,
+          {
+            courseid: course.courseId,
+            sectionname: section.sectionName,
+          },
+        );
+
+        expect(section.isAllowedToViewStudentInSection).toEqual(true);
+        expect(section.isAllowedToModifyStudent).toEqual(true);
+      }
+    }
+  });
+});

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { SearchStudentsTable } from '../app/pages-instructor/instructor-search-page/instructor-search-page.component';
+import { ResourceEndpoints } from '../types/api-endpoints';
+import { InstructorPrivilege, Student, Students } from '../types/api-output';
+import { HttpRequestService } from './http-request.service';
+
+/**
+ * Handles the logic for search.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchService {
+  constructor(private httpRequestService: HttpRequestService) {}
+
+  searchInstructor(searchKey: string): Observable<InstructorSearchResult> {
+    return this.getStudents(searchKey).pipe(
+      map((studentsRes: Students): SearchStudentsTable[] =>
+        this.getCoursesWithSections(studentsRes),
+      ),
+      map(
+        (coursesWithSections: SearchStudentsTable[]): InstructorSearchResult =>
+          this.getPrivileges(coursesWithSections),
+      ),
+    );
+  }
+
+  getStudents(searchKey: string): Observable<Students> {
+    const paramMap: { [key: string]: string } = {
+      searchkey: searchKey,
+    };
+    return this.httpRequestService.get('/search/students', paramMap);
+  }
+
+  getCoursesWithSections(studentsRes: Students): SearchStudentsTable[] {
+    const { students }: { students: Student[] } = studentsRes;
+
+    const distinctCourses: string[] = Array.from(
+      new Set(students.map((s: Student) => s.courseId)),
+    );
+    const coursesWithSections: SearchStudentsTable[] = distinctCourses.map(
+      (courseId: string) => ({
+        courseId,
+        sections: Array.from(
+          new Set(
+            students
+              .filter((s: Student) => s.courseId === courseId)
+              .map((s: Student) => s.sectionName),
+          ),
+        ).map((sectionName: string) => ({
+          sectionName,
+          isAllowedToViewStudentInSection: false,
+          isAllowedToModifyStudent: false,
+          students: students
+            .filter(
+              (s: Student) =>
+                s.courseId === courseId && s.sectionName === sectionName,
+            )
+            .map((s: Student) => ({
+              name: s.name,
+              email: s.email,
+              status: s.joinState,
+              team: s.teamName,
+            })),
+        })),
+      }),
+    );
+
+    return coursesWithSections;
+  }
+
+  getPrivileges(
+    coursesWithSections: SearchStudentsTable[],
+  ): InstructorSearchResult {
+    for (const course of coursesWithSections) {
+      for (const section of course.sections) {
+        this.httpRequestService
+          .get(ResourceEndpoints.INSTRUCTOR_PRIVILEGE, {
+            courseid: course.courseId,
+            sectionname: section.sectionName,
+          })
+          .subscribe((res: InstructorPrivilege): void => {
+            section.isAllowedToViewStudentInSection =
+              res.canViewStudentInSections;
+            section.isAllowedToModifyStudent = res.canModifyStudent;
+          });
+      }
+    }
+
+    return {
+      searchStudentsTables: coursesWithSections,
+    };
+  }
+}
+
+/**
+ * The typings for the response object returned by the instructor search service.
+ */
+export interface InstructorSearchResult {
+  searchStudentsTables: SearchStudentsTable[];
+}

--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -3,9 +3,9 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { SearchStudentsTable } from '../app/pages-instructor/instructor-search-page/instructor-search-page.component';
 import { StudentListSectionData } from '../app/pages-instructor/student-list/student-list-section-data';
-import { ResourceEndpoints } from '../types/api-endpoints';
 import { InstructorPrivilege, Student, Students } from '../types/api-output';
 import { HttpRequestService } from './http-request.service';
+import { InstructorService } from './instructor.service';
 
 /**
  * Handles the logic for search.
@@ -14,7 +14,10 @@ import { HttpRequestService } from './http-request.service';
   providedIn: 'root',
 })
 export class SearchService {
-  constructor(private httpRequestService: HttpRequestService) {}
+  constructor(
+    private httpRequestService: HttpRequestService,
+    private instructorService: InstructorService,
+  ) {}
 
   searchInstructor(searchKey: string): Observable<InstructorSearchResult> {
     return this.getStudents(searchKey).pipe(
@@ -79,13 +82,10 @@ export class SearchService {
     return forkJoin(
       coursesWithSections.map((course: SearchStudentsTable) => {
         return course.sections.map((section: StudentListSectionData) => {
-          return this.httpRequestService.get(
-            ResourceEndpoints.INSTRUCTOR_PRIVILEGE,
-            {
-              courseid: course.courseId,
-              sectionname: section.sectionName,
-            },
-          );
+          return this.instructorService.loadInstructorPrivilege({
+            courseId: course.courseId,
+            sectionName: section.sectionName,
+          });
         });
       }).reduce(
         (acc: Observable<InstructorPrivilege>[], val: Observable<InstructorPrivilege>[]) =>

--- a/src/web/services/student.service.spec.ts
+++ b/src/web/services/student.service.spec.ts
@@ -84,21 +84,4 @@ describe('StudentService', () => {
     expect(spyHttpRequestService.get)
         .toHaveBeenCalledWith(ResourceEndpoints.STUDENTS_CSV, paramMap, responseType);
   });
-
-  it('should execute GET when searching for students', () => {
-    const paramMap: { [key: string]: string } = {
-      searchkey: '',
-      searchstudents: '',
-      searchfeedbacksessiondata: '',
-    };
-
-    service.searchForStudents({
-      searchKey: paramMap.searchkey,
-      searchStudents: paramMap.searchstudents,
-      searchFeedbackSessionData: paramMap.searchfeedbacksessiondata,
-    });
-
-    expect(spyHttpRequestService.get)
-        .toHaveBeenCalledWith(ResourceEndpoints.STUDENTS_AND_FEEDBACK_SESSION_DATA_SEARCH, paramMap);
-  });
 });

--- a/src/web/services/student.service.ts
+++ b/src/web/services/student.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { SearchResult } from '../app/pages-instructor/instructor-search-page/instructor-search-page.component';
 import { ResourceEndpoints } from '../types/api-endpoints';
 import { MessageOutput, Student, Students } from '../types/api-output';
 import { StudentsEnrollRequest, StudentUpdateRequest } from '../types/api-request';
@@ -124,18 +123,5 @@ export class StudentService {
     };
     const responseType: string = 'text';
     return this.httpRequestService.get(ResourceEndpoints.STUDENTS_CSV, paramsMap, responseType);
-  }
-
-  /**
-   * Search for students based on input parameters by calling API.
-   */
-  searchForStudents(queryParams: { searchKey: string, searchStudents: string, searchFeedbackSessionData: string}):
-      Observable<SearchResult> {
-    const paramsMap: { [key: string]: string } = {
-      searchkey: queryParams.searchKey,
-      searchstudents: queryParams.searchStudents,
-      searchfeedbacksessiondata: queryParams.searchFeedbackSessionData,
-    };
-    return this.httpRequestService.get(ResourceEndpoints.STUDENTS_AND_FEEDBACK_SESSION_DATA_SEARCH, paramsMap);
   }
 }


### PR DESCRIPTION
Part of #9946.

**Outline of Solution**

This PR: 
- Implements the new instructor search service
- Migrates the instructor search page/component to use the new service
- Removes options to search for feedback sessions (only visual changes, this feature is currently already disabled in the backend)
