### PR TITLE
[#9382] Use concrete TypeScript type in result page

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponseCommentsLogic.java
@@ -292,7 +292,7 @@ public final class FeedbackResponseCommentsLogic {
                 || isResponseCommentVisibleTo(relatedQuestion, relatedComment,
                                               FeedbackParticipantType.OWN_TEAM_MEMBERS))
                 && (studentsEmailInTeam.contains(response.giver)
-                        || (student.getTeam().equals(response.giver)));
+                        || (isUserStudent && student.getTeam().equals(response.giver)));
 
         boolean isUserInResponseRecipientTeamAndRelatedResponseCommentVisibleToRecipientsTeamMembers =
                 isResponseCommentVisibleTo(relatedQuestion, relatedComment,

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -16,7 +16,7 @@
             <div class="card-header bg-primary text-white" (click)="userToTeamName[userInfo].isExpanded = !userToTeamName[userInfo].isExpanded">
               {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
               <div class="float-right">
-                <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="getGQRRelatedGiverEmailForUser(userInfo)"></tm-response-moderation-button>
+                <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(userInfo)"></tm-response-moderation-button>
                 <i class="fas fa-chevron-down" *ngIf="!userToTeamName[userInfo].isExpanded"></i>
                 <i class="fas fa-chevron-up" *ngIf="userToTeamName[userInfo].isExpanded"></i>
               </div>
@@ -49,7 +49,7 @@
       <div class="card-header bg-primary text-white" (click)="userInfo.value.isExpanded = !userInfo.value.isExpanded">
         {{ isGqr ? 'From' : 'To' }}: {{ userInfo.key }}
         <div class="float-right">
-          <tm-response-moderation-button [session]="session" [relatedGiverEmail]="getGQRRelatedGiverEmailForUser(userInfo.key)"></tm-response-moderation-button>
+          <tm-response-moderation-button [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(userInfo.key)"></tm-response-moderation-button>
           <i class="fas fa-chevron-down" *ngIf="!userInfo.value.isExpanded"></i>
           <i class="fas fa-chevron-up" *ngIf="userInfo.value.isExpanded"></i>
         </div>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.html
@@ -9,66 +9,49 @@
         </div>
       </div>
       <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
-
-        <!-- TODO extract this out -->
         <div *ngFor="let userInfo of teamInfo.value">
-          <div class="card top-padded">
-            <div class="card-header bg-primary text-white" (click)="userToTeamName[userInfo].isExpanded = !userToTeamName[userInfo].isExpanded">
-              {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
-              <div class="float-right">
-                <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(userInfo)"></tm-response-moderation-button>
-                <i class="fas fa-chevron-down" *ngIf="!userToTeamName[userInfo].isExpanded"></i>
-                <i class="fas fa-chevron-up" *ngIf="userToTeamName[userInfo].isExpanded"></i>
-              </div>
-            </div>
-            <div class="card-body" *ngIf="userToTeamName[userInfo].isExpanded">
-              <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo]">
-                <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
-                  <tm-question-text-with-info [questionNumber]="question.questionNumber" [questionDetails]="question.questionDetails" (click)="$event.stopPropagation()"></tm-question-text-with-info>
-                  <div class="float-right">
-                    <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
-                    <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
-                  </div>
-                </div>
-                <div class="card-body" *ngIf="question.isTabExpanded">
-                  <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                      [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails" [questionId]="question.questionId"></tm-per-question-view-responses>
-                </div>
-              </div>
-            </div>
-          </div>
+          <ng-container
+              [ngTemplateOutlet]="userTab"
+              [ngTemplateOutletContext]="{userInfo:userInfo}">
+          </ng-container>
         </div>
-
       </div>
     </div>
   </div>
 </div>
 <div *ngIf="!groupByTeam">
-  <div *ngFor="let userInfo of userToTeamName | keyvalue">
-    <div class="card top-padded">
-      <div class="card-header bg-primary text-white" (click)="userInfo.value.isExpanded = !userInfo.value.isExpanded">
-        {{ isGqr ? 'From' : 'To' }}: {{ userInfo.key }}
-        <div class="float-right">
-          <tm-response-moderation-button [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(userInfo.key)"></tm-response-moderation-button>
-          <i class="fas fa-chevron-down" *ngIf="!userInfo.value.isExpanded"></i>
-          <i class="fas fa-chevron-up" *ngIf="userInfo.value.isExpanded"></i>
-        </div>
+  <div *ngFor="let userInfo of userExpanded | keyvalue">
+    <ng-container
+        [ngTemplateOutlet]="userTab"
+        [ngTemplateOutletContext]="{userInfo:userInfo.key}">
+    </ng-container>
+  </div>
+</div>
+
+<ng-template #userTab let-userInfo='userInfo'>
+  <div class="card top-padded">
+    <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
+      {{ isGqr ? 'From' : 'To' }}: {{ userInfo }}
+      <div class="float-right">
+        <tm-response-moderation-button *ngIf="isGqr" [session]="session" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
+        <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>
+        <i class="fas fa-chevron-up" *ngIf="userExpanded[userInfo]"></i>
       </div>
-      <div class="card-body" *ngIf="userInfo.value.isExpanded">
-        <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo.key]">
-          <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
-            <tm-question-text-with-info [questionNumber]="question.questionNumber" [questionDetails]="question.questionDetails" (click)="$event.stopPropagation()"></tm-question-text-with-info>
-            <div class="float-right">
-              <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
-              <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
-            </div>
+    </div>
+    <div class="card-body" *ngIf="userExpanded[userInfo]">
+      <div class="card top-padded" *ngFor="let question of responsesToShow[userInfo]">
+        <div class="card-header bg-info text-white" (click)="question.isTabExpanded = !question.isTabExpanded">
+          <tm-question-text-with-info [questionNumber]="question.questionOutput.questionNumber" [questionDetails]="question.questionOutput.questionDetails" (click)="$event.stopPropagation()"></tm-question-text-with-info>
+          <div class="float-right">
+            <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
+            <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
           </div>
-          <div class="card-body" *ngIf="question.isTabExpanded">
-            <tm-per-question-view-responses [responses]="question.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
-                [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionDetails"></tm-per-question-view-responses>
-          </div>
+        </div>
+        <div class="card-body" *ngIf="question.isTabExpanded">
+          <tm-per-question-view-responses [responses]="question.questionOutput.allResponses" [section]="section" [sectionType]="sectionType" [session]="session"
+                                          [indicateMissingResponses]="true" [showGiver]="!isGqr" [showRecipient]="isGqr" [questionDetails]="question.questionOutput.questionDetails"></tm-per-question-view-responses>
         </div>
       </div>
     </div>
   </div>
-</div>
+</ng-template>

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -128,9 +128,9 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Get related giver email of specific user in GQR view.
+   * Get related giver email of specific user in the view.
    */
-  getGQRRelatedGiverEmailForUser(userInfo: string): string {
+  getRelatedGiverEmailForUser(userInfo: string): string {
     return Object.values(this.responsesToShow[userInfo])[0].allResponses[0].relatedGiverEmail;
   }
 }

--- a/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
+++ b/src/web/app/components/question-responses/gqr-rqg-view-responses/gqr-rqg-view-responses.component.ts
@@ -1,7 +1,19 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import {
+  FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+  QuestionOutput, ResponseOutput,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../../types/api-output';
+import {
   InstructorSessionResultSectionType,
 } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
+
+interface QuestionTab {
+  questionOutput: QuestionOutput;
+
+  isTabExpanded: boolean;
+}
 
 /**
  * Component to display list of responses in GQR/RQG view.
@@ -13,20 +25,37 @@ import {
 })
 export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
 
-  @Input() responses: any[] = [];
+  @Input() responses: QuestionOutput[] = [];
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
   @Input() showStatistics: boolean = true;
   @Input() indicateMissingResponses: boolean = true;
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   @Input() isGqr: boolean = true;
 
   teamsToUsers: Record<string, string[]> = {};
+
   teamExpanded: Record<string, boolean> = {};
-  userToTeamName: Record<string, any> = {};
-  responsesToShow: Record<string, any[]> = {};
+  userExpanded: Record<string, boolean> = {};
+
+  responsesToShow: Record<string, QuestionTab[]> = {};
 
   constructor() { }
 
@@ -42,7 +71,7 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
     this.responsesToShow = {};
     this.teamsToUsers = {};
     this.teamExpanded = {};
-    this.userToTeamName = {};
+    this.userExpanded = {};
     for (const question of this.responses) {
       for (const response of question.allResponses) {
         if (this.isGqr) {
@@ -51,10 +80,7 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
             this.teamsToUsers[response.giverTeam].push(response.giver);
             this.teamExpanded[response.giverTeam] = false;
           }
-          this.userToTeamName[response.giver] = {
-            teamName: response.giverTeam,
-            isExpanded: false,
-          };
+          this.userExpanded[response.giver] = false;
         } else {
           if (!response.recipientTeam) {
             // Recipient is team
@@ -63,10 +89,7 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
               this.teamsToUsers[response.recipient].push(response.recipient);
               this.teamExpanded[response.recipient] = false;
             }
-            this.userToTeamName[response.recipient] = {
-              teamName: response.recipient,
-              isExpanded: false,
-            };
+            this.userExpanded[response.recipient] = false;
             continue;
           }
           this.teamsToUsers[response.recipientTeam] = this.teamsToUsers[response.recipientTeam] || [];
@@ -74,18 +97,15 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
             this.teamsToUsers[response.recipientTeam].push(response.recipient);
             this.teamExpanded[response.recipientTeam] = false;
           }
-          this.userToTeamName[response.recipient] = {
-            teamName: response.recipientTeam,
-            isExpanded: false,
-          };
+          this.userExpanded[response.recipient] = false;
         }
       }
     }
 
-    for (const user of Object.keys(this.userToTeamName)) {
+    for (const user of Object.keys(this.userExpanded)) {
       for (const question of this.responses) {
-        const questionCopy: any = JSON.parse(JSON.stringify(question));
-        questionCopy.allResponses = questionCopy.allResponses.filter((response: any) => {
+        const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
+        questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (this.isGqr && user !== response.giver) {
             return false;
           }
@@ -121,16 +141,12 @@ export class GqrRqgViewResponsesComponent implements OnInit, OnChanges {
         });
         if (questionCopy.allResponses.length) {
           this.responsesToShow[user] = this.responsesToShow[user] || [];
-          this.responsesToShow[user].push(questionCopy);
+          this.responsesToShow[user].push({
+            questionOutput: questionCopy,
+            isTabExpanded: false,
+          });
         }
       }
     }
-  }
-
-  /**
-   * Get related giver email of specific user in the view.
-   */
-  getRelatedGiverEmailForUser(userInfo: string): string {
-    return Object.values(this.responsesToShow[userInfo])[0].allResponses[0].relatedGiverEmail;
   }
 }

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -8,7 +8,7 @@
       {{ isGrq ? 'From' : 'To' }}: {{ responses[0].allResponses[0][isGrq ? 'giver' : 'recipient']}}
     </div>
     <div class="top-padded">
-      <tm-response-moderation-button *ngIf="!isGrq" [session]="session" [relatedGiverEmail]="'TODO'"></tm-response-moderation-button>
+      <tm-response-moderation-button *ngIf="!isGrq" [session]="session" [relatedGiverEmail]="responses[0].allResponses[0].relatedGiverEmail"></tm-response-moderation-button>
     </div>
   </div>
   <div class="col-md-9">

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.html
@@ -8,7 +8,7 @@
       {{ isGrq ? 'From' : 'To' }}: {{ responses[0].allResponses[0][isGrq ? 'giver' : 'recipient']}}
     </div>
     <div class="top-padded">
-      <tm-response-moderation-button *ngIf="!isGrq" [session]="session" [relatedGiverEmail]="relatedGiverEmail"></tm-response-moderation-button>
+      <tm-response-moderation-button *ngIf="!isGrq" [session]="session" [relatedGiverEmail]="'TODO'"></tm-response-moderation-button>
     </div>
   </div>
   <div class="col-md-9">

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -20,7 +20,7 @@ export class GroupedResponsesComponent implements OnInit {
   @Input() isGrq: boolean = true;
   @Input() header: string = '';
   @Input() session: any = {};
-  @Input() relatedGiverEmail: string = '';
+
   constructor() { }
 
   ngOnInit(): void {

--- a/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
+++ b/src/web/app/components/question-responses/grouped-responses/grouped-responses.component.ts
@@ -1,7 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
 import {
-  InstructorSessionResultSectionType,
-} from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
+  FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+  QuestionOutput,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../../types/api-output';
 
 /**
  * A list of responses grouped in GRQ/RGQ mode.
@@ -13,13 +16,25 @@ import {
 })
 export class GroupedResponsesComponent implements OnInit {
 
-  @Input() responses: any = [];
-  @Input() section: string = '';
-  @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
+  @Input() responses: QuestionOutput[] = [];
 
   @Input() isGrq: boolean = true;
-  @Input() header: string = '';
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   constructor() { }
 

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -24,7 +24,7 @@
             <div class="card-body" *ngIf="userToTeamName[userInfo].isExpanded">
               <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
                 <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-                    [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)">
+                    [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(other)">
                 </tm-grouped-responses>
               </div>
             </div>
@@ -50,7 +50,7 @@
       <div class="card-body" *ngIf="userInfo.value.isExpanded">
         <div class="top-padded" *ngFor="let other of responsesToShow[userInfo.key] | keyvalue">
           <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-              [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRGQRelatedGiverEmailForUser(other)"></tm-grouped-responses>
+              [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(other)"></tm-grouped-responses>
         </div>
       </div>
     </div>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -10,25 +10,11 @@
       </div>
       <div class="card-body" *ngIf="teamExpanded[teamInfo.key]">
 
-        <!-- TODO extract this out -->
         <div *ngFor="let userInfo of teamInfo.value">
-          <div class="card top-padded">
-            <div class="card-header bg-primary text-white" (click)="userToTeamName[userInfo].isExpanded = !userToTeamName[userInfo].isExpanded">
-              {{ isGrq ? 'From' : 'To' }}: {{ userInfo }}
-              <div class="float-right">
-                <tm-response-moderation-button *ngIf="isGrq" [session]="session" [relatedGiverEmail]="getGRQRelatedGiverEmailForUser(userInfo)"></tm-response-moderation-button>
-                <i class="fas fa-chevron-down" *ngIf="!userToTeamName[userInfo].isExpanded"></i>
-                <i class="fas fa-chevron-up" *ngIf="userToTeamName[userInfo].isExpanded"></i>
-              </div>
-            </div>
-            <div class="card-body" *ngIf="userToTeamName[userInfo].isExpanded">
-              <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
-                <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-                    [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(other)">
-                </tm-grouped-responses>
-              </div>
-            </div>
-          </div>
+          <ng-container
+              [ngTemplateOutlet]="userTab"
+              [ngTemplateOutletContext]="{userInfo:userInfo}">
+          </ng-container>
         </div>
 
       </div>
@@ -36,23 +22,30 @@
   </div>
 </div>
 <div *ngIf="!groupByTeam">
-  <div *ngFor="let userInfo of userToTeamName | keyvalue">
-    <div class="card top-padded">
-      <div class="card-header bg-primary text-white" (click)="userInfo.value.isExpanded = !userInfo.value.isExpanded">
-        {{ isGrq ? 'From' : 'To' }}: {{ userInfo.key }}
-        <div class="float-right">
-          <tm-response-moderation-button *ngIf="isGrq" [relatedGiverEmail]="getGRQRelatedGiverEmailForUser(userInfo.key)"></tm-response-moderation-button>
-          <i class="fas fa-chevron-down" *ngIf="!userInfo.value.isExpanded"></i>
-          <i class="fas fa-chevron-up" *ngIf="userInfo.value.isExpanded"></i>
-        </div>
+  <div *ngFor="let userInfo of userExpanded | keyvalue">
+    <ng-container
+        [ngTemplateOutlet]="userTab"
+        [ngTemplateOutletContext]="{userInfo:userInfo.key}">
+    </ng-container>
+  </div>
+</div>
 
+<ng-template #userTab let-userInfo='userInfo'>
+  <div class="card top-padded">
+    <div class="card-header bg-primary text-white" (click)="userExpanded[userInfo] = !userExpanded[userInfo]">
+      {{ isGrq ? 'From' : 'To' }}: {{ userInfo }}
+      <div class="float-right">
+        <tm-response-moderation-button *ngIf="isGrq" [relatedGiverEmail]="userInfo"></tm-response-moderation-button>
+        <i class="fas fa-chevron-down" *ngIf="!userExpanded[userInfo]"></i>
+        <i class="fas fa-chevron-up" *ngIf="userExpanded[userInfo]"></i>
       </div>
-      <div class="card-body" *ngIf="userInfo.value.isExpanded">
-        <div class="top-padded" *ngFor="let other of responsesToShow[userInfo.key] | keyvalue">
-          <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
-              [isGrq]="isGrq" [session]="session" [relatedGiverEmail]="getRelatedGiverEmailForUser(other)"></tm-grouped-responses>
-        </div>
+
+    </div>
+    <div class="card-body" *ngIf="userExpanded[userInfo]">
+      <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
+        <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
+                              [isGrq]="isGrq" [session]="session"></tm-grouped-responses>
       </div>
     </div>
   </div>
-</div>
+</ng-template>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.html
@@ -43,7 +43,7 @@
     </div>
     <div class="card-body" *ngIf="userExpanded[userInfo]">
       <div class="top-padded" *ngFor="let other of responsesToShow[userInfo] | keyvalue">
-        <tm-grouped-responses [header]="other.key" [responses]="other.value" [section]="section" [sectionType]="sectionType"
+        <tm-grouped-responses [responses]="other.value"
                               [isGrq]="isGrq" [session]="session"></tm-grouped-responses>
       </div>
     </div>

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -145,9 +145,9 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
   }
 
   /**
-   * Get first response for specific user in rgq view.
+   * Get first response for specific user in the view.
    */
-  getRGQRelatedGiverEmailForUser(other: any): any {
+  getRelatedGiverEmailForUser(other: any): any {
     return other.value[0].allResponses[0].relatedGiverEmail;
   }
 }

--- a/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
+++ b/src/web/app/components/question-responses/grq-rgq-view-responses/grq-rgq-view-responses.component.ts
@@ -1,5 +1,12 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import {
+  FeedbackSession,
+  FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus, QuestionOutput, ResponseOutput,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../../types/api-output';
+import {
   InstructorSessionResultSectionType,
 } from '../../../pages-instructor/instructor-session-result-page/instructor-session-result-section-type.enum';
 
@@ -13,20 +20,37 @@ import {
 })
 export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
 
-  @Input() responses: any[] = [];
+  @Input() responses: QuestionOutput[] = [];
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
   @Input() showStatistics: boolean = true;
   @Input() indicateMissingResponses: boolean = true;
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   @Input() isGrq: boolean = true;
 
   teamsToUsers: Record<string, string[]> = {};
+
   teamExpanded: Record<string, boolean> = {};
-  userToTeamName: Record<string, any> = {};
-  responsesToShow: Record<string, Record<string, any[]>> = {};
+  userExpanded: Record<string, boolean> = {};
+
+  responsesToShow: Record<string, Record<string, QuestionOutput[]>> = {};
 
   constructor() { }
 
@@ -42,7 +66,7 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
     this.responsesToShow = {};
     this.teamsToUsers = {};
     this.teamExpanded = {};
-    this.userToTeamName = {};
+    this.userExpanded = {};
     for (const question of this.responses) {
       for (const response of question.allResponses) {
         if (this.isGrq) {
@@ -51,10 +75,7 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
             this.teamsToUsers[response.giverTeam].push(response.giver);
             this.teamExpanded[response.giverTeam] = false;
           }
-          this.userToTeamName[response.giver] = {
-            teamName: response.giverTeam,
-            isExpanded: false,
-          };
+          this.userExpanded[response.giver] = false;
         } else {
           if (!response.recipientTeam) {
             // Recipient is team
@@ -63,10 +84,7 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
               this.teamsToUsers[response.recipient].push(response.recipient);
               this.teamExpanded[response.recipient] = false;
             }
-            this.userToTeamName[response.recipient] = {
-              teamName: response.recipient,
-              isExpanded: false,
-            };
+            this.userExpanded[response.recipient] = false;
             continue;
           }
           this.teamsToUsers[response.recipientTeam] = this.teamsToUsers[response.recipientTeam] || [];
@@ -74,18 +92,15 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
             this.teamsToUsers[response.recipientTeam].push(response.recipient);
             this.teamExpanded[response.recipientTeam] = false;
           }
-          this.userToTeamName[response.recipient] = {
-            teamName: response.recipientTeam,
-            isExpanded: false,
-          };
+          this.userExpanded[response.recipient] = false;
         }
       }
     }
 
-    for (const user of Object.keys(this.userToTeamName)) {
+    for (const user of Object.keys(this.userExpanded)) {
       for (const question of this.responses) {
-        const questionCopy: any = JSON.parse(JSON.stringify(question));
-        questionCopy.allResponses = questionCopy.allResponses.filter((response: any) => {
+        const questionCopy: QuestionOutput = JSON.parse(JSON.stringify(question));
+        questionCopy.allResponses = questionCopy.allResponses.filter((response: ResponseOutput) => {
           if (this.isGrq && user !== response.giver) {
             return false;
           }
@@ -120,12 +135,12 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
           return true;
         });
         if (questionCopy.allResponses.length) {
-          const others: any[] = questionCopy.allResponses.map((response: any) => {
+          const others: string[] = questionCopy.allResponses.map((response: ResponseOutput) => {
             return this.isGrq ? response.recipient : response.giver;
           });
           for (const other of others) {
-            const questionCopy2: any = JSON.parse(JSON.stringify(questionCopy));
-            questionCopy2.allResponses = questionCopy2.allResponses.filter((response: any) => {
+            const questionCopy2: QuestionOutput = JSON.parse(JSON.stringify(questionCopy));
+            questionCopy2.allResponses = questionCopy2.allResponses.filter((response: ResponseOutput) => {
               return this.isGrq ? response.recipient === other : response.giver === other;
             });
             this.responsesToShow[user] = this.responsesToShow[user] || {};
@@ -135,19 +150,5 @@ export class GrqRgqViewResponsesComponent implements OnInit, OnChanges {
         }
       }
     }
-  }
-
-  /**
-   * Get first response for specific user in grq view.
-   */
-  getGRQRelatedGiverEmailForUser(userInfo: string): any {
-    return Object.values(this.responsesToShow[userInfo])[0][0].allResponses[0].relatedGiverEmail;
-  }
-
-  /**
-   * Get first response for specific user in the view.
-   */
-  getRelatedGiverEmailForUser(other: any): any {
-    return other.value[0].allResponses[0].relatedGiverEmail;
   }
 }

--- a/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
+++ b/src/web/app/components/question-responses/per-question-view-responses/per-question-view-responses.component.ts
@@ -1,6 +1,11 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { TableComparatorService } from '../../../../services/table-comparator.service';
-import { ResponseOutput } from '../../../../types/api-output';
+import {
+  FeedbackQuestionDetails,
+  FeedbackQuestionType,
+  FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+  ResponseOutput, ResponseVisibleSetting, SessionVisibleSetting,
+} from '../../../../types/api-output';
 import { SortBy, SortOrder } from '../../../../types/sort-properties';
 import {
   InstructorSessionResultSectionType,
@@ -20,17 +25,35 @@ export class PerQuestionViewResponsesComponent implements OnInit, OnChanges {
   SortOrder: typeof SortOrder = SortOrder;
 
   @Input() questionId: string = '';
-  @Input() questionDetails: any = {};
-  @Input() responses: any[] = [];
+  @Input() questionDetails: FeedbackQuestionDetails = {
+    questionType: FeedbackQuestionType.TEXT,
+    questionText: '',
+  };
+  @Input() responses: ResponseOutput[] = [];
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
   @Input() indicateMissingResponses: boolean = true;
   @Input() showGiver: boolean = true;
   @Input() showRecipient: boolean = true;
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
-  responsesToShow: any[] = [];
+  responsesToShow: ResponseOutput[] = [];
   sortBy: SortBy = SortBy.NONE;
   sortOrder: SortOrder = SortOrder.ASC;
 
@@ -45,7 +68,7 @@ export class PerQuestionViewResponsesComponent implements OnInit, OnChanges {
   }
 
   private filterResponses(): void {
-    const responsesToShow: any[] = [];
+    const responsesToShow: ResponseOutput[] = [];
     for (const response of this.responses) {
       if (this.section) {
         let shouldDisplayBasedOnSection: boolean = true;

--- a/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
+++ b/src/web/app/components/question-responses/student-view-responses/student-view-responses.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { FeedbackQuestionDetails, FeedbackQuestionType, ResponseOutput } from '../../../../types/api-output';
 
 /**
  * Feedback response in student results page view.
@@ -10,8 +11,11 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class StudentViewResponsesComponent implements OnInit {
 
-  @Input() questionDetails: any = {};
-  @Input() responses: any[] = [];
+  @Input() questionDetails: FeedbackQuestionDetails = {
+    questionType: FeedbackQuestionType.TEXT,
+    questionText: '',
+  };
+  @Input() responses: ResponseOutput[] = [];
   @Input() isSelfResponses: boolean = false;
 
   recipient: string = '';

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-no-response-panel.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input, OnChanges, OnInit } from '@angular/core';
-import { Student } from '../../../types/api-output';
+import {
+  FeedbackSession, FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+  Student,
+} from '../../../types/api-output';
 
 /**
  * Instructor sessions results page No Response Panel.
@@ -13,7 +19,22 @@ export class InstructorSessionNoResponsePanelComponent implements OnInit, OnChan
 
   @Input() noResponseStudents: Student[] = [];
   @Input() section: string = '';
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
   isTabExpanded: boolean = false;
 
   noResponseStudentsInSection: Student[] = [];

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleSectionTab(sectionInfo.key, sectionInfo.value)">
+    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-gqr-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SectionTabModel } from './instructor-session-result-page.component';
 import { InstructorSessionResultView } from './instructor-session-result-view';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -15,37 +16,9 @@ export class InstructorSessionResultGqrViewComponent extends InstructorSessionRe
   @Output()
   loadSection: EventEmitter<string> = new EventEmitter();
 
+  @Input() responses: Record<string, SectionTabModel> = {};
+
   constructor() {
     super(InstructorSessionResultViewType.GQR);
   }
-
-  /**
-   * Toggles the tab of the specified section.
-   */
-  toggleSectionTab(sectionName: string, section: any): void {
-    section.isTabExpanded = !section.isTabExpanded;
-    if (section.isTabExpanded) {
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Expands the tab of all sections.
-   */
-  expandAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = true;
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Collapses the tab of all sections.
-   */
-  collapseAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = false;
-    }
-  }
-
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleSectionTab(sectionInfo.key, sectionInfo.value)">
+    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-grq-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SectionTabModel } from './instructor-session-result-page.component';
 import { InstructorSessionResultView } from './instructor-session-result-view';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -15,37 +16,10 @@ export class InstructorSessionResultGrqViewComponent extends InstructorSessionRe
   @Output()
   loadSection: EventEmitter<string> = new EventEmitter();
 
+  @Input() responses: Record<string, SectionTabModel> = {};
+
   constructor() {
     super(InstructorSessionResultViewType.GRQ);
-  }
-
-  /**
-   * Toggles the tab of the specified section.
-   */
-  toggleSectionTab(sectionName: string, section: any): void {
-    section.isTabExpanded = !section.isTabExpanded;
-    if (section.isTabExpanded) {
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Expands the tab of all sections.
-   */
-  expandAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = true;
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Collapses the tab of all sections.
-   */
-  collapseAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = false;
-    }
   }
 
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -58,12 +58,12 @@
           View:
         </label>
         <div>
-          <select class="form-control" [(ngModel)]="viewType">
-            <option value="QUESTION">Group by - Question</option>
-            <option value="GRQ">Group by - Giver > Recipient > Question</option>
-            <option value="RGQ">Group by - Recipient > Giver > Question</option>
-            <option value="GQR">Group by - Giver > Question > Recipient</option>
-            <option value="RQG">Group by - Recipient > Question > Giver</option>
+          <select class="form-control" [ngModel]="viewType" (ngModelChange)="handleViewTypeChange($event)">
+            <option [value]="InstructorSessionResultViewType.QUESTION">Group by - Question</option>
+            <option [value]="InstructorSessionResultViewType.GRQ">Group by - Giver > Recipient > Question</option>
+            <option [value]="InstructorSessionResultViewType.RGQ">Group by - Recipient > Giver > Question</option>
+            <option [value]="InstructorSessionResultViewType.GQR">Group by - Giver > Question > Recipient</option>
+            <option [value]="InstructorSessionResultViewType.RQG">Group by - Recipient > Question > Giver</option>
           </select>
         </div>
       </div>
@@ -119,32 +119,32 @@
 </div>
 
 <div class="top-padded col-md-2 offset-md-10">
-  <button class="btn expand-btn action-btn btn-light" (click)="expandAllHandler()">
+  <button class="btn expand-btn action-btn btn-light" (click)="toggleExpandAllHandler()">
     {{this.isExpandAll ? "Collapse": "Expand"}} All
   </button>
 </div>
 
 <div *ngIf="isSectionsLoaded && isQuestionsLoaded">
-  <tm-instructor-session-result-question-view *ngIf="viewType === 'QUESTION'" [responses]="questionsModel"
+  <tm-instructor-session-result-question-view *ngIf="viewType === InstructorSessionResultViewType.QUESTION" [questions]="questionsModel"
       [section]="section" [sectionType]="sectionType" [session] = "session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadQuestion)="loadQuestion($event)"></tm-instructor-session-result-question-view>
-  <tm-instructor-session-result-grq-view *ngIf="viewType === 'GRQ'" [responses]="sectionsModel"
+      (toggleAndLoadTab)="toggleQuestionTab($event)"></tm-instructor-session-result-question-view>
+  <tm-instructor-session-result-grq-view *ngIf="viewType === InstructorSessionResultViewType.GRQ" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-grq-view>
-  <tm-instructor-session-result-rgq-view *ngIf="viewType === 'RGQ'" [responses]="sectionsModel"
+      (toggleAndLoadTab)="toggleSectionTab($event)"></tm-instructor-session-result-grq-view>
+  <tm-instructor-session-result-rgq-view *ngIf="viewType === InstructorSessionResultViewType.RGQ" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-rgq-view>
-  <tm-instructor-session-result-gqr-view *ngIf="viewType === 'GQR'" [responses]="sectionsModel"
+      (toggleAndLoadTab)="toggleSectionTab($event)"></tm-instructor-session-result-rgq-view>
+  <tm-instructor-session-result-gqr-view *ngIf="viewType === InstructorSessionResultViewType.GQR" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-gqr-view>
-  <tm-instructor-session-result-rqg-view *ngIf="viewType === 'RQG'" [responses]="sectionsModel"
+      (toggleAndLoadTab)="toggleSectionTab($event)"></tm-instructor-session-result-gqr-view>
+  <tm-instructor-session-result-rqg-view *ngIf="viewType === InstructorSessionResultViewType.RQG" [responses]="sectionsModel"
       [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
-      (loadSection)="loadSection($event)"></tm-instructor-session-result-rqg-view>
+      (toggleAndLoadTab)="toggleSectionTab($event)"></tm-instructor-session-result-rqg-view>
 </div>
 
 <div class="card top-padded" *ngIf="isNoResponsePanelLoaded">

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-page.component.html
@@ -130,19 +130,19 @@
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
       (loadQuestion)="loadQuestion($event)"></tm-instructor-session-result-question-view>
   <tm-instructor-session-result-grq-view *ngIf="viewType === 'GRQ'" [responses]="sectionsModel"
-      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
+      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
       (loadSection)="loadSection($event)"></tm-instructor-session-result-grq-view>
   <tm-instructor-session-result-rgq-view *ngIf="viewType === 'RGQ'" [responses]="sectionsModel"
-      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
+      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
       (loadSection)="loadSection($event)"></tm-instructor-session-result-rgq-view>
   <tm-instructor-session-result-gqr-view *ngIf="viewType === 'GQR'" [responses]="sectionsModel"
-      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
+      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
       (loadSection)="loadSection($event)"></tm-instructor-session-result-gqr-view>
   <tm-instructor-session-result-rqg-view *ngIf="viewType === 'RQG'" [responses]="sectionsModel"
-      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session] = "session"
+      [section]="section" [sectionType]="sectionType" [groupByTeam]="groupByTeam" [session]="session"
       [showStatistics]="showStatistics" [indicateMissingResponses]="indicateMissingResponses"
       (loadSection)="loadSection($event)"></tm-instructor-session-result-rqg-view>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -1,6 +1,6 @@
 <div class="card margin-bottom-15px" *ngFor="let question of questionsOrder">
-  <div class="card-header bg-info text-white course-tab-header" (click)="toggleQuestionTab(question)">
-    <tm-question-text-with-info [questionNumber]="question.questionNumber" [questionDetails]="question.questionDetails" (click)="$event.stopPropagation()"></tm-question-text-with-info>
+  <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(question.question.feedbackQuestionId)">
+    <tm-question-text-with-info [questionNumber]="question.question.questionNumber" [questionDetails]="question.question.questionDetails" (click)="$event.stopPropagation()"></tm-question-text-with-info>
     <div class="float-right">
       <i class="fas fa-chevron-down" *ngIf="!question.isTabExpanded"></i>
       <i class="fas fa-chevron-up" *ngIf="question.isTabExpanded"></i>
@@ -8,6 +8,6 @@
   </div>
   <div class="card-body" *ngIf="question.isTabExpanded">
     <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
-                                    [indicateMissingResponses]="true" [questionDetails]="question.questionDetails" [questionId]='question.feedbackQuestionId'></tm-per-question-view-responses>
+                                    [indicateMissingResponses]="true" [questionDetails]="question.question.questionDetails" [questionId]='question.question.feedbackQuestionId'></tm-per-question-view-responses>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.html
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="card-body" *ngIf="question.isTabExpanded">
-    <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session "
+    <tm-per-question-view-responses [responses]="question.responses" [section]="section" [sectionType]="sectionType" [session]="session"
                                     [indicateMissingResponses]="true" [questionDetails]="question.questionDetails" [questionId]='question.feedbackQuestionId'></tm-per-question-view-responses>
   </div>
 </div>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-question-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { QuestionTabModel } from './instructor-session-result-page.component';
 import { InstructorSessionResultView } from './instructor-session-result-view';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -10,51 +11,32 @@ import { InstructorSessionResultViewType } from './instructor-session-result-vie
   templateUrl: './instructor-session-result-question-view.component.html',
   styleUrls: ['./instructor-session-result-question-view.component.scss'],
 })
-export class InstructorSessionResultQuestionViewComponent extends InstructorSessionResultView implements OnInit {
+export class InstructorSessionResultQuestionViewComponent
+    extends InstructorSessionResultView implements OnInit, OnChanges {
 
   @Output()
   loadQuestion: EventEmitter<string> = new EventEmitter();
 
-  questionsOrder: any[] = [];
+  @Input() questions: Record<string, QuestionTabModel> = {};
+
+  questionsOrder: QuestionTabModel[] = [];
 
   constructor() {
     super(InstructorSessionResultViewType.QUESTION);
   }
 
   ngOnInit(): void {
-    for (const questionId of Object.keys(this.responses)) {
-      const response: any = this.responses[questionId];
-      this.questionsOrder[response.questionNumber] = response;
-    }
-    this.questionsOrder = this.questionsOrder.filter((questionId: string) => questionId);
+    this.sortQuestion();
   }
 
-  /**
-   * Toggles the tab of the specified question.
-   */
-  toggleQuestionTab(question: any): void {
-    question.isTabExpanded = !question.isTabExpanded;
-    if (question.isTabExpanded) {
-      this.loadQuestion.emit(question.feedbackQuestionId);
-    }
+  ngOnChanges(): void {
+    this.sortQuestion();
   }
 
-  /**
-   * Expands the tab for all questions.
-   */
-  expandAllQuestionTabs(): void {
-    for (const question of this.questionsOrder) {
-      question.isTabExpanded = true;
-      this.loadQuestion.emit(question.feedbackQuestionId);
-    }
-  }
-
-  /**
-   * Collapses the tab for all questions.
-   */
-  collapseAllQuestionTabs(): void {
-    for (const question of this.questionsOrder) {
-      question.isTabExpanded = false;
-    }
+  sortQuestion(): void {
+    this.questionsOrder = Object.values(this.questions)
+        .sort((val1: QuestionTabModel, val2: QuestionTabModel) => {
+          return val1.question.questionNumber - (val2.question.questionNumber);
+        });
   }
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleSectionTab(sectionInfo.key, sectionInfo.value)">
+    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rgq-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SectionTabModel } from './instructor-session-result-page.component';
 import { InstructorSessionResultView } from './instructor-session-result-view';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -15,37 +16,10 @@ export class InstructorSessionResultRgqViewComponent extends InstructorSessionRe
   @Output()
   loadSection: EventEmitter<string> = new EventEmitter();
 
+  @Input() responses: Record<string, SectionTabModel> = {};
+
   constructor() {
     super(InstructorSessionResultViewType.RGQ);
-  }
-
-  /**
-   * Toggles the tab of the specified section.
-   */
-  toggleSectionTab(sectionName: string, section: any): void {
-    section.isTabExpanded = !section.isTabExpanded;
-    if (section.isTabExpanded) {
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Expands the tab of all sections.
-   */
-  expandAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = true;
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Collapses the tab of all sections.
-   */
-  collapseAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = false;
-    }
   }
 
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.html
@@ -1,6 +1,6 @@
 <div *ngFor="let sectionInfo of responses | keyvalue">
   <div class="card margin-bottom-15px" *ngIf="!section || (sectionInfo.key == section)">
-    <div class="card-header bg-info text-white course-tab-header" (click)="toggleSectionTab(sectionInfo.key, sectionInfo.value)">
+    <div class="card-header bg-info text-white course-tab-header" (click)="toggleAndLoadTab.emit(sectionInfo.key)">
       {{ sectionInfo.key }}
       <div class="float-right">
         <i class="fas fa-chevron-down" *ngIf="!sectionInfo.value.isTabExpanded"></i>

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-rqg-view.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { SectionTabModel } from './instructor-session-result-page.component';
 import { InstructorSessionResultView } from './instructor-session-result-view';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -15,37 +16,10 @@ export class InstructorSessionResultRqgViewComponent extends InstructorSessionRe
   @Output()
   loadSection: EventEmitter<string> = new EventEmitter();
 
+  @Input() responses: Record<string, SectionTabModel> = {};
+
   constructor() {
     super(InstructorSessionResultViewType.RQG);
-  }
-
-  /**
-   * Toggles the tab of the specified section.
-   */
-  toggleSectionTab(sectionName: string, section: any): void {
-    section.isTabExpanded = !section.isTabExpanded;
-    if (section.isTabExpanded) {
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Expands the tab of all sections.
-   */
-  expandAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = true;
-      this.loadSection.emit(sectionName);
-    }
-  }
-
-  /**
-   * Collapses the tab of all sections.
-   */
-  collapseAllSectionTabs(): void {
-    for (const sectionName of Object.keys(this.responses)) {
-      this.responses[sectionName].isTabExpanded = false;
-    }
   }
 
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view-type.enum.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view-type.enum.ts
@@ -6,26 +6,26 @@ export enum InstructorSessionResultViewType {
   /**
    * Organize responses by questions.
    */
-  QUESTION,
+  QUESTION = 'QUESTION',
 
   /**
    * Organize responses by giver name, then recipient name, then questions.
    */
-  GRQ,
+  GRQ = 'GRQ',
 
   /**
    * Organize responses by recipient name, then giver name, then questions.
    */
-  RGQ,
+  RGQ = 'RGQ',
 
   /**
    * Organize responses by giver name, then questions.
    */
-  GQR,
+  GQR = 'GQR',
 
   /**
    * Organize responses by recipient name, then questions.
    */
-  RQG,
+  RQG = 'RQG',
 
 }

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -1,4 +1,4 @@
-import { Input, OnInit } from '@angular/core';
+import { EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { InstructorSessionResultSectionType } from './instructor-session-result-section-type.enum';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -7,13 +7,14 @@ import { InstructorSessionResultViewType } from './instructor-session-result-vie
  */
 export abstract class InstructorSessionResultView implements OnInit {
 
-  @Input() responses: Record<string, any> = {};
   @Input() section: string = '';
   @Input() sectionType: InstructorSessionResultSectionType = InstructorSessionResultSectionType.EITHER;
   @Input() groupByTeam: boolean = true;
   @Input() showStatistics: boolean = true;
   @Input() indicateMissingResponses: boolean = true;
   @Input() session: any = {};
+
+  @Output() toggleAndLoadTab: EventEmitter<string> = new EventEmitter<string>();
 
   constructor(protected viewType: InstructorSessionResultViewType) {}
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/instructor-session-result-view.ts
@@ -1,4 +1,11 @@
 import { EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  FeedbackSession,
+  FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../types/api-output';
 import { InstructorSessionResultSectionType } from './instructor-session-result-section-type.enum';
 import { InstructorSessionResultViewType } from './instructor-session-result-view-type.enum';
 
@@ -12,7 +19,22 @@ export abstract class InstructorSessionResultView implements OnInit {
   @Input() groupByTeam: boolean = true;
   @Input() showStatistics: boolean = true;
   @Input() indicateMissingResponses: boolean = true;
-  @Input() session: any = {};
+  @Input() session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   @Output() toggleAndLoadTab: EventEmitter<string> = new EventEmitter<string>();
 

--- a/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
+++ b/src/web/app/pages-instructor/instructor-session-result-page/response-moderation-button/response-moderation-button.component.ts
@@ -1,4 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
+import {
+  FeedbackSession, FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../../types/api-output';
 import { ANONYMOUS_PREFIX } from '../../../../types/feedback-response-details';
 
 /**
@@ -12,7 +18,22 @@ import { ANONYMOUS_PREFIX } from '../../../../types/feedback-response-details';
 export class ResponseModerationButtonComponent implements OnInit {
 
   @Input()
-  session: any = {};
+  session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
 
   @Input()
   relatedGiverEmail: string = '';

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -4,7 +4,13 @@ import moment from 'moment-timezone';
 import { FeedbackSessionsService } from '../../../services/feedback-sessions.service';
 import { StatusMessageService } from '../../../services/status-message.service';
 import { TimezoneService } from '../../../services/timezone.service';
-import { FeedbackSession, QuestionOutput, SessionResults } from '../../../types/api-output';
+import {
+  FeedbackSession, FeedbackSessionPublishStatus, FeedbackSessionSubmissionStatus,
+  QuestionOutput,
+  ResponseVisibleSetting,
+  SessionResults,
+  SessionVisibleSetting,
+} from '../../../types/api-output';
 import { Intent } from '../../../types/api-request';
 import { ErrorMessageOutput } from '../../error-message-output';
 
@@ -18,7 +24,22 @@ import { ErrorMessageOutput } from '../../error-message-output';
 })
 export class SessionResultPageComponent implements OnInit {
 
-  session: any = {};
+  session: FeedbackSession = {
+    courseId: '',
+    timeZone: '',
+    feedbackSessionName: '',
+    instructions: '',
+    submissionStartTimestamp: 0,
+    submissionEndTimestamp: 0,
+    gracePeriod: 0,
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+    createdAtTimestamp: 0,
+  };
   questions: QuestionOutput[] = [];
   formattedSessionOpeningTime: string = '';
   formattedSessionClosingTime: string = '';
@@ -35,9 +56,9 @@ export class SessionResultPageComponent implements OnInit {
         courseId,
         feedbackSessionName,
         intent: Intent.STUDENT_RESULT,
-      }).subscribe((resp: FeedbackSession) => {
+      }).subscribe((feedbackSession: FeedbackSession) => {
         const TIME_FORMAT: string = 'ddd, DD MMM, YYYY, hh:mm A zz';
-        this.session = resp;
+        this.session = feedbackSession;
         this.formattedSessionOpeningTime =
             moment(this.session.submissionStartTimestamp).tz(this.session.timeZone).format(TIME_FORMAT);
         this.formattedSessionClosingTime =
@@ -46,11 +67,11 @@ export class SessionResultPageComponent implements OnInit {
           courseId,
           feedbackSessionName,
           intent: Intent.STUDENT_RESULT,
-        }).subscribe((resp2: SessionResults) => {
-          this.questions = resp2.questions.sort(
+        }).subscribe((sessionResults: SessionResults) => {
+          this.questions = sessionResults.questions.sort(
               (a: QuestionOutput, b: QuestionOutput) => a.questionNumber - b.questionNumber);
-        }, (resp2: ErrorMessageOutput) => {
-          this.statusMessageService.showErrorMessage(resp2.error.message);
+        }, (resp: ErrorMessageOutput) => {
+          this.statusMessageService.showErrorMessage(resp.error.message);
         });
       }, (resp: ErrorMessageOutput) => {
         this.statusMessageService.showErrorMessage(resp.error.message);


### PR DESCRIPTION
Part of #9382

**Outline of Solution**

Using concrete type in TypeScript rather than `any` will provided many benefits. I believe it would be easier for others (especially the summer interns) to get involved in the result page migration (as the IDE will pop out proper type definition when needed).

The commits are very organized and can be reviewed one by one.