### PR TITLE
[#10042] Improve mobile UI for Edit Feedback Session page

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -58,12 +58,12 @@
 
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
-        <div class="row">
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+        <div class="row text-center">
+          <div class="col-md-2 text-md-right font-bold">
             Course ID
           </div>
-          <div class="col-xs-2 col-md-2">
-            <div class="col-xs-2 col-md-2" *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
+          <div class="col-md-2">
+            <div class="col-md-4 text-md-left" *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
               <select class="form-control" [ngClass]="{'is-invalid': courseCandidates.length === 0}" [ngModel]="model.courseId" (ngModelChange)="courseIdChangeHandler($event)" [disabled]="courseCandidates.length === 0">
                 <option *ngFor="let course of courseCandidates" [ngValue]="course.courseId">{{ course.courseId }}</option>
               </select>
@@ -73,28 +73,28 @@
             </div>
             <div *ngIf="formMode === SessionEditFormMode.EDIT"> {{ model.courseId }} </div>
           </div>
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+          <div class="col-md-3 text-md-right font-bold">
             Time Zone
           </div>
-          <div class="col-xs-4 col-md-4" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
+          <div class="col-md-3 text-md-left" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
             {{ model.timeZone }}
           </div>
         </div>
         <br/>
-        <div class="row">
-          <div class="col-xs-0 col-md-2 text-right font-bold">
+        <div class="row text-center">
+          <div class="col-md-2 text-md-right font-bold">
             Course Name
           </div>
-          <div class="col-xs-4 col-md-4">
+          <div class="col-md-4 text-md-left">
             {{ model.courseName }}
           </div>
         </div>
         <br/>
-        <div class="row">
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+        <div class="row text-center">
+          <div class="col-md-2 text-md-right font-bold">
             Session Name
           </div>
-          <div class="col-xs-4 col-md-4">
+          <div class="col-md-4 text-md-left">
             <div *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Enter the name of the feedback session e.g. Feedback Session 1.">
               <input type="text" class="form-control" [ngModel]="model.feedbackSessionName" (ngModelChange)="triggerModelChange('feedbackSessionName', $event)" placeholder="e.g. Feedback for Project Presentation 1" maxlength="38" />
               <div>
@@ -105,26 +105,26 @@
           </div>
         </div>
         <br/>
-        <div class="row">
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+        <div class="row text-center">
+          <div class="col-md-2 text-md-right font-bold">
             Instructions
           </div>
-          <div class="col-xs-8 col-md-8" ngbTooltip="Enter instructions for this feedback session. e.g. Avoid comments which are too critical. It will be displayed at the top of the page when users respond to the session.">
+          <div class="col-md-4 text-md-left" ngbTooltip="Enter instructions for this feedback session. e.g. Avoid comments which are too critical. It will be displayed at the top of the page when users respond to the session.">
             <tm-rich-text-editor [richText]="model.instructions" (richTextChange)="triggerModelChange('instructions', $event)" [isDisabled]="!model.isEditable"></tm-rich-text-editor>
           </div>
         </div>
         <br/>
-        <div class="row" *ngIf="formMode === SessionEditFormMode.EDIT">
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+        <div class="row text-center" *ngIf="formMode === SessionEditFormMode.EDIT">
+          <div class="col-md-2 text-md-right font-bold">
             Submission Status
           </div>
-          <div class="col-xs-4 col-md-4">
+          <div class="col-md-4 text-md-left">
             {{ model.submissionStatus | submissionStatusName }}
           </div>
-          <div class="col-xs-2 col-md-2 text-right font-bold">
+          <div class="col-md-2 text-md-left font-bold">
             Published Status
           </div>
-          <div class="col-xs-4 col-md-4">
+          <div class="col-md-3 text-md-left">
             {{ model.publishStatus | publishStatusName }}
           </div>
         </div>
@@ -133,17 +133,17 @@
 
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
-        <div class="row">
-          <div class="col-xs-5 col-md-5">
+        <div class="row text-center">
+          <div class="col-md-5">
             <div class="row">
-              <div class="col-xs-8 col-md-8" ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
+              <div class="col-md-5" ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
                 <label class="label-control font-bold">
                   Submission opening time
                 </label>
               </div>
             </div>
             <div class="row align-items-center">
-              <div class="col-7">
+              <div class="col-md-7 col-xs-center">
                 <div class="input-group">
                   <input type="text" class="form-control" ngbDatepicker [ngModel]="model.submissionStartDate" (ngModelChange)="triggerModelChange('submissionStartDate', $event)"  #startTimeDp="ngbDatepicker" [disabled]="!model.isEditable"/>
                   <div class="input-group-append" *ngIf="model.isEditable">
@@ -153,21 +153,21 @@
                   </div>
                 </div>
               </div>
-              <div class="col-xs-5 col-md-5">
+              <div class="col-md-5">
                 <tm-time-picker [time]="model.submissionStartTime" (timeChange)="triggerModelChange('submissionStartTime', $event)" [isDisabled]="!model.isEditable"></tm-time-picker>
               </div>
             </div>
           </div>
-          <div class="col-xs-5 col-md-5 border-left-gray">
-            <div class="row">
-              <div class="col-xs-8 col-md-8" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
+          <div class="col-md-5 border-left-gray">
+            <div class="row text-center">
+              <div class="col-md-5" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
                 <label class="label-control font-bold">
                   Submission closing time
                 </label>
               </div>
             </div>
             <div class="row align-items-center">
-              <div class="col-7">
+              <div class="col-md-7 col-xs-center">
                 <div class="input-group">
                   <input type="text" class="form-control" ngbDatepicker [ngModel]="model.submissionEndDate" (ngModelChange)="triggerModelChange('submissionEndDate', $event)"
                          #endTimeDp="ngbDatepicker" [disabled]="!model.isEditable" [minDate]="model.submissionStartDate"/>
@@ -183,15 +183,15 @@
               </div>
             </div>
           </div>
-          <div class="col-xs-2 col-md-2 border-left-gray">
-            <div class="row">
+          <div class="col-md-2 border-left-gray">
+            <div class="row text-center">
               <div class="col-12" ngbTooltip="Please select the amount of time that the system will continue accepting submissions after the specified deadline.">
                 <label class="control-label font-bold">
                   Grace period
                 </label>
               </div>
             </div>
-            <div class="row">
+            <div class="row text-center">
               <div class="col-12">
                 <select class="form-control" [ngModel]="model.gracePeriod" (ngModelChange)="triggerModelChange('gracePeriod', $event)" [disabled]="!model.isEditable">
                   <option *ngFor="let graceMinute of [0, 5, 10, 15, 20, 25, 30]" [ngValue]="graceMinute">{{ graceMinute + ' min'}}</option>
@@ -209,17 +209,17 @@
     </div>
     <div class="card border-primary margin-top-20px" *ngIf="model.hasVisibleSettingsPanelExpanded">
       <div class="card-body">
-        <div class="row">
-          <div class="col-xs-6 col-md-6">
+        <div class="row text-center">
+          <div class="col-md-6">
             <div class="row">
-              <div class="col-12">
+              <div class="col-md-4 col-xs-3">
                 <label class="label-control font-bold" ngbTooltip="Please select when you want the questions for the feedback session to be visible to users who need to participate. Note that users cannot submit their responses until the submissions opening time set below.">Make session visible </label>
               </div>
             </div>
-            <div class="row">
+            <div class="row text-center">
               <div class="col-12">
                 <div class="row align-items-center">
-                  <div class="col-xs-2 col-md-2" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
+                  <div class="col-md-2" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
                     <div class="form-check">
                       <label class="form-check-label">
                         <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.CUSTOM" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
@@ -227,7 +227,7 @@
                       </label>
                     </div>
                   </div>
-                  <div class="col-xs-6 col-md-6">
+                  <div class="col-md-6">
                     <div class="input-group">
                       <input type="text" class="form-control" ngbDatepicker #sessionVisibleTimeDp="ngbDatepicker" [maxDate]="maxDateForSessionVisible"
                              [ngModel]="model.customSessionVisibleDate" (ngModelChange)="triggerModelChange('customSessionVisibleDate', $event)" [disabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"/>
@@ -238,7 +238,7 @@
                       </div>
                     </div>
                   </div>
-                  <div class="col-4">
+                  <div class="col-md-4 col-xs-12">
                     <tm-time-picker [time]="model.customSessionVisibleTime" (timeChange)="triggerModelChange('customSessionVisibleTime', $event)" [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
                   </div>
                 </div>
@@ -256,16 +256,16 @@
               </div>
             </div>
           </div>
-          <div class="col-xs-6 col-md-6 sessionVisibleRadio">
+          <div class="col-md-6 sessionVisibleRadio">
             <div class="row">
-              <div class="col-12">
+              <div class="col-md-4 col-xs-3">
                 <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
               </div>
             </div>
             <div class="row">
               <div class="col-12">
                 <div class="row align-items-center">
-                  <div class="col-xs-2 col-md-2" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
+                  <div class="col-md-2" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
                     <div class="form-check">
                       <label class="form-check-label">
                         <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.CUSTOM" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable"/>
@@ -273,7 +273,7 @@
                       </label>
                     </div>
                   </div>
-                  <div class="col-6">
+                  <div class="col-md-6">
                     <div class="input-group">
                       <input type="text" class="form-control" ngbDatepicker #responseVisibleTimeDp="ngbDatepicker" [minDate]="minDateForResponseVisible"
                              [ngModel]="model.customResponseVisibleDate" (ngModelChange)="triggerModelChange('customResponseVisibleDate', $event)" [disabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"/>
@@ -284,7 +284,7 @@
                       </div>
                     </div>
                   </div>
-                  <div class="col-4">
+                  <div class="col-md-4 col-xs-12">
                     <tm-time-picker [time]="model.customResponseVisibleTime" (timeChange)="triggerModelChange('customResponseVisibleTime', $event)" [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
                   </div>
                 </div>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -59,11 +59,11 @@
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
         <div class="row">
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Course ID
           </div>
-          <div class="col-4">
-            <div *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
+          <div class="col-xs-2 col-md-2">
+            <div class="col-xs-2 col-md-2" *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
               <select class="form-control" [ngClass]="{'is-invalid': courseCandidates.length === 0}" [ngModel]="model.courseId" (ngModelChange)="courseIdChangeHandler($event)" [disabled]="courseCandidates.length === 0">
                 <option *ngFor="let course of courseCandidates" [ngValue]="course.courseId">{{ course.courseId }}</option>
               </select>
@@ -73,28 +73,28 @@
             </div>
             <div *ngIf="formMode === SessionEditFormMode.EDIT"> {{ model.courseId }} </div>
           </div>
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Time Zone
           </div>
-          <div class="col-4" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
+          <div class="col-xs-4 col-md-4" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
             {{ model.timeZone }}
           </div>
         </div>
         <br/>
         <div class="row">
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-0 col-md-2 text-right font-bold">
             Course Name
           </div>
-          <div class="col-4">
+          <div class="col-xs-4 col-md-4">
             {{ model.courseName }}
           </div>
         </div>
         <br/>
         <div class="row">
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Session Name
           </div>
-          <div class="col-4">
+          <div class="col-xs-4 col-md-4">
             <div *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Enter the name of the feedback session e.g. Feedback Session 1.">
               <input type="text" class="form-control" [ngModel]="model.feedbackSessionName" (ngModelChange)="triggerModelChange('feedbackSessionName', $event)" placeholder="e.g. Feedback for Project Presentation 1" maxlength="38" />
               <div>
@@ -106,25 +106,25 @@
         </div>
         <br/>
         <div class="row">
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Instructions
           </div>
-          <div class="col-8" ngbTooltip="Enter instructions for this feedback session. e.g. Avoid comments which are too critical. It will be displayed at the top of the page when users respond to the session.">
+          <div class="col-xs-8 col-md-8" ngbTooltip="Enter instructions for this feedback session. e.g. Avoid comments which are too critical. It will be displayed at the top of the page when users respond to the session.">
             <tm-rich-text-editor [richText]="model.instructions" (richTextChange)="triggerModelChange('instructions', $event)" [isDisabled]="!model.isEditable"></tm-rich-text-editor>
           </div>
         </div>
         <br/>
         <div class="row" *ngIf="formMode === SessionEditFormMode.EDIT">
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Submission Status
           </div>
-          <div class="col-4">
+          <div class="col-xs-4 col-md-4">
             {{ model.submissionStatus | submissionStatusName }}
           </div>
-          <div class="col-2 text-right font-bold">
+          <div class="col-xs-2 col-md-2 text-right font-bold">
             Published Status
           </div>
-          <div class="col-4">
+          <div class="col-xs-4 col-md-4">
             {{ model.publishStatus | publishStatusName }}
           </div>
         </div>
@@ -134,9 +134,9 @@
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
         <div class="row">
-          <div class="col-5">
+          <div class="col-xs-5 col-md-5">
             <div class="row">
-              <div class="col-8" ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
+              <div class="col-xs-8 col-md-8" ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
                 <label class="label-control font-bold">
                   Submission opening time
                 </label>
@@ -153,14 +153,14 @@
                   </div>
                 </div>
               </div>
-              <div class="col-5">
+              <div class="col-xs-5 col-md-5">
                 <tm-time-picker [time]="model.submissionStartTime" (timeChange)="triggerModelChange('submissionStartTime', $event)" [isDisabled]="!model.isEditable"></tm-time-picker>
               </div>
             </div>
           </div>
-          <div class="col-5 border-left-gray">
+          <div class="col-xs-5 col-md-5 border-left-gray">
             <div class="row">
-              <div class="col-8" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
+              <div class="col-xs-8 col-md-8" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
                 <label class="label-control font-bold">
                   Submission closing time
                 </label>
@@ -178,12 +178,12 @@
                   </div>
                 </div>
               </div>
-              <div class="col-5">
+              <div class="col-xs-5 col-md-5">
                 <tm-time-picker [time]="model.submissionEndTime" (timeChange)="triggerModelChange('submissionEndTime', $event)" [isDisabled]="!model.isEditable"></tm-time-picker>
               </div>
             </div>
           </div>
-          <div class="col-2 border-left-gray">
+          <div class="col-xs-2 col-md-2 border-left-gray">
             <div class="row">
               <div class="col-12" ngbTooltip="Please select the amount of time that the system will continue accepting submissions after the specified deadline.">
                 <label class="control-label font-bold">
@@ -210,7 +210,7 @@
     <div class="card border-primary margin-top-20px" *ngIf="model.hasVisibleSettingsPanelExpanded">
       <div class="card-body">
         <div class="row">
-          <div class="col-6">
+          <div class="col-xs-6 col-md-6">
             <div class="row">
               <div class="col-12">
                 <label class="label-control font-bold" ngbTooltip="Please select when you want the questions for the feedback session to be visible to users who need to participate. Note that users cannot submit their responses until the submissions opening time set below.">Make session visible </label>
@@ -219,7 +219,7 @@
             <div class="row">
               <div class="col-12">
                 <div class="row align-items-center">
-                  <div class="col-2" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
+                  <div class="col-xs-2 col-md-2" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
                     <div class="form-check">
                       <label class="form-check-label">
                         <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.CUSTOM" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
@@ -227,7 +227,7 @@
                       </label>
                     </div>
                   </div>
-                  <div class="col-6">
+                  <div class="col-xs-6 col-md-6">
                     <div class="input-group">
                       <input type="text" class="form-control" ngbDatepicker #sessionVisibleTimeDp="ngbDatepicker" [maxDate]="maxDateForSessionVisible"
                              [ngModel]="model.customSessionVisibleDate" (ngModelChange)="triggerModelChange('customSessionVisibleDate', $event)" [disabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"/>
@@ -256,7 +256,7 @@
               </div>
             </div>
           </div>
-          <div class="col-6 sessionVisibleRadio">
+          <div class="col-xs-6 col-md-6 sessionVisibleRadio">
             <div class="row">
               <div class="col-12">
                 <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
@@ -265,7 +265,7 @@
             <div class="row">
               <div class="col-12">
                 <div class="row align-items-center">
-                  <div class="col-2" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
+                  <div class="col-xs-2 col-md-2" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
                     <div class="form-check">
                       <label class="form-check-label">
                         <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.CUSTOM" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable"/>


### PR DESCRIPTION
Part of #10042 : improved page layout for part of the Edit Feedback Session page and centered the content for smaller screen sizes.

**Outline of Solution**
I used the col-xs-* and col-md-* prefixes which apply for mobile UI and desktop.

**Mobile UI**
This is what it looks like with the mobile UI:
![After d-m](https://user-images.githubusercontent.com/61196321/81966562-5f4a9800-9622-11ea-9a8f-5eb768ea2532.gif)

**Smaller screen sizes UI**
This is what it looks like with the smaller screen sizes UI:
![After l-s](https://user-images.githubusercontent.com/61196321/81966595-67a2d300-9622-11ea-9096-4f94c536b75a.gif)