### PR TITLE
[#9382] Add example for create feedback session form to help page for instructors

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -8,6 +8,9 @@ import { StudentProfileModule } from '../../pages-instructor/student-profile/stu
 import { InstructorHelpPageComponent } from './instructor-help-page.component';
 
 import {
+  SessionEditFormModule,
+} from '../../components/session-edit-form/session-edit-form.module';
+import {
   InstructorCourseStudentEditPageModule,
 } from '../../pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.module';
 import {
@@ -16,6 +19,9 @@ import {
 import {
   InstructorSearchPageModule,
 } from '../../pages-instructor/instructor-search-page/instructor-search-page.module';
+import {
+  InstructorSessionEditPageModule,
+} from '../../pages-instructor/instructor-session-edit-page/instructor-session-edit-page.module';
 import { ExampleBoxComponent } from './example-box/example-box.component';
 import {
   InstructorHelpCoursesSectionComponent,
@@ -47,6 +53,8 @@ import {
     InstructorSearchPageModule,
     InstructorCourseStudentEditPageModule,
     InstructorCoursesPageModule,
+    InstructorSessionEditPageModule,
+    SessionEditFormModule,
   ],
   declarations: [
     InstructorHelpPageComponent,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -135,7 +135,13 @@
           <p>
             This is the form used to set up sessions.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <tm-session-edit-form [formMode]="SessionEditFormMode.ADD"
+                                  [model]="exampleSessionEditFormModel"
+                                  [courseCandidates]="exampleCourseCandidates"
+                                  [templateSessions]="exampleTemplateSessions">
+            </tm-session-edit-form>
+          </tm-example-box>
         </div>
       </div>
       <br/>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -1,8 +1,27 @@
+import { Component, Input } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPageScrollCoreModule } from 'ngx-page-scroll-core';
+
+import { TemplateSession } from '../../../../services/feedback-sessions.service';
+import { Course } from '../../../../types/api-output';
+import {
+  SessionEditFormMode,
+  SessionEditFormModel,
+} from '../../../components/session-edit-form/session-edit-form-model';
 import { InstructorHelpSessionsSectionComponent } from './instructor-help-sessions-section.component';
+
+@Component({ selector: 'tm-example-box', template: '' })
+class ExampleBoxStubComponent {}
+@Component({ selector: 'tm-session-edit-form', template: '' })
+class SessionEditFormStubComponent {
+  @Input() formMode: SessionEditFormMode = SessionEditFormMode.ADD;
+  @Input() model: SessionEditFormModel = {} as SessionEditFormModel;
+  @Input() courseCandidates: Course[] = [];
+  @Input() templateSessions: TemplateSession[] = [];
+}
 
 describe('InstructorHelpSessionsSectionComponent', () => {
   let component: InstructorHelpSessionsSectionComponent;
@@ -10,7 +29,7 @@ describe('InstructorHelpSessionsSectionComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [InstructorHelpSessionsSectionComponent],
+      declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxStubComponent, SessionEditFormStubComponent],
       imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule],
     })
     .compileComponents();

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -1,26 +1,13 @@
-import { Component, Input } from "@angular/core";
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPageScrollCoreModule } from 'ngx-page-scroll-core';
 
-import { TemplateSession } from '../../../../services/feedback-sessions.service';
-import { Course } from '../../../../types/api-output';
-import {
-  SessionEditFormMode,
-  SessionEditFormModel,
-} from '../../../components/session-edit-form/session-edit-form-model';
+import { SessionEditFormModule } from '../../../components/session-edit-form/session-edit-form.module';
+import { ExampleBoxComponent } from '../example-box/example-box.component';
 import { InstructorHelpSessionsSectionComponent } from './instructor-help-sessions-section.component';
-import { ExampleBoxComponent } from "../example-box/example-box.component";
-
-@Component({ selector: 'tm-session-edit-form', template: '' })
-class SessionEditFormStubComponent {
-  @Input() formMode: SessionEditFormMode = SessionEditFormMode.ADD;
-  @Input() model: SessionEditFormModel = {} as SessionEditFormModel;
-  @Input() courseCandidates: Course[] = [];
-  @Input() templateSessions: TemplateSession[] = [];
-}
 
 describe('InstructorHelpSessionsSectionComponent', () => {
   let component: InstructorHelpSessionsSectionComponent;
@@ -28,8 +15,8 @@ describe('InstructorHelpSessionsSectionComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxComponent, SessionEditFormStubComponent],
-      imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule],
+      declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxComponent],
+      imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule, SessionEditFormModule, MatSnackBarModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input } from "@angular/core";
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -12,9 +12,8 @@ import {
   SessionEditFormModel,
 } from '../../../components/session-edit-form/session-edit-form-model';
 import { InstructorHelpSessionsSectionComponent } from './instructor-help-sessions-section.component';
+import { ExampleBoxComponent } from "../example-box/example-box.component";
 
-@Component({ selector: 'tm-example-box', template: '' })
-class ExampleBoxStubComponent {}
 @Component({ selector: 'tm-session-edit-form', template: '' })
 class SessionEditFormStubComponent {
   @Input() formMode: SessionEditFormMode = SessionEditFormMode.ADD;
@@ -29,7 +28,7 @@ describe('InstructorHelpSessionsSectionComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxStubComponent, SessionEditFormStubComponent],
+      declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxComponent, SessionEditFormStubComponent],
       imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule],
     })
     .compileComponents();

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -1,6 +1,18 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, Inject, Input, OnInit } from '@angular/core';
 import { PageScrollService } from 'ngx-page-scroll-core';
+
+import { TemplateSession } from '../../../../services/feedback-sessions.service';
+import {
+  Course,
+  FeedbackSessionPublishStatus,
+  FeedbackSessionSubmissionStatus,
+  ResponseVisibleSetting,
+  SessionVisibleSetting,
+} from '../../../../types/api-output';
+import {
+  SessionEditFormMode, SessionEditFormModel,
+} from '../../../components/session-edit-form/session-edit-form-model';
 import { InstructorHelpSectionComponent } from '../instructor-help-section.component';
 
 /**
@@ -12,6 +24,61 @@ import { InstructorHelpSectionComponent } from '../instructor-help-section.compo
   styleUrls: ['./instructor-help-sessions-section.component.scss'],
 })
 export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectionComponent implements OnInit {
+
+  // enum
+  SessionEditFormMode: typeof SessionEditFormMode = SessionEditFormMode;
+
+  readonly exampleSessionEditFormModel: SessionEditFormModel = {
+    courseId: 'CS2103T',
+    timeZone: 'UTC',
+    courseName: 'Software Engineering',
+    feedbackSessionName: 'Feedback for Project',
+    instructions: 'This is where you type the instructions for the session',
+
+    submissionStartTime: { hour: 10, minute: 0 },
+    submissionStartDate: { year: 2020, month: 3, day: 13 },
+    submissionEndTime: { hour: 12, minute: 0 },
+    submissionEndDate: { year: 2020, month: 3, day: 13 },
+    gracePeriod: 0,
+
+    sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+    customSessionVisibleTime: { hour: 9, minute: 0 },
+    customSessionVisibleDate: { year: 2020, month: 3, day: 13 },
+
+    responseVisibleSetting: ResponseVisibleSetting.CUSTOM,
+    customResponseVisibleTime: { hour: 13, minute: 0 },
+    customResponseVisibleDate: { year: 2020, month: 3, day: 13 },
+
+    submissionStatus: FeedbackSessionSubmissionStatus.OPEN,
+    publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+
+    isClosingEmailEnabled: true,
+    isPublishedEmailEnabled: true,
+
+    templateSessionName: 'Example session',
+
+    isSaving: false,
+    isEditable: false,
+    hasVisibleSettingsPanelExpanded: true,
+    hasEmailSettingsPanelExpanded: true,
+  };
+
+  readonly exampleCourseCandidates: Course[] = [
+    {
+      courseId: 'CS2103T',
+      courseName: 'Software Engineering',
+      timeZone: 'UTC',
+      creationTimestamp: 0,
+      deletionTimestamp: 0,
+    },
+  ];
+
+  readonly exampleTemplateSessions: TemplateSession[] = [
+    {
+      name: 'Example session',
+      questions: [],
+    },
+  ];
 
   @Input() isPeerEvalTipsCollapsed: boolean = false;
   isNewFeedbackSessionCollapsed: boolean = false;
@@ -44,5 +111,4 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
     });
     return false;
   }
-
 }


### PR DESCRIPTION
Part of #9382 

**Outline of Solution**
Added in the create new feedback session form. Screenshot shown below:

![image](https://user-images.githubusercontent.com/28994607/82194136-ea7ca400-9928-11ea-91c5-cd0c1b5157e8.png)

Also, the box displaying the course ID seems to be not displaying in full for the form. It is a simple fix to the bootstrap classes in the template files. Should I resolve it within this PR or open another issue/PR for this?