### PR TITLE
[#9382] Add example to preview session section of help

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -227,7 +227,29 @@
             To access the preview panel of a specific session, click the <button class="btn btn-sm btn-secondary">Edit</button> button for that session in the <b>Home</b> or <b>Sessions</b> page. The preview
             panel is located at the bottom of the Edit Feedback Session page.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <div class="card">
+              <div class="card-body background-color-light-blue text-center">
+                <div class="row align-items-center">
+                  <div class="col-2 text-right">
+                    <b>Preview Session:</b>
+                  </div>
+                  <div class="col-5" ngbTooltip="View how this session would look like to a student who is submitting feedback. Preview is unavailable if the course has yet to have any student enrolled.">
+                    <select class="form-control preview-select">
+                      <option *ngFor="let student of exampleStudents" [ngValue]="student.email">[{{ student.teamName }}] {{ student.name }}</option>
+                    </select>
+                    <button class="btn btn-primary" [disabled]="true" >Preview as Student</button>
+                  </div>
+                  <div class="col-5" ngbTooltip="View how this session would look like to an instructor who is submitting feedback. Only instructors with submit privileges are included in the list.">
+                    <select class="form-control preview-select">
+                      <option *ngFor="let instructor of exampleInstructors" [ngValue]="instructor.email">{{ instructor.name }}</option>
+                    </select>
+                    <button class="btn btn-primary" [disabled]="true" >Preview as Instructor</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </tm-example-box>
         </div>
       </div>
       <br/>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.scss
@@ -1,0 +1,12 @@
+.background-color-light-blue {
+  background-color: #EAEFF5;
+}
+
+.preview-select {
+  float: left;
+  width: 50%;
+}
+
+.margin-top-30px {
+  margin-top: 30px;
+}

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { MatSnackBarModule } from '@angular/material';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -16,7 +17,8 @@ describe('InstructorHelpSessionsSectionComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxComponent],
-      imports: [NgbModule, RouterTestingModule, NgxPageScrollCoreModule, SessionEditFormModule, MatSnackBarModule],
+      imports: [FormsModule, NgbModule, RouterTestingModule, NgxPageScrollCoreModule,
+        SessionEditFormModule, MatSnackBarModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -6,9 +6,9 @@ import { TemplateSession } from '../../../../services/feedback-sessions.service'
 import {
   Course,
   FeedbackSessionPublishStatus,
-  FeedbackSessionSubmissionStatus,
+  FeedbackSessionSubmissionStatus, Instructor, InstructorPermissionRole, JoinState,
   ResponseVisibleSetting,
-  SessionVisibleSetting,
+  SessionVisibleSetting, Student,
 } from '../../../../types/api-output';
 import {
   SessionEditFormMode, SessionEditFormModel,
@@ -77,6 +77,32 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
     {
       name: 'Example session',
       questions: [],
+    },
+  ];
+
+  readonly exampleStudents: Student[] = [
+    {
+      email: 'alice@email.com',
+      courseId: 'test.exa-demo',
+      name: 'Alice Betsy',
+      lastName: 'Betsy',
+      comments: 'Alice is a transfer student.',
+      teamName: 'Team A',
+      sectionName: 'Section A',
+      joinState: JoinState.JOINED,
+    },
+  ];
+  readonly exampleInstructors: Instructor[] = [
+    {
+      googleId: 'bob@email.com',
+      courseId: 'test.exa-demo',
+      email: 'bob@email.com',
+      isDisplayedToStudents: true,
+      displayedToStudentsAs: 'Instructor',
+      name: 'Bob Ruth',
+      key: 'impicklerick',
+      role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
+      joinState: JoinState.JOINED,
     },
   ];
 


### PR DESCRIPTION
Part of #9382

**Outline of Solution**
Copied over the relevant section from the edit session template and disabled all the buttons.

![image](https://user-images.githubusercontent.com/28994607/82320848-816b5e00-9a06-11ea-9251-0eda8a57e226.png)
