### PR TITLE
[#9946] Add additional fields for Instructor Search Migration

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -1,7 +1,6 @@
 package teammates.ui.webapi.action;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
@@ -31,21 +30,17 @@ public class SearchInstructorsAction extends Action {
 
     private void addAdditionalSearchFields(InstructorsData instructorsData, List<InstructorAttributes> instructors) {
         instructorsData.getInstructors()
-                .forEach((InstructorData data) -> {
-                    AccountAttributes account = logic.getAccount(data.getGoogleId());
-                    if (account != null) {
-                        String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                        data.setInstitute(institute);
+                .forEach((InstructorData instructor) -> {
+                    if (instructor.getGoogleId() != null) {
+                        AccountAttributes account = logic.getAccount(instructor.getGoogleId());
+                        if (account != null) {
+                            String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
+                            instructor.setInstitute(institute);
+                        }
+                        instructor.setKey(instructors);
                     }
-
-                    // Add registration key
-                    data.setKey(StringHelper.encrypt(instructors.stream()
-                            .filter((InstructorAttributes instructor)
-                                    -> instructor.getGoogleId().equals(data.getGoogleId()))
-                            .collect(Collectors.toList()).get(0).getKey()));
-
                     // Hide information
-                    data.hideInformationForSearch();
+                    instructor.hideInformationForSearch();
                 });
     }
 

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -47,13 +47,17 @@ public class SearchInstructorsAction extends Action {
                     instructorData.setInstitute(institute);
                 }
             }
+
+            // Hide certain fields
+            instructorData.setRole(null);
+            instructorData.setDisplayedToStudentsAs(null);
+            instructorData.setIsDisplayedToStudents(null);
+
             instructorDataList.add(instructorData);
         }
 
         InstructorsData instructorsData = new InstructorsData();
         instructorsData.setInstructors(instructorDataList);
-
-        instructorsData.getInstructors().forEach(InstructorData::hideInformationForSearch);
 
         return new JsonResult(instructorsData);
     }

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -29,6 +29,17 @@ public class SearchInstructorsAction extends Action {
         }
     }
 
+    private String getInstituteFromGoogleId(String googleId) {
+        if (googleId != null) {
+            AccountAttributes account = logic.getAccount(googleId);
+            if (account != null) {
+                String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
+                return institute;
+            }
+        }
+        return null;
+    }
+
     @Override
     public ActionResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
@@ -37,21 +48,10 @@ public class SearchInstructorsAction extends Action {
         List<InstructorData> instructorDataList = new ArrayList<>();
         for (InstructorAttributes instructor : instructors) {
             InstructorData instructorData = new InstructorData(instructor);
-            // Only admin will be able to access this page, so we can go ahead and set the key
-            instructorData.setKey(StringHelper.encrypt(instructor.getKey()));
-
-            if (instructor.getGoogleId() != null) {
-                AccountAttributes account = logic.getAccount(instructor.getGoogleId());
-                if (account != null) {
-                    String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                    instructorData.setInstitute(institute);
-                }
-            }
-
-            // Hide certain fields
-            instructorData.setRole(null);
-            instructorData.setDisplayedToStudentsAs(null);
-            instructorData.setIsDisplayedToStudents(null);
+            instructorData.addAdditionalInformationForAdminSearch(
+                    StringHelper.encrypt(instructor.getKey()),
+                    getInstituteFromGoogleId(instructor.getGoogleId()));
+            instructorData.hideInformationForSearch();
 
             instructorDataList.add(instructorData);
         }

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -48,17 +48,21 @@ public class SearchInstructorsAction extends Action {
     public ActionResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
         List<InstructorAttributes> instructors = logic.searchInstructorsInWholeSystem(searchKey).instructorList;
+
         List<InstructorData> instructorDataList = new ArrayList<>();
         for (InstructorAttributes instructor : instructors) {
             InstructorData instructorData = new InstructorData(instructor);
+            // Only admin will be able to access this page, so we can go ahead and set the key
             instructorData.setKey(StringHelper.encrypt(instructor.getKey()));
             instructorDataList.add(instructorData);
         }
         InstructorsData instructorsData = new InstructorsData();
         instructorsData.setInstructors(instructorDataList);
+
         instructorsData.getInstructors().forEach(InstructorData::hideInformationForSearch);
-        this.addAdditionalSearchFields(instructorsData);
         // Set additional fields for search
+        this.addAdditionalSearchFields(instructorsData);
+
         return new JsonResult(instructorsData);
     }
 }

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -29,21 +29,6 @@ public class SearchInstructorsAction extends Action {
         }
     }
 
-    private void addAdditionalSearchFields(InstructorsData instructorsData) {
-        instructorsData.getInstructors()
-                .forEach((InstructorData instructor) -> {
-                    if (instructor.getGoogleId() != null) {
-                        AccountAttributes account = logic.getAccount(instructor.getGoogleId());
-                        if (account != null) {
-                            String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                            instructor.setInstitute(institute);
-                        }
-                    }
-                    // Hide information
-                    instructor.hideInformationForSearch();
-                });
-    }
-
     @Override
     public ActionResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
@@ -54,14 +39,21 @@ public class SearchInstructorsAction extends Action {
             InstructorData instructorData = new InstructorData(instructor);
             // Only admin will be able to access this page, so we can go ahead and set the key
             instructorData.setKey(StringHelper.encrypt(instructor.getKey()));
+
+            if (instructor.getGoogleId() != null) {
+                AccountAttributes account = logic.getAccount(instructor.getGoogleId());
+                if (account != null) {
+                    String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
+                    instructorData.setInstitute(institute);
+                }
+            }
             instructorDataList.add(instructorData);
         }
+
         InstructorsData instructorsData = new InstructorsData();
         instructorsData.setInstructors(instructorDataList);
 
         instructorsData.getInstructors().forEach(InstructorData::hideInformationForSearch);
-        // Set additional fields for search
-        this.addAdditionalSearchFields(instructorsData);
 
         return new JsonResult(instructorsData);
     }

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -31,22 +31,22 @@ public class SearchInstructorsAction extends Action {
 
     private void addAdditionalSearchFields(InstructorsData instructorsData, List<InstructorAttributes> instructors) {
         instructorsData.getInstructors()
-            .forEach((InstructorData data) -> {
-                AccountAttributes account = logic.getAccount(data.getGoogleId());
-                if (account != null) {
-                    String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                    data.setInstitute(institute);
-                }
+                .forEach((InstructorData data) -> {
+                    AccountAttributes account = logic.getAccount(data.getGoogleId());
+                    if (account != null) {
+                        String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
+                        data.setInstitute(institute);
+                    }
 
-                // Add registration key
-                data.setKey(instructors.stream()
-                        .filter((InstructorAttributes instructor)
-                            -> instructor.getGoogleId() == data.getGoogleId())
-                        .collect(Collectors.toList()).get(0).getKey());
-                
-                // Hide information
-                data.hideInformationForSearch();
-            });
+                    // Add registration key
+                    data.setKey(StringHelper.encrypt(instructors.stream()
+                            .filter((InstructorAttributes instructor)
+                                    -> instructor.getGoogleId().equals(data.getGoogleId()))
+                            .collect(Collectors.toList()).get(0).getKey()));
+
+                    // Hide information
+                    data.hideInformationForSearch();
+                });
     }
 
     @Override

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -38,12 +38,10 @@ public class SearchInstructorsAction extends Action {
         instructorsData.getInstructors()
             .forEach((InstructorData data) -> {
                 AccountAttributes account = logic.getAccount(data.getGoogleId());
-                if (account == null) {
-                    return;
+                if (account != null) {
+                    String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
+                    data.setInstitute(institute);
                 }
-
-                String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                data.setInstitute(institute);
 
                 // Add registration key
                 data.setKey(instructors.stream()

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -1,5 +1,6 @@
 package teammates.ui.webapi.action;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import teammates.common.datatransfer.attributes.AccountAttributes;
@@ -28,7 +29,7 @@ public class SearchInstructorsAction extends Action {
         }
     }
 
-    private void addAdditionalSearchFields(InstructorsData instructorsData, List<InstructorAttributes> instructors) {
+    private void addAdditionalSearchFields(InstructorsData instructorsData) {
         instructorsData.getInstructors()
                 .forEach((InstructorData instructor) -> {
                     if (instructor.getGoogleId() != null) {
@@ -37,7 +38,6 @@ public class SearchInstructorsAction extends Action {
                             String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
                             instructor.setInstitute(institute);
                         }
-                        instructor.setKey(instructors);
                     }
                     // Hide information
                     instructor.hideInformationForSearch();
@@ -48,9 +48,16 @@ public class SearchInstructorsAction extends Action {
     public ActionResult execute() {
         String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
         List<InstructorAttributes> instructors = logic.searchInstructorsInWholeSystem(searchKey).instructorList;
-        InstructorsData instructorsData = new InstructorsData(instructors);
+        List<InstructorData> instructorDataList = new ArrayList<>();
+        for (InstructorAttributes instructor : instructors) {
+            InstructorData instructorData = new InstructorData(instructor);
+            instructorData.setKey(StringHelper.encrypt(instructor.getKey()));
+            instructorDataList.add(instructorData);
+        }
+        InstructorsData instructorsData = new InstructorsData();
+        instructorsData.setInstructors(instructorDataList);
         instructorsData.getInstructors().forEach(InstructorData::hideInformationForSearch);
-        this.addAdditionalSearchFields(instructorsData, instructors);
+        this.addAdditionalSearchFields(instructorsData);
         // Set additional fields for search
         return new JsonResult(instructorsData);
     }

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -33,8 +33,7 @@ public class SearchInstructorsAction extends Action {
         if (googleId != null) {
             AccountAttributes account = logic.getAccount(googleId);
             if (account != null) {
-                String institute = StringHelper.isEmpty(account.institute) ? "None" : account.institute;
-                return institute;
+                return StringHelper.isEmpty(account.institute) ? "None" : account.institute;
             }
         }
         return null;

--- a/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
+++ b/src/main/java/teammates/ui/webapi/action/SearchInstructorsAction.java
@@ -29,12 +29,7 @@ public class SearchInstructorsAction extends Action {
         }
     }
 
-    @Override
-    public ActionResult execute() {
-        String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
-        List<InstructorAttributes> instructors = logic.searchInstructorsInWholeSystem(searchKey).instructorList;
-        InstructorsData instructorsData = new InstructorsData(instructors);
-        // Set additional fields for search
+    private void addAdditionalSearchFields(InstructorsData instructorsData, List<InstructorAttributes> instructors) {
         instructorsData.getInstructors()
             .forEach((InstructorData data) -> {
                 AccountAttributes account = logic.getAccount(data.getGoogleId());
@@ -52,6 +47,16 @@ public class SearchInstructorsAction extends Action {
                 // Hide information
                 data.hideInformationForSearch();
             });
+    }
+
+    @Override
+    public ActionResult execute() {
+        String searchKey = getNonNullRequestParamValue(Const.ParamsNames.ADMIN_SEARCH_KEY);
+        List<InstructorAttributes> instructors = logic.searchInstructorsInWholeSystem(searchKey).instructorList;
+        InstructorsData instructorsData = new InstructorsData(instructors);
+        instructorsData.getInstructors().forEach(InstructorData::hideInformationForSearch);
+        this.addAdditionalSearchFields(instructorsData, instructors);
+        // Set additional fields for search
         return new JsonResult(instructorsData);
     }
 }

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -1,8 +1,12 @@
 package teammates.ui.webapi.output;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.annotation.Nullable;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
+import teammates.common.util.StringHelper;
 
 /**
  * The API output format of an instructor.
@@ -93,8 +97,11 @@ public class InstructorData extends ApiOutput {
         return key;
     }
 
-    public void setKey(String key) {
-        this.key = key;
+    public void setKey(List<InstructorAttributes> instructorAttributes) {
+        this.key = StringHelper.encrypt(instructorAttributes.stream()
+                .filter((InstructorAttributes instructorAttribute)
+                        -> this.googleId.equals(instructorAttribute.getGoogleId()))
+                .collect(Collectors.toList()).get(0).getKey());
     }
 
     public String getInstitute() {

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -1,12 +1,8 @@
 package teammates.ui.webapi.output;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 
 import teammates.common.datatransfer.attributes.InstructorAttributes;
-import teammates.common.util.StringHelper;
 
 /**
  * The API output format of an instructor.
@@ -97,11 +93,8 @@ public class InstructorData extends ApiOutput {
         return key;
     }
 
-    public void setKey(List<InstructorAttributes> instructorAttributes) {
-        this.key = StringHelper.encrypt(instructorAttributes.stream()
-                .filter((InstructorAttributes instructorAttribute)
-                        -> this.googleId.equals(instructorAttribute.getGoogleId()))
-                .collect(Collectors.toList()).get(0).getKey());
+    public void setKey(String key) {
+        this.key = key;
     }
 
     public String getInstitute() {

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -19,6 +19,9 @@ public class InstructorData extends ApiOutput {
     @Nullable
     private InstructorPermissionRole role;
     private JoinState joinState;
+    @Nullable
+    private String key;
+    private String institute;
 
     public InstructorData(InstructorAttributes instructorAttributes) {
         this.googleId = instructorAttributes.getGoogleId();
@@ -83,6 +86,22 @@ public class InstructorData extends ApiOutput {
 
     public void setJoinState(JoinState joinState) {
         this.joinState = joinState;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getInstitute() {
+        return institute;
+    }
+
+    public void setInstitute(String institute) {
+        this.institute = institute;
     }
 
     /**

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -104,4 +104,21 @@ public class InstructorData extends ApiOutput {
     public void setInstitute(String institute) {
         this.institute = institute;
     }
+    
+    /**
+     * Hides some attributes for search result.
+     */
+    public void hideInformationForSearch() {
+        setRole(null);
+        setDisplayedToStudentsAs(null);
+        setIsDisplayedToStudents(null);
+    }
+
+    /**
+     * Adds additional attributes only for search result for admin.
+     */
+    public void addAdditionalInformationForAdminSearch(String key, String institute) {
+        setKey(key);
+        setInstitute(institute);
+    }
 }

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -104,7 +104,7 @@ public class InstructorData extends ApiOutput {
     public void setInstitute(String institute) {
         this.institute = institute;
     }
-    
+
     /**
      * Hides some attributes for search result.
      */
@@ -116,6 +116,9 @@ public class InstructorData extends ApiOutput {
 
     /**
      * Adds additional attributes only for search result for admin.
+     *
+     * @param key Encrypted key for registration
+     * @param institute Institute of the student
      */
     public void addAdditionalInformationForAdminSearch(String key, String institute) {
         setKey(key);

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -104,13 +104,4 @@ public class InstructorData extends ApiOutput {
     public void setInstitute(String institute) {
         this.institute = institute;
     }
-
-    /**
-     * Hides some attributes for search result.
-     */
-    public void hideInformationForSearch() {
-        setRole(null);
-        setDisplayedToStudentsAs(null);
-        setIsDisplayedToStudents(null);
-    }
 }

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -21,6 +21,7 @@ public class InstructorData extends ApiOutput {
     private JoinState joinState;
     @Nullable
     private String key;
+    @Nullable
     private String institute;
 
     public InstructorData(InstructorAttributes instructorAttributes) {

--- a/src/main/java/teammates/ui/webapi/output/InstructorData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorData.java
@@ -117,7 +117,7 @@ public class InstructorData extends ApiOutput {
     /**
      * Adds additional attributes only for search result for admin.
      *
-     * @param key Encrypted key for registration
+     * @param key Encrypted registration key
      * @param institute Institute of the student
      */
     public void addAdditionalInformationForAdminSearch(String key, String institute) {

--- a/src/main/java/teammates/ui/webapi/output/InstructorsData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorsData.java
@@ -14,8 +14,6 @@ public class InstructorsData extends ApiOutput {
     private List<InstructorData> instructors;
 
     public InstructorsData() {
-        // Only use this constructor for SearchInstructorsAction,
-        // or if you are certain that setInstructors will be called later.
         this.instructors = new ArrayList<>();
     }
 

--- a/src/main/java/teammates/ui/webapi/output/InstructorsData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorsData.java
@@ -10,7 +10,11 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
  */
 public class InstructorsData extends ApiOutput {
 
-    private final List<InstructorData> instructors;
+    private List<InstructorData> instructors;
+
+    public InstructorsData() {
+        // Use this constructor if InstructorData should be sent with the key
+    }
 
     public InstructorsData(List<InstructorAttributes> instructorAttributesList) {
         this.instructors = instructorAttributesList.stream().map(InstructorData::new).collect(Collectors.toList());
@@ -18,5 +22,9 @@ public class InstructorsData extends ApiOutput {
 
     public List<InstructorData> getInstructors() {
         return instructors;
+    }
+
+    public void setInstructors(List<InstructorData> instructors) {
+        this.instructors = instructors;
     }
 }

--- a/src/main/java/teammates/ui/webapi/output/InstructorsData.java
+++ b/src/main/java/teammates/ui/webapi/output/InstructorsData.java
@@ -1,5 +1,6 @@
 package teammates.ui.webapi.output;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,7 +14,9 @@ public class InstructorsData extends ApiOutput {
     private List<InstructorData> instructors;
 
     public InstructorsData() {
-        // Use this constructor if InstructorData should be sent with the key
+        // Only use this constructor for SearchInstructorsAction,
+        // or if you are certain that setInstructors will be called later.
+        this.instructors = new ArrayList<>();
     }
 
     public InstructorsData(List<InstructorAttributes> instructorAttributesList) {

--- a/src/test/java/teammates/test/cases/webapi/SearchInstructorsActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/SearchInstructorsActionTest.java
@@ -82,6 +82,8 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
                 .filter(i -> i.getName().equals(acc.getName()))
                 .findAny()
                 .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
     }
 
     @Test
@@ -95,6 +97,8 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
                 .filter(i -> i.getName().equals(acc.getName()))
                 .findAny()
                 .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
     }
 
     @Test
@@ -108,6 +112,8 @@ public class SearchInstructorsActionTest extends BaseActionTest<SearchInstructor
                 .filter(i -> i.getName().equals(acc.getName()))
                 .findAny()
                 .isPresent());
+        assertTrue(response.getInstructors().get(0).getKey() != null);
+        assertTrue(response.getInstructors().get(0).getInstitute() != null);
     }
 
     @Test


### PR DESCRIPTION
Fixes #9946

**Outline of Solution**

Since the course and links PR are going to be closed in favor of using the existing course endpoint and link generation, this PR adds two fields to the existing InstructorData class

The first is key, which is the registration key. This will be used for link generation.
The second is institute. This field is currently only in the admin search endpoint, so we add it here.