### PR TITLE
[#10041] Add builder pattern to LNPSpecification class

### DIFF
--- a/src/e2e/java/teammates/e2e/cases/lnp/BaseLNPTestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/BaseLNPTestCase.java
@@ -76,7 +76,10 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
      *                          (in seconds) for the test endpoint.
      */
     protected void setupSpecification(double errorRateLimit, double meanRespTimeLimit) {
-        this.specification = new LNPSpecification(errorRateLimit, meanRespTimeLimit);
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(errorRateLimit)
+                                             .withMeanRespTimeLimit(meanRespTimeLimit)
+                                             .build();
     }
 
     /**

--- a/src/e2e/java/teammates/e2e/cases/lnp/BaseLNPTestCase.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/BaseLNPTestCase.java
@@ -70,17 +70,8 @@ public abstract class BaseLNPTestCase extends BaseTestCase {
 
     /**
      * Sets up the specification for this L&P test case.
-     * @param errorRateLimit Maximum allowable threshold for the percentage of failed requests
-     *                       (0 to 100) to the test endpoint.
-     * @param meanRespTimeLimit Maximum allowable threshold for the mean response time
-     *                          (in seconds) for the test endpoint.
      */
-    protected void setupSpecification(double errorRateLimit, double meanRespTimeLimit) {
-        this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(errorRateLimit)
-                                             .withMeanRespTimeLimit(meanRespTimeLimit)
-                                             .build();
-    }
+    protected abstract void setupSpecification();
 
     /**
      * Returns the path to the generated JSON data bundle file.

--- a/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionSubmitLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionSubmitLNPTest.java
@@ -28,6 +28,7 @@ import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.util.Const;
 import teammates.e2e.util.JMeterElements;
+import teammates.e2e.util.LNPSpecification;
 import teammates.e2e.util.LNPTestData;
 
 /**
@@ -46,6 +47,9 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
     private static final String FEEDBACK_SESSION_NAME = "Test Feedback Session";
 
     private static final int NUMBER_OF_QUESTIONS = 20;
+
+    private static final double ERROR_RATE_LIMIT = 0.01;
+    private static final double MEAN_RESP_TIME_LIMIT = 1;
 
     @Override
     protected LNPTestData getTestData() {
@@ -252,11 +256,19 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
         return testPlan;
     }
 
+    @Override
+    protected void setupSpecification() {
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
+                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                                             .build();
+    }
+
     @BeforeClass
     public void classSetup() {
         generateTimeStamp();
         createTestData();
-        setupSpecification(0.01, 1);
+        setupSpecification();
     }
 
     @Test

--- a/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionSubmitLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionSubmitLNPTest.java
@@ -259,9 +259,9 @@ public class FeedbackSessionSubmitLNPTest extends BaseLNPTestCase {
     @Override
     protected void setupSpecification() {
         this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
-                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
-                                             .build();
+                .withErrorRateLimit(ERROR_RATE_LIMIT)
+                .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                .build();
     }
 
     @BeforeClass

--- a/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionViewLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionViewLNPTest.java
@@ -27,6 +27,7 @@ import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.util.Const;
 import teammates.e2e.util.JMeterElements;
+import teammates.e2e.util.LNPSpecification;
 import teammates.e2e.util.LNPTestData;
 
 /**
@@ -45,6 +46,9 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
     private static final String FEEDBACK_SESSION_NAME = "Test Feedback Session";
 
     private static final int NUMBER_OF_QUESTIONS = 10;
+
+    private static final double ERROR_RATE_LIMIT = 0.01;
+    private static final double MEAN_RESP_TIME_LIMIT = 1;
 
     @Override
     protected LNPTestData getTestData() {
@@ -226,11 +230,19 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
         return testPlan;
     }
 
+    @Override
+    protected void setupSpecification() {
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
+                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                                             .build();
+    }
+
     @BeforeClass
     public void classSetup() {
         generateTimeStamp();
         createTestData();
-        setupSpecification(0.01, 1);
+        setupSpecification();
     }
 
     @Test

--- a/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionViewLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/FeedbackSessionViewLNPTest.java
@@ -233,9 +233,9 @@ public class FeedbackSessionViewLNPTest extends BaseLNPTestCase {
     @Override
     protected void setupSpecification() {
         this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
-                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
-                                             .build();
+                .withErrorRateLimit(ERROR_RATE_LIMIT)
+                .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                .build();
     }
 
     @BeforeClass

--- a/src/e2e/java/teammates/e2e/cases/lnp/InstructorSessionResultLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/InstructorSessionResultLNPTest.java
@@ -286,9 +286,9 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
     @Override
     protected void setupSpecification() {
         this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
-                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
-                                             .build();
+                .withErrorRateLimit(ERROR_RATE_LIMIT)
+                .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                .build();
     }
 
     private void addLoadPageController(HashTree threadGroup, Map<String, String> argumentsMap) {

--- a/src/e2e/java/teammates/e2e/cases/lnp/InstructorSessionResultLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/InstructorSessionResultLNPTest.java
@@ -31,6 +31,7 @@ import teammates.common.datatransfer.questions.FeedbackTextResponseDetails;
 import teammates.common.exception.HttpRequestFailedException;
 import teammates.common.util.Const;
 import teammates.e2e.util.JMeterElements;
+import teammates.e2e.util.LNPSpecification;
 import teammates.e2e.util.LNPTestData;
 
 /**
@@ -48,6 +49,9 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
 
     private static final String COURSE_ID = "TestData.CS101";
     private static final String FEEDBACK_SESSION_NAME = "Test Feedback Session";
+
+    private static final double ERROR_RATE_LIMIT = 0.01;
+    private static final double MEAN_RESP_TIME_LIMIT = 1;
 
     @Override
     protected LNPTestData getTestData() {
@@ -279,6 +283,14 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
         return testPlan;
     }
 
+    @Override
+    protected void setupSpecification() {
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
+                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                                             .build();
+    }
+
     private void addLoadPageController(HashTree threadGroup, Map<String, String> argumentsMap) {
         HashTree loadPageController = threadGroup.add(JMeterElements.genericController());
 
@@ -337,7 +349,7 @@ public class InstructorSessionResultLNPTest extends BaseLNPTestCase {
     public void classSetup() throws IOException, HttpRequestFailedException {
         generateTimeStamp();
         createTestData();
-        setupSpecification(0.01, 1);
+        setupSpecification();
     }
 
     @Test

--- a/src/e2e/java/teammates/e2e/cases/lnp/InstructorStudentEnrollmentLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/InstructorStudentEnrollmentLNPTest.java
@@ -176,9 +176,9 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
     @Override
     protected void setupSpecification() {
         this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
-                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
-                                             .build();
+                .withErrorRateLimit(ERROR_RATE_LIMIT)
+                .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                .build();
     }
 
     @BeforeClass

--- a/src/e2e/java/teammates/e2e/cases/lnp/InstructorStudentEnrollmentLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/InstructorStudentEnrollmentLNPTest.java
@@ -22,6 +22,7 @@ import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.util.Const;
 import teammates.common.util.JsonUtils;
 import teammates.e2e.util.JMeterElements;
+import teammates.e2e.util.LNPSpecification;
 import teammates.e2e.util.LNPTestData;
 import teammates.ui.webapi.request.StudentsEnrollRequest;
 
@@ -39,6 +40,9 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
     private static final String INSTRUCTOR_NAME = "LnPInstructor";
     private static final String INSTRUCTOR_EMAIL = "personalEmail";
     private static final String COURSE_NAME = "LnPCourse";
+
+    private static final double ERROR_RATE_LIMIT = 0.01;
+    private static final double MEAN_RESP_TIME_LIMIT = 80;
 
     @Override
     protected LNPTestData getTestData() {
@@ -169,11 +173,19 @@ public class InstructorStudentEnrollmentLNPTest extends BaseLNPTestCase {
         return testPlan;
     }
 
+    @Override
+    protected void setupSpecification() {
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
+                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                                             .build();
+    }
+
     @BeforeClass
     public void classSetup() {
         generateTimeStamp();
         createTestData();
-        setupSpecification(0.01, 80);
+        setupSpecification();
     }
 
     @Test

--- a/src/e2e/java/teammates/e2e/cases/lnp/StudentProfileLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/StudentProfileLNPTest.java
@@ -186,9 +186,9 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
     @Override
     protected void setupSpecification() {
         this.specification = LNPSpecification.builder()
-                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
-                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
-                                             .build();
+                .withErrorRateLimit(ERROR_RATE_LIMIT)
+                .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                .build();
     }
 
     @BeforeClass

--- a/src/e2e/java/teammates/e2e/cases/lnp/StudentProfileLNPTest.java
+++ b/src/e2e/java/teammates/e2e/cases/lnp/StudentProfileLNPTest.java
@@ -22,6 +22,7 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.attributes.StudentProfileAttributes;
 import teammates.common.util.Const;
 import teammates.e2e.util.JMeterElements;
+import teammates.e2e.util.LNPSpecification;
 import teammates.e2e.util.LNPTestData;
 
 /**
@@ -34,6 +35,9 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
 
     private static final String STUDENT_NAME = "LnPStudent";
     private static final String STUDENT_EMAIL = "personalEmail";
+
+    private static final double ERROR_RATE_LIMIT = 0.01;
+    private static final double MEAN_RESP_TIME_LIMIT = 1;
 
     @Override
     protected LNPTestData getTestData() {
@@ -179,11 +183,19 @@ public final class StudentProfileLNPTest extends BaseLNPTestCase {
         return testPlan;
     }
 
+    @Override
+    protected void setupSpecification() {
+        this.specification = LNPSpecification.builder()
+                                             .withErrorRateLimit(ERROR_RATE_LIMIT)
+                                             .withMeanRespTimeLimit(MEAN_RESP_TIME_LIMIT)
+                                             .build();
+    }
+
     @BeforeClass
     public void classSetup() {
         generateTimeStamp();
         createTestData();
-        setupSpecification(0.01, 1);
+        setupSpecification();
     }
 
     @Test

--- a/src/e2e/java/teammates/e2e/util/LNPSpecification.java
+++ b/src/e2e/java/teammates/e2e/util/LNPSpecification.java
@@ -16,7 +16,8 @@ public class LNPSpecification {
     private String resultsErrorMessage = "";
 
     // This class should always be constructed using builder() instead of constructor
-    private LNPSpecification() {}
+    private LNPSpecification() {
+    }
 
     /**
      * Verify the LNP results statistics with the specified threshold.

--- a/src/e2e/java/teammates/e2e/util/LNPSpecification.java
+++ b/src/e2e/java/teammates/e2e/util/LNPSpecification.java
@@ -5,12 +5,16 @@ package teammates.e2e.util;
  */
 public class LNPSpecification {
 
-    // Maximum allowable threshold for the percentage of failed requests
-    // (0 to 100) to the test endpoint
+    /**
+     * Maximum allowable threshold for the ratio of failed request
+     * (between 0 and 1) to the test endpoint.
+     */
     private double errorRateLimit;
 
-    // Maximum allowable threshold for the mean response time
-    // (in seconds) for the test endpoint
+    /**
+     * Maximum allowable threshold for the mean response time
+     * (in seconds) for the test endpoint
+     */
     private double meanResTimeLimit;
 
     private String resultsErrorMessage = "";

--- a/src/e2e/java/teammates/e2e/util/LNPSpecification.java
+++ b/src/e2e/java/teammates/e2e/util/LNPSpecification.java
@@ -13,7 +13,7 @@ public class LNPSpecification {
 
     /**
      * Maximum allowable threshold for the mean response time
-     * (in seconds) for the test endpoint
+     * (in seconds) for the test endpoint.
      */
     private double meanResTimeLimit;
 

--- a/src/e2e/java/teammates/e2e/util/LNPSpecification.java
+++ b/src/e2e/java/teammates/e2e/util/LNPSpecification.java
@@ -5,25 +5,18 @@ package teammates.e2e.util;
  */
 public class LNPSpecification {
 
-    /*
-        Note: Consider applying the builder pattern if this class gets more complicated.
-    */
-
+    // Maximum allowable threshold for the percentage of failed requests
+    // (0 to 100) to the test endpoint
     private double errorRateLimit;
+
+    // Maximum allowable threshold for the mean response time
+    // (in seconds) for the test endpoint
     private double meanResTimeLimit;
+
     private String resultsErrorMessage = "";
 
-    /**
-     * Create a specification class with the specified limits.
-     * @param errorRateLimit Maximum allowable threshold for the percentage of failed requests
-     *                       (0 to 100) to the test endpoint.
-     * @param meanResTimeLimit Maximum allowable threshold for the mean response time
-     *                         (in seconds) for the test endpoint.
-     */
-    public LNPSpecification(double errorRateLimit, double meanResTimeLimit) {
-        this.errorRateLimit = errorRateLimit;
-        this.meanResTimeLimit = meanResTimeLimit;
-    }
+    // This class should always be constructed using builder() instead of constructor
+    private LNPSpecification() {}
 
     /**
      * Verify the LNP results statistics with the specified threshold.
@@ -58,6 +51,39 @@ public class LNPSpecification {
             double exceededErrorRate = errorPct - errorRateLimit;
             resultsErrorMessage += "Error rate is " + String.format("%.2f", exceededErrorRate)
                     + "% higher than the specified threshold. ";
+        }
+    }
+
+    /**
+     * Returns a builder for {@link LNPSpecification}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class for {@link LNPSpecification}.
+     */
+    public static class Builder {
+
+        private LNPSpecification specification;
+
+        private Builder() {
+            specification = new LNPSpecification();
+        }
+
+        public Builder withErrorRateLimit(double errorRateLimit) {
+            specification.errorRateLimit = errorRateLimit;
+            return this;
+        }
+
+        public Builder withMeanRespTimeLimit(double meanResTimeLimit) {
+            specification.meanResTimeLimit = meanResTimeLimit;
+            return this;
+        }
+
+        public LNPSpecification build() {
+            return specification;
         }
     }
 }

--- a/src/e2e/java/teammates/e2e/util/LNPSpecification.java
+++ b/src/e2e/java/teammates/e2e/util/LNPSpecification.java
@@ -73,6 +73,7 @@ public class LNPSpecification {
             specification = new LNPSpecification();
         }
 
+        //CHECKSTYLE.OFF:MissingJavadocMethod
         public Builder withErrorRateLimit(double errorRateLimit) {
             specification.errorRateLimit = errorRateLimit;
             return this;
@@ -86,5 +87,6 @@ public class LNPSpecification {
         public LNPSpecification build() {
             return specification;
         }
+        //CHECKSTYLE.ON:MissingJavadocMethod
     }
 }

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -30,7 +30,7 @@
     <suppress checks="JavadocVariable" files="teammates[/\\]test[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]util[/\\].*\.java"/>
+    <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]util[/\\]LNPSpecification\.java"/>
 
     <!-- Remove all these when V7 migration is done -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]ui[/\\]controller[/\\].*\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -30,6 +30,7 @@
     <suppress checks="JavadocVariable" files="teammates[/\\]test[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
+    <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]util[/\\].*\.java"/>
 
     <!-- Remove all these when V7 migration is done -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]ui[/\\]controller[/\\].*\.java"/>

--- a/static-analysis/teammates-checkstyle-suppressions.xml
+++ b/static-analysis/teammates-checkstyle-suppressions.xml
@@ -30,7 +30,6 @@
     <suppress checks="JavadocVariable" files="teammates[/\\]test[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
     <suppress checks="JavadocVariable" files="teammates[/\\]e2e[/\\]pageobjects[/\\].*\.java"/>
-    <suppress checks="MissingJavadocMethod" files="teammates[/\\]e2e[/\\]util[/\\]LNPSpecification\.java"/>
 
     <!-- Remove all these when V7 migration is done -->
     <suppress checks="MissingJavadocMethod" files="teammates[/\\]ui[/\\]controller[/\\].*\.java"/>


### PR DESCRIPTION
Fixes #10041 

Improved the design of LNPSpecification class by applying Builder pattern.

**Outline of Solution**:
* refactored the `LNPSpecification` class to apply Builder pattern
* removed calling `LNPSpecification` constructor from `BaseLNPTestCase` class; using builder() method instead.