### PR TITLE
[#10042] Add mobile compatibility to indivual question

### DIFF
--- a/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
+++ b/src/web/app/components/question-edit-form/__snapshots__/question-edit-form.component.spec.ts.snap
@@ -112,10 +112,10 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
             class="col-12"
           >
             <div
-              class="row padding-15px align-items-center"
+              class="row padding-15px text-left"
             >
               <div
-                class="col-2"
+                class="col-md-2"
               >
                 <div
                   class="question-basic-info"
@@ -124,7 +124,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                 </div>
               </div>
               <div
-                class="col-10"
+                class="col-md-10"
               >
                 <textarea
                   class="form-control ng-untouched ng-pristine ng-valid"
@@ -138,10 +138,10 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
               </div>
             </div>
             <div
-              class="row padding-15px"
+              class="row padding-15px text-left"
             >
               <div
-                class="col-2"
+                class="col-md-2"
               >
                 <div
                   class="question-basic-info"
@@ -152,7 +152,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                 </div>
               </div>
               <div
-                class="col-10"
+                class="col-md-10"
               >
                 <tm-rich-text-editor
                   ng-reflect-is-disabled="true"
@@ -174,7 +174,7 @@ exports[`QuestionEditFormComponent should snap with default view 1`] = `
                     ng-reflect-ng-class="[object Object]"
                     ng-reflect-ng-style="[object Object]"
                     placeholder="More details about the question e.g. \\"In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.\\""
-                    style="min-height: 120px;"
+                    style="min-height: 150px;"
                   >
                     
                     <div

--- a/src/web/app/components/question-edit-form/question-edit-form.component.html
+++ b/src/web/app/components/question-edit-form/question-edit-form.component.html
@@ -76,22 +76,22 @@
     <div class="background-color-light-blue">
       <div class="row">
         <div class="col-12">
-          <div class="row padding-15px align-items-center">
-            <div class="col-2">
+          <div class="row padding-15px text-left">
+            <div class="col-md-2">
               <div class="question-basic-info">Question</div>
             </div>
-            <div class="col-10">
+            <div class="col-md-10">
               <textarea class="form-control" [ngModel]="model.questionBrief" (ngModelChange)="triggerModelChange('questionBrief', $event)" [disabled]="!model.isEditable"
                         placeholder="A concise version of the question e.g. &quot;How well did the team member communicate?&quot;"
                         ngbTooltip="Please enter the question for users to give feedback about. e.g. What is the biggest weakness of the presented product?"
               ></textarea>
             </div>
           </div>
-          <div class="row padding-15px">
-            <div class="col-2">
+          <div class="row padding-15px text-left">
+            <div class="col-md-2">
               <div class="question-basic-info">[Optional]<br/>Description</div>
             </div>
-            <div class="col-10">
+            <div class="col-md-10">
               <tm-rich-text-editor [richText]="model.questionDescription" (richTextChange)="triggerModelChange('questionDescription', $event)" [isDisabled]="!model.isEditable"
                                    placeholderText="More details about the question e.g. &quot;In answering the question, do consider communications made informally within the team, and formal communications with the instructors and tutors.&quot;"
                                    ngbTooltip="Please enter the description of the question."></tm-rich-text-editor>

--- a/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
+++ b/src/web/app/components/rich-text-editor/rich-text-editor.component.ts
@@ -17,7 +17,7 @@ export class RichTextEditorComponent implements OnInit {
   isInlineMode: boolean = true;
 
   @Input()
-  minHeightInPx: number = 120;
+  minHeightInPx: number = 150;
 
   @Input()
   placeholderText: string = '';


### PR DESCRIPTION
Added 'md' to the respective divs so the label and content feel better on small widths.
Updated the mi-width on the editor, this way the editor's placeholder will not overflow on smaller widths.

Part of #10042 

Before:

![before](https://user-images.githubusercontent.com/65744119/82760805-550f6300-9db3-11ea-8388-29256d3ab0f1.jpeg)

After:

![7E4BCF8E-7072-47A1-A398-2454234B2505](https://user-images.githubusercontent.com/65744119/82760935-162ddd00-9db4-11ea-9752-7927473aa5a1.jpeg)

