### PR TITLE
[#10006] Fix incorrect `disabled` flag for student home page view responses button

### DIFF
--- a/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
+++ b/src/web/app/pages-student/student-home-page/__snapshots__/student-home-page.component.spec.ts.snap
@@ -97,7 +97,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </td>
             <td>
               <a
-                class="btn btn-light btn-sm disabled"
+                class="btn btn-light btn-sm"
                 href="/sessions/result?courseid=CS2103&fsname=First%20Session"
                 ng-reflect-klass="btn btn-light btn-sm"
                 ng-reflect-ng-class="[object Object]"
@@ -160,7 +160,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </td>
             <td>
               <a
-                class="btn btn-light btn-sm"
+                class="btn btn-light btn-sm disabled"
                 href="/sessions/result?courseid=CS2103&fsname=Second%20Session"
                 ng-reflect-klass="btn btn-light btn-sm"
                 ng-reflect-ng-class="[object Object]"
@@ -276,7 +276,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </td>
             <td>
               <a
-                class="btn btn-light btn-sm"
+                class="btn btn-light btn-sm disabled"
                 href="/sessions/result?courseid=CS2102&fsname=Third%20Session"
                 ng-reflect-klass="btn btn-light btn-sm"
                 ng-reflect-ng-class="[object Object]"
@@ -334,7 +334,7 @@ exports[`StudentHomePageComponent should snap with all feedback sessions over 2 
             </td>
             <td>
               <a
-                class="btn btn-light btn-sm"
+                class="btn btn-light btn-sm disabled"
                 href="/sessions/result?courseid=CS2102&fsname=Fourth%20Session"
                 ng-reflect-klass="btn btn-light btn-sm"
                 ng-reflect-ng-class="[object Object]"

--- a/src/web/app/pages-student/student-home-page/student-home-page.component.html
+++ b/src/web/app/pages-student/student-home-page/student-home-page.component.html
@@ -44,7 +44,7 @@
                 </a>
               </td>
               <td>
-                <a [ngClass]="{'disabled' : session.isPublished}"
+                <a [ngClass]="{'disabled' : !session.isPublished}"
                    routerLink="../sessions/result" [queryParams]="{courseid: session.session.courseId, fsname: session.session.feedbackSessionName}"
                    class="btn btn-light btn-sm" ngbTooltip='View the submitted responses for this feedback session'>
                   View Responses


### PR DESCRIPTION
Fixes #10006

Regression introduced by https://github.com/TEAMMATES/teammates/pull/9827

**Outline of Solution**

Set `disable` to view responses button when session is not published.
