### PR TITLE
[#10072] Session edit form UI is not ideal

### DIFF
--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -314,21 +314,21 @@
         </div>
         <br>
         <div class="row">
-          <div class="col-3">
+          <div class="col-md-4">
             <div class="form-check form-check-inline">
               <label class="form-check-label" ngbTooltip="Select this option to automatically send an email to students to notify them when the session is open for submission.">
                 <input class="form-check-input" type="checkbox" checked disabled>Session opening reminder
               </label>
             </div>
           </div>
-          <div class="col-3">
+          <div class="col-md-4">
             <div class="form-check form-check-inline">
               <label class="form-check-label" ngbTooltip="Select this option to automatically send an email to students to remind them to submit 24 hours before the end of the session.">
                 <input class="form-check-input" type="checkbox" [ngModel]="model.isClosingEmailEnabled" (ngModelChange)="triggerModelChange('isClosingEmailEnabled', $event)" [disabled]="!model.isEditable"> Session closing reminder
               </label>
             </div>
           </div>
-          <div class="col-4">
+          <div class="col-md-4">
             <div class="form-check form-check-inline">
               <label class="form-check-label" ngbTooltip="Select this option to automatically send an email to students to notify them when the session results is published.">
                 <input class="form-check-input" type="checkbox" [ngModel]="model.isPublishedEmailEnabled" (ngModelChange)="triggerModelChange('isPublishedEmailEnabled', $event)" [disabled]="!model.isEditable"> Results published announcement

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -213,105 +213,88 @@
       <div class="card-body">
         <div class="row text-center">
           <div class="col-md-6">
-            <div class="row">
-              <div class="col-md-4 col-xs-3">
+            <div class="col-12 text-md-left">
+              <div>
                 <label class="label-control font-bold" ngbTooltip="Please select when you want the questions for the feedback session to be visible to users who need to participate. Note that users cannot submit their responses until the submissions opening time set below.">Make session visible </label>
               </div>
             </div>
-            <div class="row text-center">
-              <div class="col-12">
-                <div class="row align-items-center">
-                  <div class="col-md-2" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
-                    <div class="form-check">
-                      <label class="form-check-label">
-                        <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.CUSTOM" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
-                        At
-                      </label>
-                    </div>
-                  </div>
-                  <div class="col-md-6">
-                    <div class="input-group">
-                      <input type="text" class="form-control" ngbDatepicker #sessionVisibleTimeDp="ngbDatepicker" [maxDate]="maxDateForSessionVisible"
-                             [ngModel]="model.customSessionVisibleDate" (ngModelChange)="triggerModelChange('customSessionVisibleDate', $event)" [disabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"/>
-                      <div class="input-group-append" *ngIf="model.sessionVisibleSetting === SessionVisibleSetting.CUSTOM && model.isEditable">
-                        <button class="btn btn-secondary" (click)="sessionVisibleTimeDp.toggle()" type="button">
-                          <i class="fas fa-calendar-alt"></i>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="col-md-4 col-xs-12">
-                    <tm-time-picker [time]="model.customSessionVisibleTime" (timeChange)="triggerModelChange('customSessionVisibleTime', $event)" [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
+            <div class="row mt-md-2">
+              <div class="col-md-2 mt-md-1 text-md-right" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
+                <div class="form-check">
+                  <label class="form-check-label">
+                    <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.CUSTOM" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
+                    At
+                  </label>
+                </div>
+              </div>
+              <div class="col-md-6">
+                <div class="input-group">
+                  <input type="text" class="form-control" ngbDatepicker #sessionVisibleTimeDp="ngbDatepicker" [maxDate]="maxDateForSessionVisible"
+                         [ngModel]="model.customSessionVisibleDate" (ngModelChange)="triggerModelChange('customSessionVisibleDate', $event)" [disabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"/>
+                  <div class="input-group-append" *ngIf="model.sessionVisibleSetting === SessionVisibleSetting.CUSTOM && model.isEditable">
+                    <button class="btn btn-secondary" (click)="sessionVisibleTimeDp.toggle()" type="button">
+                      <i class="fas fa-calendar-alt"></i>
+                    </button>
                   </div>
                 </div>
               </div>
+              <div class="col-md-4">
+                <tm-time-picker [time]="model.customSessionVisibleTime" (timeChange)="triggerModelChange('customSessionVisibleTime', $event)" [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
+              </div>
             </div>
-            <br>
-            <div class="row">
-              <div class="col-12">
-                <div class="form-check">
-                  <label class="form-check-label" ngbTooltip="Select this option to have the feedback session become visible when it is open for submissions (as selected above).">
-                    <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.AT_OPEN" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
-                    Submission opening time
-                  </label>
-                </div>
+            <div class="col-12 text-md-left mt-md-3">
+              <div class="form-check">
+                <label class="form-check-label" ngbTooltip="Select this option to have the feedback session become visible when it is open for submissions (as selected above).">
+                  <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.AT_OPEN" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
+                  Submission opening time
+                </label>
               </div>
             </div>
           </div>
-          <div class="col-md-6 sessionVisibleRadio">
-            <div class="row">
-              <div class="col-md-4 col-xs-3">
-                <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
-              </div>
+          <div class="col-md-6 sessionVisibleRadio border-left-gray">
+            <div class="col-12 text-md-left">
+              <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
             </div>
-            <div class="row">
-              <div class="col-12">
-                <div class="row align-items-center">
-                  <div class="col-md-2" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
-                    <div class="form-check">
-                      <label class="form-check-label">
-                        <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.CUSTOM" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable"/>
-                        At
-                      </label>
-                    </div>
-                  </div>
-                  <div class="col-md-6">
-                    <div class="input-group">
-                      <input type="text" class="form-control" ngbDatepicker #responseVisibleTimeDp="ngbDatepicker" [minDate]="minDateForResponseVisible"
-                             [ngModel]="model.customResponseVisibleDate" (ngModelChange)="triggerModelChange('customResponseVisibleDate', $event)" [disabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"/>
-                      <div class="input-group-append" *ngIf="model.responseVisibleSetting === ResponseVisibleSetting.CUSTOM && model.isEditable">
-                        <button class="btn btn-secondary" (click)="responseVisibleTimeDp.toggle()" type="button">
-                          <i class="fas fa-calendar-alt"></i>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="col-md-4 col-xs-12">
-                    <tm-time-picker [time]="model.customResponseVisibleTime" (timeChange)="triggerModelChange('customResponseVisibleTime', $event)" [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
+            <div class="row mt-md-2">
+                <div class="col-md-2 text-md-right mt-md-1" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
+                  <div class="form-check">
+                    <label class="form-check-label">
+                      <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.CUSTOM" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable"/>
+                      At
+                    </label>
                   </div>
                 </div>
+                <div class="col-md-6">
+                  <div class="input-group">
+                    <input type="text" class="form-control" ngbDatepicker #responseVisibleTimeDp="ngbDatepicker" [minDate]="minDateForResponseVisible"
+                           [ngModel]="model.customResponseVisibleDate" (ngModelChange)="triggerModelChange('customResponseVisibleDate', $event)" [disabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"/>
+                    <div class="input-group-append" *ngIf="model.responseVisibleSetting === ResponseVisibleSetting.CUSTOM && model.isEditable">
+                      <button class="btn btn-secondary" (click)="responseVisibleTimeDp.toggle()" type="button">
+                        <i class="fas fa-calendar-alt"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-4">
+                  <tm-time-picker [time]="model.customResponseVisibleTime" (timeChange)="triggerModelChange('customResponseVisibleTime', $event)" [isDisabled]="model.responseVisibleSetting !== ResponseVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
+                </div>
+            </div>
+            <br>
+            <div class="col-12 text-md-left">
+              <div class="form-check">
+                <label class="form-check-label" ngbTooltip="Select this option to have the feedback responses be immediately visible when the session becomes visible to users.">
+                  <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.AT_VISIBLE" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
+                  Immediately
+                </label>
               </div>
             </div>
             <br>
-            <div class="row">
-              <div class="col-12">
-                <div class="form-check">
-                  <label class="form-check-label" ngbTooltip="Select this option to have the feedback responses be immediately visible when the session becomes visible to users.">
-                    <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.AT_VISIBLE" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
-                    Immediately
-                  </label>
-                </div>
-              </div>
-            </div>
-            <br>
-            <div class="row">
-              <div class="col-12">
-                <div class="form-check">
-                  <label class="form-check-label" ngbTooltip="Select this option if you intend to manually publish the responses for this session later on.">
-                    <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.LATER" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
-                    Not now (publish manually)
-                  </label>
-                </div>
+            <div class="col-12 text-md-left">
+              <div class="form-check">
+                <label class="form-check-label" ngbTooltip="Select this option if you intend to manually publish the responses for this session later on.">
+                  <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.LATER" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
+                  Not now (publish manually)
+                </label>
               </div>
             </div>
           </div>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -307,13 +307,11 @@
     </div>
     <div class="card border-primary margin-top-20px" *ngIf="model.hasEmailSettingsPanelExpanded">
       <div class="card-body">
-        <div class="row">
-          <div class="col-12 font-bold">
+        <div class="col-12 font-bold">
             Send emails for
-          </div>
         </div>
         <br>
-        <div class="row">
+        <div class="row ml-md-1">
           <div class="col-md-4">
             <div class="form-check form-check-inline">
               <label class="form-check-label" ngbTooltip="Select this option to automatically send an email to students to notify them when the session is open for submission.">

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -211,15 +211,15 @@
     </div>
     <div class="card border-primary margin-top-20px" *ngIf="model.hasVisibleSettingsPanelExpanded">
       <div class="card-body">
-        <div class="row text-center">
-          <div class="col-md-6">
-            <div class="col-12 text-md-left">
-              <div>
+        <div class="row align-items-start">
+          <div class="col-md-6 text-center text-md-left">
+            <div class="row ml-md-1">
+              <div class="col-12">
                 <label class="label-control font-bold" ngbTooltip="Please select when you want the questions for the feedback session to be visible to users who need to participate. Note that users cannot submit their responses until the submissions opening time set below.">Make session visible </label>
               </div>
             </div>
-            <div class="row mt-md-2">
-              <div class="col-md-2 mt-md-1 text-md-right" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
+            <div class="row mt-md-2 ml-md-1">
+              <div class="col-md-2 mt-md-1" ngbTooltip="Select this option to enter in a custom date and time for which the feedback session will become visible. Note that you can make a session visible before it is open for submissions so that users can preview the questions.">
                 <div class="form-check">
                   <label class="form-check-label">
                     <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.CUSTOM" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
@@ -242,8 +242,8 @@
                 <tm-time-picker [time]="model.customSessionVisibleTime" (timeChange)="triggerModelChange('customSessionVisibleTime', $event)" [isDisabled]="model.sessionVisibleSetting !== SessionVisibleSetting.CUSTOM || !model.isEditable"></tm-time-picker>
               </div>
             </div>
-            <div class="col-12 text-md-left mt-md-3">
-              <div class="form-check">
+            <div class="row mt-md-3 ml-md-3">
+              <div class="col-12 form-check">
                 <label class="form-check-label" ngbTooltip="Select this option to have the feedback session become visible when it is open for submissions (as selected above).">
                   <input class="form-check-input" type="radio" name="sessionVisibleRadio" [value]="SessionVisibleSetting.AT_OPEN" [ngModel]="model.sessionVisibleSetting" (ngModelChange)="triggerModelChange('sessionVisibleSetting', $event)" [disabled]="!model.isEditable">
                   Submission opening time
@@ -251,12 +251,14 @@
               </div>
             </div>
           </div>
-          <div class="col-md-6 sessionVisibleRadio border-left-gray">
-            <div class="col-12 text-md-left">
-              <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
+          <div class="col-md-6 sessionVisibleRadio border-left-gray text-center text-md-left">
+            <div class="row ml-md-1">
+              <div class="col-12">
+                <label class="label-control font-bold" ngbTooltip="Please select when the responses for the feedback session will be visible to the designated recipients. You can select the response visibility for each type of user and question later.">Make response visible </label>
+              </div>
             </div>
-            <div class="row mt-md-2">
-                <div class="col-md-2 text-md-right mt-md-1" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
+            <div class="row mt-md-2 ml-md-1">
+                <div class="col-md-2 mt-md-1" ngbTooltip="Select this option to use a custom time for when the responses of the feedback session will be visible to the designated recipients.">
                   <div class="form-check">
                     <label class="form-check-label">
                       <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.CUSTOM" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable"/>
@@ -280,21 +282,25 @@
                 </div>
             </div>
             <br>
-            <div class="col-12 text-md-left">
-              <div class="form-check">
-                <label class="form-check-label" ngbTooltip="Select this option to have the feedback responses be immediately visible when the session becomes visible to users.">
-                  <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.AT_VISIBLE" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
-                  Immediately
-                </label>
+            <div class="row mt-md-3 ml-md-1">
+              <div class="col-12">
+                <div class="form-check">
+                  <label class="form-check-label" ngbTooltip="Select this option to have the feedback responses be immediately visible when the session becomes visible to users.">
+                    <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.AT_VISIBLE" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
+                    Immediately
+                  </label>
+                </div>
               </div>
             </div>
             <br>
-            <div class="col-12 text-md-left">
-              <div class="form-check">
-                <label class="form-check-label" ngbTooltip="Select this option if you intend to manually publish the responses for this session later on.">
-                  <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.LATER" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
-                  Not now (publish manually)
-                </label>
+            <div class="row mt-md-3 ml-md-1">
+              <div class="col-12">
+                <div class="form-check">
+                  <label class="form-check-label" ngbTooltip="Select this option if you intend to manually publish the responses for this session later on.">
+                    <input class="form-check-input" type="radio" name="responseVisibleRadio" [value]="ResponseVisibleSetting.LATER" [ngModel]="model.responseVisibleSetting" (ngModelChange)="triggerModelChange('responseVisibleSetting', $event)" [disabled]="!model.isEditable">
+                    Not now (publish manually)
+                  </label>
+                </div>
               </div>
             </div>
           </div>

--- a/src/web/app/components/session-edit-form/session-edit-form.component.html
+++ b/src/web/app/components/session-edit-form/session-edit-form.component.html
@@ -11,7 +11,7 @@
           <div class="col-md-4">
             <h4 class="text-center">Create new </h4>
           </div>
-          <div class="col-10 col-md-7">
+          <div class="col-9 col-md-7">
             <select class="form-control" ngbTooltip="Select a session type here." [ngModel]="model.templateSessionName" (ngModelChange)="triggerModelChange('templateSessionName', $event)">
               <option *ngFor="let templateSession of templateSessions" [ngValue]="templateSession.name">{{ templateSession.name }}</option>
             </select>
@@ -22,11 +22,11 @@
         </div>
       </div>
       <div class="col-md-6">
-        <div class="row text-center align-items-center mt-2 mt-md-0">
-          <div class="col-md-2">
+        <div class="row text-center align-items-center mt-1">
+          <div class="col-md-3">
             <h4 class="text-md-right">Or: </h4>
           </div>
-          <div class="col-md-10 text-md-left">
+          <div class="col-md-9 text-md-left">
             <button type="button" class="btn btn-info" (click)="copyOthersHandler()">Copy from previous feedback sessions</button>
           </div>
         </div>
@@ -59,11 +59,11 @@
     <div class="card border-primary margin-top-20px">
       <div class="card-body">
         <div class="row text-center">
-          <div class="col-md-2 text-md-right font-bold">
+          <div class="col-md-2 text-md-right font-bold mt-md-2">
             Course ID
           </div>
-          <div class="col-md-2">
-            <div class="col-md-4 text-md-left" *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
+          <div class="col-md-3 text-md-left">
+            <div *ngIf="formMode === SessionEditFormMode.ADD" ngbTooltip="Please select the course for which the feedback session is to be created.">
               <select class="form-control" [ngClass]="{'is-invalid': courseCandidates.length === 0}" [ngModel]="model.courseId" (ngModelChange)="courseIdChangeHandler($event)" [disabled]="courseCandidates.length === 0">
                 <option *ngFor="let course of courseCandidates" [ngValue]="course.courseId">{{ course.courseId }}</option>
               </select>
@@ -73,11 +73,13 @@
             </div>
             <div *ngIf="formMode === SessionEditFormMode.EDIT"> {{ model.courseId }} </div>
           </div>
-          <div class="col-md-3 text-md-right font-bold">
-            Time Zone
-          </div>
-          <div class="col-md-3 text-md-left" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
-            {{ model.timeZone }}
+          <div class="row col-md-6 mt-md-1 ml-1">
+            <div class="col-md-8 text-md-right font-bold">
+              Time Zone
+            </div>
+            <div class="col-md-4 text-md-left" ngbTooltip="To change this, edit the course settings. TEAMMATES automatically adjusts to match the current time offset in your area, including clock changes due to daylight saving time.">
+              {{ model.timeZone }}
+            </div>
           </div>
         </div>
         <br/>
@@ -135,14 +137,14 @@
       <div class="card-body">
         <div class="row text-center">
           <div class="col-md-5">
-            <div class="row">
-              <div class="col-md-5" ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
+            <div class="col-12 text-md-left">
+              <div ngbTooltip="Please select the date and time for which users can start submitting responses for the feedback session.">
                 <label class="label-control font-bold">
                   Submission opening time
                 </label>
               </div>
             </div>
-            <div class="row align-items-center">
+            <div class="row text-center align-items-center">
               <div class="col-md-7 col-xs-center">
                 <div class="input-group">
                   <input type="text" class="form-control" ngbDatepicker [ngModel]="model.submissionStartDate" (ngModelChange)="triggerModelChange('submissionStartDate', $event)"  #startTimeDp="ngbDatepicker" [disabled]="!model.isEditable"/>
@@ -160,7 +162,7 @@
           </div>
           <div class="col-md-5 border-left-gray">
             <div class="row text-center">
-              <div class="col-md-5" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
+              <div class="col-12 text-md-left ml-md-2" ngbTooltip="Please select the date and time after which the feedback session will no longer accept submissions from users.">
                 <label class="label-control font-bold">
                   Submission closing time
                 </label>
@@ -178,14 +180,14 @@
                   </div>
                 </div>
               </div>
-              <div class="col-xs-5 col-md-5">
+              <div class="col-md-5">
                 <tm-time-picker [time]="model.submissionEndTime" (timeChange)="triggerModelChange('submissionEndTime', $event)" [isDisabled]="!model.isEditable"></tm-time-picker>
               </div>
             </div>
           </div>
           <div class="col-md-2 border-left-gray">
             <div class="row text-center">
-              <div class="col-12" ngbTooltip="Please select the amount of time that the system will continue accepting submissions after the specified deadline.">
+              <div class="col-12 text-md-left ml-md-2" ngbTooltip="Please select the amount of time that the system will continue accepting submissions after the specified deadline.">
                 <label class="control-label font-bold">
                   Grace period
                 </label>


### PR DESCRIPTION
Fixes #10072

**Outline of Solution**
Wrap `div` in rows so the words can occupy all the space and not overflow until screen size is small. Also added some margins around to give some space between elements

![errrr](https://user-images.githubusercontent.com/28994607/82302842-b66ab700-99ec-11ea-8782-4866448b5573.gif)
