### PR TITLE
[#10042] Improve mobile UI for add feedback sessions page

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -6,27 +6,27 @@
   </div>
   <div class="card-body">
     <div class="row" *ngIf="formMode === SessionEditFormMode.ADD">
-      <div class="col-6">
+      <div class="col-md-6">
         <div class="row align-items-center">
-          <div class="col-4">
+          <div class="col-md-4">
             <h4 class="text-center">Create new </h4>
           </div>
-          <div class="col-7">
+          <div class="col-10 col-md-7">
             <select class="form-control" ngbTooltip="Select a session type here." [ngModel]="model.templateSessionName" (ngModelChange)="triggerModelChange('templateSessionName', $event)">
               <option *ngFor="let templateSession of templateSessions" [ngValue]="templateSession.name">{{ templateSession.name }}</option>
             </select>
           </div>
-          <div class="col-1">
+          <div class="col-1 col-md-1">
             <button type="button" class="btn btn-link" (click)="sessionHelpHandler()"><i class="fas fa-info-circle"></i></button>
           </div>
         </div>
       </div>
-      <div class="col-6">
-        <div class="row align-items-center">
-          <div class="col-2">
-            <h4 class="text-right">Or: </h4>
+      <div class="col-md-6">
+        <div class="row text-center align-items-center mt-2 mt-md-0">
+          <div class="col-md-2">
+            <h4 class="text-md-right">Or: </h4>
           </div>
-          <div class="col-10">
+          <div class="col-md-10 text-md-left">
             <button type="button" class="btn btn-info" (click)="copyOthersHandler()">Copy from previous feedback sessions</button>
           </div>
         </div>


### PR DESCRIPTION
Part of #10042 

**Outline of Solution**
Added `-md` classes. 

Before:
![before](https://user-images.githubusercontent.com/28994607/82025417-e734ae80-96c3-11ea-84fa-64479cd31cab.PNG)

After:
![after](https://user-images.githubusercontent.com/28994607/82025427-e8fe7200-96c3-11ea-9d19-33948658e156.PNG)

The remainder of the form has the exact same structure as the edit feedback session page which is already being done with #10051 except for the top banner shown in the pictures. 