### PR TITLE
[#10042] Improve mobile layout for feedback session results page

### DIFF
--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -4,24 +4,24 @@
 <div class="card card-plain">
   <div class="card-body">
     <br/>
-    <div class="row">
-      <div class="col-2 text-right"><b>Course ID:</b></div>
-      <div class="col-5">{{ session.courseId }}</div>
+    <div class="row text-center">
+      <div class="col-md-2 text-md-right"><b>Course ID:</b></div>
+      <div class="col-md-5 text-md-left">{{ session.courseId }}</div>
     </div>
     <br/>
-    <div class="row">
-      <div class="col-2 text-right"><b>Session:</b></div>
-      <div class="col-5">{{ session.feedbackSessionName }}</div>
+    <div class="row text-center">
+      <div class="col-md-2 text-md-right"><b>Session:</b></div>
+      <div class="col-md-5 text-md-left">{{ session.feedbackSessionName }}</div>
     </div>
     <br/>
-    <div class="row">
-      <div class="col-2 text-right"><b>Opening time:</b></div>
-      <div class="col-5">{{ formattedSessionOpeningTime }}</div>
+    <div class="row text-center">
+      <div class="col-md-2 text-md-right"><b>Opening time:</b></div>
+      <div class="col-md-5 text-md-left">{{ formattedSessionOpeningTime }}</div>
     </div>
     <br/>
-    <div class="row">
-      <div class="col-2 text-right"><b>Closing time:</b></div>
-      <div class="col-5">{{ formattedSessionClosingTime }}</div>
+    <div class="row text-center">
+      <div class="col-md-2 text-md-right"><b>Closing time:</b></div>
+      <div class="col-md-5 text-md-left">{{ formattedSessionClosingTime }}</div>
     </div>
     <br/>
   </div>


### PR DESCRIPTION
Part of #10042, Student Pages: Feedback Session Result Page

**Outline of Solution**
Add .col-md-* prefixes so text is centered for smaller screens, left aligned for larger screens 

![teammates feedback student results](https://user-images.githubusercontent.com/28994607/81667026-5e283800-9475-11ea-88db-9d1092db6da7.gif)
