### PR TITLE
[#10020] Prevent potential overflow in TaskQueuer.java

### DIFF
--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -225,7 +225,7 @@ public class TaskQueuer {
 
         int numberOfEmailsSent = 0;
         for (EmailWrapper email : emails) {
-            long emailDelayTimer = numberOfEmailsSent * emailIntervalMillis;
+            long emailDelayTimer = (long)numberOfEmailsSent * (long)emailIntervalMillis;
             scheduleEmailForSending(email, emailDelayTimer);
             numberOfEmailsSent++;
         }

--- a/src/main/java/teammates/logic/api/TaskQueuer.java
+++ b/src/main/java/teammates/logic/api/TaskQueuer.java
@@ -225,7 +225,7 @@ public class TaskQueuer {
 
         int numberOfEmailsSent = 0;
         for (EmailWrapper email : emails) {
-            long emailDelayTimer = (long)numberOfEmailsSent * (long)emailIntervalMillis;
+            long emailDelayTimer = (long) numberOfEmailsSent * (long) emailIntervalMillis;
             scheduleEmailForSending(email, emailDelayTimer);
             numberOfEmailsSent++;
         }


### PR DESCRIPTION
Fixes #10020 

**Outline of Solution**

Cast variables numberOfEmailsSent and emailIntervalMillis to longs before performing multiplication operation to prevent overflow during integer multiplication. A really simple problem with an even simpler solution.
