### PR TITLE
[#10019] cookie is added to response without the 'secure' flag being set

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/JsonResult.java
+++ b/src/main/java/teammates/ui/webapi/action/JsonResult.java
@@ -54,6 +54,7 @@ public class JsonResult extends ActionResult {
     public void send(HttpServletResponse resp) throws IOException {
         output.setRequestId(Config.getRequestId());
         for (Cookie cookie : cookies) {
+            cookie.setSecure(true);
             resp.addCookie(cookie);
         }
         resp.setStatus(getStatusCode());

--- a/src/test/java/teammates/test/cases/webapi/JsonResultTest.java
+++ b/src/test/java/teammates/test/cases/webapi/JsonResultTest.java
@@ -37,12 +37,15 @@ public class JsonResultTest extends BaseTestCase {
         ______TS("json result with output message and cookies");
 
         List<Cookie> cookies = new ArrayList<>();
-        cookies.add(new Cookie("cookieName", "cookieValue"));
+        Cookie cookie = new Cookie("cookieName", "cookieValue");
+        cookie.setSecure(true);
+        cookies.add(cookie);
         result = new JsonResult(new MessageOutput("output message"), cookies);
 
         output = (MessageOutput) result.getOutput();
         assertEquals("output message", output.getMessage());
         assertEquals(1, result.getCookies().size());
+        assertTrue(result.getCookies().get(0).getSecure());
 
         MockHttpServletResponse respWithCookie = new MockHttpServletResponse();
         result.send(respWithCookie);


### PR DESCRIPTION
Fixes #10019 set secure flag on cookie for response in JsonResult and JsonResultTest as well for Testing.
