### PR TITLE
[#9382] Fix typo in instructor help pages

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -25,7 +25,7 @@
               Specify the feedback path that should be used to generate the appropriate feedback recipients
             </li>
           </ol>
-          <p>EXAMPLE BODY</p>
+          <p>EXAMPLE BOX</p>
         </div>
       </div>
       <br/>


### PR DESCRIPTION
Part of #9382 

I'm assuming `EXAMPLE BODY` is meant to be `EXAMPLE BOX` for modularisation of help pages.