### PR TITLE
[#10042] Improve mobile UI for Course Enrol Students Page

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -18,13 +18,13 @@
         <div class="card card-default">
           <div class="card-header"
                (click)="toggleExistingStudentsPanel()">
+            <b class="existing-students-status-message">Existing Students</b>
             <div class="float-right margin-left-7px">
               <tm-ajax-preload *ngIf="loading"></tm-ajax-preload>
               <b class="existing-students-status-message">{{ isExistingStudentsPresent ? '' : 'No existing students in course.' }}</b>
               <b class="existing-students-status-message">{{ isAjaxSuccess ? '' : 'Failed to load. Click here to retry.' }}</b>
               <i class="fas fa-chevron-{{ isExistingStudentsPanelCollapsed ? 'down' : 'up' }}"></i>
             </div>
-            <strong>Existing Students</strong>
           </div>
           <hot-table
               [licenseKey]="'non-commercial-and-evaluation'"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -4,8 +4,8 @@
     <div class="card-body fill-plain">
       <p class="text-muted">
         <i class="fas fa-info-circle"></i>
-        <a class="scroll-down" tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
-          <strong> Scroll down</strong>
+        <a tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
+          Scroll down
         </a>
         to see more information about the spreadsheet interfaces.
         <br>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -4,8 +4,8 @@
     <div class="card-body fill-plain">
       <p class="text-muted">
         <i class="fas fa-info-circle"></i>
-        <a tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
-          Scroll down
+        <a class="scroll-button" tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
+          <strong> Scroll down</strong>
         </a>
         to see more information about the spreadsheet interfaces.
         <br>
@@ -18,13 +18,13 @@
         <div class="card card-default">
           <div class="card-header"
                (click)="toggleExistingStudentsPanel()">
-            <div class="float-right margin-left-7px">
+            <b class="existing-students-status-message">Existing Students</b>
+            <div class="float-right">
               <tm-ajax-preload *ngIf="loading"></tm-ajax-preload>
               <b class="existing-students-status-message">{{ isExistingStudentsPresent ? '' : 'No existing students in course.' }}</b>
               <b class="existing-students-status-message">{{ isAjaxSuccess ? '' : 'Failed to load. Click here to retry.' }}</b>
               <i class="fas fa-chevron-{{ isExistingStudentsPanelCollapsed ? 'down' : 'up' }}"></i>
             </div>
-            <strong>Existing Students</strong>
           </div>
           <hot-table
               [licenseKey]="'non-commercial-and-evaluation'"
@@ -76,17 +76,17 @@
           </hot-table>
         </div>
         <div class="row enroll-students-spreadsheet-buttons" [hidden]="isNewStudentsPanelCollapsed">
-          <div class="col-md-6">
+          <div class="col-md-8">
             <div class="input-group">
               <button type="button" title="Add" id="button_add_empty_rows" class="btn btn-primary" (click)="addRows(numOfRows.value)">
                 Add row(s)
               </button>
-              <div class="col-xs-4">
+              <div>
                 <input type="number" id="number-of-rows" class="form-control" value="1" min="0" #numOfRows>
               </div>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-md-4">
             <button
                 type="submit"
                 title="Enroll"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -4,8 +4,8 @@
     <div class="card-body fill-plain">
       <p class="text-muted">
         <i class="fas fa-info-circle"></i>
-        <a class="scroll-button" tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
-          <strong> Scroll down</strong>
+        <a tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
+          Scroll down
         </a>
         to see more information about the spreadsheet interfaces.
         <br>
@@ -18,13 +18,13 @@
         <div class="card card-default">
           <div class="card-header"
                (click)="toggleExistingStudentsPanel()">
-            <b class="existing-students-status-message">Existing Students</b>
-            <div class="float-right">
+            <div class="float-right margin-left-7px">
               <tm-ajax-preload *ngIf="loading"></tm-ajax-preload>
               <b class="existing-students-status-message">{{ isExistingStudentsPresent ? '' : 'No existing students in course.' }}</b>
               <b class="existing-students-status-message">{{ isAjaxSuccess ? '' : 'Failed to load. Click here to retry.' }}</b>
               <i class="fas fa-chevron-{{ isExistingStudentsPanelCollapsed ? 'down' : 'up' }}"></i>
             </div>
+            <strong>Existing Students</strong>
           </div>
           <hot-table
               [licenseKey]="'non-commercial-and-evaluation'"
@@ -76,17 +76,17 @@
           </hot-table>
         </div>
         <div class="row enroll-students-spreadsheet-buttons" [hidden]="isNewStudentsPanelCollapsed">
-          <div class="col-md-8">
+          <div class="col-md-6">
             <div class="input-group">
               <button type="button" title="Add" id="button_add_empty_rows" class="btn btn-primary" (click)="addRows(numOfRows.value)">
                 Add row(s)
               </button>
-              <div>
+              <div class="col-xs-4">
                 <input type="number" id="number-of-rows" class="form-control" value="1" min="0" #numOfRows>
               </div>
             </div>
           </div>
-          <div class="col-md-4">
+          <div class="col-md-6">
             <button
                 type="submit"
                 title="Enroll"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -4,8 +4,8 @@
     <div class="card-body fill-plain">
       <p class="text-muted">
         <i class="fas fa-info-circle"></i>
-        <a tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
-          Scroll down
+        <a class="scroll-down" tabindex="0" role="button" (click)="navigateToMoreInfo()"> <!--We are just treating it as a button here-->
+          <strong> Scroll down</strong>
         </a>
         to see more information about the spreadsheet interfaces.
         <br>

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.html
@@ -76,17 +76,15 @@
           </hot-table>
         </div>
         <div class="row enroll-students-spreadsheet-buttons" [hidden]="isNewStudentsPanelCollapsed">
-          <div class="col-md-6">
+          <div class="enroll-button-group">
             <div class="input-group">
               <button type="button" title="Add" id="button_add_empty_rows" class="btn btn-primary" (click)="addRows(numOfRows.value)">
                 Add row(s)
               </button>
-              <div class="col-xs-4">
-                <input type="number" id="number-of-rows" class="form-control" value="1" min="0" #numOfRows>
-              </div>
+              <input type="number" id="number-of-rows" class="form-control" value="1" min="0" #numOfRows>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="enroll-button-group">
             <button
                 type="submit"
                 title="Enroll"

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -5,7 +5,6 @@
 .card-default {
   border-color: #DDD;
   width: 100%;
-  display: block;
   margin-bottom: 20px;
 }
 
@@ -17,9 +16,18 @@
   padding: 15px;
 }
 
+.enroll-input-group {
+    width: 50%;
+}
+
 .text-muted {
   padding: 15px;
   margin-bottom: 0;
+}
+
+.scroll-button :hover {
+    color: blue;
+    cursor: pointer;
 }
 
 .status-message {

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -72,6 +72,6 @@
 }
 
 .enroll-button-group {
-    width: 50%;
-    display: inline-block;
+  width: 50%;
+  display: inline-block;
 }

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -71,11 +71,6 @@
   margin-right: 1em;
 }
 
-.scroll-down :hover {
-    color: blue;
-    cursor: pointer;
-}
-
 .enroll-button-group {
     width: 50%;
     display: inline-block;

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -75,3 +75,8 @@
     color: blue;
     cursor: pointer;
 }
+
+.enroll-button-group {
+    width: 50%;
+    display: inline-block;
+}

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -5,6 +5,7 @@
 .card-default {
   border-color: #DDD;
   width: 100%;
+  display: block;
   margin-bottom: 20px;
 }
 
@@ -16,18 +17,9 @@
   padding: 15px;
 }
 
-.enroll-input-group {
-    width: 50%;
-}
-
 .text-muted {
   padding: 15px;
   margin-bottom: 0;
-}
-
-.scroll-button :hover {
-    color: blue;
-    cursor: pointer;
 }
 
 .status-message {

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -5,7 +5,6 @@
 .card-default {
   border-color: #DDD;
   width: 100%;
-  display: block;
   margin-bottom: 20px;
 }
 

--- a/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
+++ b/src/web/app/pages-instructor/instructor-course-enroll-page/instructor-course-enroll-page.component.scss
@@ -70,3 +70,8 @@
   margin-left: 1em;
   margin-right: 1em;
 }
+
+.scroll-down :hover {
+    color: blue;
+    cursor: pointer;
+}


### PR DESCRIPTION
Part of #10042, Course Enrol Students Page

**Before-1**: There is awkward word break for the `status message` in mobile screen.

<img width="488" alt="before-1" src="https://user-images.githubusercontent.com/32880438/81819345-c81e0b80-9561-11ea-9feb-3324bf4d4158.png">

**After-1**: 

<img width="484" alt="after-1" src="https://user-images.githubusercontent.com/32880438/81819445-e7b53400-9561-11ea-9915-09d3185469f9.png">

**Solution-1**
Re-ordered the `status-message` elements within HTML element of class `card-header`.

**Before-2**: `enroll-students-spreadsheet-buttons` are misaligned in mobile screen.

<img width="478" alt="before-2" src="https://user-images.githubusercontent.com/32880438/81819778-572b2380-9562-11ea-996f-23237515d57b.png">

**After-2**:

<img width="486" alt="after-2" src="https://user-images.githubusercontent.com/32880438/81819995-98bbce80-9562-11ea-8c44-4254127bec4f.png">

**Solution-2**:
Removed redundant layer of `div` around `input`
Removed grid layout, using CSS for more stable alignment
