### PR TITLE
[#10087] Course Details page text should be aligned to the left

### DIFF
--- a/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
+++ b/src/web/app/pages-instructor/instructor-course-details-page/__snapshots__/instructor-course-details-page.component.spec.ts.snap
@@ -37,12 +37,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course ID:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -55,12 +55,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course name:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
               id="coursename"
             >
               <p
@@ -74,12 +74,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Sections:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -92,12 +92,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Teams:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -110,12 +110,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Total students:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -129,12 +129,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
           class="form-group row"
         >
           <label
-            class="col-sm-3 control-label"
+            class="col-sm-3 text-sm-right control-label"
           >
             Instructors:
           </label>
           <div
-            class="col-sm-6"
+            class="col-sm-6 text-sm-left"
           >
             
             <div>
@@ -208,12 +208,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course ID:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -226,12 +226,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course name:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
               id="coursename"
             >
               <p
@@ -245,12 +245,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Sections:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -263,12 +263,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Teams:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -281,12 +281,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Total students:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -300,12 +300,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with a course with one
           class="form-group row"
         >
           <label
-            class="col-sm-3 control-label"
+            class="col-sm-3 text-sm-right control-label"
           >
             Instructors:
           </label>
           <div
-            class="col-sm-6"
+            class="col-sm-6 text-sm-left"
           >
             
             <div>
@@ -430,12 +430,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course ID:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -448,12 +448,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Course name:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
               id="coursename"
             >
               <p
@@ -467,12 +467,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Sections:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -485,12 +485,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Teams:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -503,12 +503,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
             class="form-group row"
           >
             <label
-              class="col-sm-3"
+              class="col-sm-3 text-sm-right"
             >
               Total students:
             </label>
             <div
-              class="col-sm-6"
+              class="col-sm-6 text-sm-left"
             >
               <p
                 class="form-control-static"
@@ -522,12 +522,12 @@ exports[`InstructorCourseDetailsPageComponent should snap with default fields 1`
           class="form-group row"
         >
           <label
-            class="col-sm-3 control-label"
+            class="col-sm-3 text-sm-right control-label"
           >
             Instructors:
           </label>
           <div
-            class="col-sm-6"
+            class="col-sm-6 text-sm-left"
           >
             
           </div>

--- a/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.html
+++ b/src/web/app/pages-instructor/instructor-course-details-page/instructor-course-details-page.component.html
@@ -4,39 +4,39 @@
     <div class="card-body fill-plain">
       <div class="form">
         <div class="form-group row">
-          <label class="col-sm-3">Course ID:</label>
-          <div class="col-sm-6">
+          <label class="col-sm-3 text-sm-right">Course ID:</label>
+          <div class="col-sm-6 text-sm-left">
             <p class="form-control-static">{{courseDetails.course.courseId}}</p>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-3">Course name:</label>
-          <div class="col-sm-6" id="coursename">
+          <label class="col-sm-3 text-sm-right">Course name:</label>
+          <div class="col-sm-6 text-sm-left" id="coursename">
             <p class="form-control-static">{{courseDetails.course.courseName}}</p>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-3">Sections:</label>
-          <div class="col-sm-6">
+          <label class="col-sm-3 text-sm-right">Sections:</label>
+          <div class="col-sm-6 text-sm-left">
             <p class="form-control-static">{{courseDetails.stats.sectionsTotal}}</p>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-3">Teams:</label>
-          <div class="col-sm-6">
+          <label class="col-sm-3 text-sm-right">Teams:</label>
+          <div class="col-sm-6 text-sm-left">
             <p class="form-control-static">{{courseDetails.stats.teamsTotal}}</p>
           </div>
         </div>
         <div class="form-group row">
-          <label class="col-sm-3">Total students:</label>
-          <div class="col-sm-6">
+          <label class="col-sm-3 text-sm-right">Total students:</label>
+          <div class="col-sm-6 text-sm-left">
             <p class="form-control-static">{{courseDetails.stats.studentsTotal}}</p>
           </div>
         </div>
       </div>
       <div class="form-group row">
-        <label class="col-sm-3 control-label">Instructors:</label>
-        <div class="col-sm-6">
+        <label class="col-sm-3 text-sm-right control-label">Instructors:</label>
+        <div class="col-sm-6 text-sm-left">
           <div *ngFor="let instructor of instructors">
             {{instructor.role | instructorRoleName}}: {{instructor.name}} ({{instructor.email}})
           </div>


### PR DESCRIPTION
Fixes #10087 

**Outline of Solution**
![image](https://user-images.githubusercontent.com/28994607/82532849-b990af00-9b74-11ea-8f05-4a617e6ae365.png)