### PR TITLE
[#9382] Add comment feature for instructor session result page

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -288,16 +288,18 @@ public final class FeedbackResponseCommentsLogic {
                 && response.recipient.equals(student.team);
 
         boolean isUserInResponseGiverTeamAndRelatedResponseCommentVisibleToGiversTeamMembers =
-                (relatedQuestion.giverType == FeedbackParticipantType.TEAMS
-                || isResponseCommentVisibleTo(relatedQuestion, relatedComment,
-                                              FeedbackParticipantType.OWN_TEAM_MEMBERS))
-                && (studentsEmailInTeam.contains(response.giver)
-                        || (student.getTeam().equals(response.giver)));
+                isUserStudent
+                && (relatedQuestion.giverType == FeedbackParticipantType.TEAMS
+                    || isResponseCommentVisibleTo(relatedQuestion, relatedComment,
+                                                  FeedbackParticipantType.OWN_TEAM_MEMBERS))
+                    && (studentsEmailInTeam.contains(response.giver)
+                            || (student.getTeam().equals(response.giver)));
 
         boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers =
-                isResponseCommentVisibleTo(relatedQuestion, relatedComment,
-                                           FeedbackParticipantType.RECEIVER_TEAM_MEMBERS)
-                && studentsEmailInTeam.contains(response.recipient);
+                isUserStudent
+                && isResponseCommentVisibleTo(relatedQuestion, relatedComment,
+                                               FeedbackParticipantType.RECEIVER_TEAM_MEMBERS)
+                    && studentsEmailInTeam.contains(response.recipient);
 
         return isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipients
                 || isUserInResponseGiverTeamAndRelatedResponseCommentVisibleToGiversTeamMembers

--- a/src/main/java/teammates/ui/webapi/output/FeedbackResponseCommentData.java
+++ b/src/main/java/teammates/ui/webapi/output/FeedbackResponseCommentData.java
@@ -22,6 +22,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
     private List<CommentVisibilityType> showGiverNameTo;
     private List<CommentVisibilityType> showCommentTo;
     private boolean isVisibilityFollowingFeedbackQuestion;
+    private boolean isCommentFromFeedbackParticipant;
 
     public FeedbackResponseCommentData(FeedbackResponseCommentAttributes frc) {
         this.feedbackResponseCommentId = frc.getId();
@@ -33,6 +34,7 @@ public class FeedbackResponseCommentData extends ApiOutput {
         this.lastEditedAt = frc.getLastEditedAt().toEpochMilli();
         this.lastEditorEmail = frc.getLastEditorEmail();
         this.isVisibilityFollowingFeedbackQuestion = frc.isVisibilityFollowingFeedbackQuestion;
+        this.isCommentFromFeedbackParticipant = frc.isCommentFromFeedbackParticipant;
     }
 
     /**
@@ -100,5 +102,9 @@ public class FeedbackResponseCommentData extends ApiOutput {
 
     public boolean isVisibilityFollowingFeedbackQuestion() {
         return isVisibilityFollowingFeedbackQuestion;
+    }
+
+    public boolean isCommentFromFeedbackParticipant() {
+        return isCommentFromFeedbackParticipant;
     }
 }

--- a/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -23,7 +23,6 @@ import teammates.logic.core.FeedbackResponseCommentsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.ui.webapi.action.CreateFeedbackResponseCommentAction;
-import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.CommentVisibilityType;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;

--- a/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/CreateFeedbackResponseCommentActionTest.java
@@ -23,6 +23,7 @@ import teammates.logic.core.FeedbackResponseCommentsLogic;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.storage.api.FeedbackResponseCommentsDb;
 import teammates.ui.webapi.action.CreateFeedbackResponseCommentAction;
+import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.CommentVisibilityType;
 import teammates.ui.webapi.output.FeedbackResponseCommentData;

--- a/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseCommentActionTest.java
@@ -12,6 +12,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.ui.webapi.action.DeleteFeedbackResponseCommentAction;
+import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.MessageOutput;
 import teammates.ui.webapi.request.Intent;

--- a/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/DeleteFeedbackResponseCommentActionTest.java
@@ -12,7 +12,6 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.ui.webapi.action.DeleteFeedbackResponseCommentAction;
-import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.output.MessageOutput;
 import teammates.ui.webapi.request.Intent;

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
@@ -18,7 +18,6 @@ import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
 import teammates.logic.core.FeedbackSessionsLogic;
-import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.action.UpdateFeedbackResponseCommentAction;
 import teammates.ui.webapi.output.CommentVisibilityType;

--- a/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/UpdateFeedbackResponseCommentActionTest.java
@@ -18,6 +18,7 @@ import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
 import teammates.logic.core.FeedbackSessionsLogic;
+import teammates.ui.webapi.action.Intent;
 import teammates.ui.webapi.action.JsonResult;
 import teammates.ui.webapi.action.UpdateFeedbackResponseCommentAction;
 import teammates.ui.webapi.output.CommentVisibilityType;

--- a/src/web/app/components/comment-box/comment-box.module.ts
+++ b/src/web/app/components/comment-box/comment-box.module.ts
@@ -6,7 +6,13 @@ import { SingleResponseModule } from '../question-responses/single-response/sing
 import { RichTextEditorModule } from '../rich-text-editor/rich-text-editor.module';
 import { TeammatesCommonModule } from '../teammates-common/teammates-common.module';
 import { CommentEditFormComponent } from './comment-edit-form/comment-edit-form.component';
+import {
+  CommentVisibilityControlNamePipe,
+  CommentVisibilityTypeDescriptionPipe, CommentVisibilityTypeNamePipe,
+} from './comment-edit-form/comment-visibility-setting.pipe';
 import { CommentRowComponent } from './comment-row/comment-row.component';
+import { CommentTableModalComponent } from './comment-table-modal/comment-table-modal.component';
+import { CommentTableComponent } from './comment-table/comment-table.component';
 import {
   ConfirmDeleteCommentModalComponent,
 } from './confirm-delete-comment-modal/confirm-delete-comment-modal.component';
@@ -19,6 +25,11 @@ import {
     CommentEditFormComponent,
     CommentRowComponent,
     ConfirmDeleteCommentModalComponent,
+    CommentTableModalComponent,
+    CommentTableComponent,
+    CommentVisibilityControlNamePipe,
+    CommentVisibilityTypeDescriptionPipe,
+    CommentVisibilityTypeNamePipe,
   ],
   imports: [
     TeammatesCommonModule,
@@ -30,9 +41,11 @@ import {
   ],
   exports: [
     CommentRowComponent,
+    CommentTableComponent,
   ],
   entryComponents: [
     ConfirmDeleteCommentModalComponent,
+    CommentTableModalComponent,
   ],
 })
 export class CommentBoxModule { }

--- a/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-edit-form.component.html
@@ -5,7 +5,7 @@
   <div class="col-sm-6">
     <div class="float-right">
       <span>
-        <button *ngIf="isVisibilityOptionEnabled" class="btn btn-info btn-sm">
+        <button *ngIf="isVisibilityOptionEnabled" class="btn btn-info btn-sm" (click)="toggleVisibilityTable()">
           <i class="fas fa-eye-slash"></i> Show Visibility Options</button>
       </span>
       <span style="margin-left: 10px;">
@@ -17,6 +17,27 @@
     </div>
   </div>
 </div>
+<br/>
+
+<table *ngIf="isVisibilityTableExpanded" class="table margin-bottom-0 background-color-white table-striped">
+  <thead>
+  <tr>
+    <th scope="col" class="text-center">User/Group</th>
+    <th scope="col" class="text-center" *ngFor="let commentVisibilityControl of CommentVisibilityControl | enumToArray">{{ commentVisibilityControl | commentVisibilityControlName }}</th>
+  </tr>
+  </thead>
+  <tbody>
+  <ng-container *ngFor="let commentVisibilityType of CommentVisibilityType | enumToArray">
+    <tr *ngIf="isVisibilityTypeApplicable(commentVisibilityType)">
+      <td [ngbTooltip]="commentVisibilityType | commentVisibilityTypeDescription" container="body"> {{ commentVisibilityType | visibilityTypeName }}</td>
+      <td *ngFor="let commentVisibilityControl of CommentVisibilityControl | enumToArray" class="text-center">
+        <input type="checkbox" [checked]="hasVisibilityType(commentVisibilityType, commentVisibilityControl)"
+               (click)="modifyVisibilityControl(commentVisibilityType, commentVisibilityControl)">
+      </td>
+    </tr>
+  </ng-container>
+  </tbody>
+</table>
 
 <div style="margin: 10px 0;">
   <tm-rich-text-editor [richText]="model.commentText" (richTextChange)="triggerModelChange('commentText', $event)"

--- a/src/web/app/components/comment-box/comment-edit-form/comment-visibility-setting.pipe.spec.ts
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-visibility-setting.pipe.spec.ts
@@ -1,0 +1,18 @@
+import {
+  CommentVisibilityControlNamePipe,
+  CommentVisibilityTypeDescriptionPipe,
+} from './comment-visibility-setting.pipe';
+
+describe('VisibilityControlNamePipe', () => {
+  it('create an instance', () => {
+    const pipe: CommentVisibilityControlNamePipe = new CommentVisibilityControlNamePipe();
+    expect(pipe).toBeTruthy();
+  });
+});
+
+describe('VisibilityTypeDescriptionPipe', () => {
+  it('create an instance', () => {
+    const pipe: CommentVisibilityTypeDescriptionPipe = new CommentVisibilityTypeDescriptionPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/web/app/components/comment-box/comment-edit-form/comment-visibility-setting.pipe.ts
+++ b/src/web/app/components/comment-box/comment-edit-form/comment-visibility-setting.pipe.ts
@@ -1,0 +1,86 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { CommentVisibilityType } from '../../../../types/api-output';
+import { CommentVisibilityControl } from '../../../../types/visibility-control';
+
+/**
+ * Pipe to handle the simple display of {@link CommentVisibilityControl}.
+ */
+@Pipe({
+  name: 'commentVisibilityControlName',
+})
+export class CommentVisibilityControlNamePipe implements PipeTransform {
+  /**
+   * Transforms {@code type} to a simple name.
+   */
+  transform(type: CommentVisibilityControl): any {
+    switch (type) {
+      case CommentVisibilityControl.SHOW_COMMENT:
+        return 'Can see this comment';
+      case CommentVisibilityControl.SHOW_GIVER_NAME:
+        return "Can see comment giver's name";
+      default:
+        return 'Unknown';
+    }
+  }
+}
+
+/**
+ * Pipe to handle the detailed display of {@link CommentVisibilityType} in the context of
+ * comment visibility control.
+ */
+@Pipe({
+  name: 'commentVisibilityTypeDescription',
+})
+export class CommentVisibilityTypeDescriptionPipe implements PipeTransform {
+  /**
+   * Transforms {@code type} to a detailed description.
+   */
+  transform(type: CommentVisibilityType): any {
+    switch (type) {
+      case CommentVisibilityType.GIVER:
+        return 'Control what response giver(s) can view';
+      case CommentVisibilityType.RECIPIENT:
+        return 'Control what response recipient(s) can view';
+      case CommentVisibilityType.INSTRUCTORS:
+        return 'Control what instructors can view';
+      case CommentVisibilityType.GIVER_TEAM_MEMBERS:
+        return 'Control what team members of response giver can view';
+      case CommentVisibilityType.RECIPIENT_TEAM_MEMBERS:
+        return 'Control what team members of response recipient(s) can view';
+      case CommentVisibilityType.STUDENTS:
+        return 'Control what other students in this course can view';
+      default:
+        return 'Unknown';
+    }
+  }
+}
+
+/**
+ * Pipe to handle the simple display of {@link FeedbackParticipantType}.
+ */
+@Pipe({
+  name: 'visibilityTypeName',
+})
+export class CommentVisibilityTypeNamePipe implements PipeTransform {
+  /**
+   * Transforms {@code type} to a simple name.
+   */
+  transform(type: CommentVisibilityType): any {
+    switch (type) {
+      case CommentVisibilityType.GIVER:
+        return 'Response Giver(s)';
+      case CommentVisibilityType.RECIPIENT:
+        return 'Response Recipient(s)';
+      case CommentVisibilityType.INSTRUCTORS:
+        return 'Instructors';
+      case CommentVisibilityType.GIVER_TEAM_MEMBERS:
+        return "Response Giver's Team Members";
+      case CommentVisibilityType.RECIPIENT_TEAM_MEMBERS:
+        return "Response Recipient's Team Members";
+      case CommentVisibilityType.STUDENTS:
+        return 'Other students in this course';
+      default:
+        return 'Unknown';
+    }
+  }
+}

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.html
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.html
@@ -1,9 +1,9 @@
-<tm-comment-edit-form *ngIf="model.isEditing || mode == CommentRowMode.ADD"
-                      [model]="model.commentEditFormModel"
+<tm-comment-edit-form *ngIf="model.isEditing || mode == CommentRowMode.ADD" [model]="model.commentEditFormModel"
                       (modelChange)="triggerModelChange('commentEditFormModel', $event)"
                       [isVisibilityOptionEnabled]="isVisibilityOptionEnabled"
                       [isDisabled]="isDisabled"
                       [shouldHideSavingButton]="shouldHideSavingButton"
+                      [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType"
                       (closeCommentBoxEvent)="triggerCloseEditing()"
                       (saveCommentEvent)="triggerSaveCommentEvent()"></tm-comment-edit-form>
 
@@ -22,7 +22,7 @@
           </ng-container>
         </span>
 
-        <i class="fa fa-eye-slash" aria-hidden="true" ngbTooltip="This comment is visible to PLACEHOLDER"></i>
+        <i class="fa fa-eye-slash" aria-hidden="true" ngbTooltip="This comment is visible to {{getVisibilityHint()}}"></i>
 
         <div class="float-right comment-row">
           <button type="button" class="btn btn-secondary btn-sm"  ngbTooltip='Edit this comment'

--- a/src/web/app/components/comment-box/comment-row/comment-row.component.ts
+++ b/src/web/app/components/comment-box/comment-row/comment-row.component.ts
@@ -18,7 +18,7 @@ export interface CommentRowModel {
   // timezone and originalComment are optional under ADD mode.
 
   commentEditFormModel: CommentEditFormModel;
-  isEditing: boolean;
+  isEditing?: boolean;
 }
 
 /**

--- a/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.html
+++ b/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.html
@@ -1,0 +1,31 @@
+<div class="modal-header">
+  <h5 class="modal-title">Comments</h5>
+  <button type="button" class="close" (click)="activeModal.dismiss()">
+    <i class="fas fa-times"></i>
+  </button>
+</div>
+<div class="modal-body">
+  <div *ngIf="response">
+    <div *ngIf="response.giver !== response.recipient, else selfFeedback">
+      Feedback given by {{response.giver}} for {{response.recipient}}</div>
+    <ng-template #selfFeedback>Self-feedback given by {{response.giver}}</ng-template>
+    <div class="blockquote" style="margin-top: 10px;">
+      <tm-single-response [responseDetails]="response.responseDetails"
+                          [questionDetails]="questionDetails"
+      ></tm-single-response>
+    </div>
+  </div>
+  <div style="margin-top: 10px;">
+    <tm-comment-table [commentsTableModel]="commentsTableModel" [timezone]="timeZone"
+                      [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType"
+                      (modelChange)="triggerModelChange($event)"
+                      (updateCommentEvent)="triggerUpdateCommentEvent($event)"
+                      (deleteCommentEvent)="triggerDeleteCommentEvent($event)"
+                      (saveNewCommentEvent)="triggerSaveNewCommentEvent()"
+                      (closeEditingEvent)="triggerCloseEditingEvent($event)"
+    ></tm-comment-table>
+  </div>
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-light" (click)="activeModal.dismiss()">Close</button>
+</div>

--- a/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.scss
+++ b/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.scss
@@ -1,0 +1,6 @@
+.blockquote {
+  background: #F9F9F9;
+  border-left: 10px solid #CCC;
+  margin: 1.5em 10px;
+  padding: .5em 10px;
+}

--- a/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.spec.ts
+++ b/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.spec.ts
@@ -1,0 +1,40 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { SingleResponseModule } from '../../question-responses/single-response/single-response.module';
+import { CommentEditFormComponent } from '../comment-edit-form/comment-edit-form.component';
+import { CommentRowComponent } from '../comment-row/comment-row.component';
+import { CommentTableComponent } from '../comment-table/comment-table.component';
+import { CommentTableModalComponent } from './comment-table-modal.component';
+
+describe('CommentTableModalComponent', () => {
+  let component: CommentTableModalComponent;
+  let fixture: ComponentFixture<CommentTableModalComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CommentTableModalComponent,
+        CommentTableComponent,
+        CommentRowComponent,
+        CommentEditFormComponent,
+      ],
+      imports: [
+        FormsModule,
+        SingleResponseModule,
+      ],
+      providers: [NgbActiveModal],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CommentTableModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.ts
+++ b/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.ts
@@ -1,0 +1,232 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { FeedbackResponseCommentService } from '../../../../services/feedback-response-comment.service';
+import { CommentVisibilityType, FeedbackResponseComment } from '../../../../types/api-output';
+import { FeedbackVisibilityType } from '../../../../types/api-request';
+import { CommentVisibilityControl } from '../../../../types/visibility-control';
+import { Intent } from '../../../Intent';
+import { CommentEditFormModel } from '../comment-edit-form/comment-edit-form.component';
+import { CommentRowModel } from '../comment-row/comment-row.component';
+
+/**
+ * Modal for the comments table.
+ */
+@Component({
+  selector: 'tm-comment-table-modal',
+  templateUrl: './comment-table-modal.component.html',
+  styleUrls: ['./comment-table-modal.component.scss'],
+})
+export class CommentTableModalComponent implements OnInit {
+
+  @Input() response: any = '';
+  @Input() questionDetails: any = '';
+  @Input() comments: FeedbackResponseComment[] = [];
+  @Input() timeZone: string = '';
+  @Input() showResponsesTo: FeedbackVisibilityType[] = [];
+
+  @Output() commentsChange: EventEmitter<FeedbackResponseComment[]> = new EventEmitter();
+
+  commentsTableModel: CommentRowModel[] = [];
+  FeedbackVisibilityType: typeof FeedbackVisibilityType = FeedbackVisibilityType;
+  showResponsesToInCommentVisibilityType: CommentVisibilityType[] = [];
+
+  constructor(private commentService: FeedbackResponseCommentService,
+              public activeModal: NgbActiveModal) { }
+
+  ngOnInit(): void {
+    this.showResponsesToInCommentVisibilityType =
+      this.showResponsesTo.map((visibilityType: FeedbackVisibilityType) => {
+        switch (visibilityType) {
+          case FeedbackVisibilityType.INSTRUCTORS:
+            return CommentVisibilityType.INSTRUCTORS;
+            break;
+          case FeedbackVisibilityType.STUDENTS:
+            return CommentVisibilityType.STUDENTS;
+            break;
+          case FeedbackVisibilityType.RECIPIENT:
+            return CommentVisibilityType.RECIPIENT;
+            break;
+          case FeedbackVisibilityType.GIVER_TEAM_MEMBERS:
+            return CommentVisibilityType.GIVER_TEAM_MEMBERS;
+            break;
+          case FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS:
+            return CommentVisibilityType.RECIPIENT_TEAM_MEMBERS;
+            break;
+          default:
+            return CommentVisibilityType.GIVER;
+        }
+      });
+    this.showResponsesToInCommentVisibilityType.push(CommentVisibilityType.GIVER);
+
+    // push the new comment edit form
+    this.commentsTableModel.push({
+      commentEditFormModel: {
+        commentText: '',
+        commentVisibility:
+            this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType,
+                this.showResponsesToInCommentVisibilityType),
+      },
+      timezone: this.timeZone,
+      isEditing: true,
+    });
+
+    this.comments.forEach((comment: FeedbackResponseComment) => {
+      this.commentsTableModel.push({
+        originalComment: comment,
+        timezone: this.timeZone,
+        commentEditFormModel: {
+          commentText: comment.commentText,
+          commentVisibility: this.getCommentVisibilityMap(comment.showCommentTo, comment.showGiverNameTo),
+        },
+        isEditing: false,
+      });
+    });
+  }
+
+  /**
+   * Triggers the delete comment event.
+   */
+  triggerDeleteCommentEvent(commentId: number): void {
+    this.commentService.deleteComment(commentId, Intent.INSTRUCTOR_RESULT).subscribe(() => {
+      this.commentsTableModel = this.commentsTableModel.filter((commentRow: CommentRowModel) =>
+          !commentRow.originalComment || commentRow.originalComment.feedbackResponseCommentId !== commentId);
+      const updatedComments: FeedbackResponseComment[] =
+          this.comments.filter((comment: FeedbackResponseComment) => comment.feedbackResponseCommentId !== commentId);
+      this.commentsChange.emit(updatedComments);
+    });
+  }
+
+  /**
+   * Triggers the update comment event.
+   */
+  triggerUpdateCommentEvent(index: number): void {
+    const commentData: CommentRowModel = this.commentsTableModel[index];
+
+    this.commentService.updateComment({
+      commentText: commentData.commentEditFormModel.commentText,
+      showCommentTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          commentData.commentEditFormModel.commentVisibility, CommentVisibilityControl.SHOW_COMMENT),
+      showGiverNameTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          commentData.commentEditFormModel.commentVisibility, CommentVisibilityControl.SHOW_GIVER_NAME),
+      // tslint:disable-next-line:no-non-null-assertion
+    }, commentData.originalComment!.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
+    .subscribe((commentResponse: FeedbackResponseComment) => {
+      this.commentsTableModel[index] = {
+        originalComment: commentResponse,
+        commentEditFormModel: {
+          commentText: commentResponse.commentText,
+          commentVisibility: this.getCommentVisibilityMap(commentResponse.showCommentTo,
+              commentResponse.showGiverNameTo),
+        },
+        timezone: this.timeZone,
+        isEditing: false,
+      };
+
+      const updatedComments: FeedbackResponseComment[] = this.comments.slice();
+      const commentToUpdateIndex: number =
+          updatedComments.findIndex((comment: FeedbackResponseComment) =>
+            // tslint:disable-next-line:no-non-null-assertion
+            comment.feedbackResponseCommentId === commentData.originalComment!.feedbackResponseCommentId);
+      updatedComments[commentToUpdateIndex] = {...updatedComments[commentToUpdateIndex],
+        lastEditedAt: commentResponse.lastEditedAt,
+        commentText: commentResponse.commentText,
+        showCommentTo: commentResponse.showCommentTo,
+        showGiverNameTo: commentResponse.showGiverNameTo,
+      };
+      this.commentsChange.emit(updatedComments);
+    });
+  }
+
+  /**
+   * Triggers the add new comment event.
+   */
+  triggerSaveNewCommentEvent(): void {
+    const newCommentEditForm: CommentEditFormModel = this.commentsTableModel[0].commentEditFormModel;
+    this.commentService.createComment({
+      commentText: newCommentEditForm.commentText,
+      showCommentTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          newCommentEditForm.commentVisibility, CommentVisibilityControl.SHOW_COMMENT),
+      showGiverNameTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          newCommentEditForm.commentVisibility, CommentVisibilityControl.SHOW_GIVER_NAME),
+    }, this.response.responseId, Intent.INSTRUCTOR_RESULT)
+    .subscribe((commentResponse: FeedbackResponseComment) => {
+      this.commentsTableModel.push({
+        originalComment: commentResponse,
+        timezone: this.timeZone,
+        commentEditFormModel: {
+          commentText: commentResponse.commentText,
+          commentVisibility: this.getCommentVisibilityMap(commentResponse.showCommentTo,
+              commentResponse.showGiverNameTo),
+        },
+        isEditing: false,
+      });
+
+      this.commentsTableModel[0] = {
+        commentEditFormModel: {
+          commentText: '',
+          commentVisibility: this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType,
+              this.showResponsesToInCommentVisibilityType),
+        },
+        timezone: this.timeZone,
+        isEditing: true,
+      };
+
+      const updatedComments: FeedbackResponseComment[] = this.comments.slice();
+      updatedComments.push(commentResponse);
+      this.commentsChange.emit(updatedComments);
+    });
+  }
+
+  /**
+   * Triggers the change of the model for the form.
+   */
+  triggerModelChange(data: any): void {
+    this.commentsTableModel[data.index] = data.commentRow;
+  }
+
+  /**
+   * Triggers the close editing event.
+   */
+  triggerCloseEditingEvent(index: number): void {
+    // tslint:disable-next-line:no-non-null-assertion
+    const originalComment: FeedbackResponseComment = this.commentsTableModel[index].originalComment!;
+    if (originalComment) {
+      this.commentsTableModel[index].commentEditFormModel = {
+        commentText: originalComment.commentText,
+        commentVisibility: this.getCommentVisibilityMap(originalComment.showCommentTo, originalComment.showGiverNameTo),
+      };
+    } else {
+      this.commentsTableModel[index].commentEditFormModel = {
+        commentText: '',
+        commentVisibility: this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType,
+            this.showResponsesToInCommentVisibilityType),
+      };
+    }
+    this.commentsTableModel[index].isEditing = false;
+  }
+
+  /**
+   * Gets the CommentVisibilityType arrays under certain visibilityControl.
+   */
+  getCommentVisibilityTypesUnderVisibilityControl(commentVisibility: Map<CommentVisibilityControl,
+      Set<CommentVisibilityType>>, commentVisibilityControl: CommentVisibilityControl): CommentVisibilityType[] {
+    const visibilityTypes: CommentVisibilityType[] = [];
+    // tslint:disable-next-line:no-non-null-assertion
+    commentVisibility.get(commentVisibilityControl)!.forEach((visibilityType: CommentVisibilityType) => {
+      visibilityTypes.push(visibilityType);
+    });
+    return visibilityTypes;
+  }
+
+  /**
+   * Gets the CommentVisibilityType map combined from showCommentTo and showGiverNameTo.
+   */
+
+  getCommentVisibilityMap(showCommentTo: CommentVisibilityType[], showGiverNameTo: CommentVisibilityType[]):
+      Map<CommentVisibilityControl, Set<CommentVisibilityType>> {
+    const commentVisibility: Map<CommentVisibilityControl, Set<CommentVisibilityType>> = new Map();
+    commentVisibility.set(CommentVisibilityControl.SHOW_COMMENT, new Set(showCommentTo));
+    commentVisibility.set(CommentVisibilityControl.SHOW_GIVER_NAME, new Set(showGiverNameTo));
+    return commentVisibility;
+  }
+}

--- a/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.ts
+++ b/src/web/app/components/comment-box/comment-table-modal/comment-table-modal.component.ts
@@ -2,9 +2,8 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { FeedbackResponseCommentService } from '../../../../services/feedback-response-comment.service';
 import { CommentVisibilityType, FeedbackResponseComment } from '../../../../types/api-output';
-import { FeedbackVisibilityType } from '../../../../types/api-request';
+import { FeedbackVisibilityType, Intent } from '../../../../types/api-request';
 import { CommentVisibilityControl } from '../../../../types/visibility-control';
-import { Intent } from '../../../Intent';
 import { CommentEditFormModel } from '../comment-edit-form/comment-edit-form.component';
 import { CommentRowModel } from '../comment-row/comment-row.component';
 

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.html
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.html
@@ -14,7 +14,7 @@
                       (closeEditingEvent)="triggerCloseEditingEvent(i + 1)"
       ></tm-comment-row>
       <!-- "Add new comment" row -->
-    <li class="list-group-item">
+    <li class="list-group-item" *ngIf="isNewCommentExpanded">
       <tm-comment-row [model]="commentsTableModel[0]" [isDisabled]="false" [isVisibilityOptionEnabled]="true"
                       [mode]="CommentRowMode.ADD"
                       [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType"

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.html
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.html
@@ -1,0 +1,27 @@
+<div class="card">
+  <div class="card-header comment-table-header" *ngIf="false">
+    Comments
+  </div>
+
+  <ul class="list-group list-group-flush" >
+    <li class="list-group-item" *ngFor="let comment of commentsTableModel.slice(1); let i = index">
+      <tm-comment-row *ngIf="comment.originalComment" [model]="comment" [isVisibilityOptionEnabled]="true"
+                      [isDisabled]="false" [mode]="CommentRowMode.EDIT"
+                      [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType"
+                      (modelChange)="triggerModelChange(i + 1, $event)"
+                      (deleteCommentEvent)="triggerDeleteCommentEvent(comment.originalComment!.feedbackResponseCommentId)"
+                      (saveCommentEvent)="triggerUpdateCommentEvent(i + 1)"
+                      (closeEditingEvent)="triggerCloseEditingEvent(i + 1)"
+      ></tm-comment-row>
+      <!-- "Add new comment" row -->
+    <li class="list-group-item">
+      <tm-comment-row [model]="commentsTableModel[0]" [isDisabled]="false" [isVisibilityOptionEnabled]="true"
+                      [mode]="CommentRowMode.ADD"
+                      [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType"
+                      (modelChange)="triggerModelChange(0, $event)"
+                      (saveCommentEvent)="triggerSaveNewCommentEvent()"
+                      (closeEditingEvent)="triggerCloseEditingEvent(0)"
+      ></tm-comment-row>
+    </li>
+  </ul>
+</div>

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.scss
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.scss
@@ -1,0 +1,3 @@
+.comment-table-header {
+  background-color: transparent;
+}

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.spec.ts
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.spec.ts
@@ -1,0 +1,34 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { CommentEditFormComponent } from '../comment-edit-form/comment-edit-form.component';
+import { CommentRowComponent } from '../comment-row/comment-row.component';
+import { CommentTableComponent } from './comment-table.component';
+
+describe('CommentTableComponent', () => {
+  let component: CommentTableComponent;
+  let fixture: ComponentFixture<CommentTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        CommentTableComponent,
+        CommentRowComponent,
+        CommentEditFormComponent,
+      ],
+      imports: [
+        FormsModule,
+      ],
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CommentTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.ts
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.ts
@@ -1,0 +1,70 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { CommentVisibilityType } from '../../../../types/api-output';
+import { CommentRowMode, CommentRowModel } from '../comment-row/comment-row.component';
+
+/**
+ * Component for the comments table.
+ */
+@Component({
+  selector: 'tm-comment-table',
+  templateUrl: './comment-table.component.html',
+  styleUrls: ['./comment-table.component.scss'],
+})
+export class CommentTableComponent implements OnInit {
+
+  // enum
+  CommentRowMode: typeof CommentRowMode = CommentRowMode;
+
+  @Input() commentsTableModel: CommentRowModel[] = [];
+  @Input() timezone: string = '';
+  @Input() showResponsesToInCommentVisibilityType: CommentVisibilityType[] = [];
+
+  @Output() modelChange: EventEmitter<any> = new EventEmitter();
+  @Output() saveNewCommentEvent: EventEmitter<any> = new EventEmitter();
+  @Output() deleteCommentEvent: EventEmitter<number> = new EventEmitter();
+  @Output() updateCommentEvent: EventEmitter<number> = new EventEmitter();
+  @Output() closeEditingEvent: EventEmitter<number> = new EventEmitter();
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  /**
+   * Triggers the delete comment event.
+   */
+  triggerDeleteCommentEvent(commentId: number): void {
+    this.deleteCommentEvent.emit(commentId);
+  }
+
+  /**
+   * Triggers the update comment event.
+   */
+  triggerUpdateCommentEvent(index: number): void {
+    this.updateCommentEvent.emit(index);
+  }
+
+  /**
+   * Triggers the add new comment event.
+   */
+  triggerSaveNewCommentEvent(): void {
+    this.saveNewCommentEvent.emit();
+  }
+
+  /**
+   * Triggers the change of the model for the form.
+   */
+  triggerModelChange(index: number, data: CommentRowModel): void {
+    this.modelChange.emit({
+      index,
+      commentRow: data,
+    });
+  }
+
+  /**
+   * Triggers the close editing event.
+   */
+  triggerCloseEditingEvent(index: number): void {
+    this.closeEditingEvent.emit(index);
+  }
+}

--- a/src/web/app/components/comment-box/comment-table/comment-table.component.ts
+++ b/src/web/app/components/comment-box/comment-table/comment-table.component.ts
@@ -18,6 +18,7 @@ export class CommentTableComponent implements OnInit {
   @Input() commentsTableModel: CommentRowModel[] = [];
   @Input() timezone: string = '';
   @Input() showResponsesToInCommentVisibilityType: CommentVisibilityType[] = [];
+  @Input() isNewCommentExpanded: boolean = true;
 
   @Output() modelChange: EventEmitter<any> = new EventEmitter();
   @Output() saveNewCommentEvent: EventEmitter<any> = new EventEmitter();

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -31,8 +31,8 @@
                   </div>
                 </div>
                 <div class="card-body" *ngIf="question.isTabExpanded">
-                  <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                      [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails" [questionId]="question.questionId"></tm-per-question-view-responses>
+                  <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session" [showResponsesTo]="question.showResponsesTo"
+                      [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails" [questionId]="question.questionId" (commentsChangeInResponse)="triggerCommentChangeInResponseEvent($event)"></tm-per-question-view-responses>
                 </div>
               </div>
             </div>
@@ -64,8 +64,8 @@
             </div>
           </div>
           <div class="card-body" *ngIf="question.isTabExpanded">
-            <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails"></tm-per-question-view-responses>
+            <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session" [showResponsesTo]="question.showResponsesTo"
+                [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails" (commentsChangeInResponse)="triggerCommentChangeInResponseEvent($event)"></tm-per-question-view-responses>
           </div>
         </div>
       </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import {
   InstructorSessionResultSectionType,
 } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
@@ -22,6 +22,8 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
   @Input() session: any = {};
 
   @Input() isGqr: boolean = true;
+
+  @Output() commentsChangeInResponse: EventEmitter<any> = new EventEmitter();
 
   teamsToUsers: { [key: string]: string[] } = {};
   teamExpanded: { [key: string]: boolean } = {};
@@ -132,5 +134,12 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
    */
   getGQRRelatedGiverEmailForUser(userInfo: string): string {
     return Object.values(this.responsesToShow[userInfo])[0].allResponses[0].relatedGiverEmail;
+  }
+
+  /**
+   * Triggers the comment change in response event.
+   */
+  triggerCommentChangeInResponseEvent(responseToUpdate: any): void {
+    this.commentsChangeInResponse.emit(responseToUpdate);
   }
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -12,13 +12,24 @@
     </div>
   </div>
   <div class="col-md-9">
-    <div *ngFor="let response of responses">
+    <div *ngFor="let response of responses; let i = index">
       <div class="card bottom-padded">
         <div class="card-header bg-info text-white">
           <tm-question-text-with-info [questionNumber]="response.questionNumber" [questionDetails]="response.questionDetails"></tm-question-text-with-info>
         </div>
         <div class="card-body">
           <tm-single-response [responseDetails]="response.allResponses[0].responseDetails" [questionDetails]="response.questionDetails"></tm-single-response>
+          <button type="button" class="btn btn-primary float-right" (click)="triggerNewCommentRow()"><i class="fas fa-comment"></i></button>
+        </div>
+        <div style="margin-top: 1rem;">
+          <tm-comment-table [commentsTableModel]="commentsTablesModel[i]" [isNewCommentExpanded]="isNewCommentRowExpanded"
+                            [showResponsesToInCommentVisibilityType]="showResponsesToInCommentVisibilityType[i]"
+                            (modelChange)="triggerModelChange($event, i)"
+                            (saveNewCommentEvent)="triggerSaveNewCommentEvent(i)"
+                            (updateCommentEvent)="triggerUpdateCommentEvent($event, i)"
+                            (deleteCommentEvent)="triggerDeleteCommentEvent($event, i)"
+                            (closeEditingEvent)="triggerCloseEditingEvent($event, i)"
+          ></tm-comment-table>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -1,7 +1,13 @@
-import { Component, Input, OnInit } from '@angular/core';
-import {
-  InstructorSessionResultSectionType,
-} from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FeedbackResponseCommentService } from '../../../../services/feedback-response-comment.service';
+import { CommentVisibilityType, FeedbackResponseComment } from '../../../../types/api-output';
+import { FeedbackVisibilityType } from '../../../../types/api-request';
+import { CommentVisibilityControl } from '../../../../types/visibility-control';
+import { Intent } from '../../../Intent';
+// tslint:disable-next-line:max-line-length
+import { InstructorSessionResultSectionType } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
+import { CommentEditFormModel } from '../../comment-box/comment-edit-form/comment-edit-form.component';
+import { CommentRowModel } from '../../comment-box/comment-row/comment-row.component';
 
 /**
  * A list of responses grouped in GRQ/RGQ mode.
@@ -21,9 +27,229 @@ export class GroupedResponsesComponent implements OnInit {
   @Input() header: string = '';
   @Input() session: any = {};
   @Input() relatedGiverEmail: string = '';
-  constructor() { }
+
+  @Output() commentsChangeInResponse: EventEmitter<any> = new EventEmitter();
+
+  showResponsesToInCommentVisibilityType: CommentVisibilityType[][] = [];
+  commentsTablesModel: CommentRowModel[][] = [];
+  isNewCommentRowExpanded: boolean = false;
+
+  constructor(private commentService: FeedbackResponseCommentService) { }
 
   ngOnInit(): void {
+    this.responses.forEach((response: any, i: number) => {
+      const comments: FeedbackResponseComment[] = response.allResponses[0].allComments;
+
+      this.showResponsesToInCommentVisibilityType[i] =
+          response.showResponsesTo.map((visibilityType: FeedbackVisibilityType) => {
+            switch (visibilityType) {
+              case FeedbackVisibilityType.INSTRUCTORS:
+                return CommentVisibilityType.INSTRUCTORS;
+                break;
+              case FeedbackVisibilityType.STUDENTS:
+                return CommentVisibilityType.STUDENTS;
+                break;
+              case FeedbackVisibilityType.RECIPIENT:
+                return CommentVisibilityType.RECIPIENT;
+                break;
+              case FeedbackVisibilityType.GIVER_TEAM_MEMBERS:
+                return CommentVisibilityType.GIVER_TEAM_MEMBERS;
+                break;
+              case FeedbackVisibilityType.RECIPIENT_TEAM_MEMBERS:
+                return CommentVisibilityType.RECIPIENT_TEAM_MEMBERS;
+                break;
+              default:
+                return CommentVisibilityType.GIVER;
+            }
+          });
+
+      this.showResponsesToInCommentVisibilityType[i].push(CommentVisibilityType.GIVER);
+
+      // push the new comment edit form
+      this.commentsTablesModel[i] = [({
+        commentEditFormModel: {
+          commentText: '',
+          commentVisibility:
+              this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType[i],
+                  this.showResponsesToInCommentVisibilityType[i]),
+        },
+        timezone: this.session.timeZone,
+        isEditing: true,
+      })];
+
+      comments.forEach((comment: FeedbackResponseComment) => {
+        this.commentsTablesModel[i].push({
+          originalComment: comment,
+          timezone: this.session.timeZone,
+          commentEditFormModel: {
+            commentText: comment.commentText,
+            commentVisibility: this.getCommentVisibilityMap(comment.showCommentTo, comment.showGiverNameTo),
+          },
+          isEditing: false,
+        });
+      });
+    });
   }
 
+  /**
+   * Triggers the delete comment event
+   */
+  triggerDeleteCommentEvent(commentId: number, i: number): void {
+    this.commentService.deleteComment(commentId, Intent.INSTRUCTOR_RESULT).subscribe(() => {
+      this.commentsTablesModel[i] = this.commentsTablesModel[i].filter((commentRow: CommentRowModel) =>
+          !commentRow.originalComment || commentRow.originalComment.feedbackResponseCommentId !== commentId);
+      const updatedResponse: any = {
+        ...this.responses[i].allResponses[0],
+        allComments: this.responses[i].allResponses[0].allComments.filter((comment: FeedbackResponseComment) =>
+                comment.feedbackResponseCommentId !== commentId),
+      };
+      this.commentsChangeInResponse.emit(updatedResponse);
+    });
+  }
+
+  /**
+   * Triggers the update comment event.
+   */
+  triggerUpdateCommentEvent(index: number, i: number): void {
+
+    const commentData: CommentRowModel = this.commentsTablesModel[i][index];
+
+    this.commentService.updateComment({
+      commentText: commentData.commentEditFormModel.commentText,
+      showCommentTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          commentData.commentEditFormModel.commentVisibility, CommentVisibilityControl.SHOW_COMMENT),
+      showGiverNameTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          commentData.commentEditFormModel.commentVisibility, CommentVisibilityControl.SHOW_GIVER_NAME),
+      // tslint:disable-next-line:no-non-null-assertion
+    }, commentData.originalComment!.feedbackResponseCommentId, Intent.INSTRUCTOR_RESULT)
+        .subscribe((commentResponse: FeedbackResponseComment) => {
+
+          this.commentsTablesModel[i][index] = {
+            originalComment: commentResponse,
+            commentEditFormModel: {
+              commentText: commentResponse.commentText,
+              commentVisibility: this.getCommentVisibilityMap(commentResponse.showCommentTo,
+                  commentResponse.showGiverNameTo),
+            },
+            timezone: this.session.timeZone,
+            isEditing: false,
+          };
+
+          const updatedComments: FeedbackResponseComment[] = this.responses[i].allResponses[0].allComments.slice();
+          const commentToUpdateIndex: number =
+              updatedComments.findIndex((comment: FeedbackResponseComment) =>
+                // tslint:disable-next-line:no-non-null-assertion
+                comment.feedbackResponseCommentId === commentData.originalComment!.feedbackResponseCommentId);
+          updatedComments[commentToUpdateIndex] = {...updatedComments[commentToUpdateIndex],
+            lastEditedAt: commentResponse.lastEditedAt,
+            commentText: commentResponse.commentText,
+            showCommentTo: commentResponse.showCommentTo,
+            showGiverNameTo: commentResponse.showGiverNameTo,
+          };
+          const updatedResponse: any = { ...this.responses[i].allResponses[0], allComments: updatedComments };
+          this.commentsChangeInResponse.emit(updatedResponse);
+        });
+  }
+
+  /**
+   * Triggers the add new comment event.
+   */
+  triggerSaveNewCommentEvent(i: number): void {
+    const newCommentEditForm: CommentEditFormModel = this.commentsTablesModel[i][0].commentEditFormModel;
+    this.commentService.createComment({
+      commentText: newCommentEditForm.commentText,
+      showCommentTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          newCommentEditForm.commentVisibility, CommentVisibilityControl.SHOW_COMMENT),
+      showGiverNameTo: this.getCommentVisibilityTypesUnderVisibilityControl(
+          newCommentEditForm.commentVisibility, CommentVisibilityControl.SHOW_GIVER_NAME),
+    }, this.responses[i].allResponses[0].responseId, Intent.INSTRUCTOR_RESULT)
+        .subscribe((commentResponse: FeedbackResponseComment) => {
+          this.commentsTablesModel[i].push({
+            originalComment: commentResponse,
+            timezone: this.session.timeZone,
+            commentEditFormModel: {
+              commentText: commentResponse.commentText,
+              commentVisibility: this.getCommentVisibilityMap(commentResponse.showCommentTo,
+                  commentResponse.showGiverNameTo),
+            },
+            isEditing: false,
+          });
+
+          this.commentsTablesModel[i][0]  = {
+            commentEditFormModel: {
+              commentText: '',
+              commentVisibility: this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType[i],
+                  this.showResponsesToInCommentVisibilityType[i]),
+            },
+            timezone: this.session.timeZone,
+            isEditing: true,
+          };
+
+          const updatedComments: FeedbackResponseComment[] = this.responses[i].allResponses[0].allComments.slice();
+          updatedComments.push(commentResponse);
+
+          const updatedResponse: any = { ...this.responses[i].allResponses[0], allComments: updatedComments };
+          this.commentsChangeInResponse.emit(updatedResponse);
+        });
+  }
+
+  /**
+   * Triggers the change of the model for the form.
+   */
+  triggerModelChange(data: any, i: number): void {
+    this.commentsTablesModel[i][data.index] = data.commentRow;
+  }
+
+  /**
+   * Triggers the close editing event.
+   */
+  triggerCloseEditingEvent(index: number, i: number): void {
+    // tslint:disable-next-line:no-non-null-assertion
+    const originalComment: FeedbackResponseComment = this.commentsTablesModel[i][index].originalComment!;
+    if (originalComment) {
+      this.commentsTablesModel[i][index].commentEditFormModel = {
+        commentText: originalComment.commentText,
+        commentVisibility: this.getCommentVisibilityMap(originalComment.showCommentTo,
+            originalComment.showGiverNameTo),
+      };
+    } else {
+      this.commentsTablesModel[i][index].commentEditFormModel = {
+        commentText: '',
+        commentVisibility: this.getCommentVisibilityMap(this.showResponsesToInCommentVisibilityType[i],
+            this.showResponsesToInCommentVisibilityType[i]),
+      };
+    }
+    this.commentsTablesModel[i][index].isEditing = false;
+  }
+
+  /**
+   * Gets the CommentVisibilityType arrays under certain visibilityControl.
+   */
+  getCommentVisibilityTypesUnderVisibilityControl(commentVisibility: Map<CommentVisibilityControl,
+      Set<CommentVisibilityType>>, commentVisibilityControl: CommentVisibilityControl): CommentVisibilityType[] {
+    const visibilityTypes: CommentVisibilityType[] = [];
+    // tslint:disable-next-line:no-non-null-assertion
+    commentVisibility.get(commentVisibilityControl)!.forEach((visibilityType: CommentVisibilityType) => {
+      visibilityTypes.push(visibilityType);
+    });
+    return visibilityTypes;
+  }
+
+  /**
+   * Gets the CommentVisibilityType map combined from showCommentTo and showGiverNameTo.
+   */
+  getCommentVisibilityMap(showCommentTo: CommentVisibilityType[], showGiverNameTo: CommentVisibilityType[]):
+      Map<CommentVisibilityControl, Set<CommentVisibilityType>> {
+    const commentVisibility: Map<CommentVisibilityControl, Set<CommentVisibilityType>> = new Map();
+    commentVisibility.set(CommentVisibilityControl.SHOW_COMMENT, new Set(showCommentTo));
+    commentVisibility.set(CommentVisibilityControl.SHOW_GIVER_NAME, new Set(showGiverNameTo));
+    return commentVisibility;
+  }
+
+  /**
+   * Toggles the add new comment row.
+   */
+  triggerNewCommentRow(): void {
+    this.isNewCommentRowExpanded = !this.isNewCommentRowExpanded;
+  }
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -1,9 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FeedbackResponseCommentService } from '../../../../services/feedback-response-comment.service';
 import { CommentVisibilityType, FeedbackResponseComment } from '../../../../types/api-output';
-import { FeedbackVisibilityType } from '../../../../types/api-request';
+import { FeedbackVisibilityType, Intent } from '../../../../types/api-request';
 import { CommentVisibilityControl } from '../../../../types/visibility-control';
-import { Intent } from '../../../Intent';
 // tslint:disable-next-line:max-line-length
 import { InstructorSessionResultSectionType } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 import { CommentEditFormModel } from '../../comment-box/comment-edit-form/comment-edit-form.component';

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.module.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
+import { CommentBoxModule } from '../../comment-box/comment-box.module';
 import { QuestionTextWithInfoModule } from '../../question-text-with-info/question-text-with-info.module';
 import { SingleResponseModule } from '../single-response/single-response.module';
 import { GroupedResponsesComponent } from './grouped-responses.component';
@@ -18,6 +19,7 @@ import { GroupedResponsesComponent } from './grouped-responses.component';
     QuestionTextWithInfoModule,
     SingleResponseModule,
     ResponseModerationButtonModule,
+    CommentBoxModule,
   ],
 })
 export class GroupedResponsesModule { }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -24,7 +24,7 @@
             <div class="card-body" *ngIf="userToTeamName[userInfo].isExpanded">
               <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
                 <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-                    [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)">
+                    [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)">
                 </tm-grouped-responses>
               </div>
             </div>
@@ -50,7 +50,7 @@
       <div class="card-body" *ngIf="userInfo.value.isExpanded">
         <div class="top-padded" *ngFor="let other of responsesToShow[userInfo.key] | keyvalue">
           <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-              [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)"></tm-grouped-responses>
+              [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"></tm-grouped-responses>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import {
   InstructorSessionResultSectionType,
 } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
@@ -22,6 +22,8 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
   @Input() session: any = {};
 
   @Input() isGrq: boolean = true;
+
+  @Output() commentsChangeInResponse: EventEmitter<any> = new EventEmitter();
 
   teamsToUsers: { [key: string]: string[] } = {};
   teamExpanded: { [key: string]: boolean } = {};
@@ -149,5 +151,12 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
    */
   getRGQRelatedGiverEmailForUser(other: any): any {
     return other.value[0].allResponses[0].relatedGiverEmail;
+  }
+
+  /**
+   * Triggers the commentsChangeInResponse event.
+   */
+  triggerCommentsChangeInResponseEvent(response: any): void {
+    this.commentsChangeInResponse.emit(response);
   }
 }

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.html
@@ -22,6 +22,12 @@
         <td>
           <tm-response-moderation-button [session]="session" [relatedGiverEmail]="response.relatedGiverEmail" [moderatedQuestionId]="questionId"></tm-response-moderation-button>
         </td>
+        <td>
+          <button class="btn btn-light btn-sm" style="border: 1px solid #CCC;"
+                  (click)="triggerShowCommentTableEvent(response)">Comment <span class="badge badge-secondary">
+            {{response.allComments.length}}</span>
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.module.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 
 // tslint:disable-next-line:max-line-length
 import { ResponseModerationButtonModule } from '../../../pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.module';
+import { CommentBoxModule } from '../../comment-box/comment-box.module';
 import { SingleResponseModule } from '../single-response/single-response.module';
 import { PerQuestionViewResponsesComponent } from './per-question-view-responses.component';
 
@@ -18,6 +19,7 @@ import { PerQuestionViewResponsesComponent } from './per-question-view-responses
     PerQuestionViewResponsesComponent,
   ],
   imports: [
+    CommentBoxModule,
     CommonModule,
     RouterModule,
     SingleResponseModule,

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -9,7 +9,7 @@
     </div>
     <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
       <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="section" [sectionType]="sectionType"
-          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="true" [session]="session"
+          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="true" [session]="session" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"
           style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -9,7 +9,7 @@
     </div>
     <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
       <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="section" [sectionType]="sectionType"
-          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="true" [session]="session"
+          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="true" [session]="session" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"
           style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -116,11 +116,13 @@
   <tm-instructor-session-result-question-view *ngIf="viewType === 'QUESTION'" [responses]="questionsModel"
       [section]="section" [sectionType]="sectionType" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadQuestion)="loadQuestion($event)"></tm-instructor-session-result-question-view>
+      (loadQuestion)="loadQuestion($event)" (commentsChangeInResponse)="commentsChangeHandler($event)">
+  </tm-instructor-session-result-question-view>
   <tm-instructor-session-result-grq-view *ngIf="viewType === 'GRQ'" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-grq-view>
+      (loadSection)="loadSection($event)" (commentsChangeInResponse)="commentsChangeHandler($event)">
+  </tm-instructor-session-result-grq-view>
   <tm-instructor-session-result-rgq-view *ngIf="viewType === 'RGQ'" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
@@ -128,11 +130,13 @@
   <tm-instructor-session-result-gqr-view *ngIf="viewType === 'GQR'" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-gqr-view>
+      (loadSection)="loadSection($event)" (commentsChangeInResponse)="commentsChangeHandler($event)">
+  </tm-instructor-session-result-gqr-view>
   <tm-instructor-session-result-rqg-view *ngIf="viewType === 'RQG'" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-rqg-view>
+      (loadSection)="loadSection($event)" (commentsChangeInResponse)="commentsChangeHandler($event)">
+  </tm-instructor-session-result-rqg-view>
 </div>
 
 <div class="top-padded" *ngIf="isNoResponsePanelLoaded">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.ts
@@ -209,4 +209,38 @@ export class InstructorSessionResultPageComponent implements OnInit {
       });
     }, () => {});
   }
+  
+  /**
+   * Updates questionsModel when there's a change in the comments table.
+   */
+  commentsChangeHandler(responseToUpdate: any): void {
+    for (const key of Object.keys(this.questionsModel)) {
+      if (!this.questionsModel[key].hasPopulated) {
+        continue;
+      }
+      this.questionsModel[key].responses.forEach((response: any, index: number) => {
+        if (response.responseId === responseToUpdate.responseId) {
+          const updatedResponses: any[] = this.questionsModel[key].responses.slice();
+          updatedResponses[index] = responseToUpdate;
+          this.questionsModel[key].responses = updatedResponses;
+          return;
+        }
+      });
+    }
+
+    for (const key of Object.keys(this.sectionsModel)) {
+      if (!this.sectionsModel[key].hasPopulated) {
+        continue;
+      }
+      this.sectionsModel[key].questions.forEach((question: any, questionIndex: number) => {
+        question.allResponses.forEach((response: any, responseIndex: number) => {
+          if (response.responseId === responseToUpdate.responseId) {
+            const updatedResponses: any[] = question.allResponses;
+            updatedResponses[responseIndex] = responseToUpdate;
+            this.sectionsModel[key].questions[questionIndex].allResponses = updatedResponses;
+          }
+        });
+      });
+    }
+  }
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -8,6 +8,6 @@
   </div>
   <div class="card-body" *ngIf="question.isTabExpanded">
     <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session "
-                                    [indicateMissingResponses]="true" [questionDetails]="question.questionDetails" [questionId]='question.feedbackQuestionId'></tm-per-question-view-responses>
+                                    [indicateMissingResponses]="true" [questionDetails]="question.questionDetails" [questionId]='question.feedbackQuestionId' [showResponsesTo] = question.showResponsesTo (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"></tm-per-question-view-responses>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -9,7 +9,7 @@
     </div>
     <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
       <tm-grq-rgq-view-responses [responses]="sectionInfo.value.questions || []" [section]="section" [sectionType]="sectionType"
-          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="false" [session]="session"
+          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGrq]="false" [session]="session" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"
           style="margin-bottom: 20px;"></tm-grq-rgq-view-responses>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -9,7 +9,7 @@
     </div>
     <div class="card-body" *ngIf="sectionInfo.value.isTabExpanded">
       <tm-gqr-rqg-view-responses [responses]="sectionInfo.value.questions || []" [section]="section" [sectionType]="sectionType"
-          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="false" [session]="session"
+          [groupByTeam]="groupByTeam" [showStatistics]="showStatistics" [isGqr]="false" [session]="session" (commentsChangeInResponse)="triggerCommentsChangeInResponseEvent($event)"
           style="margin-bottom: 20px;"></tm-gqr-rqg-view-responses>
     </div>
   </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -1,4 +1,4 @@
-import { Input, OnInit } from '@angular/core';
+import { EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { InstructorSessionResultSectionType } from './instructor-session-result-section-type.enum';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -15,9 +15,17 @@ export abstract class InstructorSessionResultView implements OnInit {
   @Input() indicateMissingResponses: boolean = true;
   @Input() session: any = {};
 
+  @Output() commentsChangeInResponse: EventEmitter<any> = new EventEmitter();
+
   constructor(protected viewType: InstructorSessionResultViewType) {}
 
   ngOnInit(): void {
   }
 
+  /**
+   * Triggers the event concerning change response comments in a question
+   */
+  triggerCommentsChangeInResponseEvent(response: any): void {
+    this.commentsChangeInResponse.emit(response);
+  }
 }

--- a/src/web/types/visibility-control.ts
+++ b/src/web/types/visibility-control.ts
@@ -18,3 +18,18 @@ export enum VisibilityControl {
    */
   SHOW_RECIPIENT_NAME = 'SHOW_RECIPIENT_NAME',
 }
+
+/**
+ * The comment visibility controls.
+ */
+export enum CommentVisibilityControl {
+  /**
+   * Show Comment visibility control.
+   */
+  SHOW_COMMENT = 'SHOW_COMMENT',
+
+  /**
+   * Show giver name visibility control.
+   */
+  SHOW_GIVER_NAME = 'SHOW_GIVER_NAME',
+}


### PR DESCRIPTION
Part of #9382

migrate comment feature for instructor session result page, however the backend api call is in the child components, while the best pratice is to put them in the page controller. Due to the complication of propgating down the changes from the model in page component to the comment table, it will be considered as a further refactoring.(mentioned in #10010)