### PR TITLE
[#9382] Add example boxes for restoring deleted session section of instructor help page

### DIFF
--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.html
@@ -3,69 +3,69 @@
     <h2 class="text-muted">
       <i class="fas fa-trash-alt"></i> Deleted Feedback Sessions
     </h2>
-    <div class="card bg-light top-padded">
-      <div class="card-header bg-secondary recycle-bin-header" (click)="recycleBinExpandEvent.emit()">
-        <div class="row align-items-center">
-          <div class="col-6 text-white">
-            <b>Recycle Bin</b>
-          </div>
-          <div class="col-6 text-right bin-header-button">
-            <button type="button" class="btn btn-light btn-sm" ngbTooltip="Restore all feedback sessions"
-                    (click)="$event.stopPropagation(); restoreAllRecycleBinFeedbackSessionEvent.emit()"><i class="fas fa-check"></i> Restore All</button>
-            <button type="button" class="btn btn-light btn-sm text-danger" ngbTooltip="Permanently delete all feedback sessions"
-                    (click)="$event.stopPropagation(); permanentDeleteAllSessionsEvent.emit()"><i class="fas fa-times"></i> Delete All</button>
-            <i class="fas fa-chevron-down text-white" *ngIf="!isRecycleBinExpanded"></i>
-            <i class="fas fa-chevron-up text-white" *ngIf="isRecycleBinExpanded"></i>
+      <div class="card bg-light top-padded">
+        <div class="card-header bg-secondary recycle-bin-header" (click)="recycleBinExpandEvent.emit()">
+          <div class="row align-items-center">
+            <div class="col-6 text-white">
+              <b>Recycle Bin</b>
+            </div>
+            <div class="col-6 text-right bin-header-button">
+              <button type="button" class="btn btn-light btn-sm" ngbTooltip="Restore all feedback sessions"
+                      (click)="$event.stopPropagation(); restoreAllRecycleBinFeedbackSessionEvent.emit()"><i class="fas fa-check"></i> Restore All</button>
+              <button type="button" class="btn btn-light btn-sm text-danger" ngbTooltip="Permanently delete all feedback sessions"
+                      (click)="$event.stopPropagation(); permanentDeleteAllSessionsEvent.emit()"><i class="fas fa-times"></i> Delete All</button>
+              <i class="fas fa-chevron-down text-white" *ngIf="!isRecycleBinExpanded"></i>
+              <i class="fas fa-chevron-up text-white" *ngIf="isRecycleBinExpanded"></i>
+            </div>
           </div>
         </div>
-      </div>
-    <table class="table table-responsive-lg table-striped table-bordered recycle-bin-table" *ngIf="isRecycleBinExpanded">
-      <thead class="recycle-bin-table-header">
-      <tr>
-        <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.COURSE_ID)" class="sortable-header">
-          Course ID
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.COURSE_ID"><i class="fas fa-sort"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-        </th>
-        <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_NAME)" class="sortable-header">
-          Session Name
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_NAME"><i class="fas fa-sort"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-        </th>
-        <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_CREATION_DATE)" class="sortable-header">
-          Creation Date
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_CREATION_DATE"><i class="fas fa-sort"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-        </th>
-        <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_DELETION_DATE)" class="sortable-header">
-          Deletion Date
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_DELETION_DATE"><i class="fas fa-sort"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
-          <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
-        </th>
-        <th class="text-center">Action(s)</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr *ngFor="let recycleBinFeedbackSessionRowModel of recycleBinFeedbackSessionRowModels">
-        <td>{{ recycleBinFeedbackSessionRowModel.feedbackSession.courseId }}</td>
-        <td>{{ recycleBinFeedbackSessionRowModel.feedbackSession.feedbackSessionName }}</td>
-        <td [ngbTooltip]="recycleBinFeedbackSessionRowModel.feedbackSession.createdAtTimestamp | formatDateDetail:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone" container="body">
-          {{ recycleBinFeedbackSessionRowModel.feedbackSession.createdAtTimestamp | recycleBinTableFormatDate:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone }}
-        </td>
-        <td [ngbTooltip]="recycleBinFeedbackSessionRowModel.feedbackSession.deletedAtTimestamp | formatDateDetail:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone" container="body">
-          {{ recycleBinFeedbackSessionRowModel.feedbackSession.deletedAtTimestamp | recycleBinTableFormatDate:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone }}
-        </td>
-        <td class="text-center actions-cell">
-          <button type="button" class="btn btn-light btn-sm" ngbTooltip="Restore the feedback session" (click)="restoreSessionEvent.emit(recycleBinFeedbackSessionRowModel)">Restore</button>
-          <button type="button" class="btn btn-light btn-sm text-danger" ngbTooltip="Permanently delete the feedback session" (click)="permanentlyDeleteSessionEvent.emit(recycleBinFeedbackSessionRowModel)">Delete Permanently</button>
-        </td>
-      </tr>
-      </tbody>
-    </table>
+      <table class="table table-responsive-lg table-striped table-bordered recycle-bin-table" *ngIf="isRecycleBinExpanded">
+        <thead class="recycle-bin-table-header">
+        <tr>
+          <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.COURSE_ID)" class="sortable-header">
+            Course ID
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.COURSE_ID"><i class="fas fa-sort"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.COURSE_ID && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+          </th>
+          <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_NAME)" class="sortable-header">
+            Session Name
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_NAME"><i class="fas fa-sort"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_NAME && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+          </th>
+          <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_CREATION_DATE)" class="sortable-header">
+            Creation Date
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_CREATION_DATE"><i class="fas fa-sort"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_CREATION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+          </th>
+          <th (click)="sortRecycleBinFeedbackSessionRows(SortBy.SESSION_DELETION_DATE)" class="sortable-header">
+            Deletion Date
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy !== SortBy.SESSION_DELETION_DATE"><i class="fas fa-sort"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.DESC"><i class="fas fa-sort-down"></i></span>
+            <span *ngIf="recycleBinFeedbackSessionRowModelsSortBy === SortBy.SESSION_DELETION_DATE && recycleBinFeedbackSessionRowModelsSortOrder === SortOrder.ASC"><i class="fas fa-sort-up"></i></span>
+          </th>
+          <th class="text-center">Action(s)</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr *ngFor="let recycleBinFeedbackSessionRowModel of recycleBinFeedbackSessionRowModels">
+          <td>{{ recycleBinFeedbackSessionRowModel.feedbackSession.courseId }}</td>
+          <td>{{ recycleBinFeedbackSessionRowModel.feedbackSession.feedbackSessionName }}</td>
+          <td [ngbTooltip]="recycleBinFeedbackSessionRowModel.feedbackSession.createdAtTimestamp | formatDateDetail:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone" container="body">
+            {{ recycleBinFeedbackSessionRowModel.feedbackSession.createdAtTimestamp | recycleBinTableFormatDate:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone }}
+          </td>
+          <td [ngbTooltip]="recycleBinFeedbackSessionRowModel.feedbackSession.deletedAtTimestamp | formatDateDetail:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone" container="body">
+            {{ recycleBinFeedbackSessionRowModel.feedbackSession.deletedAtTimestamp | recycleBinTableFormatDate:recycleBinFeedbackSessionRowModel.feedbackSession.timeZone }}
+          </td>
+          <td class="text-center actions-cell">
+            <button type="button" class="btn btn-light btn-sm" ngbTooltip="Restore the feedback session" (click)="restoreSessionEvent.emit(recycleBinFeedbackSessionRowModel)">Restore</button>
+            <button type="button" class="btn btn-light btn-sm text-danger" ngbTooltip="Permanently delete the feedback session" (click)="permanentlyDeleteSessionEvent.emit(recycleBinFeedbackSessionRowModel)">Delete Permanently</button>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
 </div>

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
@@ -2,6 +2,9 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FeedbackSession } from '../../../types/api-output';
 import { SortBy, SortOrder } from '../../../types/sort-properties';
 
+/**
+ * Model for a row of recycle bin feedback session
+ */
 export interface RecycleBinFeedbackSessionRowModel {
   feedbackSession: FeedbackSession;
 }

--- a/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
+++ b/src/web/app/components/sessions-recycle-bin-table/sessions-recycle-bin-table.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FeedbackSession } from '../../../types/api-output';
 import { SortBy, SortOrder } from '../../../types/sort-properties';
 
-interface RecycleBinFeedbackSessionRowModel {
+export interface RecycleBinFeedbackSessionRowModel {
   feedbackSession: FeedbackSession;
 }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -14,6 +14,9 @@ import {
   SessionEditFormModule,
 } from '../../components/session-edit-form/session-edit-form.module';
 import {
+  SessionsRecycleBinTableModule,
+} from '../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.module';
+import {
   InstructorCourseStudentEditPageModule,
 } from '../../pages-instructor/instructor-course-student-edit-page/instructor-course-student-edit-page.module';
 import {
@@ -41,7 +44,6 @@ import {
 import {
   InstructorHelpStudentsSectionComponent,
 } from './instructor-help-students-section/instructor-help-students-section.component';
-import { SessionsRecycleBinTableModule } from "../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.module";
 
 /**
  * Module for instructor help page.

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-page.module.ts
@@ -41,6 +41,7 @@ import {
 import {
   InstructorHelpStudentsSectionComponent,
 } from './instructor-help-students-section/instructor-help-students-section.component';
+import { SessionsRecycleBinTableModule } from "../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.module";
 
 /**
  * Module for instructor help page.
@@ -61,6 +62,7 @@ import {
     SessionEditFormModule,
     QuestionEditFormModule,
     QuestionSubmissionFormModule,
+    SessionsRecycleBinTableModule,
   ],
   declarations: [
     InstructorHelpPageComponent,

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.html
@@ -517,7 +517,12 @@
             You can view all your deleted feedback sessions by navigating to the <b>Sessions</b> page.<br>
             Scroll to the <b>Deleted feedback sessions</b> heading, which looks similar to this:
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <tm-sessions-recycle-bin-table
+                [recycleBinFeedbackSessionRowModels]="exampleRecycleBinFeedbackSessions"
+                [isRecycleBinExpanded]="false">
+            </tm-sessions-recycle-bin-table>
+          </tm-example-box>
           <p>
             The feedback sessions you have previously deleted are listed here.
             In order to access information in a deleted session, <a (click)="jumpTo('restore-session'); isRestoreSessionCollapsed = true" [routerLink]="">restore the session</a>.
@@ -541,7 +546,12 @@
             To restore a deleted feedback session, first <a (click)="jumpTo('view-deleted-session'); isViewDeletedCollapsed = true" [routerLink]="">view the session</a> that you would like to restore in the <b>Sessions</b> page.<br>
             Then, click on the <button href="#" class="btn btn-secondary btn-sm" type="button">Restore</button> button corresponding to the session you want to restore.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <tm-sessions-recycle-bin-table
+                [recycleBinFeedbackSessionRowModels]="exampleRecycleBinFeedbackSessions"
+                [isRecycleBinExpanded]="true">
+            </tm-sessions-recycle-bin-table>
+          </tm-example-box>
           <p>
             After restoring the session, all the information relevant to the session (e.g. questions, responses, comments) will also be restored.
           </p>
@@ -564,7 +574,12 @@
             To permanently delete a feedback session, first <a (click)="jumpTo('view-deleted-session'); isViewDeletedCollapsed = true" [routerLink]="">view the session</a> that you would like to permanently delete in the <b>Sessions</b> page.<br>
             Then, click on the <button href="#" class="btn btn-sm btn-danger" type="button">Delete Permanently</button> button corresponding to the session you want to delete.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <tm-sessions-recycle-bin-table
+                [recycleBinFeedbackSessionRowModels]="exampleRecycleBinFeedbackSessions"
+                [isRecycleBinExpanded]="true">
+            </tm-sessions-recycle-bin-table>
+          </tm-example-box>
           <p>
             After deleting the session, all the information relevant to the session (e.g. questions, responses, comments) will also be permanently deleted.
           </p>
@@ -588,7 +603,12 @@
             To restore all sessions, click on the <button href="#" class="btn btn-sm btn-secondary"><i class="fas fa-check"></i><strong> Restore All</strong></button> button in <b>Deleted feedback sessions</b> heading;
             to delete all sessions, click on the <button href="#" class="btn btn-sm btn-danger"><i class="fas fa-times"></i><strong> Delete All</strong></button> button in <b>Deleted feedback sessions</b> heading.
           </p>
-          <p>EXAMPLE BOX</p>
+          <tm-example-box>
+            <tm-sessions-recycle-bin-table
+                [recycleBinFeedbackSessionRowModels]="exampleRecycleBinFeedbackSessions"
+                [isRecycleBinExpanded]="false">
+            </tm-sessions-recycle-bin-table>
+          </tm-example-box>
         </div>
       </div>
       <br/>

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.spec.ts
@@ -7,6 +7,9 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgxPageScrollCoreModule } from 'ngx-page-scroll-core';
 
 import { SessionEditFormModule } from '../../../components/session-edit-form/session-edit-form.module';
+import {
+  SessionsRecycleBinTableModule,
+} from '../../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.module';
 import { ExampleBoxComponent } from '../example-box/example-box.component';
 import { InstructorHelpSessionsSectionComponent } from './instructor-help-sessions-section.component';
 
@@ -18,7 +21,7 @@ describe('InstructorHelpSessionsSectionComponent', () => {
     TestBed.configureTestingModule({
       declarations: [InstructorHelpSessionsSectionComponent, ExampleBoxComponent],
       imports: [FormsModule, NgbModule, RouterTestingModule, NgxPageScrollCoreModule,
-        SessionEditFormModule, MatSnackBarModule],
+        SessionEditFormModule, MatSnackBarModule, SessionsRecycleBinTableModule],
     })
     .compileComponents();
   }));

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -4,7 +4,7 @@ import { PageScrollService } from 'ngx-page-scroll-core';
 
 import { TemplateSession } from '../../../../services/feedback-sessions.service';
 import {
-  Course, FeedbackSession,
+  Course,
   FeedbackSessionPublishStatus,
   FeedbackSessionSubmissionStatus, Instructor, InstructorPermissionRole, JoinState,
   ResponseVisibleSetting,
@@ -13,8 +13,10 @@ import {
 import {
   SessionEditFormMode, SessionEditFormModel,
 } from '../../../components/session-edit-form/session-edit-form-model';
+import {
+  RecycleBinFeedbackSessionRowModel,
+} from '../../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.component';
 import { InstructorHelpSectionComponent } from '../instructor-help-section.component';
-import { RecycleBinFeedbackSessionRowModel } from "../../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.component";
 
 /**
  * Sessions Section of the Instructor Help Page.
@@ -109,7 +111,7 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
 
   readonly exampleRecycleBinFeedbackSessions: RecycleBinFeedbackSessionRowModel[] = [
     {
-      feedbackSession: <FeedbackSession> {
+      feedbackSession: {
         courseId: 'CS2103T',
         timeZone: 'UTC',
         feedbackSessionName: 'Project Feedback 1',
@@ -117,6 +119,13 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
         submissionStartTimestamp: 0,
         submissionEndTimestamp: 0,
         gracePeriod: 0,
+        sessionVisibleSetting: SessionVisibleSetting.AT_OPEN,
+        responseVisibleSetting: ResponseVisibleSetting.AT_VISIBLE,
+        submissionStatus: FeedbackSessionSubmissionStatus.CLOSED,
+        publishStatus: FeedbackSessionPublishStatus.NOT_PUBLISHED,
+        isClosingEmailEnabled: true,
+        isPublishedEmailEnabled: true,
+        createdAtTimestamp: 0,
       },
     },
   ];

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-sessions-section/instructor-help-sessions-section.component.ts
@@ -4,7 +4,7 @@ import { PageScrollService } from 'ngx-page-scroll-core';
 
 import { TemplateSession } from '../../../../services/feedback-sessions.service';
 import {
-  Course,
+  Course, FeedbackSession,
   FeedbackSessionPublishStatus,
   FeedbackSessionSubmissionStatus, Instructor, InstructorPermissionRole, JoinState,
   ResponseVisibleSetting,
@@ -14,6 +14,7 @@ import {
   SessionEditFormMode, SessionEditFormModel,
 } from '../../../components/session-edit-form/session-edit-form-model';
 import { InstructorHelpSectionComponent } from '../instructor-help-section.component';
+import { RecycleBinFeedbackSessionRowModel } from "../../../components/sessions-recycle-bin-table/sessions-recycle-bin-table.component";
 
 /**
  * Sessions Section of the Instructor Help Page.
@@ -103,6 +104,20 @@ export class InstructorHelpSessionsSectionComponent extends InstructorHelpSectio
       key: 'impicklerick',
       role: InstructorPermissionRole.INSTRUCTOR_PERMISSION_ROLE_COOWNER,
       joinState: JoinState.JOINED,
+    },
+  ];
+
+  readonly exampleRecycleBinFeedbackSessions: RecycleBinFeedbackSessionRowModel[] = [
+    {
+      feedbackSession: <FeedbackSession> {
+        courseId: 'CS2103T',
+        timeZone: 'UTC',
+        feedbackSessionName: 'Project Feedback 1',
+        instructions: 'Enter your feedback for projects',
+        submissionStartTimestamp: 0,
+        submissionEndTimestamp: 0,
+        gracePeriod: 0,
+      },
     },
   ];
 


### PR DESCRIPTION
Part of #9382

**Outline of Solution**
Added boxes for the relevant sections and fixed some indentation for template file. 
Screenshots below

**Viewing Sessions**
![image](https://user-images.githubusercontent.com/28994607/82522019-c6080e00-9b5a-11ea-8865-8ae4a46f0c52.png)

**Restoring a deleted session**
![image](https://user-images.githubusercontent.com/28994607/82522067-e20baf80-9b5a-11ea-8898-ee0125ec138a.png)

**Permanently delete a session**
![image](https://user-images.githubusercontent.com/28994607/82522078-e932bd80-9b5a-11ea-9197-475fa4d27ec6.png)

**Restore/Delete all sessions**
![image](https://user-images.githubusercontent.com/28994607/82522093-f059cb80-9b5a-11ea-9615-cd14b83947a7.png)
