### PR TITLE
[#10088] Add notification on no result for instructor search

### DIFF
--- a/src/web/services/search.service.ts
+++ b/src/web/services/search.service.ts
@@ -128,6 +128,9 @@ export class SearchService {
   getPrivileges(
     coursesWithSections: SearchStudentsTable[],
   ): Observable<InstructorPrivilege[]> {
+    if (coursesWithSections.length === 0) {
+      return of([]);
+    }
     return forkJoin(
       coursesWithSections.map((course: SearchStudentsTable) => {
         return course.sections.map((section: StudentListSectionData) => {


### PR DESCRIPTION
Fixes #10088 

![image](https://user-images.githubusercontent.com/32454748/82542185-2495b200-9b84-11ea-92d3-2bf9e4549da9.png)

**Outline of Solution**

Add check for empty array for early termination.

The bug was caused by `forkJoin` not executing when given an empty array, so a check for empty array would solve the issue.
