### PR TITLE
[#9382] Add remaining question sections setup example boxes

### DIFF
--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -565,7 +565,13 @@
               Specify the feedback path that should be used to generate the appropriate feedback recipients
             </li>
           </ol>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+              <tm-question-edit-form
+                  [formModel]="exampleRubricQuestionModel"
+                  [formMode]="QuestionEditFormMode.EDIT"
+                  [isDisplayOnly]="true">
+              </tm-question-edit-form>
+          </tm-example-box>
           <p>
             Result statistics for rubric questions show how often a choice is selected for each sub-question.<br>
             If weights are assigned to the choices, the weights will be used to calculate an average score.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -164,7 +164,7 @@
           </ol>
           <tm-example-box>
               <tm-question-edit-form
-                  [formModel]="exampleNumericalScaleEditFormModel"
+                  [formModel]="exampleNumericalScaleQuestionModel"
                   [formMode]="QuestionEditFormMode.EDIT"
                   [isDisplayOnly]="true">
               </tm-question-edit-form>
@@ -290,7 +290,13 @@
           <p>
             The feedback path for this question type is fixed: the feedback giver must be a student, and the student must give feedback about his/her team members and himself.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+              <tm-question-edit-form
+                  [formModel]="exampleTeamContributionQuestionModel"
+                  [formMode]="QuestionEditFormMode.EDIT"
+                  [isDisplayOnly]="true">
+              </tm-question-edit-form>
+          </tm-example-box>
           <p>
             Contribution questions in TEAMMATES are unique because they are targeted at measuring team contributions. <br>
             Thus, TEAMMATES purposefully prevents students from influencing their own ‘perceived contribution’ value.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -259,7 +259,13 @@
               Specify the feedback path that should be used to generate the appropriate feedback recipients
             </li>
           </ol>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+              <tm-question-edit-form
+                  [formModel]="exampleDistributedPointRecipientModel"
+                  [formMode]="QuestionEditFormMode.EDIT"
+                  [isDisplayOnly]="true">
+              </tm-question-edit-form>
+          </tm-example-box>
         </div>
       </div>
       <br/>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.html
@@ -212,7 +212,13 @@
               Specify the feedback path that should be used to generate the appropriate feedback recipients
             </li>
           </ol>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+              <tm-question-edit-form
+                  [formModel]="exampleDistributedPointOptionModel"
+                  [formMode]="QuestionEditFormMode.EDIT"
+                  [isDisplayOnly]="true">
+              </tm-question-edit-form>
+          </tm-example-box>
           <p>
             In the results view, TEAMMATES provides statistics on the average number of points each option received.
           </p>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -9,6 +9,9 @@ import {
   NumberOfEntitiesToGiveFeedbackToSetting,
 } from '../../../../types/api-output';
 import {
+    DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS,
+    DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS,
+    DEFAULT_CONTRIBUTION_QUESTION_DETAILS,
     DEFAULT_MCQ_QUESTION_DETAILS,
     DEFAULT_NUMSCALE_QUESTION_DETAILS,
     DEFAULT_RANK_OPTIONS_QUESTION_DETAILS,
@@ -57,7 +60,7 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
-  readonly exampleNumericalScaleEditFormModel: QuestionEditFormModel = {
+  readonly exampleNumericalScaleQuestionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',
     isQuestionHasResponses: false,
 
@@ -77,6 +80,31 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
 
     showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+    showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
+    showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+  };
+
+  readonly exampleTeamContributionQuestionModel: QuestionEditFormModel = {
+    feedbackQuestionId: '',
+    isQuestionHasResponses: false,
+
+    questionNumber: 1,
+    questionBrief: '',
+    questionDescription: '',
+    questionType: FeedbackQuestionType.CONTRIB,
+    questionDetails: DEFAULT_CONTRIBUTION_QUESTION_DETAILS(),
+
+    isEditable: false,
+    isSaving: false,
+
+    giverType: FeedbackParticipantType.STUDENTS,
+    recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF,
+
+    customNumberOfEntitiesToGiveFeedbackTo: 0,
+    numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+
+    showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT,
+      FeedbackVisibilityType.GIVER_TEAM_MEMBERS],
     showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -159,27 +159,27 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
   };
 
   readonly exampleRubricQuestionModel: QuestionEditFormModel = {
-      feedbackQuestionId: '',
-      isQuestionHasResponses: false,
+    feedbackQuestionId: '',
+    isQuestionHasResponses: false,
 
-      questionNumber: 1,
-      questionBrief: '',
-      questionDescription: '',
-      questionType: FeedbackQuestionType.RUBRIC,
-      questionDetails: DEFAULT_RUBRIC_QUESTION_DETAILS(),
+    questionNumber: 1,
+    questionBrief: '',
+    questionDescription: '',
+    questionType: FeedbackQuestionType.RUBRIC,
+    questionDetails: DEFAULT_RUBRIC_QUESTION_DETAILS(),
 
-      isEditable: false,
-      isSaving: false,
+    isEditable: false,
+    isSaving: false,
 
-      giverType: FeedbackParticipantType.STUDENTS,
-      recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS,
+    giverType: FeedbackParticipantType.STUDENTS,
+    recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS,
 
-      customNumberOfEntitiesToGiveFeedbackTo: 0,
-      numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+    customNumberOfEntitiesToGiveFeedbackTo: 0,
+    numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
 
-      showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
-      showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
-      showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+    showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+    showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
+    showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
   readonly exampleRankRecipientQuestionModel: QuestionEditFormModel = {

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -84,6 +84,30 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
+  readonly exampleDistributedPointOptionModel: QuestionEditFormModel = {
+    feedbackQuestionId: '',
+    isQuestionHasResponses: false,
+
+    questionNumber: 1,
+    questionBrief: '',
+    questionDescription: '',
+    questionType: FeedbackQuestionType.CONSTSUM_OPTIONS,
+    questionDetails: DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS(),
+
+    isEditable: false,
+    isSaving: false,
+
+    giverType: FeedbackParticipantType.STUDENTS,
+    recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS,
+
+    customNumberOfEntitiesToGiveFeedbackTo: 0,
+    numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+
+    showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+    showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
+    showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+  };
+
   readonly exampleTeamContributionQuestionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',
     isQuestionHasResponses: false,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -108,6 +108,30 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
+  readonly exampleDistributedPointRecipientModel: QuestionEditFormModel = {
+    feedbackQuestionId: '',
+    isQuestionHasResponses: false,
+
+    questionNumber: 1,
+    questionBrief: '',
+    questionDescription: '',
+    questionType: FeedbackQuestionType.CONSTSUM_RECIPIENTS,
+    questionDetails: DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS(),
+
+    isEditable: false,
+    isSaving: false,
+
+    giverType: FeedbackParticipantType.STUDENTS,
+    recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS,
+
+    customNumberOfEntitiesToGiveFeedbackTo: 0,
+    numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+
+    showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+    showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
+    showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+  };
+
   readonly exampleTeamContributionQuestionModel: QuestionEditFormModel = {
     feedbackQuestionId: '',
     isQuestionHasResponses: false,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -5,7 +5,9 @@ import { PageScrollService } from 'ngx-page-scroll-core';
 import {
   FeedbackMcqQuestionDetails,
   FeedbackParticipantType,
-  FeedbackQuestionType, FeedbackVisibilityType,
+  FeedbackQuestionType,
+  FeedbackRubricQuestionDetails,
+  FeedbackVisibilityType,
   NumberOfEntitiesToGiveFeedbackToSetting,
 } from '../../../../types/api-output';
 import {
@@ -166,7 +168,20 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
     questionBrief: '',
     questionDescription: '',
     questionType: FeedbackQuestionType.RUBRIC,
-    questionDetails: DEFAULT_RUBRIC_QUESTION_DETAILS(),
+    questionDetails: {
+      ...DEFAULT_RUBRIC_QUESTION_DETAILS(),
+      numOfRubricChoices: 4,
+      rubricChoices: ['Strongly Disagree', 'Disagree', 'Agree', 'Strongly Agree'],
+      numOfRubricSubQuestions: 2,
+      rubricSubQuestions:
+        ['This student participates well in online discussions.', 'This student completes assigned tasks on time.'],
+      rubricDescriptions: [
+        ['Rarely or never responds.', 'Occasionally responds, but never initiates discussions.',
+          'Takes part in discussions and sometimes initiates discussions.',
+          'Initiates discussions frequently, and engages the team.'],
+        ['Rarely or never completes tasks.', 'Often misses deadlines.', 'Occasionally misses deadlines.',
+          'Tasks are always completed before the deadline.']],
+    } as FeedbackRubricQuestionDetails,
 
     isEditable: false,
     isSaving: false,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-section.component.ts
@@ -16,6 +16,7 @@ import {
     DEFAULT_NUMSCALE_QUESTION_DETAILS,
     DEFAULT_RANK_OPTIONS_QUESTION_DETAILS,
     DEFAULT_RANK_RECIPIENTS_QUESTION_DETAILS,
+    DEFAULT_RUBRIC_QUESTION_DETAILS,
     DEFAULT_TEXT_QUESTION_DETAILS,
 } from '../../../../types/default-question-structs';
 import {
@@ -155,6 +156,30 @@ export class InstructorHelpQuestionsSectionComponent extends InstructorHelpSecti
       FeedbackVisibilityType.GIVER_TEAM_MEMBERS],
     showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
     showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+  };
+
+  readonly exampleRubricQuestionModel: QuestionEditFormModel = {
+      feedbackQuestionId: '',
+      isQuestionHasResponses: false,
+
+      questionNumber: 1,
+      questionBrief: '',
+      questionDescription: '',
+      questionType: FeedbackQuestionType.RUBRIC,
+      questionDetails: DEFAULT_RUBRIC_QUESTION_DETAILS(),
+
+      isEditable: false,
+      isSaving: false,
+
+      giverType: FeedbackParticipantType.STUDENTS,
+      recipientType: FeedbackParticipantType.OWN_TEAM_MEMBERS,
+
+      customNumberOfEntitiesToGiveFeedbackTo: 0,
+      numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
+
+      showResponsesTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
+      showGiverNameTo: [FeedbackVisibilityType.INSTRUCTORS],
+      showRecipientNameTo: [FeedbackVisibilityType.INSTRUCTORS, FeedbackVisibilityType.RECIPIENT],
   };
 
   readonly exampleRankRecipientQuestionModel: QuestionEditFormModel = {


### PR DESCRIPTION
Part of #9382 

**Outline of Solution**

- add distribute point (option) question
<img width="805" alt="Screenshot 2020-05-20 at 11 44 32" src="https://user-images.githubusercontent.com/32880438/82402894-254d1c00-9a90-11ea-8ca3-cb24f7313811.png">

- add distribute point (recipient) question
<img width="860" alt="Screenshot 2020-05-20 at 11 44 16" src="https://user-images.githubusercontent.com/32880438/82403007-69402100-9a90-11ea-856c-27fbe4af83fe.png">

- add team contribution question
<img width="859" alt="Screenshot 2020-05-20 at 11 44 03" src="https://user-images.githubusercontent.com/32880438/82402798-e4550780-9a8f-11ea-9249-80c5ef0d78ae.png">

- add rubric question
<img width="698" alt="Screenshot 2020-05-20 at 12 22 01" src="https://user-images.githubusercontent.com/32880438/82404828-e372a480-9a94-11ea-8acb-2fae14b7cbfd.png">

