### PR TITLE
[#10042] Improve mobile layout for webpage bottom banner

### DIFF
--- a/src/web/app/page.component.html
+++ b/src/web/app/page.component.html
@@ -113,7 +113,7 @@
 </div>
 <div>
   <footer>
-    <div class="container footer text-nowrap">
+    <div class="container footer">
       <div class="row">
         <div class="col-sm-4 col-md-4 text-left">
           <i class="fas fa-bolt"></i><a routerLink="/web/front/home"> TEAMMATES</a> V{{ version }}


### PR DESCRIPTION
Part of #10042, Webpage Bottom Banner

**Original**

The hamburger menu is only accessible if you scroll to the right

![image](https://user-images.githubusercontent.com/32454748/81773396-bfeead80-951a-11ea-98f0-4db247b9a2dc.png)

The banner at the bottom behaves weirdly.

Also notice that the navbar did not stick to the top of the page.

![image](https://user-images.githubusercontent.com/32454748/81773429-cbda6f80-951a-11ea-92db-b137b20f6d03.png)

**After Change**

After this change, you can scroll to the bottom of the page, with the navbar and the hamburger menu remaining in view. The bottom banner content also stays in view.

![image](https://user-images.githubusercontent.com/32454748/81773266-84ec7a00-951a-11ea-8d6c-a5797dfa106c.png)

**Outline of Solution**

Removed the nowrap rule such that the bottom banner would not stretch outside of the mobile screen, forcing users to have to scroll to view the hamburger menu