### PR TITLE
[#10058] Fix inconsistent exception thrown in BasicFeedbackSubmissionAction#checkAccessControl*

### DIFF
--- a/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
@@ -67,10 +67,6 @@ public abstract class BasicFeedbackSubmissionAction extends Action {
      */
     protected void checkAccessControlForStudentFeedbackSubmission(
             StudentAttributes student, FeedbackSessionAttributes feedbackSession) {
-        if (student == null) {
-            throw new EntityNotFoundException(new EntityDoesNotExistException("Student does not exist"));
-        }
-
         String moderatedPerson = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON);
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 

--- a/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
@@ -65,6 +65,10 @@ public abstract class BasicFeedbackSubmissionAction extends Action {
      */
     protected void checkAccessControlForStudentFeedbackSubmission(
             StudentAttributes student, FeedbackSessionAttributes feedbackSession) {
+        if (student == null) {
+            throw new UnauthorizedAccessException("Trying to access system using a non-existent student entity");
+        }
+
         String moderatedPerson = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_PERSON);
         String previewAsPerson = getRequestParamValue(Const.ParamsNames.PREVIEWAS);
 

--- a/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
+++ b/src/main/java/teammates/ui/webapi/action/BasicFeedbackSubmissionAction.java
@@ -8,8 +8,6 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.common.exception.EntityDoesNotExistException;
-import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpRequestBodyException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Assumption;

--- a/src/test/java/teammates/test/cases/webapi/ConfirmFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/ConfirmFeedbackSessionSubmissionActionTest.java
@@ -310,8 +310,7 @@ public class ConfirmFeedbackSessionSubmissionActionTest extends BaseActionTest<C
                 Const.ParamsNames.SEND_SUBMISSION_EMAIL, "true",
         };
 
-        assertThrows(EntityNotFoundException.class,
-                () -> getAction(studentSubmitSessionInOtherCourseParams).checkAccessControl());
+        verifyCannotAccess(studentSubmitSessionInOtherCourseParams);
 
         ______TS("Student intends to submit feedback session in his course, should be accessible");
 

--- a/src/test/java/teammates/test/cases/webapi/ConfirmFeedbackSessionSubmissionActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/ConfirmFeedbackSessionSubmissionActionTest.java
@@ -11,7 +11,6 @@ import teammates.common.datatransfer.attributes.FeedbackResponseAttributes;
 import teammates.common.datatransfer.attributes.FeedbackSessionAttributes;
 import teammates.common.datatransfer.attributes.InstructorAttributes;
 import teammates.common.datatransfer.attributes.StudentAttributes;
-import teammates.common.exception.EntityNotFoundException;
 import teammates.common.exception.InvalidHttpParameterException;
 import teammates.common.util.Const;
 import teammates.common.util.EmailWrapper;

--- a/src/test/java/teammates/test/cases/webapi/GetFeedbackResponsesActionTest.java
+++ b/src/test/java/teammates/test/cases/webapi/GetFeedbackResponsesActionTest.java
@@ -233,8 +233,7 @@ public class GetFeedbackResponsesActionTest extends BaseActionTest<GetFeedbackRe
                 Const.ParamsNames.FEEDBACK_QUESTION_ID, qn1InSession1InCourse1.getId(),
                 Const.ParamsNames.INTENT, Intent.STUDENT_SUBMISSION.toString(),
         };
-        assertThrows(EntityNotFoundException.class,
-                () -> getAction(studentAccessOtherStudentsParams).checkAccessControl());
+        verifyCannotAccess(studentAccessOtherStudentsParams);
 
         ______TS("instructor access other instructor's response from different course");
         loginAsInstructor(instructor1OfCourse2.getGoogleId());


### PR DESCRIPTION
Fixes #10058

**Outline of Solution**
Change null check in `BasicFeedbackSubmissionAction#checkAccessControlForStudentFeedbackSubmission` to throw `UnauthorizedAccessException` instead of `EntityNotFoundException`